### PR TITLE
Add `tox-uv` to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dev = [
     "pre-commit~=3.5.0",
     "sphinx~=7.1.2",
     "tox~=4.16.0",
+    "tox-uv", # version is tied to tox version
 
     # testing
     "pytest~=8.2.2",


### PR DESCRIPTION
This significantly speeds up `tox` initial environment setup. We already use this for CI but helpful to add to the dev dependencies as well. 