### PR TITLE
WIP: Qwen3 VL (image‑text) training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Speculators is a unified library for building, training and storing speculative 
 
 Speculators standardizes this process by providing a productionized end-to-end framework to train draft models with reusable formats and tools. Trained models can seamlessly run in vLLM, enabling the deployment of speculative decoding in production-grade inference servers.
 
+<!-- TODO(VL): Clarify current VL training status vs. deployment support and
+add links to multimodal training docs once available. -->
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/speculators/main/docs/assets/branding/speculators-user-flow-dark.svg" />
@@ -38,7 +41,7 @@ ______________________________________________________________________
 ## Key Features
 
 - **Offline Training Data Generation using vLLM:** Enable the generation of hidden states using vLLM. Data samples are saved to disk and can be used for draft model training.
-- **Draft Model Training Support:** E2E training support of single and multi-layer draft models. Training is supported for both non-MoE and MoE models. VL Training is coming soon.
+- **Draft Model Training Support:** E2E training support of single and multi-layer draft models. Training is supported for both non-MoE and MoE models. VL (single image-text) training is supported.
 - **Standardized, Extensible Format:** Provides a Hugging Face-compatible format for defining speculative models, with tools to convert from external research repositories into a standard speculators format for easy adoption.
 - **Seamless vLLM Integration:** Built for direct deployment into vLLM, enabling low-latency, production-grade inference with minimal overhead.
 

