### PR TITLE
Fix 'test_download_with_cache_dir'

### DIFF
--- a/tests/unit/convert/test_eagle_utils.py
+++ b/tests/unit/convert/test_eagle_utils.py
@@ -90,10 +90,10 @@ class TestEnsureCheckpointIsLocal:
         cache_dir = tmp_path / "cache"
         mock_download.return_value = tmp_path / "downloaded"
 
-        ensure_checkpoint_is_local("test-model/checkpoint", cache_dir=cache_dir)
+        ensure_checkpoint_is_local("test-model/checkpoint", cache_dir=str(cache_dir))
 
         mock_download.assert_called_once_with(
-            model_id="test-model/checkpoint", cache_dir=cache_dir
+            model_id="test-model/checkpoint", cache_dir=str(cache_dir)
         )
 
 


### PR DESCRIPTION
Update the test so it converts the `Path` object to a string before using it/comparing to it.

Verified with a local run before/after:

```shell
# before
$ pytest tests/unit/convert/test_eagle_utils.py
…
1 failed, 21 passed, 1 warning

#after
$ pytest tests/unit/convert/test_eagle_utils.py
…
22 passed, 1 warning
```