### PR TITLE
Extend E2E Tests for EAGLE3 Models

### DIFF
--- a/tests/e2e/vllm/test_eagle3.py
+++ b/tests/e2e/vllm/test_eagle3.py
@@ -104,18 +104,6 @@ class TestEagle3vLLM:
                 },
                 id="llama3-2layer",
             ),
-            # Note: This test may use a lot of memory due to the model size
-            pytest.param(
-                {
-                    "unconverted_model": "nvidia/Llama-4-Maverick-17B-128E-Eagle3",
-                    "base_model": (
-                        "RedHatAI/Llama-4-Maverick-17B-128E-Instruct-quantized.w4a16"
-                    ),
-                    "norm_before_residual": False,
-                    "eagle_aux_hidden_state_layer_ids": [1, 23, 44],
-                },
-                id="llama4-diff-hidden",
-            ),
         ],
     )
     def test_convert_run_vllm_engine_eagle3(self, model_info, temp_cache_dir, tmp_path):


### PR DESCRIPTION
This PR extends the end-to-end (e2e) test coverage for EAGLE3 models by adding four new test cases with pneumonic test IDs. The tests cover different model architectures and configurations to ensure comprehensive validation of the conversion and vLLM inference pipeline.

## Changes

### New E2E Test Cases

Added four new parametrized test cases to `test_convert_run_vllm_engine_eagle3`:

1. **`llama3-8b`** - Standard Llama 3.1 8B EAGLE3 model
   - Model: `yuhuili/EAGLE3-LLaMA3.1-Instruct-8B`
   - Verifier: `meta-llama/Meta-Llama-3.1-8B-Instruct`
   - Tests: Basic conversion and vLLM inference workflow

2. **`qwen3-8b`** - Qwen3 8B with norm before residual
   - Model: `nm-testing/Speculator-Qwen3-8B-Eagle3`
   - Verifier: `Qwen/Qwen3-8B`
   - Tests: `norm_before_residual=True` configuration

3. **`llama3-2layer`** - Multi-layer decoder architecture
   - Model: `nm-testing/random-weights-llama3.1.8b-2layer-eagle3-unconverted`
   - Verifier: `meta-llama/Meta-Llama-3.1-8B-Instruct`
   - Tests: Models with multiple (2) decoder layers in the drafter

4. REMOVED FOR NOW due to massive GPU requirements, will land a subsequent PR with an appropriately sized verifier in the future ~**`llama4-diff-hidden`** - Llama 4 with different hidden states auxiliary layers~
   ~- Model: `nvidia/Llama-4-Maverick-17B-128E-Eagle3`~
   ~- Verifier: `RedHatAI/Llama-4-Maverick-17B-128E-Instruct-quantized.w4a16`~
   ~- Tests:~
     ~- Different `target_hidden_size` vs `draft_hidden_size`~
     ~- Auxiliary hidden state layers via `eagle_aux_hidden_state_layer_ids=[1, 23, 44]`~

### Implementation Details

**Conditional Parameter Passing**
- Updated converter call to only pass `eagle_aux_hidden_state_layer_ids` when explicitly specified in test config
- Prevents passing `None` values which could interfere with converter defaults

```python
convert_kwargs = {
    "input_path": unconverted_model,
    "output_path": converted_path,
    "base_model": base_model,
    "cache_dir": temp_cache_dir,
    "norm_before_residual": norm_before_residual,
}

if "eagle_aux_hidden_state_layer_ids" in model_info:
    convert_kwargs["eagle_aux_hidden_state_layer_ids"] = model_info[
        "eagle_aux_hidden_state_layer_ids"
    ]

converter.convert(**convert_kwargs)
```

**Pneumonic Test IDs**
- All test cases now have clear, descriptive IDs using `pytest.param(..., id="...")`
- Makes it easy to run specific tests: `pytest tests/e2e/vllm/test_eagle3.py::TestEagle3vLLM::test_convert_run_vllm_engine_eagle3[llama4-diff-hidden]`

**Pre-converted Model Tests**
- Also added IDs to existing pre-converted model tests:
  - `llama3-converted-quantized`
  - `qwen3-converted-quantized`

## Test Coverage

Each test validates:
- ✅ Model download from HuggingFace
- ✅ Conversion to speculators format via `Eagle3Converter`
- ✅ Configuration parameters correctly set
- ✅ vLLM can load and run inference on converted model
- ✅ Output validation (20 tokens generated, all integers)

## Testing Architecture Coverage

| Test Case | Hidden Size Diff | Aux Hidden Layers | Norm Before Residual | Decoder Layers |
|-----------|------------------|-------------------|----------------------|----------------|
| llama3-8b | ❌ | ❌ | ❌ | 1 |
| qwen3-8b | ❌ | ❌ | ✅ | 1 |
| llama3-2layer | ❌ | ❌ | ❌ | 2 |
| llama4-diff-hidden | ✅ | ✅ [1,23,44] | ❌ | 1 |

## Running Tests

```bash
# Run all new e2e tests
tox -e test-e2e

# Run specific test by ID
VLLM_PYTHON=/path/to/vllm/.venv/bin/python python -m pytest \
  tests/e2e/vllm/test_eagle3.py::TestEagle3vLLM::test_convert_run_vllm_engine_eagle3[llama3-8b] -v

# List all tests
python -m pytest tests/e2e/vllm/test_eagle3.py --collect-only -q
```

## Notes

- The `llama4-diff-hidden` test may require more GPU memory due to the 17B model size
- Tests require `VLLM_PYTHON` environment variable pointing to vLLM installation
- Environment variables `HF_HOME` and `HF_TOKEN` may be needed for model downloads
- All tests pass code quality checks (`tox -e style` and `tox -e quality`)
