### PR TITLE
feat: add Qwen3-VL preprocessing and multimodal data generation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Speculators is a unified library for building, training and storing speculative 
 
 Speculators standardizes this process by providing a productionized end-to-end framework to train draft models with reusable formats and tools. Trained models can seamlessly run in vLLM, enabling the deployment of speculative decoding in production-grade inference servers.
 
+
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/speculators/main/docs/assets/branding/speculators-user-flow-dark.svg" />
@@ -38,7 +40,7 @@ ______________________________________________________________________
 ## Key Features
 
 - **Offline Training Data Generation using vLLM:** Enable the generation of hidden states using vLLM. Data samples are saved to disk and can be used for draft model training.
-- **Draft Model Training Support:** E2E training support of single and multi-layer draft models. Training is supported for both non-MoE and MoE models. VL Training is coming soon.
+- **Draft Model Training Support:** E2E training support of single and multi-layer draft models. Training is supported for both non-MoE and MoE models. VL (single image-text) training is supported.
 - **Standardized, Extensible Format:** Provides a Hugging Face-compatible format for defining speculative models, with tools to convert from external research repositories into a standard speculators format for easy adoption.
 - **Seamless vLLM Integration:** Built for direct deployment into vLLM, enabling low-latency, production-grade inference with minimal overhead.
 

--- a/examples/data_generation_and_training/qwen3_8b_sharegpt_20k.py
+++ b/examples/data_generation_and_training/qwen3_8b_sharegpt_20k.py
@@ -1,0 +1,69 @@
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to path so we can import the run_e2e function.
+scripts_path = Path(__file__).absolute().parent.parent.parent / "scripts"
+sys.path.append(str(scripts_path))
+
+from gen_and_train import (  # noqa: E402
+    DataGenArgs,
+    TrainArgs,
+    VocabMappingArgs,
+    run_e2e,
+)
+
+### Example E2E run for Llama 3.1 8B on 20k samples from ShareGPT ###
+
+# Note: With just 20k samples, the model performance will not be very good, however there
+# are enough samples to verify that the pipeline is working correctly and that the model
+# is learning something. This is a good sanity check when creating a drafter for a new
+# target model.
+
+# Timing (on 2x NVIDIA H100 80GB GPUs)
+# Data Generation: 839 seconds
+# Vocab Mapping: 6 seconds
+# Training: 1254 seconds
+# Total: 2099 seconds (35 mins)
+
+# Results on MT-Bench:
+# first token accuracy: 0.40
+# second token accuracy: 0.13
+# third token accuracy: 0.04
+# average acceptance length: 1.57
+
+
+if __name__ == "__main__":
+    VERIFIER_NAME_OR_PATH = "Qwen/Qwen3-8B"
+    OUTPUT_PATH = "./output/qwen3_8b_sharegpt_20k"
+    TOTAL_SEQ_LEN = 8192
+
+    # Data Generation
+    data_gen_args_sharegpt = DataGenArgs(
+        train_data_path="sharegpt",
+        seq_length=TOTAL_SEQ_LEN,
+        max_samples=40000,  # Only use 5000 samples from ShareGPT
+    )
+
+    # Vocab Mapping
+    vocab_mapping_args = VocabMappingArgs(
+        draft_vocab_size=32000,  # Use an 32k draft vocabulary
+        target_vocab_size=151936,  # From https://huggingface.co/Qwen/Qwen3-8B/blob/main/config.json#L29
+    )
+
+    # Training
+    train_args = TrainArgs(
+        logger="wandb",
+        lr=3e-5,
+        total_seq_len=TOTAL_SEQ_LEN,
+        run_name="qwen3_8b_sharegpt_20k",
+        epochs=10,
+    )
+
+    run_e2e(
+        verifier_name_or_path=VERIFIER_NAME_OR_PATH,
+        output_path=OUTPUT_PATH,
+        data_gen_args=data_gen_args_sharegpt,
+        vocab_mapping_args=vocab_mapping_args,
+        train_args=train_args,
+    )

