### PR TITLE
Fix link redirects

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -70,8 +70,8 @@ Community leaders will follow these Community Impact Guidelines in determining t
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct/.
 
-Community Impact Guidelines were inspired by [Mozilla’s code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by [Mozilla’s code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
 
-For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq/. Translations are available at https://www.contributor-covenant.org/translations/.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ You can either clone the repository directly or fork it if you plan to contribut
 1. Clone the repository to your local machine:
 
    ```bash
-   git clone https://github.com/neuralmagic/speculators.git
+   git clone https://github.com/vllm-project/speculators.git
    cd speculators
    ```
 
@@ -64,7 +64,7 @@ Note: the data generation components off speculators (i.e. `src/speculators/data
 We follow strict coding standards to ensure code quality and maintainability. Please adhere to the following guidelines:
 
 - **Code Style**: Use [Ruff](https://github.com/astral-sh/ruff) for formatting and linting.
-- **Type Checking**: Use [Mypy](http://mypy-lang.org/) for type checking.
+- **Type Checking**: Use [Mypy](https://mypy-lang.org/) for type checking.
 - **Testing**: Write unit tests for new features and bug fixes. Use [pytest](https://docs.pytest.org/) for testing.
 - **Documentation**: Update documentation for any changes to the codebase.
 
@@ -198,14 +198,14 @@ If you encounter a bug or have a feature request, please open an issue on GitHub
 
 ## Community Standards
 
-We are committed to fostering a welcoming and inclusive community. Please read and adhere to our [Code of Conduct](https://github.com/neuralmagic/speculators/blob/main/CODE_OF_CONDUCT.md).
+We are committed to fostering a welcoming and inclusive community. Please read and adhere to our [Code of Conduct](https://github.com/vllm-project/speculators/blob/main/CODE_OF_CONDUCT.md).
 
 ## Additional Resources
 
-- [CODE_OF_CONDUCT.md](https://github.com/neuralmagic/speculators/blob/main/CODE_OF_CONDUCT.md): Our expectations for community behavior.
-- [tox.ini](https://github.com/neuralmagic/speculators/blob/main/tox.ini): Configuration for Tox environments.
-- [.pre-commit-config.yaml](https://github.com/neuralmagic/speculators/blob/main/.pre-commit-config.yaml): Configuration for pre-commit hooks.
+- [CODE_OF_CONDUCT.md](https://github.com/vllm-project/speculators/blob/main/CODE_OF_CONDUCT.md): Our expectations for community behavior.
+- [tox.ini](https://github.com/vllm-project/speculators/blob/main/tox.ini): Configuration for Tox environments.
+- [.pre-commit-config.yaml](https://github.com/vllm-project/speculators/blob/main/.pre-commit-config.yaml): Configuration for pre-commit hooks.
 
 ## License
 
-By contributing to Speculators, you agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/neuralmagic/speculators/blob/main/LICENSE).
+By contributing to Speculators, you agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/vllm-project/speculators/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
 
 <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/neuralmagic/speculators/main/docs/assets/branding/speculators-logo-white.svg" />
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/neuralmagic/speculators/main/docs/assets/branding/speculators-logo-black.svg" />
-    <img alt="Speculators logo" src="https://raw.githubusercontent.com/neuralmagic/speculators/main/docs/assets/branding/speculators-logo-black.svg" height="64" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/speculators/main/docs/assets/branding/speculators-logo-white.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/vllm-project/speculators/main/docs/assets/branding/speculators-logo-black.svg" />
+    <img alt="Speculators logo" src="https://raw.githubusercontent.com/vllm-project/speculators/main/docs/assets/branding/speculators-logo-black.svg" height="64" />
   </picture>
 
-[![License](https://img.shields.io/github/license/neuralmagic/speculators.svg)](https://github.com/neuralmagic/speculators/blob/main/LICENSE) [![Python Versions](https://img.shields.io/badge/Python-3.10--3.13-orange)](https://pypi.python.org/pypi/speculators) [![docs](https://img.shields.io/badge/docs-Speculators-blue)](https://docs.vllm.ai/projects/speculators/en/latest/) [![PyPI](https://img.shields.io/pypi/v/speculators.svg)](https://pypi.org/project/speculators/) [![tests](https://github.com/vllm-project/speculators/actions/workflows/main.yml/badge.svg)](https://github.com/vllm-project/speculators/actions/workflows/main.yml)
+[![License](https://img.shields.io/github/license/vllm-project/speculators.svg)](https://github.com/vllm-project/speculators/blob/main/LICENSE) [![Python Versions](https://img.shields.io/badge/Python-3.10--3.13-orange)](https://pypi.org/project/speculators/) [![docs](https://img.shields.io/badge/docs-Speculators-blue)](https://docs.vllm.ai/projects/speculators/en/latest/) [![PyPI](https://img.shields.io/pypi/v/speculators.svg)](https://pypi.org/project/speculators/) [![tests](https://github.com/vllm-project/speculators/actions/workflows/main.yml/badge.svg)](https://github.com/vllm-project/speculators/actions/workflows/main.yml)
 
 </div>
 
@@ -16,9 +16,9 @@
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/neuralmagic/speculators/main/docs/assets/branding/speculators-user-flow-dark.svg" />
-    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/neuralmagic/speculators/main/docs/assets/branding/speculators-user-flow-light.svg" />
-    <img alt="Speculators user flow diagram" src="https://raw.githubusercontent.com/neuralmagic/speculators/main/docs/assets/branding/speculators-user-flow-light.svg" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/speculators/main/docs/assets/branding/speculators-user-flow-dark.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/vllm-project/speculators/main/docs/assets/branding/speculators-user-flow-light.svg" />
+    <img alt="Speculators user flow diagram" src="https://raw.githubusercontent.com/vllm-project/speculators/main/docs/assets/branding/speculators-user-flow-light.svg" />
   </picture>
 </p>
 
@@ -142,8 +142,8 @@ Served models can then be benchmarked using [GuideLLM](https://github.com/vllm-p
 
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/neuralmagic/speculators/main/docs/assets/qwen_quant_benchmark.png">
-    <img alt="GuideLLM Logo" src="https://raw.githubusercontent.com/neuralmagic/speculators/main/docs/assets/qwen_quant_benchmark.png" width=180%>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/speculators/main/docs/assets/qwen_quant_benchmark.png">
+    <img alt="GuideLLM Logo" src="https://raw.githubusercontent.com/vllm-project/speculators/main/docs/assets/qwen_quant_benchmark.png" width=180%>
   </picture>
 </p>
 
@@ -172,7 +172,7 @@ pip install speculators
 For the latest development version or to contribute to the project:
 
 ```bash
-git clone https://github.com/neuralmagic/speculators.git
+git clone https://github.com/vllm-project/speculators.git
 cd speculators
 
 pip install -e .
@@ -215,7 +215,7 @@ Here you can find links to our research implementations. These provide prototype
 
 ## License
 
-Speculators is licensed under the [Apache License 2.0](https://github.com/neuralmagic/speculators/blob/main/LICENSE).
+Speculators is licensed under the [Apache License 2.0](https://github.com/vllm-project/speculators/blob/main/LICENSE).
 
 ## Cite
 
@@ -226,6 +226,6 @@ If you find Speculators helpful in your research or projects, please consider ci
   title={Speculators: A Unified Library for Speculative Decoding Algorithms in LLM Serving},
   author={Red Hat},
   year={2025},
-  howpublished={\url{https://github.com/neuralmagic/speculators}},
+  howpublished={\url{https://github.com/vllm-project/speculators}},
 }
 ```

--- a/docs/developer/branding.md
+++ b/docs/developer/branding.md
@@ -90,7 +90,7 @@ All files reside in `docs/assets/branding`.
 
 ## License & Attribution
 
-- License: assets are distributed under the [Apache License 2.0](https://github.com/neuralmagic/speculators/blob/main/LICENSE) for identifying the Speculators open-source project
+- License: assets are distributed under the [Apache License 2.0](https://github.com/vllm-project/speculators/blob/main/LICENSE) for identifying the Speculators open-source project
 - Do not use assets to misrepresent affiliation or create derivative brand identities
 
 ## Changelog

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -44,7 +44,7 @@ Speculators is an open-source project that values community contributions. We ma
 ### Quick Setup
 
 1. **Prerequisites**: Ensure you have Python 3.10+ and Git installed
-2. **Clone**: `git clone https://github.com/neuralmagic/speculators.git`
+2. **Clone**: `git clone https://github.com/vllm-project/speculators.git`
 3. **Install**: `pip install -e .[dev]`
 4. **Code Quality**: Run `pre-commit install` to set up code quality checks
 
@@ -54,6 +54,6 @@ Speculators is developed and maintained by Neural Magic and the open-source comm
 
 For questions, discussions, or support:
 
-- **Issues**: [GitHub Issues](https://github.com/neuralmagic/speculators/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/neuralmagic/speculators/discussions)
-- **License**: [Apache 2.0](https://github.com/neuralmagic/speculators/blob/main/LICENSE)
+- **Issues**: [GitHub Issues](https://github.com/vllm-project/speculators/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/vllm-project/speculators/discussions)
+- **License**: [Apache 2.0](https://github.com/vllm-project/speculators/blob/main/LICENSE)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 
 <div align="center" style="display: flex; align-items: center; justify-content: center; gap: 20px; text-align: left;">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/neuralmagic/speculators/main/docs/assets/branding/speculators-model-icon-blue.png">
-    <img alt="Speculators Logo" src="https://raw.githubusercontent.com/neuralmagic/speculators/main/docs/assets/branding/speculators-model-icon-blue.png" width="120">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/speculators/main/docs/assets/branding/speculators-model-icon-blue.png">
+    <img alt="Speculators Logo" src="https://raw.githubusercontent.com/vllm-project/speculators/main/docs/assets/branding/speculators-model-icon-blue.png" width="120">
   </picture>
 
   <h3 style="margin: 0; text-align: left;">
@@ -84,7 +84,7 @@ pip install speculators
 Or install directly from source:
 
 ```bash
-pip install git+https://github.com/neuralmagic/speculators.git
+pip install git+https://github.com/vllm-project/speculators.git
 ```
 
 Convert a speculative model and serve with vLLM:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: Speculators Docs
 site_description: A unified library for building, and storing speculative decoding algorithms for large language model (LLM) inference
-site_url: https://neuralmagic.github.io/speculators
-repo_url: https://github.com/neuralmagic/speculators
-edit_uri: https://github.com/neuralmagic/speculators/tree/main/docs
+site_url: https://vllm-project.github.io/speculators
+repo_url: https://github.com/vllm-project/speculators
+edit_uri: https://github.com/vllm-project/speculators/tree/main/docs
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,9 +117,9 @@ datagen = ["vllm==0.11.0"]
 speculators = "speculators.__main__:app"
 
 [project.urls]
-homepage = "https://github.com/neuralmagic/speculators"
-source = "https://github.com/neuralmagic/speculators"
-issues = "https://github.com/neuralmagic/speculators/issues"
+homepage = "https://github.com/vllm-project/speculators"
+source = "https://github.com/vllm-project/speculators"
+issues = "https://github.com/vllm-project/speculators/issues"
 
 # ************************************************
 # ********** Code Quality Tools **********


### PR DESCRIPTION
Closes #192 

There are a lot of links in the repo that reference the old repo location https://github.com/neuralmagic/speculators as well as other links to third-party websites that go through several redirects.

This pr replaces those links with links directly to the final destination.


Note the only redirect left after this pr is pypi's:
Redirects: https://docs.pytest.org/ --> https://docs.pytest.org/en/stable/

This is intentional, so that users with different local languages will be redirect to their local language option. 