### PR TITLE
Prevent forced casting to fp16 dtype

### DIFF
--- a/research/eagle3/ge_data/llamasharegpt.py
+++ b/research/eagle3/ge_data/llamasharegpt.py
@@ -141,10 +141,10 @@ def build_ds(
     return ds1
 
 
-bigtokenizer = AutoTokenizer.from_pretrained(bigname, use_fast=False)
+bigtokenizer = AutoTokenizer.from_pretrained(bigname)
 ds = build_ds(bigtokenizer)
 bigmodel = AutoModelForCausalLM.from_pretrained(
-    bigname, device_map="auto", torch_dtype=torch.float16
+    bigname, device_map="auto", torch_dtype="auto"
 )
 bigmodel.eval()
 

--- a/research/eagle3/ge_data/llamaultrachat.py
+++ b/research/eagle3/ge_data/llamaultrachat.py
@@ -104,10 +104,10 @@ def build_ds(
     return ds1
 
 
-bigtokenizer = AutoTokenizer.from_pretrained(bigname, use_fast=False)
+bigtokenizer = AutoTokenizer.from_pretrained(bigname)
 ds = build_ds(bigtokenizer)
 bigmodel = AutoModelForCausalLM.from_pretrained(
-    bigname, device_map="auto", torch_dtype=torch.float16
+    bigname, device_map="auto", torch_dtype="auto"
 )
 bigmodel.eval()
 

--- a/research/eagle3/ge_data/qwensharegpt.py
+++ b/research/eagle3/ge_data/qwensharegpt.py
@@ -117,11 +117,11 @@ def build_ds(
     return ds1
 
 
-bigtokenizer = AutoTokenizer.from_pretrained(bigname, use_fast=False)
+bigtokenizer = AutoTokenizer.from_pretrained(bigname)
 ds = build_ds(bigtokenizer)
 
 bigmodel = AutoModelForCausalLM.from_pretrained(
-    bigname, device_map="auto", torch_dtype=torch.float16
+    bigname, device_map="auto", torch_dtype="auto"
 )
 bigmodel.eval()
 

--- a/research/eagle3/ge_data/qwenultrachat.py
+++ b/research/eagle3/ge_data/qwenultrachat.py
@@ -87,10 +87,10 @@ def build_ds(
     return ds1
 
 
-bigtokenizer = AutoTokenizer.from_pretrained(bigname, use_fast=False)
+bigtokenizer = AutoTokenizer.from_pretrained(bigname)
 ds = build_ds(bigtokenizer)
 bigmodel = AutoModelForCausalLM.from_pretrained(
-    bigname, device_map="auto", torch_dtype=torch.float16
+    bigname, device_map="auto", torch_dtype="auto"
 )
 bigmodel.eval()
 


### PR DESCRIPTION
When we want to generate data with quantized models, this forced casting of dtype to fp16 messes up the model completely. We should let AutoModelForCausalLM infer the dtype.