--- a/scripts/convert_pokemon_gpt4o_to_jsonl.py
+++ b/scripts/convert_pokemon_gpt4o_to_jsonl.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Convert a HF dataset with images + conversations into speculators JSONL.
+
+This script loads a HuggingFace dataset split, attaches each sample's images to the
+first user turn, and writes a JSONL file with speculators-style multimodal messages.
+
+Example:
+    python scripts/convert_pokemon_gpt4o_to_jsonl.py \
+    --dataset llamafactory/pokemon-gpt4o-captions \
+    --split train \
+    --output ./data/pokemon_vl.jsonl \
+    --image-output-dir ./pokemon_images
+
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+from io import BytesIO
+from typing import Any
+
+from datasets import Image, Sequence, load_dataset
+from PIL import Image as PILImage
+from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    # Parse CLI arguments for dataset conversion to JSONL.
+    parser = argparse.ArgumentParser(
+        description="Convert pokemon-gpt4o-captions to JSONL with multimodal content."
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default=None,
+        help="HuggingFace dataset name (e.g., llamafactory/pokemon-gpt4o-captions).",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="train",
+        help="Dataset split to load (default: train).",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Output JSONL path.",
+    )
+    parser.add_argument(
+        "--image-root",
+        type=str,
+        default=None,
+        help=(
+            "Optional root directory for resolving image paths. If set, image"
+            " paths are written as basenames and resolved later using --image-root"
+            " in data generation."
+        ),
+    )
+    parser.add_argument(
+        "--image-output-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory to write image bytes when the dataset stores images as bytes"
+            " (e.g., decode=False). If omitted, byte images will raise an error."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _normalize_role(role: str) -> str:
+    # Normalize dataset roles to speculators roles.
+    if role in ("human", "user"):
+        return "user"
+    if role in ("gpt", "assistant"):
+        return "assistant"
+    return role
+
+
+def _normalize_image_path(image_path: str, image_root: str | None) -> str:
+    # Normalize image paths and apply optional root prefix.
+    if image_path.startswith("file://"):
+        image_path = image_path[len("file://") :]
+    if image_root:
+        return os.path.basename(image_path)
+    if (not image_path.startswith(("http://", "https://", "data:"))) and (
+        not os.path.isabs(image_path)
+    ):
+        return image_path
+    return image_path
+
+
+def _write_image_bytes(
+    image_bytes: bytes | memoryview,
+    output_dir: str,
+    sample_idx: int,
+    image_idx: int,
+) -> str:
+    # Save raw image bytes to disk and return the saved file path.
+    if isinstance(image_bytes, memoryview):
+        image_bytes = image_bytes.tobytes()
+    os.makedirs(output_dir, exist_ok=True)
+    image = PILImage.open(BytesIO(image_bytes)).convert("RGB")
+    filename = f"img_{sample_idx}_{image_idx}.png"
+    output_path = os.path.join(output_dir, filename)
+    image.save(output_path)
+    return filename
+
+
+def _copy_image_file(
+    image_path: str,
+    output_dir: str,
+    sample_idx: int,
+    image_idx: int,
+) -> str:
+    # Copy an image file into the output directory and return the saved filename.
+    os.makedirs(output_dir, exist_ok=True)
+    image = PILImage.open(image_path).convert("RGB")
+    filename = f"img_{sample_idx}_{image_idx}.png"
+    output_path = os.path.join(output_dir, filename)
+    image.save(output_path)
+    return filename
+
+
+def _prepare_image_ref(
+    image_path: str,
+    image_root: str | None,
+    image_output_dir: str | None,
+    sample_idx: int,
+    image_idx: int,
+) -> str:
+    # Normalize and optionally copy image paths into the output directory.
+    if image_path.startswith("file://"):
+        image_path = image_path[len("file://") :]
+    if image_output_dir:
+        if image_path.startswith(("http://", "https://", "data:")):
+            return image_path
+        if image_root and not os.path.isabs(image_path):
+            image_path = os.path.join(image_root, image_path)
+        return _copy_image_file(image_path, image_output_dir, sample_idx, image_idx)
+    return _normalize_image_path(image_path, image_root)
+
+
+def _resolve_image_ref(
+    image_ref: Any,
+    image_root: str | None,
+    image_output_dir: str | None,
+    sample_idx: int,
+    image_idx: int,
+) -> str:
+    # Resolve image references into file paths or URLs.
+    if isinstance(image_ref, dict):
+        path = image_ref.get("path") or image_ref.get("image")
+        url = image_ref.get("url")
+        if path:
+            return _prepare_image_ref(
+                path, image_root, image_output_dir, sample_idx, image_idx
+            )
+        if url:
+            return url
+        image_bytes = image_ref.get("bytes")
+        if image_bytes is not None:
+            if image_output_dir is None:
+                raise ValueError(
+                    "Image bytes found but --image-output-dir was not provided."
+                )
+            return _write_image_bytes(
+                image_bytes, image_output_dir, sample_idx, image_idx
+            )
+    elif isinstance(image_ref, str):
+        return _prepare_image_ref(
+            image_ref, image_root, image_output_dir, sample_idx, image_idx
+        )
+    raise ValueError(f"Unsupported image reference: {type(image_ref)}")
+
+
+def _extract_image_refs(
+    images: list[Any],
+    image_root: str | None,
+    image_output_dir: str | None,
+    sample_idx: int,
+) -> list[str]:
+    # Extract all image references for a sample into a list of strings.
+    image_refs: list[str] = []
+    for image_idx, image_ref in enumerate(images):
+        image_refs.append(
+            _resolve_image_ref(
+                image_ref, image_root, image_output_dir, sample_idx, image_idx
+            )
+        )
+    return image_refs
+
+
+def _build_messages(
+    conversations: list[dict[str, Any]],
+    image_refs: list[str],
+) -> list[dict[str, Any]]:
+    # Build speculators-style messages with images attached to first user turn.
+    messages: list[dict[str, Any]] = []
+    images_attached = False
+    for turn in conversations:
+        role = _normalize_role(turn.get("from") or turn.get("role", ""))
+        text = turn.get("value") or turn.get("content") or ""
+        text = re.sub(r"<\s*/?\s*image\s*>", "", text, flags=re.IGNORECASE).strip()
+        if role == "user" and image_refs and not images_attached:
+            content: list[dict[str, Any]] = [
+                {"type": "image", "image": ref} for ref in image_refs
+            ]
+            content.append({"type": "text", "text": text})
+            messages.append({"role": role, "content": content})
+            images_attached = True
+            continue
+        messages.append({"role": role, "content": [{"type": "text", "text": text}]})
+    return messages
+
+
+def main() -> None:
+    # Run dataset conversion from HF/parquet to JSONL.
+    args = parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    image_root = args.image_root
+    image_output_dir = args.image_output_dir
+
+    if not args.dataset:
+        raise ValueError("Provide --dataset.")
+
+    logger.info("Loading dataset...")
+    ds = load_dataset(args.dataset, split=args.split)
+
+    if "images" in ds.column_names:
+        ds = ds.cast_column("images", Sequence(Image(decode=False)))
+
+    logger.info("Loaded %s samples. Writing JSONL to %s", len(ds), args.output)
+    total = 0
+    with open(args.output, "w") as f:
+        for idx, row in enumerate(tqdm(ds, desc="Converting", unit="sample")):
+            conversations = row.get("conversations") or row.get("messages")
+            if not conversations:
+                continue
+            images = row.get("images") or []
+            image_refs = _extract_image_refs(images, image_root, image_output_dir, idx)
+            messages = _build_messages(conversations, image_refs)
+            out = {"conversations": messages}
+            if "lang" in row:
+                out["lang"] = row["lang"]
+            f.write(json.dumps(out, ensure_ascii=False) + "\n")
+            total += 1
+    logger.info("Wrote %s samples to %s", total, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -11,27 +11,40 @@ Preprocessing is cached automatically by HuggingFace datasets.
 Token frequencies are saved in the current directory by default.
 
 Usage:
-    python data_generation_offline.py \
+    python scripts/data_generation_offline.py \
         --target-model-path meta-llama/Llama-3.1-8B-Instruct \
         --train-data-path sharegpt \
         --output-dir ./training_data \
         --hf-cache-dir /path/to/cache \
         --max-samples 5000
+
+    # Multimodal (VL) example:
+    # (Assumes you already converted the dataset to JSONL, e.g. ./data/pokemon_vl.jsonl)
+    python scripts/data_generation_offline.py \
+        --target-model-path Qwen/Qwen3-VL-8B-Instruct \
+        --train-data-path ./data/pokemon_vl.jsonl \
+        --output-dir ./training_data_vl \
+        --data-mode vl \
+        --image-root ./pokemon_images
 """
 
 import argparse
 import json
 import logging
+import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import Any
 
 import torch
 from datasets import config as datasets_config
+from PIL import Image
 from tqdm import tqdm  # type: ignore[import-untyped]
 
 # Set vLLM to use 'spawn' instead of 'fork'
 # to prevent "Cannot re-initialize CUDA in forked subprocess" errors
 from vllm import envs
+from vllm.multimodal.utils import fetch_image as vllm_fetch_image
 
 envs.VLLM_WORKER_MULTIPROC_METHOD = "spawn"
 
@@ -55,7 +68,10 @@ logging.basicConfig(
 log = PipelineLogger(__name__)
 
 
+
+
 def parse_args():
+    # Parse CLI arguments for offline data generation.
     parser = argparse.ArgumentParser(description="Generate EAGLE training data offline")
 
     # Model arguments
@@ -86,6 +102,22 @@ def parse_args():
         help="Path to training data (same as used in preprocessing)",
     )
     parser.add_argument(
+        "--data-mode",
+        type=str,
+        choices=["text", "vl"],
+        default="text",
+        help="Data mode: text (default) or vl for image-text inputs.",
+    )
+    parser.add_argument(
+        "--image-field",
+        type=str,
+        default="image",
+        help=(
+            "Field name for image entries in multimodal data (VL mode only). "
+            "Default: image."
+        ),
+    )
+    parser.add_argument(
         "--seq-length",
         type=int,
         default=2048,
@@ -102,6 +134,15 @@ def parse_args():
         type=str,
         default="./token_freq.pt",
         help="Path to save token frequency distribution (default: ./token_freq.pt)",
+    )
+    parser.add_argument(
+        "--image-root",
+        type=str,
+        default=None,
+        help=(
+            "Optional root directory for resolving image paths in multimodal data "
+            "(VL mode only)."
+        ),
     )
     parser.add_argument(
         "--hf-cache-dir",
@@ -173,7 +214,17 @@ def parse_args():
         default=8,
         help="Number of CPU processes for dataset preprocessing (default: 8)",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    if args.data_mode != "vl":
+        uses_vl_args = args.image_root is not None or args.image_field != "image"
+        if uses_vl_args:
+            parser.error(
+                "Image arguments (--image-field/--image-root) "
+                "are only valid with --data-mode vl."
+            )
+
+    return args
 
 
 def find_last_checkpoint(output_dir: str) -> int:
@@ -224,7 +275,117 @@ def save_config(args, generator, num_samples, output_dir):
     log.info(f"Saved config v{config.version} to {config_path}")
 
 
-def generate_and_save_hidden_states(args, dataset):
+def _resolve_image_ref(
+    image_ref: Any,
+    image_root: str | None,
+    image_fetcher: Any,
+) -> Image.Image:
+    # Resolve a single image reference into a PIL image.
+    if isinstance(image_ref, dict):
+        image_ref = (
+            image_ref.get("url") or image_ref.get("path") or image_ref.get("image")
+        )
+    if not isinstance(image_ref, str):
+        raise ValueError(f"Unsupported image reference: {type(image_ref)}")
+
+    image_path = image_ref
+    if image_path.startswith(("http://", "https://", "data:")):
+        return image_fetcher(image_path)
+
+    if image_path.startswith("file://"):
+        image_path = image_path[len("file://") :]
+
+    if os.path.exists(image_path):
+        return Image.open(image_path).convert("RGB")
+
+    candidate_path = None
+    if image_root and not os.path.isabs(image_ref):
+        candidate_path = os.path.join(image_root, image_ref)
+        if os.path.exists(candidate_path):
+            return Image.open(candidate_path).convert("RGB")
+
+    if candidate_path is None:
+        candidate_path = image_path
+
+    abs_path = os.path.abspath(candidate_path)
+    return image_fetcher(f"file://{abs_path}")
+
+
+def _build_multimodal_inputs(
+    batch_mm_data: list[dict[str, list[Any]]],
+    image_root: str | None,
+    image_fetcher: Any,
+    image_field: str,
+    placeholder_counts: list[int] | None = None,
+) -> list[dict[str, Any]]:
+    # Convert multimodal data refs into vLLM MultiModalDataDict inputs.
+    # NOTE: This path only supports a single image per sample for now.
+    # TODO(VL): Extend to multi-image prompts once alignment is stable.
+    multimodal_inputs: list[dict[str, Any]] = []
+    for idx, mm_data in enumerate(batch_mm_data):
+        if not mm_data:
+            multimodal_inputs.append({})
+            continue
+        images = []
+        for image_ref in mm_data.get(image_field, []):
+            images.append(_resolve_image_ref(image_ref, image_root, image_fetcher))
+        if placeholder_counts is not None and images:
+            target_count = placeholder_counts[idx]
+            if target_count == 0:
+                raise ValueError(
+                    "Multimodal data provided but prompt has no image placeholders."
+                )
+            if target_count != len(images):
+                raise ValueError(
+                    "Single-image mode requires exactly one image placeholder."
+                )
+        if len(images) != 1:
+            raise ValueError("Single-image mode requires exactly one image ref.")
+        mm_input: dict[str, Any] = {}
+        if images:
+            # vLLM expects a list for image modality; keep length=1.
+            mm_input["image"] = images
+        multimodal_inputs.append(mm_input)
+    return multimodal_inputs
+
+
+def _align_loss_mask_to_vllm(
+    vllm_input_ids: list[int],
+    pre_input_ids: list[int],
+    pre_loss_mask: torch.Tensor,
+    image_pad_id: int | None,
+) -> torch.Tensor:
+    # Align preprocessing loss_mask to vLLM tokenization by expanding image pads.
+    if image_pad_id is None:
+        return pre_loss_mask[: len(vllm_input_ids)]
+    aligned: list[int] = []
+    i = 0
+    j = 0
+    pre_mask_list = pre_loss_mask.tolist()
+    while i < len(vllm_input_ids) and j < len(pre_input_ids) and j < len(pre_mask_list):
+        v_id = vllm_input_ids[i]
+        p_id = pre_input_ids[j]
+        if v_id == image_pad_id and p_id == image_pad_id:
+            aligned.append(pre_mask_list[j])
+            i += 1
+            j += 1
+            continue
+        if v_id == image_pad_id and p_id != image_pad_id:
+            aligned.append(0)
+            i += 1
+            continue
+        aligned.append(pre_mask_list[j])
+        i += 1
+        j += 1
+    # If vLLM has extra tokens beyond preprocessing, pad with 0 mask.
+    while i < len(vllm_input_ids):
+        aligned.append(0)
+        i += 1
+    # If preprocessing had extra tokens, ignore the tail (already truncated).
+    return torch.tensor(aligned, dtype=torch.long)
+
+
+def generate_and_save_hidden_states(args, dataset):  # noqa: C901, PLR0915
     """Generate hidden states and save each sample as a .pt file"""
     Path(args.output_dir).mkdir(parents=True, exist_ok=True)
 
@@ -266,6 +427,9 @@ def generate_and_save_hidden_states(args, dataset):
         total=num_batches,
     )
 
+    image_fetcher = None
+    image_pad_id = None
+
     with ThreadPoolExecutor(max_workers=max_io_workers) as thread_executor:
         futures = []
 
@@ -274,18 +438,66 @@ def generate_and_save_hidden_states(args, dataset):
             batch = dataset[i:batch_end]
             batch_input_ids = batch["input_ids"]
             batch_loss_mask = batch["loss_mask"]
+            if args.data_mode == "vl":
+                batch_mm_data = batch.get("multi_modal_data")
+                batch_prompts = batch.get("prompt")
 
-            results = generator.generate(batch_input_ids)
+                if batch_mm_data is None or batch_prompts is None:
+                    raise ValueError(
+                        "VL mode requires multi_modal_data and prompt fields "
+                        "from preprocessing. Ensure the dataset uses image-text "
+                        "format and preprocessing supports multimodal outputs."
+                    )
+
+                if image_fetcher is None:
+                    image_fetcher = vllm_fetch_image
+                mm_inputs = _build_multimodal_inputs(
+                    batch_mm_data,
+                    args.image_root,
+                    image_fetcher,
+                    args.image_field,
+                )
+                request_ids = [f"sample_{i + j}" for j in range(len(batch_prompts))]
+                results = generator.generate(
+                    batch_input_ids,
+                    prompt_texts=batch_prompts,
+                    multimodal_inputs=mm_inputs,
+                    request_ids=request_ids,
+                )
+            else:
+                results = generator.generate(batch_input_ids)
 
             # Submit save operations to thread pool (async I/O)
             for j, result in enumerate(results):
                 # Truncate loss_mask to match input_ids length (generator may truncate)
-                input_len = len(result["input_ids"])
+                input_ids_list = (
+                    result["input_ids"].tolist()
+                    if isinstance(result["input_ids"], torch.Tensor)
+                    else result["input_ids"]
+                )
+                input_len = len(input_ids_list)
                 sample_lengths[file_idx] = input_len
-                loss_mask = batch_loss_mask[j][:input_len]
+                if args.data_mode == "vl":
+                    if image_pad_id is None:
+                        image_pad_id = generator.tokenizer.convert_tokens_to_ids(
+                            "<|image_pad|>"
+                        )
+                    pre_ids = (
+                        batch_input_ids[j].tolist()
+                        if isinstance(batch_input_ids[j], torch.Tensor)
+                        else batch_input_ids[j]
+                    )
+                    loss_mask = _align_loss_mask_to_vllm(
+                        input_ids_list,
+                        pre_ids,
+                        batch_loss_mask[j],
+                        image_pad_id,
+                    )[:input_len]
+                else:
+                    loss_mask = batch_loss_mask[j][:input_len]
 
                 result_cleaned = {
-                    "input_ids": result["input_ids"],
+                    "input_ids": torch.as_tensor(input_ids_list, dtype=torch.long),
                     "hidden_states": [h.contiguous() for h in result["hidden_states"]],
                     "loss_mask": loss_mask,
                 }
@@ -316,6 +528,7 @@ def generate_and_save_hidden_states(args, dataset):
 
 
 def main():
+    # Entry point for offline data generation.
     args = parse_args()
 
     log.section("EAGLE Offline Data Generation")


### PR DESCRIPTION
# WIP: VL (single image-text) training support

**Status:** Work in progress. This PR is a scaffold to track the remaining work for vision-language (image-text) training support in speculators.

## Planned work

- [x] Add multimodal parsing in preprocessing (image + text) and use processor instead of tokenizer
- [x] Pass multimodal inputs into vLLM request path during hidden-state extraction
- [x] Add a new data format version for multimodal samples in training (vl-v1 currently aliases v1)
- [x] Update training pipeline to consume multimodal data format (blocked on a dedicated VL schema)
- [x] Document dataset format and E2E usage for VL training



## Notes
- Current branch includes TODO markers only to outline the intended changes.
- Will update this PR as implementation lands.
