### PR TITLE
bump vllm to latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ dev = [
     "mkdocs-linkcheck~=1.0.6",
 ]
 
-datagen = ["vllm>=0.12.0,<=0.14.0"]
+datagen = ["vllm>=0.12.0,<=0.15.0"]
 
 [project.entry-points.console_scripts]
 speculators = "speculators.__main__:app"


### PR DESCRIPTION
update vllm upper bound to latest released version.

Test plan:
Ran speculators nightly and e2e passed: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/22195035101