### PR TITLE
Update typer-slim dependency to typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "torch<2.10.0",
     "tqdm",
     "transformers<5.0.0",
-    "typer-slim>=0.12.0",
+    "typer>=0.12.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Hi! Just a quick heads-up that we've removed support for `typer-slim`. From v0.22.0 onwards, `typer-slim` will be the same as `typer`, with external requirements `shellingham` and `rich` installed by default, see https://github.com/fastapi/typer/pull/1522. I saw that `rich` is already an external dependency of this library so this should have little influence. `huggingface-hub` has also switched to using `typer` instead of `typer-slim`.

Let me know if you have any questions/concerns!