--- a/examples/evaluate/eval-guidellm/scripts/run_vl_chat_eval.py
+++ b/examples/evaluate/eval-guidellm/scripts/run_vl_chat_eval.py
@@ -1,0 +1,571 @@
+#!/usr/bin/env python3
+"""Run a simple multimodal chat benchmark against vLLM OpenAI endpoint.
+
+This script is intentionally lightweight and avoids external dependencies.
+It is designed to be invoked by `run_guidellm.sh` when a dataset file is
+detected as multimodal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, unquote, urlparse
+from urllib.request import Request, urlopen
+
+
+EXIT_NOT_MULTIMODAL = 10
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run VL chat evaluation")
+    parser.add_argument("--target", type=str, required=True, help="Target base URL, e.g. http://localhost:8000/v1")
+    parser.add_argument("--dataset-file", type=str, required=True, help="Local JSON/JSONL dataset file")
+    parser.add_argument(
+        "--image-root",
+        type=str,
+        default=None,
+        help="Optional image root directory used to resolve relative image paths",
+    )
+    parser.add_argument("--output-file", type=str, required=True, help="Per-request output JSONL path")
+    parser.add_argument("--summary-file", type=str, required=True, help="Summary JSON output path")
+    parser.add_argument("--temperature", type=float, default=0.6)
+    parser.add_argument("--top-p", type=float, default=0.95)
+    parser.add_argument("--top-k", type=int, default=20)
+    parser.add_argument("--max-tokens", type=int, default=8192)
+    parser.add_argument("--timeout", type=float, default=180.0)
+    return parser.parse_args()
+
+
+def _request_json(
+    method: str,
+    url: str,
+    payload: dict[str, Any] | None,
+    timeout: float,
+) -> dict[str, Any]:
+    headers = {"Content-Type": "application/json"}
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = Request(url=url, data=data, headers=headers, method=method)
+    with urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        raw = resp.read().decode("utf-8")
+    return json.loads(raw) if raw else {}
+
+
+def _normalize_url(base_url: str) -> str:
+    return base_url.rstrip("/")
+
+
+def _read_json_or_jsonl(path: Path) -> list[dict[str, Any]]:
+    if path.suffix.lower() == ".jsonl":
+        records: list[dict[str, Any]] = []
+        with path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                obj = json.loads(line)
+                if isinstance(obj, dict):
+                    records.append(obj)
+        return records
+
+    if path.suffix.lower() == ".json":
+        with path.open("r", encoding="utf-8") as f:
+            obj = json.load(f)
+        if isinstance(obj, list):
+            return [x for x in obj if isinstance(x, dict)]
+        if isinstance(obj, dict):
+            for key in ("data", "items", "samples", "questions", "annotations"):
+                value = obj.get(key)
+                if isinstance(value, list):
+                    return [x for x in value if isinstance(x, dict)]
+            return [obj]
+
+    raise ValueError(f"Unsupported dataset format: {path}")
+
+
+def _extract_text_from_content(content: Any) -> str | None:
+    if isinstance(content, str):
+        text = content.strip()
+        return text or None
+    if isinstance(content, list):
+        chunks: list[str] = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    chunks.append(text.strip())
+        if chunks:
+            return "\n".join(chunks)
+    return None
+
+
+def _extract_ref_from_value(value: Any) -> str | None:
+    if isinstance(value, str):
+        ref = value.strip()
+        return ref or None
+
+    if not isinstance(value, dict):
+        return None
+
+    for key in ("image", "image_url", "url", "path", "file", "image_path", "image_file"):
+        nested = value.get(key)
+        if key == "image_url" and isinstance(nested, dict):
+            nested = nested.get("url")
+        ref = _extract_ref_from_value(nested)
+        if ref:
+            return ref
+    return None
+
+
+def _collect_image_refs_from_content(content: Any) -> list[str]:
+    refs: list[str] = []
+    if not isinstance(content, list):
+        return refs
+
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+
+        item_type = str(item.get("type", "")).lower()
+        candidates: list[Any] = []
+        if item_type == "image":
+            candidates.append(item.get("image"))
+        elif item_type == "image_url":
+            candidates.append(item.get("image_url"))
+
+        for key in ("image", "image_url", "url", "path", "file", "image_path"):
+            candidates.append(item.get(key))
+
+        for candidate in candidates:
+            ref = _extract_ref_from_value(candidate)
+            if ref:
+                refs.append(ref)
+
+    return refs
+
+
+def _extract_prompt(record: dict[str, Any]) -> str:
+    for key in ("question", "query", "prompt", "instruction", "text"):
+        value = record.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    messages = record.get("messages")
+    if isinstance(messages, list):
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            role = str(msg.get("role", "")).lower()
+            if role != "user":
+                continue
+            text = _extract_text_from_content(msg.get("content"))
+            if text:
+                return text
+
+    conversations = record.get("conversations")
+    if isinstance(conversations, list):
+        for turn in conversations:
+            if not isinstance(turn, dict):
+                continue
+            role = str(turn.get("from", turn.get("role", ""))).lower()
+            if role not in {"human", "user"}:
+                continue
+            value = turn.get("value", turn.get("content"))
+            text = _extract_text_from_content(value)
+            if text:
+                return text
+
+    return ""
+
+
+def _extract_image_refs(record: dict[str, Any]) -> list[str]:
+    refs: list[str] = []
+
+    for key in ("image", "img", "image_path", "image_file", "image_name", "image_url"):
+        ref = _extract_ref_from_value(record.get(key))
+        if ref:
+            refs.append(ref)
+
+    for key in ("images", "image_paths", "image_files"):
+        value = record.get(key)
+        if isinstance(value, list):
+            for one in value:
+                ref = _extract_ref_from_value(one)
+                if ref:
+                    refs.append(ref)
+
+    mm_data = record.get("multi_modal_data")
+    if isinstance(mm_data, dict):
+        images = mm_data.get("image")
+        if isinstance(images, list):
+            for image in images:
+                ref = _extract_ref_from_value(image)
+                if ref:
+                    refs.append(ref)
+        else:
+            ref = _extract_ref_from_value(images)
+            if ref:
+                refs.append(ref)
+
+    messages = record.get("messages")
+    if isinstance(messages, list):
+        for msg in messages:
+            if isinstance(msg, dict):
+                refs.extend(_collect_image_refs_from_content(msg.get("content")))
+
+    conversations = record.get("conversations")
+    if isinstance(conversations, list):
+        for turn in conversations:
+            if not isinstance(turn, dict):
+                continue
+            content = turn.get("content", turn.get("value"))
+            refs.extend(_collect_image_refs_from_content(content))
+
+    dedup: list[str] = []
+    seen: set[str] = set()
+    for ref in refs:
+        if ref in seen:
+            continue
+        seen.add(ref)
+        dedup.append(ref)
+    return dedup
+
+
+def _existing_file(path: Path) -> bool:
+    try:
+        return path.exists() and path.is_file()
+    except OSError:
+        return False
+
+
+def _resolve_local_image_path(
+    image_ref: str,
+    dataset_dir: Path,
+    image_root: Path | None,
+) -> Path | None:
+    raw_ref = image_ref.strip()
+    if not raw_ref:
+        return None
+
+    path = Path(raw_ref).expanduser()
+    candidates: list[Path] = []
+
+    if path.is_absolute():
+        candidates.append(path)
+    else:
+        if image_root is not None:
+            candidates.append(image_root / path)
+        dataset_dir = dataset_dir.resolve()
+        candidates.append(dataset_dir / path)
+        for parent in dataset_dir.parents:
+            candidates.append(parent / path)
+        candidates.append(Path.cwd() / path)
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate.absolute()
+        key = str(resolved)
+        if key in seen:
+            continue
+        seen.add(key)
+        if _existing_file(resolved):
+            return resolved
+    return None
+
+
+def _to_image_url(image_ref: str, dataset_dir: Path, image_root: Path | None) -> str | None:
+    ref = image_ref.strip()
+    if not ref:
+        return None
+
+    if ref.startswith(("http://", "https://", "data:")):
+        return ref
+
+    if ref.startswith("file://"):
+        parsed = urlparse(ref)
+        local_path = Path(unquote(parsed.path))
+        if _existing_file(local_path):
+            return ref
+        return None
+
+    parsed = urlparse(ref)
+    if parsed.scheme and len(parsed.scheme) > 1:
+        return None
+
+    local_path = _resolve_local_image_path(ref, dataset_dir, image_root)
+    if local_path is None:
+        return None
+
+    return f"file://{quote(str(local_path), safe='/:._-')}"
+
+
+def _is_multimodal_record(record: dict[str, Any]) -> bool:
+    return len(_extract_image_refs(record)) > 0
+
+
+def _sample_id(record: dict[str, Any], idx: int) -> str:
+    for key in ("id", "sample_id", "uid", "question_id", "qid"):
+        value = record.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return f"sample_{idx}"
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    ordered = sorted(values)
+    k = (len(ordered) - 1) * pct
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return ordered[int(k)]
+    return ordered[f] * (c - k) + ordered[c] * (k - f)
+
+
+def main() -> int:
+    args = parse_args()
+    target = _normalize_url(args.target)
+    dataset_file = Path(args.dataset_file)
+    dataset_dir = dataset_file.parent
+    image_root = Path(args.image_root).expanduser().resolve() if args.image_root else None
+    output_file = Path(args.output_file)
+    summary_file = Path(args.summary_file)
+
+    records = _read_json_or_jsonl(dataset_file)
+    if not records:
+        raise ValueError(f"Dataset has no records: {dataset_file}")
+
+    multimodal_records = [r for r in records if _is_multimodal_record(r)]
+    if not multimodal_records:
+        print(f"[INFO] No multimodal records found in {dataset_file}", flush=True)
+        return EXIT_NOT_MULTIMODAL
+
+    model_resp = _request_json("GET", f"{target}/models", payload=None, timeout=args.timeout)
+    model_items = model_resp.get("data") if isinstance(model_resp, dict) else None
+    model_id = None
+    if isinstance(model_items, list):
+        for item in model_items:
+            if isinstance(item, dict) and isinstance(item.get("id"), str):
+                model_id = item["id"]
+                break
+    if not model_id:
+        raise ValueError(f"Failed to resolve model id from {target}/models")
+
+    print(
+        f"[INFO] Running VL eval: records={len(multimodal_records)} model={model_id}",
+        flush=True,
+    )
+
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    summary_file.parent.mkdir(parents=True, exist_ok=True)
+
+    latency_ms_values: list[float] = []
+    prompt_tokens_total = 0
+    completion_tokens_total = 0
+    total_tokens_total = 0
+    success = 0
+    failed = 0
+    skipped_invalid_image_ref = 0
+    invalid_image_ref_total = 0
+    started = time.perf_counter()
+
+    with output_file.open("w", encoding="utf-8") as fout:
+        for idx, record in enumerate(multimodal_records):
+            sample_id = _sample_id(record, idx)
+            prompt = _extract_prompt(record)
+            image_refs = _extract_image_refs(record)
+            image_urls: list[str] = []
+            invalid_image_refs: list[str] = []
+            for ref in image_refs:
+                url = _to_image_url(ref, dataset_dir, image_root)
+                if url is None:
+                    invalid_image_refs.append(ref)
+                    continue
+                image_urls.append(url)
+
+            invalid_image_ref_total += len(invalid_image_refs)
+
+            if not image_urls:
+                failed += 1
+                skipped_invalid_image_ref += 1
+                fout.write(
+                    json.dumps(
+                        {
+                            "sample_id": sample_id,
+                            "status": "error",
+                            "error": "no_resolvable_image_ref",
+                            "skip_reason": "invalid_image_ref",
+                            "invalid_image_refs": invalid_image_refs,
+                        },
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                )
+                continue
+
+            content: list[dict[str, Any]] = []
+            if prompt:
+                content.append({"type": "text", "text": prompt})
+            for url in image_urls:
+                content.append({"type": "image_url", "image_url": {"url": url}})
+            if not content:
+                failed += 1
+                fout.write(
+                    json.dumps(
+                        {
+                            "sample_id": sample_id,
+                            "status": "error",
+                            "error": "empty multimodal content",
+                        },
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                )
+                continue
+
+            payload: dict[str, Any] = {
+                "model": model_id,
+                "messages": [{"role": "user", "content": content}],
+                "temperature": args.temperature,
+                "top_p": args.top_p,
+                "top_k": args.top_k,
+                "max_tokens": args.max_tokens,
+                "stream": False,
+            }
+
+            try:
+                t0 = time.perf_counter()
+                response = _request_json(
+                    "POST",
+                    f"{target}/chat/completions",
+                    payload=payload,
+                    timeout=args.timeout,
+                )
+                latency_ms = (time.perf_counter() - t0) * 1000.0
+
+                usage = response.get("usage") if isinstance(response, dict) else {}
+                if not isinstance(usage, dict):
+                    usage = {}
+                prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+                completion_tokens = int(usage.get("completion_tokens", 0) or 0)
+                total_tokens = int(
+                    usage.get("total_tokens", prompt_tokens + completion_tokens) or 0
+                )
+
+                success += 1
+                latency_ms_values.append(latency_ms)
+                prompt_tokens_total += prompt_tokens
+                completion_tokens_total += completion_tokens
+                total_tokens_total += total_tokens
+
+                fout.write(
+                    json.dumps(
+                        {
+                            "sample_id": sample_id,
+                            "status": "ok",
+                            "latency_ms": round(latency_ms, 3),
+                            "prompt_tokens": prompt_tokens,
+                            "completion_tokens": completion_tokens,
+                            "total_tokens": total_tokens,
+                            "num_images": len(image_urls),
+                            "invalid_image_refs": invalid_image_refs,
+                            "response_id": response.get("id"),
+                            "finish_reason": (
+                                (((response.get("choices") or [None])[0] or {}).get("finish_reason"))
+                                if isinstance(response, dict)
+                                else None
+                            ),
+                        },
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                )
+            except Exception as exc:  # noqa: BLE001
+                failed += 1
+                fout.write(
+                    json.dumps(
+                        {
+                            "sample_id": sample_id,
+                            "status": "error",
+                            "error": str(exc),
+                            "num_images": len(image_urls),
+                            "invalid_image_refs": invalid_image_refs,
+                        },
+                        ensure_ascii=False,
+                    )
+                    + "\n"
+                )
+
+            if (idx + 1) % 50 == 0:
+                print(
+                    f"[INFO] progress={idx + 1}/{len(multimodal_records)} "
+                    f"success={success} failed={failed}",
+                    flush=True,
+                )
+
+    elapsed_s = max(time.perf_counter() - started, 1e-9)
+    summary = {
+        "dataset_file": str(dataset_file),
+        "image_root": str(image_root) if image_root is not None else None,
+        "target": target,
+        "model": model_id,
+        "num_records": len(multimodal_records),
+        "success": success,
+        "failed": failed,
+        "success_rate": (success / len(multimodal_records)) if multimodal_records else 0.0,
+        "data_quality": {
+            "invalid_image_ref_total": invalid_image_ref_total,
+            "skipped_invalid_image_ref": skipped_invalid_image_ref,
+        },
+        "latency_ms": {
+            "avg": statistics.fmean(latency_ms_values) if latency_ms_values else 0.0,
+            "p50": _percentile(latency_ms_values, 0.50),
+            "p95": _percentile(latency_ms_values, 0.95),
+            "max": max(latency_ms_values) if latency_ms_values else 0.0,
+        },
+        "tokens": {
+            "prompt_total": prompt_tokens_total,
+            "completion_total": completion_tokens_total,
+            "all_total": total_tokens_total,
+            "all_tokens_per_sec": total_tokens_total / elapsed_s,
+            "completion_tokens_per_sec": completion_tokens_total / elapsed_s,
+        },
+        "throughput": {
+            "elapsed_s": elapsed_s,
+            "requests_per_sec": success / elapsed_s,
+        },
+    }
+
+    summary_file.write_text(json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    print(
+        f"[INFO] VL eval complete: success={success} failed={failed} "
+        f"output={output_file} summary={summary_file}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        print(f"[ERROR] {exc}", file=sys.stderr, flush=True)
+        raise SystemExit(1)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,6 +7,7 @@ Speculators currently supports training of Eagle3 models. This functionality is 
 4. (Optional) [gen_and_train.py](/scripts/gen_and_train.py): A convenience wrapper around the above scripts that runs the full pipeline in one command.
 
 
+
 ## Table of Contents
 - **[Data Generation](#data-generation)**<br>
     - **[Quick Start](#quick-start)**<br>
@@ -143,6 +144,46 @@ Built-in datasets (can be used directly by name in the `--train-data-path` argum
 
 Alternatively, you can use a different dataset by passing the HuggingFace dataset path or local JSON/JSONL file path in the `--train-data-path` argument.
 
+### Multimodal (VL) Data Generation
+
+This pipeline is compatible with the HuggingFace dataset format used by
+`llamafactory/pokemon-gpt4o-captions` (and similar datasets). The raw dataset
+contains:
+
+```json
+{
+  "conversations": [
+    {"from": "human", "value": "Please describe it.<image>"},
+    {"from": "gpt", "value": "A short description."}
+  ],
+  "images": ["..."]  // HF image column (bytes or file paths)
+}
+```
+
+Convert the HF dataset to speculators JSONL (images are attached to the first user
+turn), then run data generation:
+
+```bash
+python scripts/convert_pokemon_gpt4o_to_jsonl.py \
+    --dataset llamafactory/pokemon-gpt4o-captions \
+    --split train \
+    --output ./data/pokemon_vl.jsonl \
+    --image-output-dir ./pokemon_images
+
+python scripts/data_generation_offline.py \
+    --target-model-path Qwen/Qwen3-VL-8B-Instruct \
+    --train-data-path ./data/pokemon_vl.jsonl \
+    --output-dir ./training_data_vl \
+    --data-mode vl \
+    --image-root ./pokemon_images
+```
+
+If your dataset uses a different multimodal image field name, override it with
+`--image-field`.
+
+Note: the current VL pipeline supports a single image per sample. Multi-image
+support is coming soon.
+
 #### Caching
 
 Preprocessing is automatically cached by HuggingFace datasets using fingerprint-based cache invalidation. The cache automatically updates when:
@@ -214,6 +255,16 @@ Once complete, this step will generate and save `t2d.npy` and `d2t.npy` files to
 ## Training
 
 `scripts/train.py` provides the main entry point for training Eagle3 models.
+
+To train on multimodal-generated data, set `--data-format vl-v1`:
+
+```bash
+python scripts/train.py \
+    --verifier-name-or-path Qwen/Qwen3-VL-8B-Instruct \
+    --data-path ./training_data_vl \
+    --save-path ./checkpoints/qwen3-vl.eagle3 \
+    --data-format vl-v1
+```
 
 ### Quick Start
 

--- a/scripts/convert_pokemon_gpt4o_to_jsonl.py
+++ b/scripts/convert_pokemon_gpt4o_to_jsonl.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Convert a HF dataset with images + conversations into speculators JSONL.
+
+This script loads a HuggingFace dataset split, attaches each sample's images to the
+first user turn, and writes a JSONL file with speculators-style multimodal messages.
+
+Example:
+    python scripts/convert_pokemon_gpt4o_to_jsonl.py \
+    --dataset llamafactory/pokemon-gpt4o-captions \
+    --split train \
+    --output ./data/pokemon_vl.jsonl \
+    --image-output-dir ./pokemon_images
+
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+from io import BytesIO
+from typing import Any
+
+from datasets import Image, Sequence, load_dataset
+from PIL import Image as PILImage
+from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    # Parse CLI arguments for dataset conversion to JSONL.
+    parser = argparse.ArgumentParser(
+        description="Convert pokemon-gpt4o-captions to JSONL with multimodal content."
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default=None,
+        help="HuggingFace dataset name (e.g., llamafactory/pokemon-gpt4o-captions).",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="train",
+        help="Dataset split to load (default: train).",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        required=True,
+        help="Output JSONL path.",
+    )
+    parser.add_argument(
+        "--image-root",
+        type=str,
+        default=None,
+        help=(
+            "Optional root directory for resolving image paths. If set, image"
+            " paths are written as basenames and resolved later using --image-root"
+            " in data generation."
+        ),
+    )
+    parser.add_argument(
+        "--image-output-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory to write image bytes when the dataset stores images as bytes"
+            " (e.g., decode=False). If omitted, byte images will raise an error."
+        ),
+    )
+    return parser.parse_args()
+
+
+def _normalize_role(role: str) -> str:
+    # Normalize dataset roles to speculators roles.
+    if role in ("human", "user"):
+        return "user"
+    if role in ("gpt", "assistant"):
+        return "assistant"
+    return role
+
+
+def _normalize_image_path(image_path: str, image_root: str | None) -> str:
+    # Normalize image paths and apply optional root prefix.
+    if image_path.startswith("file://"):
+        image_path = image_path[len("file://") :]
+    if image_root:
+        return os.path.basename(image_path)
+    if (not image_path.startswith(("http://", "https://", "data:"))) and (
+        not os.path.isabs(image_path)
+    ):
+        return image_path
+    return image_path
+
+
+def _write_image_bytes(
+    image_bytes: bytes | memoryview,
+    output_dir: str,
+    sample_idx: int,
+    image_idx: int,
+) -> str:
+    # Save raw image bytes to disk and return the saved file path.
+    if isinstance(image_bytes, memoryview):
+        image_bytes = image_bytes.tobytes()
+    os.makedirs(output_dir, exist_ok=True)
+    image = PILImage.open(BytesIO(image_bytes)).convert("RGB")
+    filename = f"img_{sample_idx}_{image_idx}.png"
+    output_path = os.path.join(output_dir, filename)
+    image.save(output_path)
+    return filename
+
+
+def _copy_image_file(
+    image_path: str,
+    output_dir: str,
+    sample_idx: int,
+    image_idx: int,
+) -> str:
+    # Copy an image file into the output directory and return the saved filename.
+    os.makedirs(output_dir, exist_ok=True)
+    image = PILImage.open(image_path).convert("RGB")
+    filename = f"img_{sample_idx}_{image_idx}.png"
+    output_path = os.path.join(output_dir, filename)
+    image.save(output_path)
+    return filename
+
+
+def _prepare_image_ref(
+    image_path: str,
+    image_root: str | None,
+    image_output_dir: str | None,
+    sample_idx: int,
+    image_idx: int,
+) -> str:
+    # Normalize and optionally copy image paths into the output directory.
+    if image_path.startswith("file://"):
+        image_path = image_path[len("file://") :]
+    if image_output_dir:
+        if image_path.startswith(("http://", "https://", "data:")):
+            return image_path
+        if image_root and not os.path.isabs(image_path):
+            image_path = os.path.join(image_root, image_path)
+        return _copy_image_file(image_path, image_output_dir, sample_idx, image_idx)
+    return _normalize_image_path(image_path, image_root)
+
+
+def _resolve_image_ref(
+    image_ref: Any,
+    image_root: str | None,
+    image_output_dir: str | None,
+    sample_idx: int,
+    image_idx: int,
+) -> str:
+    # Resolve image references into file paths or URLs.
+    if isinstance(image_ref, dict):
+        path = image_ref.get("path") or image_ref.get("image")
+        url = image_ref.get("url")
+        if path:
+            return _prepare_image_ref(
+                path, image_root, image_output_dir, sample_idx, image_idx
+            )
+        if url:
+            return url
+        image_bytes = image_ref.get("bytes")
+        if image_bytes is not None:
+            if image_output_dir is None:
+                raise ValueError(
+                    "Image bytes found but --image-output-dir was not provided."
+                )
+            return _write_image_bytes(
+                image_bytes, image_output_dir, sample_idx, image_idx
+            )
+    elif isinstance(image_ref, str):
+        return _prepare_image_ref(
+            image_ref, image_root, image_output_dir, sample_idx, image_idx
+        )
+    raise ValueError(f"Unsupported image reference: {type(image_ref)}")
+
+
+def _extract_image_refs(
+    images: list[Any],
+    image_root: str | None,
+    image_output_dir: str | None,
+    sample_idx: int,
+) -> list[str]:
+    # Extract all image references for a sample into a list of strings.
+    image_refs: list[str] = []
+    for image_idx, image_ref in enumerate(images):
+        image_refs.append(
+            _resolve_image_ref(
+                image_ref, image_root, image_output_dir, sample_idx, image_idx
+            )
+        )
+    return image_refs
+
+
+def _build_messages(
+    conversations: list[dict[str, Any]],
+    image_refs: list[str],
+) -> list[dict[str, Any]]:
+    # Build speculators-style messages with images attached to first user turn.
+    messages: list[dict[str, Any]] = []
+    images_attached = False
+    for turn in conversations:
+        role = _normalize_role(turn.get("from") or turn.get("role", ""))
+        text = turn.get("value") or turn.get("content") or ""
+        text = re.sub(r"<\s*/?\s*image\s*>", "", text, flags=re.IGNORECASE).strip()
+        if role == "user" and image_refs and not images_attached:
+            content: list[dict[str, Any]] = [
+                {"type": "image", "image": ref} for ref in image_refs
+            ]
+            content.append({"type": "text", "text": text})
+            messages.append({"role": role, "content": content})
+            images_attached = True
+            continue
+        messages.append({"role": role, "content": [{"type": "text", "text": text}]})
+    return messages
+
+
+def main() -> None:
+    # Run dataset conversion from HF/parquet to JSONL.
+    args = parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    image_root = args.image_root
+    image_output_dir = args.image_output_dir
+
+    if not args.dataset:
+        raise ValueError("Provide --dataset.")
+
+    logger.info("Loading dataset...")
+    ds = load_dataset(args.dataset, split=args.split)
+
+    if "images" in ds.column_names:
+        ds = ds.cast_column("images", Sequence(Image(decode=False)))
+
+    logger.info("Loaded %s samples. Writing JSONL to %s", len(ds), args.output)
+    total = 0
+    with open(args.output, "w") as f:
+        for idx, row in enumerate(tqdm(ds, desc="Converting", unit="sample")):
+            conversations = row.get("conversations") or row.get("messages")
+            if not conversations:
+                continue
+            images = row.get("images") or []
+            image_refs = _extract_image_refs(images, image_root, image_output_dir, idx)
+            messages = _build_messages(conversations, image_refs)
+            out = {"conversations": messages}
+            if "lang" in row:
+                out["lang"] = row["lang"]
+            f.write(json.dumps(out, ensure_ascii=False) + "\n")
+            total += 1
+    logger.info("Wrote %s samples to %s", total, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -11,27 +11,40 @@ Preprocessing is cached automatically by HuggingFace datasets.
 Token frequencies are saved in the current directory by default.
 
 Usage:
-    python data_generation_offline.py \
+    python scripts/data_generation_offline.py \
         --target-model-path meta-llama/Llama-3.1-8B-Instruct \
         --train-data-path sharegpt \
         --output-dir ./training_data \
         --hf-cache-dir /path/to/cache \
         --max-samples 5000
+
+    # Multimodal (VL) example:
+    # (Assumes you already converted the dataset to JSONL, e.g. ./data/pokemon_vl.jsonl)
+    python scripts/data_generation_offline.py \
+        --target-model-path Qwen/Qwen3-VL-8B-Instruct \
+        --train-data-path ./data/pokemon_vl.jsonl \
+        --output-dir ./training_data_vl \
+        --data-mode vl \
+        --image-root ./pokemon_images
 """
 
 import argparse
 import json
 import logging
