### PR TITLE
Fix documentation link checker errors

### DIFF
--- a/docs/developer/branding.md
+++ b/docs/developer/branding.md
@@ -2,9 +2,9 @@
 
 <div align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="assets/branding/speculators-logo-white.svg" />
-    <source media="(prefers-color-scheme: light)" srcset="assets/branding/speculators-logo-black.svg" />
-    <img alt="Speculators logo" src="assets/branding/speculators-logo-black.svg" style="height: 64px; max-width: 100%; display: inline-block;" />
+    <source media="(prefers-color-scheme: dark)" srcset="../assets/branding/speculators-logo-white.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="../assets/branding/speculators-logo-black.svg" />
+    <img alt="Speculators logo" src="../assets/branding/speculators-logo-black.svg" style="height: 64px; max-width: 100%; display: inline-block;" />
   </picture>
 </div>
 
@@ -39,19 +39,19 @@ All files reside in `docs/assets/branding`.
 
 | Category | Variant / Name | SVG | PNG | Notes |
 | -------- | -------------- | --- | --- | ----- |
-| Logo | Black | [`speculators-logo-black.svg`](assets/branding/speculators-logo-black.svg) | [`speculators-logo-black.png`](assets/branding/speculators-logo-black.png) | Default on light backgrounds |
-| Logo | Blue | [`speculators-logo-blue.svg`](assets/branding/speculators-logo-blue.svg) | [`speculators-logo-blue.png`](assets/branding/speculators-logo-blue.png) | Accent / section headers |
-| Logo | White | [`speculators-logo-white.svg`](assets/branding/speculators-logo-white.svg) | [`speculators-logo-white.png`](assets/branding/speculators-logo-white.png) | Use on dark imagery/backgrounds |
-| Icon | Black | [`speculators-icon-black.svg`](assets/branding/speculators-icon-black.svg) | [`speculators-icon-black.png`](assets/branding/speculators-icon-black.png) | App tile / light UI |
-| Icon | Blue | [`speculators-icon-blue.svg`](assets/branding/speculators-icon-blue.svg) | [`speculators-icon-blue.png`](assets/branding/speculators-icon-blue.png) | Accent |
-| Icon | White | [`speculators-icon-white.svg`](assets/branding/speculators-icon-white.svg) | [`speculators-icon-white.png`](assets/branding/speculators-icon-white.png) | Dark backgrounds |
-| Icon | White-Orange | [`speculators-icon-white-orange.svg`](assets/branding/speculators-icon-white-orange.svg) | [`speculators-icon-white-orange.png`](assets/branding/speculators-icon-white-orange.png) | Limited highlight |
-| Model Icon | Black | [`speculators-model-icon-black.svg`](assets/branding/speculators-model-icon-black.svg) | [`speculators-model-icon-black.png`](assets/branding/speculators-model-icon-black.png) | Architecture visuals |
-| Model Icon | Blue | [`speculators-model-icon-blue.svg`](assets/branding/speculators-model-icon-blue.svg) | [`speculators-model-icon-blue.png`](assets/branding/speculators-model-icon-blue.png) | Architecture visuals |
-| Model Icon | White | [`speculators-model-icon-white.svg`](assets/branding/speculators-model-icon-white.svg) | [`speculators-model-icon-white.png`](assets/branding/speculators-model-icon-white.png) | Dark backgrounds |
-| Model Icon | White-Orange | [`speculators-model-icon-white-orange.svg`](assets/branding/speculators-model-icon-white-orange.svg) | [`speculators-model-icon-white-orange.png`](assets/branding/speculators-model-icon-white-orange.png) | Highlight sparingly |
-| Diagram | User Flow (Light) | [`speculators-user-flow-light.svg`](assets/branding/speculators-user-flow-light.svg) | [`speculators-user-flow-light.png`](assets/branding/speculators-user-flow-light.png) | Light docs / print |
-| Diagram | User Flow (Dark) | [`speculators-user-flow-dark.svg`](assets/branding/speculators-user-flow-dark.svg) | [`speculators-user-flow-dark.png`](assets/branding/speculators-user-flow-dark.png) | Dark slides / sites |
+| Logo | Black | [`speculators-logo-black.svg`](../assets/branding/speculators-logo-black.svg) | [`speculators-logo-black.png`](../assets/branding/speculators-logo-black.png) | Default on light backgrounds |
+| Logo | Blue | [`speculators-logo-blue.svg`](../assets/branding/speculators-logo-blue.svg) | [`speculators-logo-blue.png`](../assets/branding/speculators-logo-blue.png) | Accent / section headers |
+| Logo | White | [`speculators-logo-white.svg`](../assets/branding/speculators-logo-white.svg) | [`speculators-logo-white.png`](../assets/branding/speculators-logo-white.png) | Use on dark imagery/backgrounds |
+| Icon | Black | [`speculators-icon-black.svg`](../assets/branding/speculators-icon-black.svg) | [`speculators-icon-black.png`](../assets/branding/speculators-icon-black.png) | App tile / light UI |
+| Icon | Blue | [`speculators-icon-blue.svg`](../assets/branding/speculators-icon-blue.svg) | [`speculators-icon-blue.png`](../assets/branding/speculators-icon-blue.png) | Accent |
+| Icon | White | [`speculators-icon-white.svg`](../assets/branding/speculators-icon-white.svg) | [`speculators-icon-white.png`](../assets/branding/speculators-icon-white.png) | Dark backgrounds |
+| Icon | White-Orange | [`speculators-icon-white-orange.svg`](../assets/branding/speculators-icon-white-orange.svg) | [`speculators-icon-white-orange.png`](../assets/branding/speculators-icon-white-orange.png) | Limited highlight |
+| Model Icon | Black | [`speculators-model-icon-black.svg`](../assets/branding/speculators-model-icon-black.svg) | [`speculators-model-icon-black.png`](../assets/branding/speculators-model-icon-black.png) | Architecture visuals |
+| Model Icon | Blue | [`speculators-model-icon-blue.svg`](../assets/branding/speculators-model-icon-blue.svg) | [`speculators-model-icon-blue.png`](../assets/branding/speculators-model-icon-blue.png) | Architecture visuals |
+| Model Icon | White | [`speculators-model-icon-white.svg`](../assets/branding/speculators-model-icon-white.svg) | [`speculators-model-icon-white.png`](../assets/branding/speculators-model-icon-white.png) | Dark backgrounds |
+| Model Icon | White-Orange | [`speculators-model-icon-white-orange.svg`](../assets/branding/speculators-model-icon-white-orange.svg) | [`speculators-model-icon-white-orange.png`](../assets/branding/speculators-model-icon-white-orange.png) | Highlight sparingly |
+| Diagram | User Flow (Light) | [`speculators-user-flow-light.svg`](../assets/branding/speculators-user-flow-light.svg) | [`speculators-user-flow-light.png`](../assets/branding/speculators-user-flow-light.png) | Light docs / print |
+| Diagram | User Flow (Dark) | [`speculators-user-flow-dark.svg`](../assets/branding/speculators-user-flow-dark.svg) | [`speculators-user-flow-dark.png`](../assets/branding/speculators-user-flow-dark.png) | Dark slides / sites |
 
 ## Usage Guidelines
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,13 +48,13 @@ Unified Library for Speculative Decoding: Build, Evaluate, and Deploy Faster LLM
 
   [:octicons-arrow-right-24: Entrypoints](./entrypoints/)
 
