### PR TITLE
bump version after v0.2.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from packaging.version import Version
 from setuptools import setup
 from setuptools_git_versioning import count_since, get_branch, get_sha, get_tags
 
-LAST_RELEASE_VERSION = Version("0.1.0")
+LAST_RELEASE_VERSION = Version("0.2.0")
 TAG_VERSION_PATTERN = re.compile(r"^v(\d+\.\d+\.\d+)$")
 
 


### PR DESCRIPTION
v0.2.0 has gone out so bumping up version again.