+import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import Any
 
 import torch
 from datasets import config as datasets_config
+from PIL import Image
 from tqdm import tqdm  # type: ignore[import-untyped]
 
 # Set vLLM to use 'spawn' instead of 'fork'
 # to prevent "Cannot re-initialize CUDA in forked subprocess" errors
 from vllm import envs
+from vllm.multimodal.utils import fetch_image as vllm_fetch_image
 
 envs.VLLM_WORKER_MULTIPROC_METHOD = "spawn"
 
@@ -55,7 +68,10 @@ logging.basicConfig(
 log = PipelineLogger(__name__)
 
 
+
+
 def parse_args():
+    # Parse CLI arguments for offline data generation.
     parser = argparse.ArgumentParser(description="Generate EAGLE training data offline")
 
     # Model arguments
@@ -86,6 +102,22 @@ def parse_args():
         help="Path to training data (same as used in preprocessing)",
     )
     parser.add_argument(
+        "--data-mode",
+        type=str,
+        choices=["text", "vl"],
+        default="text",
+        help="Data mode: text (default) or vl for image-text inputs.",
+    )
+    parser.add_argument(
+        "--image-field",
+        type=str,
+        default="image",
+        help=(
+            "Field name for image entries in multimodal data (VL mode only). "
+            "Default: image."
+        ),
+    )
+    parser.add_argument(
         "--seq-length",
         type=int,
         default=2048,
@@ -102,6 +134,15 @@ def parse_args():
         type=str,
         default="./token_freq.pt",
         help="Path to save token frequency distribution (default: ./token_freq.pt)",
+    )
+    parser.add_argument(
+        "--image-root",
+        type=str,
+        default=None,
+        help=(
+            "Optional root directory for resolving image paths in multimodal data "
+            "(VL mode only)."
+        ),
     )
     parser.add_argument(
         "--hf-cache-dir",
@@ -173,7 +214,17 @@ def parse_args():
         default=8,
         help="Number of CPU processes for dataset preprocessing (default: 8)",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    if args.data_mode != "vl":
+        uses_vl_args = args.image_root is not None or args.image_field != "image"
+        if uses_vl_args:
+            parser.error(
+                "Image arguments (--image-field/--image-root) "
+                "are only valid with --data-mode vl."
+            )
+
+    return args
 
 
 def find_last_checkpoint(output_dir: str) -> int:
@@ -224,7 +275,117 @@ def save_config(args, generator, num_samples, output_dir):
     log.info(f"Saved config v{config.version} to {config_path}")
 
 
-def generate_and_save_hidden_states(args, dataset):
+def _resolve_image_ref(
+    image_ref: Any,
+    image_root: str | None,
+    image_fetcher: Any,
+) -> Image.Image:
+    # Resolve a single image reference into a PIL image.
+    if isinstance(image_ref, dict):
+        image_ref = (
+            image_ref.get("url") or image_ref.get("path") or image_ref.get("image")
+        )
+    if not isinstance(image_ref, str):
+        raise ValueError(f"Unsupported image reference: {type(image_ref)}")
+
+    image_path = image_ref
+    if image_path.startswith(("http://", "https://", "data:")):
+        return image_fetcher(image_path)
+
+    if image_path.startswith("file://"):
+        image_path = image_path[len("file://") :]
+
+    if os.path.exists(image_path):
+        return Image.open(image_path).convert("RGB")
+
+    candidate_path = None
+    if image_root and not os.path.isabs(image_ref):
+        candidate_path = os.path.join(image_root, image_ref)
+        if os.path.exists(candidate_path):
+            return Image.open(candidate_path).convert("RGB")
+
+    if candidate_path is None:
+        candidate_path = image_path
+
+    abs_path = os.path.abspath(candidate_path)
+    return image_fetcher(f"file://{abs_path}")
+
+
+def _build_multimodal_inputs(
+    batch_mm_data: list[dict[str, list[Any]]],
+    image_root: str | None,
+    image_fetcher: Any,
+    image_field: str,
+    placeholder_counts: list[int] | None = None,
+) -> list[dict[str, Any]]:
+    # Convert multimodal data refs into vLLM MultiModalDataDict inputs.
+    # NOTE: This path only supports a single image per sample for now.
+    # TODO(VL): Extend to multi-image prompts once alignment is stable.
+    multimodal_inputs: list[dict[str, Any]] = []
+    for idx, mm_data in enumerate(batch_mm_data):
+        if not mm_data:
+            multimodal_inputs.append({})
+            continue
+        images = []
+        for image_ref in mm_data.get(image_field, []):
+            images.append(_resolve_image_ref(image_ref, image_root, image_fetcher))
+        if placeholder_counts is not None and images:
+            target_count = placeholder_counts[idx]
+            if target_count == 0:
+                raise ValueError(
+                    "Multimodal data provided but prompt has no image placeholders."
+                )
+            if target_count != len(images):
+                raise ValueError(
+                    "Single-image mode requires exactly one image placeholder."
+                )
+        if len(images) != 1:
+            raise ValueError("Single-image mode requires exactly one image ref.")
+        mm_input: dict[str, Any] = {}
+        if images:
+            # vLLM expects a list for image modality; keep length=1.
+            mm_input["image"] = images
+        multimodal_inputs.append(mm_input)
+    return multimodal_inputs
+
+
+def _align_loss_mask_to_vllm(
+    vllm_input_ids: list[int],
+    pre_input_ids: list[int],
+    pre_loss_mask: torch.Tensor,
+    image_pad_id: int | None,
+) -> torch.Tensor:
+    # Align preprocessing loss_mask to vLLM tokenization by expanding image pads.
+    if image_pad_id is None:
+        return pre_loss_mask[: len(vllm_input_ids)]
+    aligned: list[int] = []
+    i = 0
+    j = 0
+    pre_mask_list = pre_loss_mask.tolist()
+    while i < len(vllm_input_ids) and j < len(pre_input_ids) and j < len(pre_mask_list):
+        v_id = vllm_input_ids[i]
+        p_id = pre_input_ids[j]
+        if v_id == image_pad_id and p_id == image_pad_id:
+            aligned.append(pre_mask_list[j])
+            i += 1
+            j += 1
+            continue
+        if v_id == image_pad_id and p_id != image_pad_id:
+            aligned.append(0)
+            i += 1
+            continue
+        aligned.append(pre_mask_list[j])
+        i += 1
+        j += 1
+    # If vLLM has extra tokens beyond preprocessing, pad with 0 mask.
+    while i < len(vllm_input_ids):
+        aligned.append(0)
+        i += 1
+    # If preprocessing had extra tokens, ignore the tail (already truncated).
+    return torch.tensor(aligned, dtype=torch.long)
+
+
+def generate_and_save_hidden_states(args, dataset):  # noqa: C901, PLR0915
     """Generate hidden states and save each sample as a .pt file"""
     Path(args.output_dir).mkdir(parents=True, exist_ok=True)
 
@@ -266,6 +427,9 @@ def generate_and_save_hidden_states(args, dataset):
         total=num_batches,
     )
 
