### PR TITLE
Fix Verifier stubs in eval examples

### DIFF
--- a/examples/evaluate/eval-guidellm/configs/qwen-32b-eagle3.env
+++ b/examples/evaluate/eval-guidellm/configs/qwen-32b-eagle3.env
@@ -2,7 +2,7 @@
 # Evaluation on math_reasoning dataset
 
 # Model configuration
-BASE_MODEL="Qwen/Qwen2.5-32B-Instruct"
+BASE_MODEL="Qwen/Qwen3-32B"
 SPECULATOR_MODEL="RedHatAI/Qwen3-32B-speculator.eagle3"
 NUM_SPEC_TOKENS=3
 METHOD="eagle3"

--- a/examples/evaluate/eval-guidellm/configs/qwen3-8b-eagle3.env
+++ b/examples/evaluate/eval-guidellm/configs/qwen3-8b-eagle3.env
@@ -2,7 +2,7 @@
 # Evaluation on math_reasoning dataset
 
 # Model configuration
-BASE_MODEL="Qwen/Qwen2.5-3B-Instruct"
+BASE_MODEL="Qwen/Qwen3-8B"
 SPECULATOR_MODEL="RedHatAI/Qwen3-8B-speculator.eagle3"
 NUM_SPEC_TOKENS=3
 METHOD="eagle3"


### PR DESCRIPTION
  ### Summary

  - Fixes incorrect or missing Verifier stub configurations in the evaluation examples
  - Ensures eval example configurations work correctly with the Qwen model verifier setup

  ### Test plan

  - Verify evaluation examples run without errors
  - Confirm Verifier stubs are correctly configured