### PR TITLE
Add seeding to train.py

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -34,15 +34,17 @@ PREFETCH_FACTOR = 4
 NOISE_STD = 0.05
 
 
-def set_seed(seed: int):
+def set_seed(seed: int, deterministic: bool = False):
     """Set random seeds for reproducibility."""
     random.seed(seed)
-    np.random.seed(seed)
+    np.random.seed(seed)  # noqa: NPY002
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
-    # For deterministic behavior (may impact performance)
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False
+
+    if deterministic:
+        # For deterministic behavior (may impact performance)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
 
 
 def setup_dataloader(
@@ -124,7 +126,7 @@ def create_transformer_layer_config(
 
 def main(args: argparse.Namespace):
     # Set random seed for reproducibility
-    set_seed(args.seed)
+    set_seed(args.seed, args.deterministic_cuda)
 
     # Setup logging
     setup_root_logger()
@@ -258,6 +260,12 @@ def parse_args():
     parser.add_argument("--ttt-step-loss-decay", type=float, default=1.0)
     parser.add_argument(
         "--seed", type=int, default=42, help="Random seed for reproducibility"
+    )
+    parser.add_argument(
+        "--deterministic-cuda",
+        action="store_true",
+        default=False,
+        help="Sets cuda to deterministic mode. This may impact performance.",
     )
     parser.add_argument(
         "--use-off-policy-tokens",


### PR DESCRIPTION
Set an initial random seed. This improves stability when training on multiple devices. 