+    image_fetcher = None
+    image_pad_id = None
+
     with ThreadPoolExecutor(max_workers=max_io_workers) as thread_executor:
         futures = []
 
@@ -274,18 +438,66 @@ def generate_and_save_hidden_states(args, dataset):
             batch = dataset[i:batch_end]
             batch_input_ids = batch["input_ids"]
             batch_loss_mask = batch["loss_mask"]
+            if args.data_mode == "vl":
+                batch_mm_data = batch.get("multi_modal_data")
+                batch_prompts = batch.get("prompt")
 
-            results = generator.generate(batch_input_ids)
+                if batch_mm_data is None or batch_prompts is None:
+                    raise ValueError(
+                        "VL mode requires multi_modal_data and prompt fields "
+                        "from preprocessing. Ensure the dataset uses image-text "
+                        "format and preprocessing supports multimodal outputs."
+                    )
+
+                if image_fetcher is None:
+                    image_fetcher = vllm_fetch_image
+                mm_inputs = _build_multimodal_inputs(
+                    batch_mm_data,
+                    args.image_root,
+                    image_fetcher,
+                    args.image_field,
+                )
+                request_ids = [f"sample_{i + j}" for j in range(len(batch_prompts))]
+                results = generator.generate(
+                    batch_input_ids,
+                    prompt_texts=batch_prompts,
+                    multimodal_inputs=mm_inputs,
+                    request_ids=request_ids,
+                )
+            else:
+                results = generator.generate(batch_input_ids)
 
             # Submit save operations to thread pool (async I/O)
             for j, result in enumerate(results):
                 # Truncate loss_mask to match input_ids length (generator may truncate)
