### PR TITLE
pin datasets version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ keywords = [
 dependencies = [
     "accelerate",
     "click",
-    "datasets>=4.4.1",
+    "datasets>=4.0.0",
     "deepspeed",
     "httpx[http2]",
     "huggingface-hub",


### PR DESCRIPTION
python 3.10 was failing because pyarrow 22.0.0 and datasets 2.14.4 were not compatible. Pinning datasets version to >= 4.4.1 to avoid this failure.