### PR TITLE
Fix dev link checker workflow to comment directly on PRs

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout code
@@ -18,16 +19,16 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           fail: false
-      - name: Create Comment
+      - name: Create PR Comment
         if: steps.lychee.outputs.exit_code != '0'
         uses: peter-evans/create-or-update-comment@v4
         with:
-          issue-number: 128
+          issue-number: ${{ github.event.pull_request.number }}
           body-path: ./lychee/out.md
       - name: Fail on Issues
         if: steps.lychee.outputs.exit_code != '0'
         run: |
-          echo "Link Checker found issues. Please check the created issue for details."
+          echo "Link Checker found issues. Please check the PR comment for details."
           exit 1
 
   quality-checks:


### PR DESCRIPTION
## Summary

Updates the development link-checking workflow to improve reviewer visibility and ensure separation from the main branch link checking workflow. Previously, link check failures were posted to a fixed issue along with results from main, which made it harder to track validation results per pull request and separate them from results merged to main. The workflow now creates or updates a comment directly on the relevant PR when broken links are detected.