-                input_len = len(result["input_ids"])
+                input_ids_list = (
+                    result["input_ids"].tolist()
+                    if isinstance(result["input_ids"], torch.Tensor)
+                    else result["input_ids"]
+                )
+                input_len = len(input_ids_list)
                 sample_lengths[file_idx] = input_len
-                loss_mask = batch_loss_mask[j][:input_len]
+                if args.data_mode == "vl":
+                    if image_pad_id is None:
+                        image_pad_id = generator.tokenizer.convert_tokens_to_ids(
+                            "<|image_pad|>"
+                        )
+                    pre_ids = (
+                        batch_input_ids[j].tolist()
+                        if isinstance(batch_input_ids[j], torch.Tensor)
+                        else batch_input_ids[j]
+                    )
+                    loss_mask = _align_loss_mask_to_vllm(
+                        input_ids_list,
+                        pre_ids,
+                        batch_loss_mask[j],
+                        image_pad_id,
+                    )[:input_len]
+                else:
+                    loss_mask = batch_loss_mask[j][:input_len]
 
                 result_cleaned = {
-                    "input_ids": result["input_ids"],
+                    "input_ids": torch.as_tensor(input_ids_list, dtype=torch.long),
                     "hidden_states": [h.contiguous() for h in result["hidden_states"]],
                     "loss_mask": loss_mask,
                 }
@@ -316,6 +528,7 @@ def generate_and_save_hidden_states(args, dataset):
 
 
 def main():
+    # Entry point for offline data generation.
     args = parse_args()
 
     log.section("EAGLE Offline Data Generation")

--- a/src/speculators/data_generation/vllm_hidden_states_generator.py
+++ b/src/speculators/data_generation/vllm_hidden_states_generator.py
@@ -29,6 +29,20 @@ from vllm.v1.structured_output import StructuredOutputManager
 from speculators.utils.util import empty_cache, is_npu_available, mem_get_info
 
 from .logging_utils import PipelineLogger
+from .vllm_hidden_states_utils import (
+    build_generation_results,
+    ensure_tokenizer_max_token_id,
+    get_embed_length_mismatch,
+    get_request_id,
+    infer_num_hidden_layers,
+    normalize_token_ids_batch,
+    resolve_layer_ids,
+    sequence_lengths,
+    to_token_id_list,
+    truncate_text_only_batch,
+    validate_multimodal_batch_alignment,
+    validate_multimodal_engine_features,
+)
 
 __all__ = ["VllmHiddenStatesGenerator"]
 
@@ -36,7 +50,7 @@ __all__ = ["VllmHiddenStatesGenerator"]
 CACHE_MEMORY_FRACTION = 0.2  # Fraction of GPU memory for KV cache
 VLLM_BLOCK_SIZE = 128 if is_npu_available() else 16  # Block size for KV cache
 MAX_NUM_SEQS = 32  # Maximum sequences for prefill-only workload
-MIN_MAX_BATCHED_TOKENS = 8192  # Minimum batched tokens threshold
+MIN_MAX_BATCHED_TOKENS = 32768  # Minimum batched tokens threshold
 MAX_DECODE_TOKENS = 1  # Maximum tokens to generate (prefill only)
 SAMPLING_TEMPERATURE = 0.0  # Temperature for sampling (greedy)
 INITIAL_ARRIVAL_TIME = 0.0  # Initial request arrival time
@@ -78,51 +92,34 @@ class VllmHiddenStatesGenerator:
         self,
         model_path: str,
         layer_ids: list[int] | None = None,
-        max_model_len: int = 2048,
+        max_model_len: int = 4096,
         gpu_memory_utilization: float = 0.8,
         tensor_parallel_size: int = 1,
     ):
         self.model_path = model_path
         self.tensor_parallel_size = tensor_parallel_size
         self._request_counter = 0
+        self._mm_request_counter = 0
         self._input_processor: InputProcessor | None = None
 
         log.info(f"Initializing hidden states generator for {model_path}")
         log.info(f"Tensor parallel size: {tensor_parallel_size}")
 
         self.tokenizer = AutoTokenizer.from_pretrained(model_path)
-        if not hasattr(self.tokenizer, "max_token_id"):
-            try:
-                max_token_id = self.tokenizer.vocab_size - 1
-            except Exception:
-                max_token_id = len(self.tokenizer) - 1
-            self.tokenizer.max_token_id = max_token_id
+        ensure_tokenizer_max_token_id(self.tokenizer)
 
         config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
-        if hasattr(config, "num_hidden_layers"):
-            num_layers = config.num_hidden_layers
-        elif hasattr(config, "text_config"):
-            num_layers = config.text_config.num_hidden_layers
-        else:
-            raise ValueError("Cannot determine num_layers from config")
+        num_layers = infer_num_hidden_layers(config)
 
         log.info(f"Model has {num_layers} layers")
-
+        self.layer_ids = resolve_layer_ids(layer_ids, num_layers)
         if layer_ids is None:
