### PR TITLE
switch to H100 runner for the tests

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -80,7 +80,7 @@ jobs:
         run: pre-commit run --all-files
 
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ibm-wdc-k8s-vllm-h100-solo
     strategy:
       matrix:
         python: ["3.10", "3.13"]
@@ -96,7 +96,7 @@ jobs:
         run: tox -e test-unit
 
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ibm-wdc-k8s-vllm-h100-solo
     strategy:
       matrix:
         python: ["3.10", "3.13"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
         run: pre-commit run --all-files
 
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ibm-wdc-k8s-vllm-h100-solo
     strategy:
       matrix:
         python: ["3.10", "3.13"]
@@ -96,7 +96,7 @@ jobs:
         run: tox -e test-unit
 
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ibm-wdc-k8s-vllm-h100-solo
     strategy:
       matrix:
         python: ["3.10", "3.13"]


### PR DESCRIPTION
Switch to use the h100 runner for test jobs. Still keep the ubuntu-latest runner for link and quality checks etc.