-- :material-api:{ .lg .middle } API Reference
+<!-- - :material-api:{ .lg .middle } API Reference
 
     ---
 
     Complete reference documentation for the Speculators API to integrate speculative decoding into your workflow.
 
-    [:octicons-arrow-right-24: API Reference](./api/)
+    [:octicons-arrow-right-24: API Reference](./api/) -->
 
 </div>
 
@@ -85,5 +85,5 @@ VLLM_USE_V1=1 vllm serve RedHatAI/Qwen3-8B-speculator.eagle3
 
 Speculators includes prototype implementations of cutting-edge speculative decoding research:
 
-- **[EAGLE 3](./research/eagle3/)**: Train Time Test method implementation for advanced token speculation
-- **[HASS](./research/hass/)**: EAGLE 1 architecture variation using the HASS training method
+- **EAGLE 3**: Train Time Test method implementation for advanced token speculation
+- **HASS**: EAGLE 1 architecture variation using the HASS training method


### PR DESCRIPTION
## Summary

Resolves 32 broken file links identified by the nightly link checker workflow that were causing CI failures.

## Root Cause

The documentation had two categories of broken links:
1. **Incorrect relative paths**: Branding assets referenced from `docs/developer/branding.md` used relative paths that didn't account for the subdirectory structure
2. **Missing directories**: Links to non-existent API documentation and research sections

## Changes

### Fixed Branding Asset Links
- Updated all asset references in `docs/developer/branding.md` to use `../assets/branding/` instead of `assets/branding/`
- Fixed both the header logo display and the asset catalog table links
- All 26 branding assets (SVG/PNG files) exist but were incorrectly referenced

### Removed Broken Directory Links  
- Commented out API Reference section in `docs/index.md` until API docs are created
- Removed broken links to `./research/eagle3/` and `./research/hass/` directories
- Converted research section items to plain text descriptions

## Validation

- All referenced branding assets verified to exist in `docs/assets/branding/`
- Link paths tested to ensure proper relative traversal from subdirectories
- Commented sections can be easily re-enabled when target directories are created

## Impact

- Fixes nightly CI link checker failures
- Maintains documentation functionality while removing broken references
- Preserves future extensibility for API docs and research sections