-            self.layer_ids = [2, num_layers // 2, num_layers - 3, num_layers - 1]
             log.info(
                 f"Auto-selected layers: {self.layer_ids} "
                 f"(from {num_layers} total layers)"
             )
         else:
-            self.layer_ids = layer_ids
-            log.info(f"Using specified layers: {layer_ids}")
-
-        for layer_id in self.layer_ids:
-            if layer_id < 0 or layer_id >= num_layers:
-                raise ValueError(
-                    f"Layer index {layer_id} out of bounds [0, {num_layers - 1}]"
-                )
+            log.info(f"Using specified layers: {self.layer_ids}")
 
         self.vllm_config = self._create_vllm_config(
             model_path=model_path,
@@ -216,7 +213,10 @@ class VllmHiddenStatesGenerator:
             cache_config=cache_config,
             parallel_config=ParallelConfig(
                 tensor_parallel_size=tensor_parallel_size,
-                worker_extension_cls="speculators.data_generation.custom_worker.HiddenStatesWorkerExtension",
+                worker_extension_cls=(
+                    "speculators.data_generation.custom_worker."
+                    "HiddenStatesWorkerExtension"
+                ),
             ),
             scheduler_config=SchedulerConfig(
                 max_num_seqs=max_num_seqs,
@@ -238,9 +238,74 @@ class VllmHiddenStatesGenerator:
         # Lazily construct the vLLM input processor for multimodal requests.
         if self._input_processor is None:
             self._input_processor = InputProcessor(
-                self.vllm_config, tokenizer=self.tokenizer
+                self.vllm_config
             )
         return self._input_processor
+
+    def _process_multimodal_inputs_with_truncation(
+        self,
+        *,
+        request_id: str,
+        prompt_text: str,
+        multimodal_item: dict,
+        sampling_params: SamplingParams,
+    ):
+        """Build multimodal engine request and fail fast on max-length overflow."""
+        processor = self._get_input_processor()
+        unique_suffix = f"{self._mm_request_counter}"
+        self._mm_request_counter += 1
+        engine_request_id = f"{request_id}__mm_{unique_suffix}"
+        image_uuid = f"{engine_request_id}_img0"
+
+        prompt = {
+            "prompt": prompt_text,
+            "multi_modal_data": multimodal_item,
+            "multi_modal_uuids": {"image": [image_uuid]},
+        }
+        try:
+            return processor.process_inputs(
+                request_id=engine_request_id,
+                prompt=prompt,
+                params=sampling_params,
+                arrival_time=INITIAL_ARRIVAL_TIME,
+            )
+        except ValueError as exc:
+            msg = str(exc)
+            if "longer than the maximum model length" not in msg:
+                raise
+            raise ValueError(
+                "Multimodal prompt exceeds max_model_len and strict mode is enabled; "
+                f"request_id={request_id}. {msg}"
+            ) from exc
+
+    def get_multimodal_prompt_token_count(
+        self,
+        *,
+        request_id: str,
+        prompt_text: str,
+        multimodal_item: dict,
+    ) -> int:
+        """Return exact multimodal prompt token count for strict pre-check."""
+        sampling_params = SamplingParams(
+            max_tokens=MAX_DECODE_TOKENS, temperature=SAMPLING_TEMPERATURE
+        )
+        engine_req = self._process_multimodal_inputs_with_truncation(
+            request_id=request_id,
+            prompt_text=prompt_text,
+            multimodal_item=multimodal_item,
+            sampling_params=sampling_params,
+        )
+        validate_multimodal_engine_features(engine_req)
+        prompt_token_ids = engine_req.prompt_token_ids
+        if prompt_token_ids is None:
+            raise ValueError("Multimodal request missing prompt_token_ids")
+        max_len = self.vllm_config.model_config.max_model_len - MAX_DECODE_TOKENS
+        if len(prompt_token_ids) > max_len:
+            raise ValueError(
+                "Multimodal prompt token ids exceed prefill-safe limit in strict mode: "
+                f"len={len(prompt_token_ids)} max_len={max_len} request_id={request_id}"
+            )
+        return len(prompt_token_ids)
 
     def generate(  # noqa: PLR0912, PLR0915
         self,
@@ -259,39 +324,24 @@ class VllmHiddenStatesGenerator:
         Returns:
             List of dicts with keys: input_ids, hidden_states, loss_mask
         """
-        if isinstance(token_ids, torch.Tensor):
-            input_ids_list = token_ids.tolist()
-        else:
-            if not token_ids:
-                raise ValueError("token_ids cannot be empty")
-            input_ids_list = token_ids
-
-        # Guard against multimodal misalignment: prompt text + mm inputs must be
-        # present and batch-aligned with token IDs, or vLLM will mix samples.
-        if multimodal_inputs is not None:
-            if prompt_texts is None:
-                raise ValueError("prompt_texts is required for multimodal inputs")
-            if len(prompt_texts) != len(input_ids_list):
-                raise ValueError(
-                    "prompt_texts length must match token_ids length for multimodal"
-                )
-            if len(multimodal_inputs) != len(input_ids_list):
-                raise ValueError("multimodal_inputs length must match token_ids length")
+        input_ids_list = normalize_token_ids_batch(token_ids)
+        validate_multimodal_batch_alignment(
+            input_ids_list,
+            prompt_texts=prompt_texts,
+            multimodal_inputs=multimodal_inputs,
+        )
 
         log.debug(f"Generating hidden states for {len(input_ids_list)} sequences")
-        # Account for max_tokens=1 in sampling params
-        # (vLLM enforces: len(prompt) + max_tokens <= max_model_len)
+        # Account for max_tokens=1 in sampling params for pure text mode.
+        # Multimodal mode is handled in strict mode and raises on overflow.
         max_len = self.vllm_config.model_config.max_model_len - 1
         if multimodal_inputs is None:
-            input_ids_list = [ids[:max_len] for ids in input_ids_list]
+            input_ids_list = truncate_text_only_batch(input_ids_list, max_len=max_len)
 
         for i, ids in enumerate(input_ids_list):
             # Ensure ids is a list (not tensor) for vLLM Request
-            ids_list = ids.tolist() if isinstance(ids, torch.Tensor) else ids
-            if request_ids is not None:
-                request_id = request_ids[i]
-            else:
-                request_id = f"req_{self._request_counter}_{i}"
+            ids_list = to_token_id_list(ids)
+            request_id = get_request_id(request_ids, self._request_counter, i)
             sampling_params = SamplingParams(
                 max_tokens=MAX_DECODE_TOKENS, temperature=SAMPLING_TEMPERATURE
             )
@@ -311,54 +361,21 @@ class VllmHiddenStatesGenerator:
                 # Provide per-request UUIDs for multimodal items to avoid
                 # cache collisions that can drop mm_feature.data in vLLM.
                 assert prompt_texts is not None
-                prompt = {
-                    "prompt": prompt_texts[i],
-                    "multi_modal_data": mm_item,
-                    "multi_modal_uuids": {"image": [f"{request_id}_img0"]},
-                }
-                processor = self._get_input_processor()
-                engine_req = processor.process_inputs(
+                engine_req = self._process_multimodal_inputs_with_truncation(
                     request_id=request_id,
-                    prompt=prompt,
-                    params=sampling_params,
-                    arrival_time=INITIAL_ARRIVAL_TIME,
+                    prompt_text=prompt_texts[i],
+                    multimodal_item=mm_item,
+                    sampling_params=sampling_params,
                 )
-                # vLLM should return multimodal features; if missing, the prompt
-                # likely lacks image placeholders or preprocessing failed.
-                if engine_req.mm_features is None:
-                    raise ValueError(
-                        "Multimodal request missing mm_features; "
-                        "prompt may lack multimodal placeholders."
-                    )
-                for mm_index, mm_feature in enumerate(engine_req.mm_features):
-                    mm_data = mm_feature.data
-                    # Guard against empty feature payloads (would crash later).
-                    if mm_data is None:
-                        raise ValueError(
-                            "Multimodal feature data is None; "
-                            f"feature_index={mm_index} modality={mm_feature.modality}"
-                        )
-                    if mm_feature.modality == "image":
-                        # Ensure image preprocessing produced grid sizes.
-                        if (
-                            not hasattr(mm_data, "get")
-                            or mm_data.get("image_grid_thw") is None
-                        ):
-                            keys = (
-                                list(mm_data.keys())
-                                if hasattr(mm_data, "keys")
-                                else type(mm_data)
-                            )
-                            raise ValueError(
-                                "Multimodal image feature missing image_grid_thw; "
-                                f"feature_index={mm_index} keys={keys}"
-                            )
+                validate_multimodal_engine_features(engine_req)
                 prompt_token_ids = engine_req.prompt_token_ids
                 if prompt_token_ids is None:
                     raise ValueError("Multimodal request missing prompt_token_ids")
                 if len(prompt_token_ids) > max_len:
                     raise ValueError(
-                        "Multimodal prompt exceeds max_model_len; reduce seq length"
+                        "Multimodal prompt token ids exceed prefill-safe limit in "
+                        f"strict mode: len={len(prompt_token_ids)} max_len={max_len} "
+                        f"request_id={request_id}"
                     )
                 # Use vLLM tokenization for multimodal prompts to keep
                 # image-expanded tokens consistent with model inputs.
@@ -404,40 +421,71 @@ class VllmHiddenStatesGenerator:
 
         log.debug(f"Successfully captured {len(aux_hidden_states)} layers")
 
-        seq_lens = [len(ids) for ids in input_ids_list]
-        if captured_input_embeds is not None:
-            expected_num_tokens = sum(seq_lens)
-            actual_num_tokens = int(captured_input_embeds.shape[0])
-            if actual_num_tokens != expected_num_tokens:
-                # Fail fast to avoid silently writing misaligned embeddings to samples.
-                raise RuntimeError(
-                    "Captured input embeddings length mismatch: "
-                    f"expected={expected_num_tokens}, actual={actual_num_tokens}"
-                )
-        results = []
-        offset = 0
-        for i, seq_len in enumerate(seq_lens):
-            layer_states = [
-                h[offset : offset + seq_len].clone().cpu() for h in aux_hidden_states
-            ]
-
-            input_ids_tensor = torch.as_tensor(input_ids_list[i], dtype=torch.long)
-            input_embeds_slice = None
-            if captured_input_embeds is not None:
-                # Slice embeddings per sample to keep sample-level alignment with input_ids.
-                input_embeds_slice = (
-                    captured_input_embeds[offset : offset + seq_len].clone().cpu()
-                )
-
-            results.append(
-                {
-                    "input_ids": input_ids_tensor,
-                    "hidden_states": layer_states,
-                    "loss_mask": None,
-                    "input_embeds": input_embeds_slice,
-                }
+        seq_lens = sequence_lengths(input_ids_list)
+        mismatch, expected_num_tokens, actual_num_tokens = get_embed_length_mismatch(
+            captured_input_embeds,
+            seq_lens,
+        )
+        if mismatch:
+            batch_max_tokens = self.vllm_config.scheduler_config.max_num_batched_tokens
+            max_model_len = self.vllm_config.model_config.max_model_len
+            shortfall = expected_num_tokens - actual_num_tokens
+            expected_exceeds_batch_cap = expected_num_tokens > batch_max_tokens
+            seq_lens_top = sorted(seq_lens, reverse=True)[:8]
+            mismatch_context = (
+                "Mismatch details: "
+                f"num_requests={len(input_ids_list)}, "
+                f"schedule_iterations={schedule_iterations}, "
+                f"max_model_len={max_model_len}, "
+                f"batch_max_tokens={batch_max_tokens}, "
+                f"expected_exceeds_batch_cap={expected_exceeds_batch_cap}, "
+                f"shortfall={shortfall}, "
+                f"min_seq_len={min(seq_lens)}, "
+                f"max_seq_len={max(seq_lens)}, "
+                f"top_seq_lens={seq_lens_top}."
             )
-            offset += seq_len
+            # Fallback: some vLLM schedules chunk prefill when total prompt
+            # tokens exceed max_num_batched_tokens; our prefill-only abort
+            # path can then capture only the first chunk embeddings.
+            # Regenerate this batch sample-by-sample to keep exact alignment.
+            if len(input_ids_list) > 1:
+                log.warning(
+                    "Captured input embeddings length mismatch in batched mode "
+                    f"(expected={expected_num_tokens}, actual={actual_num_tokens}); "
+                    f"{mismatch_context} "
+                    "Try reducing data_generation batch_size or increasing total token "
+                    "budget (max_model_len / max_num_batched_tokens); "
+                    "falling back to per-sample generation for this batch."
+                )
+                fallback_results: list[dict] = []
+                for i in range(len(input_ids_list)):
+                    sample_prompt = None if prompt_texts is None else [prompt_texts[i]]
+                    sample_mm = (
+                        None if multimodal_inputs is None else [multimodal_inputs[i]]
+                    )
+                    sample_req_id = None if request_ids is None else [request_ids[i]]
+                    fallback_results.extend(
+                        self.generate(
+                            [input_ids_list[i]],
+                            prompt_texts=sample_prompt,
+                            multimodal_inputs=sample_mm,
+                            request_ids=sample_req_id,
+                        )
+                    )
+                return fallback_results
+
+            # Single-sample mismatch should not happen; fail fast for visibility.
+            raise RuntimeError(
+                "Captured input embeddings length mismatch: "
+                f"expected={expected_num_tokens}, actual={actual_num_tokens}. "
+                f"{mismatch_context}"
+            )
+
+        results = build_generation_results(
+            aux_hidden_states=aux_hidden_states,
+            input_ids_list=input_ids_list,
+            captured_input_embeds=captured_input_embeds,
+        )
         empty_cache()
 
         return results

--- a/src/speculators/data_generation/vllm_hidden_states_utils.py
+++ b/src/speculators/data_generation/vllm_hidden_states_utils.py
@@ -1,0 +1,214 @@
+"""Helper utilities for vLLM hidden state generation."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_PROMPT_OVERFLOW_PATTERN = re.compile(
+    r"length\s+(\d+)\)\s+is longer than the maximum model length of\s+(\d+)"
+)
+
+
+def ensure_tokenizer_max_token_id(tokenizer: Any) -> None:
+    """Backfill tokenizer.max_token_id for tokenizers that do not expose it."""
+    if hasattr(tokenizer, "max_token_id"):
+        return
+    try:
+        max_token_id = tokenizer.vocab_size - 1
+    except Exception:
+        max_token_id = len(tokenizer) - 1
+    tokenizer.max_token_id = max_token_id
+
+
+def infer_num_hidden_layers(config: Any) -> int:
+    """Infer model hidden layer count from HF config."""
+    if hasattr(config, "num_hidden_layers"):
+        return config.num_hidden_layers
+    if hasattr(config, "text_config") and hasattr(
+        config.text_config, "num_hidden_layers"
+    ):
+        return config.text_config.num_hidden_layers
+    raise ValueError("Cannot determine num_layers from config")
+
+
+def resolve_layer_ids(layer_ids: list[int] | None, num_layers: int) -> list[int]:
+    """Resolve default/specified layer IDs and validate index range."""
+    resolved = [2, num_layers // 2, num_layers - 3, num_layers - 1]
+    if layer_ids is not None:
+        resolved = layer_ids
+    for layer_id in resolved:
+        if layer_id < 0 or layer_id >= num_layers:
+            raise ValueError(
+                f"Layer index {layer_id} out of bounds [0, {num_layers - 1}]"
+            )
+    return resolved
+
+
+def normalize_token_ids_batch(token_ids: list[list[int]] | torch.Tensor) -> list:
+    """Normalize batch token IDs input to a Python list."""
+    if isinstance(token_ids, torch.Tensor):
+        return token_ids.tolist()
+    if not token_ids:
+        raise ValueError("token_ids cannot be empty")
+    return token_ids
+
+
+def validate_multimodal_batch_alignment(
+    input_ids_list: list,
+    prompt_texts: list[str] | None,
+    multimodal_inputs: list[dict] | None,
+) -> None:
+    """Ensure multimodal-side inputs are present and batch aligned."""
+    if multimodal_inputs is None:
+        return
+    if prompt_texts is None:
+        raise ValueError("prompt_texts is required for multimodal inputs")
+    if len(prompt_texts) != len(input_ids_list):
+        raise ValueError(
+            "prompt_texts length must match token_ids length for multimodal"
+        )
+    if len(multimodal_inputs) != len(input_ids_list):
+        raise ValueError("multimodal_inputs length must match token_ids length")
+
+
+def truncate_text_only_batch(input_ids_list: list, max_len: int) -> list:
+    """Truncate text-only token IDs to prefill-safe length."""
+    return [ids[:max_len] for ids in input_ids_list]
+
+
+def to_token_id_list(token_ids: list[int] | torch.Tensor) -> list[int]:
+    """Normalize one sequence into a list of token IDs."""
+    if isinstance(token_ids, torch.Tensor):
+        return token_ids.tolist()
+    return token_ids
+
+
+def get_request_id(
+    request_ids: list[str] | None, request_counter: int, batch_index: int
+) -> str:
+    """Get caller-provided request ID or a deterministic fallback."""
+    if request_ids is not None:
+        return request_ids[batch_index]
+    return f"req_{request_counter}_{batch_index}"
+
+
+def parse_prompt_overflow(error_msg: str) -> int | None:
+    """Parse prompt overflow count from vLLM length validation errors."""
+    match = _PROMPT_OVERFLOW_PATTERN.search(error_msg)
+    if not match:
+        return None
+    prompt_len = int(match.group(1))
+    max_len = int(match.group(2))
+    overflow = prompt_len - max_len
+    return overflow if overflow > 0 else None
+
+
+def validate_multimodal_engine_features(engine_req: Any) -> None:
+    """Validate vLLM multimodal feature payload before Request conversion."""
+    if engine_req.mm_features is None:
+        raise ValueError(
+            "Multimodal request missing mm_features; "
+            "prompt may lack multimodal placeholders."
+        )
+
+    for mm_index, mm_feature in enumerate(engine_req.mm_features):
+        mm_data = mm_feature.data
+        if mm_data is None:
+            raise ValueError(
+                "Multimodal feature data is None; "
+                f"feature_index={mm_index} modality={mm_feature.modality}"
+            )
+        if mm_feature.modality == "image":
+            if not hasattr(mm_data, "get") or mm_data.get("image_grid_thw") is None:
+                keys = (
+                    list(mm_data.keys()) if hasattr(mm_data, "keys") else type(mm_data)
+                )
+                raise ValueError(
+                    "Multimodal image feature missing image_grid_thw; "
+                    f"feature_index={mm_index} keys={keys}"
+                )
+
+
+def truncate_engine_prompt_token_ids(
+    engine_req: Any,
+    *,
+    max_len: int,
+    request_id: str,
+    log_warning: Callable[[str], None],
+) -> list[int]:
+    """Ensure multimodal prompt token IDs fit max_len and stay synchronized."""
+    prompt_token_ids = engine_req.prompt_token_ids
+    if prompt_token_ids is None:
+        raise ValueError("Multimodal request missing prompt_token_ids")
+    if len(prompt_token_ids) > max_len:
+        truncated_ids = prompt_token_ids[:max_len]
+        engine_req.prompt_token_ids = truncated_ids
+        if (
+            hasattr(engine_req, "decoder_inputs")
+            and engine_req.decoder_inputs is not None
+            and hasattr(engine_req.decoder_inputs, "prompt_token_ids")
+        ):
+            engine_req.decoder_inputs.prompt_token_ids = truncated_ids
+        prompt_token_ids = truncated_ids
+        log_warning(
+            "Multimodal prompt token ids exceeded limit and were "
+            f"truncated to {max_len} tokens for request_id={request_id}"
+        )
+    return prompt_token_ids
+
+
+def sequence_lengths(input_ids_list: list) -> list[int]:
+    """Get per-sample sequence lengths."""
+    return [len(ids) for ids in input_ids_list]
+
+
+def get_embed_length_mismatch(
+    captured_input_embeds: torch.Tensor | None, seq_lens: list[int]
+) -> tuple[bool, int, int]:
+    """Check whether captured embeddings length matches flattened input tokens."""
+    if captured_input_embeds is None:
+        return False, 0, 0
+    expected_num_tokens = sum(seq_lens)
+    actual_num_tokens = int(captured_input_embeds.shape[0])
+    return (
+        actual_num_tokens != expected_num_tokens,
+        expected_num_tokens,
+        actual_num_tokens,
+    )
+
+
+def build_generation_results(
+    *,
+    aux_hidden_states: list[torch.Tensor],
+    input_ids_list: list,
+    captured_input_embeds: torch.Tensor | None,
+) -> list[dict[str, Any]]:
+    """Slice flattened capture buffers back to sample-level outputs."""
+    results: list[dict[str, Any]] = []
+    offset = 0
+    for i, seq_len in enumerate(sequence_lengths(input_ids_list)):
+        layer_states = [
+            h[offset : offset + seq_len].clone().cpu() for h in aux_hidden_states
+        ]
+        input_ids_tensor = torch.as_tensor(input_ids_list[i], dtype=torch.long)
+        input_embeds_slice = None
+        if captured_input_embeds is not None:
+            input_embeds_slice = (
+                captured_input_embeds[offset : offset + seq_len].clone().cpu()
+            )
+        results.append(
+            {
+                "input_ids": input_ids_tensor,
+                "hidden_states": layer_states,
+                "loss_mask": None,
+                "input_embeds": input_embeds_slice,
+            }
+        )
+        offset += seq_len
+    return results

--- a/src/speculators/models/eagle3/model_components.py
+++ b/src/speculators/models/eagle3/model_components.py
@@ -1,0 +1,9 @@
+from typing import NamedTuple
+
+
+class ModelComponents(NamedTuple):
+    first_layer_class: type
+    decoder_layer_class: type
+    norm_class: type
+    rotary_emb_class: type
+

--- a/src/speculators/models/eagle3/model_definitions.py
+++ b/src/speculators/models/eagle3/model_definitions.py
@@ -1,111 +1,12 @@
-# ruff: noqa: ERA001
-from typing import NamedTuple
-
-import torch
-from transformers import Cache, LlamaConfig
-from transformers.models.llama.modeling_llama import (
-    LlamaDecoderLayer,
-    LlamaRMSNorm,
-    LlamaRotaryEmbedding,
-)
-from transformers.processing_utils import Unpack
-from transformers.utils.generic import TransformersKwargs
-
-
-class LlamaDecoderEagle3FirstLayer(LlamaDecoderLayer):
-    def __init__(
-        self,
-        config: LlamaConfig,
-        layer_idx: int,
-        norm_before_residual: bool = False,
-    ):
-        # Run original init
-        super().__init__(config, layer_idx)
-
-        # Apply Eagle3 modifications
-        self.norm_before_residual = norm_before_residual
-        self.hidden_norm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.self_attn.q_proj = torch.nn.Linear(
-            2 * config.hidden_size,  # previous: config.hidden_size
-            config.num_attention_heads * config.head_dim,
-            bias=config.attention_bias,
-        )
-        self.self_attn.k_proj = torch.nn.Linear(
-            2 * config.hidden_size,  # previous: config.hidden_size
-            config.num_key_value_heads * config.head_dim,
-            bias=config.attention_bias,
-        )
-        self.self_attn.v_proj = torch.nn.Linear(
-            2 * config.hidden_size,  # previous: config.hidden_size
-            config.num_key_value_heads * config.head_dim,
-            bias=config.attention_bias,
-        )
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        attention_mask: torch.Tensor | None = None,
-        position_ids: torch.LongTensor | None = None,
-        past_key_values: Cache | None = None,
-        use_cache: bool | None = False,
-        cache_position: torch.LongTensor | None = None,
-        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
-        **kwargs: Unpack[TransformersKwargs],  # type: ignore[valid-type]
-    ) -> torch.Tensor:
-        # Previously in LlamaDecoderLayer:
-        #   residual = hidden_states
-        #   hidden_states = self.input_layernorm(hidden_states)
-
-        # ##### Start of Eagle3 modifications #####
-
-        # hidden_states are cat([embeds, hidden], dim=-1)
-        # so residual should be hidden part only, and embeds should be normalized
-        mid = hidden_states.shape[2] // 2
-        embeds, hidden = hidden_states.split(mid, dim=-1)
-        residual = hidden
-
-        # Apply norms
-        embeds = self.input_layernorm(embeds)
-        hidden = self.hidden_norm(hidden)
-        if self.norm_before_residual:
-            residual = hidden  # set residual to normalized hidden
-        hidden_states = torch.cat([embeds, hidden], dim=-1)
-
-        # ##### End of Eagle3 modifications #####
-
-        # Self Attention
-        hidden_states, _ = self.self_attn(
-            hidden_states=hidden_states,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_values=past_key_values,
-            use_cache=use_cache,
-            cache_position=cache_position,
-            position_embeddings=position_embeddings,
-            **kwargs,
-        )
-        hidden_states = residual + hidden_states
-
-        # Fully Connected
-        residual = hidden_states
-        hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
-        return hidden_states  # noqa: RET504
-
-
-class ModelComponents(NamedTuple):
-    first_layer_class: type
-    decoder_layer_class: type
-    norm_class: type
-    rotary_emb_class: type
-
+from speculators.models.eagle3.model_components import ModelComponents
+from speculators.models.eagle3.model_definitions_llama import LLAMA_MODEL_COMPONENTS
+from speculators.models.eagle3.model_definitions_qwen3 import QWEN3_MODEL_COMPONENTS
 
 model_classes: dict[str, ModelComponents] = {
-    "llama": ModelComponents(
-        LlamaDecoderEagle3FirstLayer,
-        LlamaDecoderLayer,
-        LlamaRMSNorm,
-        LlamaRotaryEmbedding,
-    ),
+    "llama": LLAMA_MODEL_COMPONENTS,
+    "qwen3": QWEN3_MODEL_COMPONENTS,
+    "qwen3_vl": QWEN3_MODEL_COMPONENTS,
+    "qwen3_vl_text": QWEN3_MODEL_COMPONENTS,
+    "qwen3vl": QWEN3_MODEL_COMPONENTS,
 }
+

--- a/src/speculators/models/eagle3/model_definitions_llama.py
+++ b/src/speculators/models/eagle3/model_definitions_llama.py
@@ -1,0 +1,87 @@
+import torch
+from transformers import Cache, LlamaConfig
+from transformers.models.llama.modeling_llama import (
+    LlamaDecoderLayer,
+    LlamaRMSNorm,
+    LlamaRotaryEmbedding,
+)
+from transformers.processing_utils import Unpack
+from transformers.utils.generic import TransformersKwargs
+
+from speculators.models.eagle3.model_components import ModelComponents
+
+
+class LlamaDecoderEagle3FirstLayer(LlamaDecoderLayer):
+    def __init__(
+        self,
+        config: LlamaConfig,
+        layer_idx: int,
+        norm_before_residual: bool = False,
+    ):
+        super().__init__(config, layer_idx)
+
+        self.norm_before_residual = norm_before_residual
+        self.hidden_norm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.self_attn.q_proj = torch.nn.Linear(
+            2 * config.hidden_size,
+            config.num_attention_heads * config.head_dim,
+            bias=config.attention_bias,
+        )
+        self.self_attn.k_proj = torch.nn.Linear(
+            2 * config.hidden_size,
+            config.num_key_value_heads * config.head_dim,
+            bias=config.attention_bias,
+        )
+        self.self_attn.v_proj = torch.nn.Linear(
+            2 * config.hidden_size,
+            config.num_key_value_heads * config.head_dim,
+            bias=config.attention_bias,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        use_cache: bool | None = False,
+        cache_position: torch.LongTensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        **kwargs: Unpack[TransformersKwargs],  # type: ignore[valid-type]
+    ) -> torch.Tensor:
+        mid = hidden_states.shape[2] // 2
+        embeds, hidden = hidden_states.split(mid, dim=-1)
+        residual = hidden
+
+        embeds = self.input_layernorm(embeds)
+        hidden = self.hidden_norm(hidden)
+        if self.norm_before_residual:
+            residual = hidden
+        hidden_states = torch.cat([embeds, hidden], dim=-1)
+
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+LLAMA_MODEL_COMPONENTS = ModelComponents(
+    first_layer_class=LlamaDecoderEagle3FirstLayer,
+    decoder_layer_class=LlamaDecoderLayer,
+    norm_class=LlamaRMSNorm,
+    rotary_emb_class=LlamaRotaryEmbedding,
+)
+

--- a/src/speculators/models/eagle3/model_definitions_qwen3.py
+++ b/src/speculators/models/eagle3/model_definitions_qwen3.py
@@ -1,0 +1,102 @@
+import torch
+from transformers import Cache, PretrainedConfig
+from transformers.models.llama.modeling_llama import (
+    LlamaDecoderLayer,
+    LlamaRMSNorm,
+    LlamaRotaryEmbedding,
+)
+from transformers.processing_utils import Unpack
+from transformers.utils.generic import TransformersKwargs
+
+from speculators.models.eagle3.model_components import ModelComponents
+
+
+def _ensure_qwen3_llama_compat(config: PretrainedConfig) -> None:
+    # Qwen3-VL text config may omit fields read directly by HF Llama layers.
+    if not hasattr(config, "mlp_bias"):
+        setattr(config, "mlp_bias", False)
+    if not hasattr(config, "attention_bias"):
+        setattr(config, "attention_bias", False)
+
+
+class Qwen3DecoderEagle3FirstLayer(LlamaDecoderLayer):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        layer_idx: int,
+        norm_before_residual: bool = False,
+    ):
+        _ensure_qwen3_llama_compat(config)
+        super().__init__(config, layer_idx)
+
+        self.norm_before_residual = norm_before_residual
+        self.hidden_norm = LlamaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.self_attn.q_proj = torch.nn.Linear(
+            2 * config.hidden_size,
+            config.num_attention_heads * config.head_dim,
+            bias=config.attention_bias,
+        )
+        self.self_attn.k_proj = torch.nn.Linear(
+            2 * config.hidden_size,
+            config.num_key_value_heads * config.head_dim,
+            bias=config.attention_bias,
+        )
+        self.self_attn.v_proj = torch.nn.Linear(
+            2 * config.hidden_size,
+            config.num_key_value_heads * config.head_dim,
+            bias=config.attention_bias,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        use_cache: bool | None = False,
+        cache_position: torch.LongTensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        **kwargs: Unpack[TransformersKwargs],  # type: ignore[valid-type]
+    ) -> torch.Tensor:
+        mid = hidden_states.shape[2] // 2
+        embeds, hidden = hidden_states.split(mid, dim=-1)
+        residual = hidden
+
+        embeds = self.input_layernorm(embeds)
+        hidden = self.hidden_norm(hidden)
+        if self.norm_before_residual:
+            residual = hidden
+        hidden_states = torch.cat([embeds, hidden], dim=-1)
+
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class Qwen3DecoderLayer(LlamaDecoderLayer):
+    def __init__(self, config: PretrainedConfig, layer_idx: int):
+        _ensure_qwen3_llama_compat(config)
+        super().__init__(config, layer_idx)
+
+
+QWEN3_MODEL_COMPONENTS = ModelComponents(
+    first_layer_class=Qwen3DecoderEagle3FirstLayer,
+    decoder_layer_class=Qwen3DecoderLayer,
+    norm_class=LlamaRMSNorm,
+    rotary_emb_class=LlamaRotaryEmbedding,
+)
+


### PR DESCRIPTION
# Qwen3-VL (single image-text) training support


- [x] Add multimodal parsing in preprocessing (image + text) and use processor instead of tokenizer
- [x] Pass multimodal inputs into vLLM request path during hidden-state extraction
- [x] Add a new data format version for multimodal samples in training (vl-v1)
- [x] Update training pipeline to consume multimodal data format (blocked on a dedicated VL schema)
- [x] Document dataset format and E2E usage for VL training

## Background
This PR adds vision‑language (image‑text) data generation and training support, aligning preprocessing with vLLM’s multimodal tokenization.

## Test

No impact to existing branches.
Successfully ran end‑to‑end training on llamafactory/pokemon-gpt4o-captions.