### PR TITLE
Fix type annotation override in SpeculatorModel.generate method

### DIFF
--- a/src/speculators/model.py
+++ b/src/speculators/model.py
@@ -513,7 +513,7 @@ class SpeculatorModel(ClassRegistryMixin, PreTrainedModel, GenerationMixin):  # 
         negative_prompt_ids: Optional[torch.Tensor] = None,  # noqa: ARG002
         negative_prompt_attention_mask: Optional[torch.Tensor] = None,  # noqa: ARG002
         use_model_defaults: Optional[bool] = None,  # noqa: ARG002
-        custom_generate: Optional[str] = None,  # noqa: ARG002
+        custom_generate: Union[str, Callable[..., Any], None] = None,  # noqa: ARG002
         **kwargs,  # noqa: ARG002
     ) -> Union[GenerateOutput, torch.LongTensor]:
         """


### PR DESCRIPTION
## Summary

Resolves a mypy type checking error caused by incompatible method override in the `SpeculatorModel.generate` method. The `custom_generate` parameter type annotation was not compatible with the parent class `GenerationMixin.generate` method signature.

## Changes

- Updated `custom_generate` parameter type from `Optional[str]` to `Union[str, Callable[..., Any], None]`
- Ensures compliance with Liskov substitution principle for method overrides
- Maintains full compatibility with existing transformers generation interface

## Technical Details

The mypy error indicated that argument 12 of the `generate` method was incompatible with the supertype, specifically:
```
src/speculators/model.py:516: error: Argument 12 of "generate" is incompatible with supertype "GenerationMixin"
```

This occurred because the parent `GenerationMixin.generate` method expects `custom_generate` to accept either a string or callable, while our override only specified string type.

## Testing

- [x] Type checking passes with `tox -e types`
- [x] No functional changes to existing behavior

## TLDR;

Fixes the Mypy error we are seeing on main; Let's make it Green!