### PR TITLE
Add lr scheduler options to train.py and gen_and_train.py

### DIFF
--- a/scripts/gen_and_train.py
+++ b/scripts/gen_and_train.py
@@ -125,6 +125,10 @@ class TrainArgs(NamedTuple):
     num_layers: int | _NS = _NOTSET
     ttt_step_loss_decay: float | _NS = _NOTSET
     use_off_policy_tokens: bool | _NS = _NOTSET
+    scheduler_type: str | _NS = _NOTSET
+    scheduler_warmup_steps: int | _NS = _NOTSET
+    scheduler_total_steps: int | _NS = _NOTSET
+    scheduler_num_cosine_cycles: float | _NS = _NOTSET
 
 
 ### END OF SCRIPT ARGUMENTS ###

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -189,6 +189,10 @@ def main(args: argparse.Namespace):
             "ttt_steps": args.ttt_steps,
             "ttt_step_loss_decay": args.ttt_step_loss_decay,
         },
+        scheduler_type=args.scheduler_type,
+        scheduler_warmup_steps=args.scheduler_warmup_steps,
+        scheduler_total_steps=args.scheduler_total_steps,
+        scheduler_num_cosine_cycles=args.scheduler_num_cosine_cycles,
     )
     trainer = Trainer(draft_model, trainer_config, train_loader, val_loader)
 
@@ -228,6 +232,11 @@ def parse_args():
         default=False,
         help="Use off-policy tokens during training (required for regenerated data)",
     )
+    # lr scheduler
+    parser.add_argument("--scheduler-type", type=str, default="linear")
+    parser.add_argument("--scheduler-warmup-steps", type=int, default=None)
+    parser.add_argument("--scheduler-total-steps", type=int, default=None)
+    parser.add_argument("--scheduler-num-cosine-cycles", type=float, default=0.5)
     return parser.parse_args()
 
 


### PR DESCRIPTION
We already have support in `trainer.py` for different learning rate schedulers, however the options to configure them aren't currently exposed in the user scripts (`train.py` and `gen_and_train.py`). This pr exposes those options. 