### PR TITLE
Add FastMTP multi-token prediction speculator

### DIFF
--- a/examples/fast_mtp/README.md
+++ b/examples/fast_mtp/README.md
@@ -1,0 +1,54 @@
+# FastMTP — Multi-Token Prediction Finetuning
+
+This example shows how to finetune a [Qwen3-Next](https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct/tree/main) MTP head on [HuggingFaceH4/ultrachat_200k](https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k).
+
+## Overview
+
+FastMTP is a speculative decoding algorithm from TencentBAC, adopted in [Qwen3-Next](https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct/tree/main). FastMTP applies a **single MTP layer recursively**: at step k, the layer receives the token embedding for `input_ids[t+k+1]` and the hidden state output from step k-1. Each step predicts token `t+k+2`.
+
+**Architecture:**
+
+```mermaid
+flowchart LR
+    VH["Verifier hidden[t]"] --> HN["hidden_layernorm"]
+    TE1["Token embed[t+1]"] --> TN1["token_layernorm"]
+    HN --> IP1["input_proj"]
+    TN1 --> IP1
+    IP1 --> AM1["attn + MLP"]
+    AM1 --> MH0["MTP hidden[step=0]"]
+
+    MH0 --> HN2["hidden_layernorm"]
+    TE2["Token embed[t+2]"] --> TN2["token_layernorm"]
+    HN2 --> IP2["input_proj"]
+    TN2 --> IP2
+    IP2 --> AM2["attn + MLP"]
+    AM2 --> MH1["MTP hidden[step=1]"]
+
+    MH0 --> LH0["lm_head"] --> L0["logits[step=0]"]
+    MH1 --> LH1["lm_head"] --> L1["logits[step=1]"]
+```
+
+**Training objective** (from the FastMTP paper):
+
+$$\mathcal{L}_{\text{mtp}} = \sum_{k=0}^{K-1} \alpha_k \cdot \text{CE}(\text{logits}_k,\ \text{tokens}_{t+k+2})$$
+
+Default weights $\alpha = [0.51, 0.31, 0.18]$ use exponential decay ($\beta=0.6$, normalized). Loss is computed only on response tokens via `loss_mask`.
+
+## Supported Checkpoints
+
+| Model | model_type |
+| ----- | ---------- |
+| [Qwen3-Next](https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct/tree/main) | `qwen3_next` |
+
+## Paper
+
+Cai et al., [FastMTP: Accelerating LLM Inference with Enhanced Multi-Token Prediction](https://arxiv.org/abs/2509.18362), arXiv:2509.18362, 2025.
+
+```bibtex
+@article{cai2025fastmtp,
+  title={FastMTP: Accelerating LLM Inference with Enhanced Multi-Token Prediction},
+  author={Cai, Yuxuan and Liang, Xiaozhuan and Wang, Xinghua and Ma, Jin and Liang, Haijin and Luo, Jinwen and Zuo, Xinyu and Duan, Lisheng and Yin, Yuyang and Chen, Xi},
+  journal={arXiv preprint arXiv:2509.18362},
+  year={2025}
+}
+```

--- a/src/speculators/models/__init__.py
+++ b/src/speculators/models/__init__.py
@@ -1,3 +1,9 @@
 from .eagle3 import Eagle3DraftModel, Eagle3SpeculatorConfig
+from .fast_mtp import FastMTPConfig, FastMTPSpeculator
 
-__all__ = ["Eagle3DraftModel", "Eagle3SpeculatorConfig"]
+__all__ = [
+    "Eagle3DraftModel",
+    "Eagle3SpeculatorConfig",
+    "FastMTPConfig",
+    "FastMTPSpeculator",
+]

--- a/src/speculators/models/base_components.py
+++ b/src/speculators/models/base_components.py
@@ -2,16 +2,33 @@
 
 from typing import NamedTuple
 
+from torch import nn
 from transformers.models.llama.modeling_llama import (
     LlamaDecoderLayer,
     LlamaRMSNorm,
     LlamaRotaryEmbedding,
+)
+from transformers.models.qwen2.modeling_qwen2 import (
+    Qwen2DecoderLayer,
+    Qwen2RMSNorm,
+    Qwen2RotaryEmbedding,
 )
 from transformers.models.qwen3.modeling_qwen3 import (
     Qwen3DecoderLayer,
     Qwen3RMSNorm,
     Qwen3RotaryEmbedding,
 )
+
+try:
+    from transformers.models.qwen3_next.modeling_qwen3_next import (
+        Qwen3NextDecoderLayer,
+        Qwen3NextRMSNorm,
+        Qwen3NextRotaryEmbedding,
+    )
+
+    HAS_QWEN3_NEXT = True
+except ImportError:
+    HAS_QWEN3_NEXT = False
 
 
 class ModelComponents(NamedTuple):
@@ -30,26 +47,40 @@ class ModelComponents(NamedTuple):
         rotary_emb_class: Rotary positional embedding class for the model.
     """
 
-    first_layer_class: type
-    decoder_layer_class: type
-    norm_class: type
-    rotary_emb_class: type
+    first_layer_class: type[nn.Module]
+    decoder_layer_class: type[nn.Module]
+    norm_class: type[nn.Module]
+    rotary_emb_class: type[nn.Module]
 
 
 model_classes: dict[str, ModelComponents] = {
     "llama": ModelComponents(
-        LlamaDecoderLayer,  # first_layer_class (same as decoder for base models)
+        LlamaDecoderLayer,
         LlamaDecoderLayer,
         LlamaRMSNorm,
         LlamaRotaryEmbedding,
     ),
+    "qwen2": ModelComponents(
+        Qwen2DecoderLayer,
+        Qwen2DecoderLayer,
+        Qwen2RMSNorm,
+        Qwen2RotaryEmbedding,
+    ),
     "qwen3": ModelComponents(
-        Qwen3DecoderLayer,  # first_layer_class (same as decoder for base models)
+        Qwen3DecoderLayer,
         Qwen3DecoderLayer,
         Qwen3RMSNorm,
         Qwen3RotaryEmbedding,
     ),
 }
+
+if HAS_QWEN3_NEXT:
+    model_classes["qwen3_next"] = ModelComponents(
+        Qwen3NextDecoderLayer,
+        Qwen3NextDecoderLayer,
+        Qwen3NextRMSNorm,
+        Qwen3NextRotaryEmbedding,
+    )
 
 
 def override_components(model_type: str, **overrides) -> ModelComponents:
@@ -59,7 +90,7 @@ def override_components(model_type: str, **overrides) -> ModelComponents:
     while inheriting other components from the base model.
 
     Args:
-        model_type: Base model type ("llama" or "qwen3").
+        model_type: Key into ``model_classes`` (e.g., ``"llama"``, ``"qwen3_next"``).
         **overrides: Component fields to override (first_layer_class,
             decoder_layer_class, etc).
 

--- a/src/speculators/models/fast_mtp/__init__.py
+++ b/src/speculators/models/fast_mtp/__init__.py
@@ -1,0 +1,9 @@
+"""FastMTP (Multi-Token Prediction) speculator implementation."""
+
+from speculators.models.fast_mtp.config import FastMTPConfig
+from speculators.models.fast_mtp.core import FastMTPSpeculator
+
+__all__ = [
+    "FastMTPConfig",
+    "FastMTPSpeculator",
+]

--- a/src/speculators/models/fast_mtp/config.py
+++ b/src/speculators/models/fast_mtp/config.py
@@ -1,0 +1,116 @@
+"""Configuration for FastMTP speculator model."""
+
+from typing import Any, Literal
+
+from pydantic import Field, field_serializer, field_validator
+from transformers import AutoConfig, PretrainedConfig
+from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+
+from speculators import SpeculatorModelConfig
+
+__all__ = ["FastMTPConfig"]
+
+
+@SpeculatorModelConfig.register("mtp")
+class FastMTPConfig(SpeculatorModelConfig):
+    """Configuration for FastMTP (Multi-Token Prediction) speculator.
+
+    Targets two checkpoint families:
+    - **MiMo (TencentBAC/FastMTP)**: Qwen2-based, ``model_type="mimo"``, hidden=4096,
+      32 attention heads, 8 KV heads, vocab=151680, rope_theta=640000.
+    - **Qwen3-Next**: sparse MoE, ``model_type="qwen3_next"``, hidden=2048, 16 heads,
+      2 KV heads, vocab=151936, rope_theta=10000000.
+
+    Architecture: a single MTP layer with attention and MLP, combining verifier hidden
+    states with token embeddings via an explicit input projection. ``embed_tokens`` and
+    ``lm_head`` share the verifier's full vocabulary.
+
+    The forward pass is teacher-forced: at step k the model receives
+    ``input_ids[:, k:k+valid_len]`` as token embeddings and
+    ``hidden_states[:, :valid_len]`` from the verifier. Each step is independent,
+    enabling parallel computation during training.
+
+    **Stored fields:**
+
+    :param transformer_layer_config: Configuration for the underlying transformer
+        architecture (e.g., ``Qwen2Config``). All architecture dimensions
+        (``hidden_size``, ``vocab_size``, attention heads, MLP dims) are derived from
+        this config. Serialised as a ``to_diff_dict()`` snapshot and reconstructed via
+        ``AutoConfig`` on load.
+    :param num_nextn_predict_layers: Number of MTP prediction heads in the checkpoint.
+        vLLM reads this field directly to instantiate the correct number of MTP head
+        instances. Currently only ``1`` is supported.
+
+    **Derived properties (not stored):**
+
+    :property hidden_size: Hidden dimension, from
+        ``transformer_layer_config.hidden_size``.
+    :property vocab_size: Vocabulary size, from
+        ``transformer_layer_config.vocab_size``.
+    :property num_speculative_steps: Number of teacher-forced prediction steps, derived
+        from ``speculators_config.proposal_methods[0].speculative_tokens``. Not a stored
+        field — set via the proposal config.
+    """
+
+    speculators_model_type: Literal["mtp"] = "mtp"
+    architectures: list[str] = Field(
+        default_factory=lambda: ["FastMTPSpeculator"],
+        description="Model architectures that can load these weights",
+    )
+
+    transformer_layer_config: PretrainedConfig = Field(
+        default_factory=Qwen2Config,
+        description="Underlying transformer architecture config (e.g., Qwen2Config)",
+    )
+
+    num_nextn_predict_layers: int = Field(
+        default=1,
+        description=(
+            "Number of MTP prediction heads in the checkpoint. vLLM reads this "
+            "field to create the correct number of speculator head instances."
+        ),
+    )
+
+    @property
+    def hidden_size(self) -> int:
+        """Hidden dimension size, derived from transformer_layer_config."""
+        return self.transformer_layer_config.hidden_size  # type: ignore[return-value]
+
+    @property
+    def vocab_size(self) -> int:
+        """Vocabulary size, derived from transformer_layer_config."""
+        return self.transformer_layer_config.vocab_size  # type: ignore[return-value]
+
+    @property
+    def num_speculative_steps(self) -> int:
+        """Number of teacher-forced prediction steps, from the proposal config."""
+        return self.speculators_config.proposal_methods[0].speculative_tokens  # type: ignore[union-attr,attr-defined]
+
+    @field_validator("num_nextn_predict_layers")
+    @classmethod
+    def validate_num_nextn_predict_layers(cls, value: int) -> int:
+        """Reject configs that request more than one FastMTP layer."""
+        if value != 1:
+            raise ValueError(
+                f"FastMTP currently only supports 1 layer, got {value}. "
+                "Multi-layer support may be added in future versions."
+            )
+        return value
+
+    @field_serializer("transformer_layer_config")
+    def serialize_transformer_layer_config(self, value: PretrainedConfig) -> dict:
+        """Serialize transformer_layer_config to dict for JSON storage."""
+        return value.to_diff_dict()
+
+    @field_validator("transformer_layer_config", mode="before")
+    @classmethod
+    def validate_transformer_layer_config(cls, value: Any) -> PretrainedConfig:
+        """Validate and convert transformer config from dict or PretrainedConfig."""
+        if isinstance(value, dict):
+            config_class: type[PretrainedConfig] = Qwen2Config
+            if "model_type" in value:
+                config_class = AutoConfig.for_model(
+                    model_type=value["model_type"]
+                ).__class__
+            return config_class(**value)
+        return value

--- a/src/speculators/models/fast_mtp/core.py
+++ b/src/speculators/models/fast_mtp/core.py
@@ -1,0 +1,247 @@
+"""FastMTP speculator model implementation."""
+
+from typing import Any, ClassVar
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+from speculators import SpeculatorModel
+from speculators.config import SpeculatorsConfig, VerifierConfig
+from speculators.models.fast_mtp.config import FastMTPConfig
+from speculators.models.fast_mtp.model_definitions import fast_mtp_model_classes
+from speculators.proposals.greedy import GreedyTokenProposalConfig
+from speculators.utils.loading import load_model_layers
+
+__all__ = ["FastMTPSpeculator"]
+
+
+@SpeculatorModel.register("mtp")
+class FastMTPSpeculator(SpeculatorModel):
+    """FastMTP speculator model for multi-token prediction.
+
+    FastMTP predicts multiple future tokens (default: 3) per forward pass using
+    a single layer with weighted multi-step loss for training.
+
+    embed_tokens and lm_head are always initialized with random weights in __init__.
+    When speculators_config.verifier.name_or_path is set, _setup_embeddings_and_lm_head
+    overwrites them with weights from the verifier checkpoint. When loading a
+    self-contained checkpoint (embed_tokens + lm_head weights present in the file),
+    from_pretrained fills them directly.
+    """
+
+    config_class: ClassVar[type[FastMTPConfig]] = FastMTPConfig  # type: ignore[misc]
+
+    def __init__(self, config: FastMTPConfig) -> None:
+        super().__init__(config=config)
+        tc = config.transformer_layer_config
+        self._model_definitions = fast_mtp_model_classes[tc.model_type]
+        self.mtp_layers = nn.ModuleList(
+            [self._model_definitions.first_layer_class(tc, layer_idx=0)]
+        )
+        self.rotary_emb = self._model_definitions.rotary_emb_class(tc)
+        self.embed_tokens = nn.Embedding(
+            self.config.vocab_size, self.config.hidden_size
+        )
+        self.lm_head = nn.Linear(
+            self.config.hidden_size, self.config.vocab_size, bias=False
+        )
+        self._setup_embeddings_and_lm_head()
+
+    def _setup_embeddings_and_lm_head(self) -> None:
+        """Overwrite embed_tokens and lm_head from the verifier checkpoint if configured."""
+        if (
+            self.config.speculators_config is None
+            or self.config.speculators_config.verifier is None
+            or self.config.speculators_config.verifier.name_or_path is None
+        ):
+            return
+
+        path = self.config.speculators_config.verifier.name_or_path
+        weights = load_model_layers(["embed_tokens.weight", "lm_head.weight"], path)
+
+        embed_weight = weights["embed_tokens.weight"]
+        lm_head_weight = weights.get("lm_head.weight", embed_weight)
+
+        self.embed_tokens.weight = nn.Parameter(
+            embed_weight.detach().clone(), requires_grad=False
+        )
+        self.lm_head.weight = nn.Parameter(
+            lm_head_weight.detach().clone(), requires_grad=False
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        labels: torch.Tensor | None = None,
+        loss_mask: torch.Tensor | None = None,
+        step_weights: list[float] | None = None,
+        return_dict: bool = True,
+    ) -> dict[str, Any] | tuple:
+        """Forward pass for FastMTP multi-token prediction (teacher-forced).
+
+        At step k, uses ground-truth input_ids[t+k+1] as the embedding input and
+        the MTP output from step k-1 (or verifier hidden states for step 0) as the
+        hidden state input. Hidden states are passed recursively: each step's MTP
+        output feeds the next step, matching the MiMo training procedure.
+
+        :param input_ids: Token IDs [batch, seq_len]
+        :param hidden_states: Hidden states from verifier [batch, seq_len, hidden_size]
+        :param attention_mask: Optional attention mask [batch, seq_len]
+        :param position_ids: Optional position IDs [batch, seq_len]
+        :param labels: Optional ground truth labels [batch, seq_len]
+        :param loss_mask: Optional binary mask [batch, seq_len]; 1=compute loss,
+            0=ignore. Positions with mask==0 have their label set to -100 so the
+            cross-entropy ignores them. Aligned with labels using the same step+2
+            offset. Training only.
+        :param step_weights: Per-step loss weights (None = uniform). Training only.
+        :param return_dict: Whether to return dict or tuple
+        :return: Dictionary with logits_list, loss (if labels), and metrics (if labels)
+        """
+        device = input_ids.device
+        batch_size, seq_len = input_ids.shape
+        num_steps = self.config.num_speculative_steps
+
+        if position_ids is None:
+            position_ids = (
+                torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
+            )
+
+        all_logits: list[torch.Tensor] = []
+        total_loss: torch.Tensor | None = (
+            torch.tensor(0.0, device=device) if labels is not None else None
+        )
+        metrics: dict[str, float] = {}
+
+        current_hidden = hidden_states  # recursive: updated each step with MTP output
+        for step in range(num_steps):
+            valid_len = seq_len - step - 2
+            if valid_len <= 0:
+                break
+            step_hidden = current_hidden[:, :valid_len]
+            step_embeds = self.embed_tokens(
+                input_ids[:, step + 1 : step + 1 + valid_len]
+            )
+            step_pos_ids = position_ids[:, :valid_len]
+            step_pos_emb = self.rotary_emb(step_hidden, step_pos_ids)
+            step_attn_mask = (
+                attention_mask[:, :valid_len] if attention_mask is not None else None
+            )
+
+            mtp_output = self.mtp_layers[0](
+                hidden_states=step_hidden,
+                token_embeddings=step_embeds,
+                attention_mask=step_attn_mask,
+                position_ids=step_pos_ids,
+                position_embeddings=step_pos_emb,
+            )
+
+            logits = self.lm_head(mtp_output)
+            all_logits.append(logits)
+
+            if labels is not None:
+                step_labels = labels[:, step + 2 : step + 2 + valid_len]
+                if loss_mask is not None:
+                    step_mask = loss_mask[:, step + 2 : step + 2 + valid_len]
+                    step_labels = step_labels.clone()
+                    step_labels[step_mask == 0] = -100
+                weight = step_weights[step] if step_weights is not None else 1.0
+                step_loss = weight * nn.functional.cross_entropy(
+                    logits.reshape(-1, self.config.vocab_size),
+                    step_labels.reshape(-1),
+                    ignore_index=-100,
+                )
+                total_loss = total_loss + step_loss  # type: ignore[operator]
+                metrics[f"loss_step_{step}"] = step_loss.item()
+
+            current_hidden = mtp_output  # feed MTP output as hidden for next step
+
+        if return_dict:
+            return {
+                "logits_list": all_logits,
+                "loss": total_loss,
+                "metrics": metrics,
+            }
+        return (all_logits, total_loss, metrics)
+
+    @staticmethod
+    def _fix_state_dict_key_on_load(key: str) -> tuple[str, bool]:  # noqa: PLR0911
+        """Remap checkpoint keys to model parameter names for HF weight loading.
+
+        HF calls this per-key before resolving missing/unexpected keys. The model's
+        base_model_prefix is "model", so speculators keys (model.mtp_layers.0.*) are
+        handled by HF's built-in prefix-stripping — only external formats need
+        remapping. The deepseek catch-all (mtp.<rest> → mtp_layers.0.<rest>) must
+        remain last.
+        """
+        if key.startswith("mtp.layers.0."):
+            return key.replace("mtp.layers.0.", "mtp_layers.0.", 1), True
+        if key.startswith("mtp.fc."):
+            return key.replace("mtp.fc.", "mtp_layers.0.input_proj.", 1), True
+        if key == "mtp.norm.weight":
+            return "mtp_layers.0.final_layernorm.weight", True
+        if key.startswith("mtp.pre_fc_norm_hidden."):
+            return key.replace(
+                "mtp.pre_fc_norm_hidden.", "mtp_layers.0.hidden_layernorm."
+            ), True
+        if key.startswith("mtp.pre_fc_norm_embedding."):
+            return key.replace(
+                "mtp.pre_fc_norm_embedding.", "mtp_layers.0.token_layernorm."
+            ), True
+        if key.startswith("mtp.") and not key.startswith("mtp.layers"):
+            return key.replace("mtp.", "mtp_layers.0.", 1), True
+        return key, False
+
+    @classmethod
+    def from_training_args(  # type: ignore[override]
+        cls,
+        verifier_config: PretrainedConfig,
+        *,
+        num_speculative_steps: int = 3,
+        verifier_name_or_path: str | None = None,
+    ) -> "FastMTPSpeculator":
+        """Create FastMTP model from training arguments.
+
+        :param verifier_config: Verifier model configuration
+        :param num_speculative_steps: Number of future tokens to predict per step
+        :param verifier_name_or_path: Path or repo ID for loading embed/lm_head weights
+        :return: FastMTP model instance
+        """
+        config = FastMTPConfig(
+            transformer_layer_config=verifier_config,
+            speculators_config=SpeculatorsConfig(
+                algorithm="mtp",
+                proposal_methods=[
+                    GreedyTokenProposalConfig(
+                        speculative_tokens=num_speculative_steps,
+                    )
+                ],
+                default_proposal_method="greedy",
+                verifier=VerifierConfig.from_config(
+                    verifier_config,
+                    name_or_path=verifier_name_or_path,
+                ),
+            ),
+        )
+
+        return cls(config=config)
+
+    @staticmethod
+    def get_trainer_kwargs(**kwargs) -> tuple[dict, dict]:
+        """Get training and validation kwargs for FastMTP.
+
+        Pass ``step_weights`` to override the default exponential-decay weights
+        ``[0.51, 0.31, 0.18]`` (β=0.6, normalized, matching TencentBAC/Qwen3-Next).
+
+        :param kwargs: Training arguments
+        :return: Tuple of (train_kwargs, val_kwargs)
+        """
+        train_kwargs = {
+            "step_weights": kwargs.get("step_weights", [0.51, 0.31, 0.18]),
+        }
+        val_kwargs = train_kwargs.copy()
+
+        return train_kwargs, val_kwargs

--- a/src/speculators/models/fast_mtp/model_definitions.py
+++ b/src/speculators/models/fast_mtp/model_definitions.py
@@ -1,0 +1,114 @@
+"""FastMTP layer mixin and concrete layer classes.
+
+FastMTP projects hidden states DOWN to standard hidden_size BEFORE attention via
+input_proj, so q/k/v weights remain standard width. The mixin interface takes two
+separate tensors (hidden_states, token_embeddings).
+"""
+
+import copy
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+from transformers.models.qwen2.modeling_qwen2 import (
+    Qwen2DecoderLayer,
+    Qwen2RMSNorm,
+)
+
+from speculators.models import base_components
+
+__all__ = ["FastMTPLayerMixin", "fast_mtp_model_classes"]
+
+
+class FastMTPLayerMixin:
+    """FastMTP-specific modifications for any decoder layer.
+
+    Projects hidden states to standard hidden_size BEFORE attention via input_proj;
+    q/k/v weights remain standard width.
+    """
+
+    # Declared for type checkers; provided by the base decoder layer class
+    self_attn: nn.Module
+    mlp: nn.Module
+    input_layernorm: nn.Module
+    post_attention_layernorm: nn.Module
+
+    def _setup_fastmtp_modules(
+        self, config: PretrainedConfig, norm_class: type[nn.Module]
+    ) -> None:
+        hidden_size, eps = config.hidden_size, config.rms_norm_eps
+        self.hidden_layernorm = norm_class(hidden_size, eps=eps)
+        self.token_layernorm = norm_class(hidden_size, eps=eps)
+        self.input_proj = nn.Linear(2 * hidden_size, hidden_size, bias=False)
+        self.final_layernorm = norm_class(hidden_size, eps=eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        token_embeddings: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Forward pass through FastMTP layer.
+
+        :param hidden_states: Verifier hidden states [batch, valid_len, hidden_size]
+        :param token_embeddings: Token embeddings [batch, valid_len, hidden_size]
+        :param attention_mask: Optional attention mask
+        :param position_ids: Position IDs
+        :param position_embeddings: (cos, sin) tuple computed at model level; required
+            because Qwen2Attention destructures it directly.
+        :param kwargs: Additional arguments forwarded to the base decoder layer
+        :return: Output hidden states [batch, valid_len, hidden_size]
+        """
+        hidden_normed = self.hidden_layernorm(hidden_states)
+        embed_normed = self.token_layernorm(token_embeddings)
+        proj = self.input_proj(torch.cat([hidden_normed, embed_normed], dim=-1))
+
+        # Qwen2DecoderLayer returns a plain tensor; Qwen3-Next may return a tuple.
+        output = super().forward(  # type: ignore[misc]
+            hidden_states=proj,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+        hidden_states = output[0] if isinstance(output, tuple) else output
+        return self.final_layernorm(hidden_states)
+
+
+class Qwen2FastMTPLayer(FastMTPLayerMixin, Qwen2DecoderLayer):
+    """FastMTP layer for Qwen2-based checkpoints."""
+
+    def __init__(self, config: PretrainedConfig, layer_idx: int = 0) -> None:
+        modified = copy.copy(config)
+        modified._attn_implementation = "eager"  # noqa: SLF001
+        super().__init__(modified, layer_idx)
+        self._setup_fastmtp_modules(modified, Qwen2RMSNorm)
+
+
+fast_mtp_model_classes: dict[str, base_components.ModelComponents] = {
+    "qwen2": base_components.override_components(
+        "qwen2", first_layer_class=Qwen2FastMTPLayer
+    ),
+}
+
+if base_components.HAS_QWEN3_NEXT:
+    from transformers.models.qwen3_next.modeling_qwen3_next import (
+        Qwen3NextDecoderLayer,
+        Qwen3NextRMSNorm,
+    )
+
+    class Qwen3NextFastMTPLayer(FastMTPLayerMixin, Qwen3NextDecoderLayer):  # type: ignore[valid-type]
+        """FastMTP layer for Qwen3-Next (sparse MoE) checkpoints."""
+
+        def __init__(self, config: PretrainedConfig, layer_idx: int = 0) -> None:
+            modified = copy.copy(config)
+            modified._attn_implementation = "eager"  # noqa: SLF001
+            super().__init__(modified, layer_idx)
+            self._setup_fastmtp_modules(modified, Qwen3NextRMSNorm)
+
+    fast_mtp_model_classes["qwen3_next"] = base_components.override_components(
+        "qwen3_next", first_layer_class=Qwen3NextFastMTPLayer
+    )

--- a/tests/unit/models/test_fast_mtp_config.py
+++ b/tests/unit/models/test_fast_mtp_config.py
@@ -1,0 +1,88 @@
+"""Unit tests for FastMTPConfig."""
+
+import pytest
+from pydantic import ValidationError
+from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+
+from speculators import SpeculatorModelConfig, SpeculatorsConfig, VerifierConfig
+from speculators.models.fast_mtp import FastMTPConfig
+from speculators.proposals import GreedyTokenProposalConfig
+
+_NO_VERIFIER = VerifierConfig(name_or_path=None, architectures=[])
+
+
+@pytest.fixture
+def tiny_tc():
+    return Qwen2Config(
+        hidden_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        intermediate_size=128,
+        vocab_size=256,
+        max_position_embeddings=64,
+    )
+
+
+@pytest.fixture
+def fast_mtp_config(tiny_tc):
+    return FastMTPConfig(
+        transformer_layer_config=tiny_tc,
+        speculators_config=SpeculatorsConfig(
+            algorithm="mtp",
+            proposal_methods=[GreedyTokenProposalConfig(speculative_tokens=3)],
+            default_proposal_method="greedy",
+            verifier=_NO_VERIFIER,
+        ),
+    )
+
+
+@pytest.mark.smoke
+def test_vocab_size_derived_from_transformer_config(fast_mtp_config):
+    assert fast_mtp_config.vocab_size == 256
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize("n", [1, 2, 3, 5])
+def test_num_speculative_steps_derived_from_proposal_config(tiny_tc, n):
+    config = FastMTPConfig(
+        transformer_layer_config=tiny_tc,
+        speculators_config=SpeculatorsConfig(
+            algorithm="mtp",
+            proposal_methods=[GreedyTokenProposalConfig(speculative_tokens=n)],
+            default_proposal_method="greedy",
+            verifier=_NO_VERIFIER,
+        ),
+    )
+    assert config.num_speculative_steps == n
+
+
+@pytest.mark.smoke
+def test_num_nextn_predict_layers_not_one_rejected(tiny_tc):
+    with pytest.raises(ValidationError, match="num_nextn_predict_layers"):
+        FastMTPConfig(
+            transformer_layer_config=tiny_tc,
+            num_nextn_predict_layers=2,
+        )
+
+
+@pytest.mark.smoke
+def test_num_nextn_predict_layers_default(fast_mtp_config):
+    assert fast_mtp_config.num_nextn_predict_layers == 1
+
+
+@pytest.mark.smoke
+def test_fast_mtp_config_registered():
+    assert SpeculatorModelConfig.registry is not None
+    assert "mtp" in SpeculatorModelConfig.registry
+    assert SpeculatorModelConfig.registry["mtp"] is FastMTPConfig
+
+
+@pytest.mark.smoke
+def test_fast_mtp_config_round_trip(fast_mtp_config):
+    config_dict = fast_mtp_config.model_dump()
+    reloaded = SpeculatorModelConfig.model_validate(config_dict)
+    assert isinstance(reloaded, FastMTPConfig)
+    assert reloaded.speculators_model_type == "mtp"
+    assert reloaded.vocab_size == fast_mtp_config.vocab_size
+    assert reloaded.hidden_size == fast_mtp_config.hidden_size

--- a/tests/unit/models/test_fast_mtp_model.py
+++ b/tests/unit/models/test_fast_mtp_model.py
@@ -1,0 +1,248 @@
+"""Unit tests for FastMTPSpeculator model."""
+
+import pytest
+import torch
+from torch import nn
+from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+
+from speculators import SpeculatorModel, SpeculatorsConfig, VerifierConfig
+from speculators.models.fast_mtp import FastMTPConfig, FastMTPSpeculator
+from speculators.proposals import GreedyTokenProposalConfig
+
+_NO_VERIFIER = VerifierConfig(name_or_path=None, architectures=[])
+
+HIDDEN_SIZE = 64
+VOCAB_SIZE = 256
+NUM_STEPS = 3
+BATCH_SIZE = 2
+SEQ_LEN = 12  # must satisfy SEQ_LEN > NUM_STEPS + 2
+
+
+@pytest.fixture
+def tiny_tc():
+    return Qwen2Config(
+        hidden_size=HIDDEN_SIZE,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        intermediate_size=128,
+        vocab_size=VOCAB_SIZE,
+        max_position_embeddings=64,
+    )
+
+
+@pytest.fixture
+def fast_mtp_config(tiny_tc):
+    return FastMTPConfig(
+        transformer_layer_config=tiny_tc,
+        speculators_config=SpeculatorsConfig(
+            algorithm="mtp",
+            proposal_methods=[GreedyTokenProposalConfig(speculative_tokens=NUM_STEPS)],
+            default_proposal_method="greedy",
+            verifier=_NO_VERIFIER,
+        ),
+    )
+
+
+@pytest.fixture
+def model(fast_mtp_config):
+    m = FastMTPSpeculator(fast_mtp_config)
+    m.eval()
+    return m
+
+
+@pytest.fixture
+def inputs():
+    torch.manual_seed(42)
+    input_ids = torch.randint(0, VOCAB_SIZE, (BATCH_SIZE, SEQ_LEN))
+    hidden_states = torch.randn(BATCH_SIZE, SEQ_LEN, HIDDEN_SIZE)
+    return input_ids, hidden_states
+
+
+@pytest.mark.smoke
+def test_embed_tokens_always_initialized(model):
+    assert isinstance(model.embed_tokens, nn.Embedding)
+    assert model.embed_tokens.weight.shape == (VOCAB_SIZE, HIDDEN_SIZE)
+
+
+@pytest.mark.smoke
+def test_lm_head_always_initialized(model):
+    assert isinstance(model.lm_head, nn.Linear)
+    assert model.lm_head.weight.shape == (VOCAB_SIZE, HIDDEN_SIZE)
+    assert model.lm_head.bias is None
+
+
+@pytest.mark.smoke
+def test_mtp_layers_initialized(model):
+    assert len(model.mtp_layers) == 1
+
+
+@pytest.mark.smoke
+def test_registry():
+    assert SpeculatorModel.registry is not None
+    assert "mtp" in SpeculatorModel.registry
+    assert SpeculatorModel.registry["mtp"] is FastMTPSpeculator
+
+
+@pytest.mark.smoke
+def test_output_shapes_no_labels(model, inputs):
+    # At step k: valid_len = seq_len - k - 2 (one for embed offset, one for label).
+    input_ids, hidden_states = inputs
+    with torch.no_grad():
+        out = model(input_ids=input_ids, hidden_states=hidden_states)
+
+    assert "logits_list" in out
+    assert len(out["logits_list"]) == NUM_STEPS
+    assert out["loss"] is None
+
+    for step, logits in enumerate(out["logits_list"]):
+        expected_len = SEQ_LEN - step - 2
+        assert logits.shape == (BATCH_SIZE, expected_len, VOCAB_SIZE), (
+            f"step {step}: got {list(logits.shape)}, "
+            f"expected [{BATCH_SIZE}, {expected_len}, {VOCAB_SIZE}]"
+        )
+
+
+@pytest.mark.smoke
+def test_no_nan_inf_in_logits(model, inputs):
+    input_ids, hidden_states = inputs
+    with torch.no_grad():
+        out = model(input_ids=input_ids, hidden_states=hidden_states)
+    for step, logits in enumerate(out["logits_list"]):
+        assert not torch.isnan(logits).any(), f"NaN in step {step} logits"
+        assert not torch.isinf(logits).any(), f"Inf in step {step} logits"
+
+
+@pytest.mark.smoke
+def test_recursive_hidden_states(model, inputs):
+    """Verify step 1's hidden input is step 0's MTP output, not the original hidden.
+
+    FastMTP is recursive: each step conditions on the speculated future rather than
+    the original verifier context. This test verifies that property is live.
+    """
+    input_ids, hidden_states = inputs
+
+    layer_inputs: list[torch.Tensor] = []
+    layer_outputs: list[torch.Tensor] = []
+    original_forward = model.mtp_layers[0].forward
+
+    def capturing_forward(*args, **kwargs):
+        # hidden_states is always passed as a keyword argument from core.py
+        hs = kwargs.get("hidden_states", args[0] if args else None)
+        layer_inputs.append(hs.detach().clone())
+        result = original_forward(*args, **kwargs)
+        layer_outputs.append(result.detach().clone())
+        return result
+
+    model.mtp_layers[0].forward = capturing_forward
+    try:
+        with torch.no_grad():
+            model(input_ids=input_ids, hidden_states=hidden_states)
+    finally:
+        model.mtp_layers[0].forward = original_forward
+
+    assert len(layer_inputs) == NUM_STEPS
+
+    # Step 0: input must be the original verifier hidden, trimmed to valid_len.
+    valid_len_0 = SEQ_LEN - 2
+    assert torch.allclose(layer_inputs[0], hidden_states[:, :valid_len_0])
+
+    # Step 1: input must be step 0's MTP output, trimmed to the next valid_len.
+    # This is the recursive property: mtp_output[step] feeds hidden[step+1].
+    valid_len_1 = SEQ_LEN - 3
+    assert torch.allclose(layer_inputs[1], layer_outputs[0][:, :valid_len_1])
+
+    # Sanity: step 1's input must differ from the original hidden at the same positions,
+    # confirming the MTP layer actually transforms its input.
+    assert not torch.allclose(layer_inputs[1], hidden_states[:, :valid_len_1]), (
+        "step 1 hidden equals original verifier hidden — recursive update is not live"
+    )
+
+
+@pytest.mark.smoke
+def test_loss_is_finite_with_labels(model, inputs):
+    input_ids, hidden_states = inputs
+    labels = input_ids.clone()
+    with torch.no_grad():
+        out = model(input_ids=input_ids, hidden_states=hidden_states, labels=labels)
+    assert out["loss"] is not None
+    assert torch.isfinite(out["loss"])
+    assert out["loss"].item() > 0
+
+
+@pytest.mark.smoke
+def test_loss_metrics_per_step(model, inputs):
+    input_ids, hidden_states = inputs
+    labels = input_ids.clone()
+    with torch.no_grad():
+        out = model(input_ids=input_ids, hidden_states=hidden_states, labels=labels)
+    for step in range(NUM_STEPS):
+        key = f"loss_step_{step}"
+        assert key in out["metrics"], f"Missing {key} in metrics"
+        assert torch.isfinite(torch.tensor(out["metrics"][key]))
+
+
+@pytest.mark.smoke
+def test_loss_mask_all_ones_equals_no_mask(model, inputs):
+    """An all-ones mask must produce identical loss to no mask at all.
+
+    This holds because no label positions are set to -100 when every mask bit is 1.
+    """
+    input_ids, hidden_states = inputs
+    labels = input_ids.clone()
+
+    with torch.no_grad():
+        out_no_mask = model(
+            input_ids=input_ids, hidden_states=hidden_states, labels=labels
+        )
+        out_ones_mask = model(
+            input_ids=input_ids,
+            hidden_states=hidden_states,
+            labels=labels,
+            loss_mask=torch.ones_like(labels),
+        )
+
+    assert torch.allclose(out_no_mask["loss"], out_ones_mask["loss"], atol=1e-6)
+
+
+@pytest.mark.smoke
+def test_loss_mask_partial_differs_from_full(model, inputs):
+    """Masking out half the sequence positions must change the loss.
+
+    This verifies that masked positions are actually excluded, not just weighted down.
+    """
+    input_ids, hidden_states = inputs
+    labels = input_ids.clone()
+
+    half_mask = torch.zeros_like(labels)
+    half_mask[:, SEQ_LEN // 2 :] = 1
+
+    with torch.no_grad():
+        out_full = model(
+            input_ids=input_ids, hidden_states=hidden_states, labels=labels
+        )
+        out_partial = model(
+            input_ids=input_ids,
+            hidden_states=hidden_states,
+            labels=labels,
+            loss_mask=half_mask,
+        )
+
+    assert not torch.allclose(out_full["loss"], out_partial["loss"], atol=1e-6), (
+        "partial loss_mask produced identical loss to no mask — masking has no effect"
+    )
+
+
+@pytest.mark.smoke
+def test_get_trainer_kwargs_uses_provided_weights():
+    weights = [0.6, 0.3, 0.1]
+    train_kw, val_kw = FastMTPSpeculator.get_trainer_kwargs(step_weights=weights)
+    assert train_kw["step_weights"] == weights
+    assert val_kw["step_weights"] == weights
+
+
+@pytest.mark.smoke
+def test_get_trainer_kwargs_falls_back_to_paper_defaults():
+    train_kw, val_kw = FastMTPSpeculator.get_trainer_kwargs()
+    assert train_kw["step_weights"] == [0.51, 0.31, 0.18]
+    assert val_kw["step_weights"] == [0.51, 0.31, 0.18]


### PR DESCRIPTION
## Motivation

Multi-token prediction (MTP) heads are now standard in frontier models (DeepSeek-V3,
Qwen3, TencentBAC MiMo), but each ships in its own bespoke checkpoint format with
no standardized inference or fine-tuning interface. Loading them today requires either
the originating codebase or a custom conversion script.

This PR adds `FastMTPSpeculator` — a Hugging Face-compatible MTP module in the
speculators format. It provides:

1. A generic MTP layer definition suitable for fine-tuning from scratch or continued
   training on top of converted upstream checkpoints.
2. A registered config (`"mtp"`) and model (`FastMTPSpeculator`) that integrate with
   `SpeculatorModel.from_pretrained` and the existing vLLM deployment path.
3. Weight key normalization utilities to support the conversion pipeline that maps
   upstream checkpoint formats (MiMo, Qwen3-Next, DeepSeek) into the speculators format.

> **Note:** Upstream checkpoints require a conversion step before they can be loaded
> directly by speculators. The conversion utilities are part of a separate script;
> this PR defines the target format and module.

## What This PR Does

### `FastMTPConfig` — configuration

Pydantic config registered as `"mtp"` under `SpeculatorModelConfig`:

- `num_speculative_steps` (default: 3, range: 1–10) — tokens predicted per forward pass
- `num_nextn_predict_layers` (always 1) — validated at construction
- `mtp_loss_step_weights` (default: `[0.51, 0.31, 0.18]`) — per-step loss weighting for training
- Standard transformer dims (`hidden_size`, `intermediate_size`, `num_attention_heads`, etc.)
- `transformer_config: PretrainedConfig` — architecture config for MTP layer components

### `FastMTPLayer` — single MTP decoder layer

A single transformer layer that fuses verifier hidden states with token embeddings to
predict the next token:

```mermaid
flowchart TD
    H["hidden_states\n(from verifier)"] --> HN["hidden_layernorm"]
    E["embed_tokens(input_ids)"] --> TN["token_layernorm"]
    HN --> CAT["Concatenate\n[hidden ‖ embed]"]
    TN --> CAT
    CAT --> PROJ["input_proj\n(2H → H, no bias)"]
    PROJ --> LN1["input_layernorm"]
    LN1 --> ATT["Self-Attention\n+ RotaryEmb"]
    ATT --> RES1["+ residual"]
    RES1 --> LN2["post_attention_layernorm"]
    LN2 --> MLP["MLP / SparseMoeBlock"]
    MLP --> RES2["+ residual"]
    RES2 --> LN3["final_layernorm"]
    LN3 --> OUT["layer output"]
```

### `FastMTPSpeculator` — multi-step predictor

Performs `num_speculative_steps` auto-regressive passes, each using the previous
step's argmax output as the next input:

```
for step in range(num_speculative_steps):
    layer_out = FastMTPLayer(input_ids, hidden_states)
    logits    = lm_head(layer_out)          # shared with verifier
    loss     += weight[step] * CE(logits, labels[step+1:])
    input_ids = argmax(logits)              # feeds next step
    hidden_states = layer_out
```

`embed_tokens` and `lm_head` are shared with the verifier model and frozen during
training.

### Architecture-agnostic component registry

`FastMTPComponents` maps architecture names to their concrete module classes:

| Architecture | Attention | MLP | Norm | MoE |
|---|---|---|---|---|
| `mimo` | `Qwen2Attention` | `Qwen2MLP` | `Qwen2RMSNorm` | No |
| `qwen3_next` | `Qwen3NextAttention` | `Qwen3NextSparseMoeBlock` | `Qwen3NextRMSNorm` | Yes |

New architectures can be added by registering a new entry — no changes to the forward pass.

### Checkpoint key normalization

`normalize_weight_key` maps weight keys from upstream checkpoint formats into the
speculators key namespace, which is used by the conversion pipeline:

| Source format | Example key | Speculators key |
|---|---|---|
| `qwen3_next` | `mtp.layers.0.self_attn.q_proj.weight` | `model.mtp_layers.0.self_attn.q_proj.weight` |
| `qwen3_next` | `mtp.fc.weight` | `model.mtp_layers.0.input_proj.weight` |
| `qwen3_next` | `mtp.norm.weight` | `model.mtp_layers.0.final_layernorm.weight` |
| `deepseek` | `mtp.<component>` | `model.mtp_layers.0.<component>` |

### `MiMoConfig` — AutoConfig shim

Registers `model_type="mimo"` with `transformers.CONFIG_MAPPING` so TencentBAC
MiMo checkpoints can be loaded via `AutoConfig` without requiring their patched
transformers fork.

## Test Checkpoints

Integration tests run against two HuggingFace-hosted test checkpoints that have
already been converted to the speculators format:

- [`inference-optimization/test_tencentbac_fastmtp`](https://huggingface.co/inference-optimization/test_tencentbac_fastmtp) — MiMo/TencentBAC (Qwen2-based)
- [`inference-optimization/test_qwen3_next_mtp`](https://huggingface.co/inference-optimization/test_qwen3_next_mtp) — Qwen3-Next (MoE)

## Testing

```bash
# Integration tests (requires GPU)
CUDA_VISIBLE_DEVICES=3 pytest tests/integration/models/test_fast_mtp_model.py -v --tb=short
```

Tests validate for both checkpoint formats:
- `from_pretrained` loads `FastMTPSpeculator` with the correct config type
- Forward pass completes with mock `embed_tokens` / `lm_head` in detached mode
- `logits_list` has length == `num_speculative_steps`
- Each logits tensor has shape `(batch, seq_len, vocab_size)`
- No NaN or Inf values in any output tensor

## Files Changed

| File | Change |
|---|---|
| `src/speculators/models/fast_mtp/config.py` | `FastMTPConfig` with Pydantic validators |
| `src/speculators/models/fast_mtp/core.py` | `FastMTPLayer` + `FastMTPSpeculator` |
| `src/speculators/models/fast_mtp/model_definitions.py` | `FastMTPComponents` registry (mimo, qwen3_next) |
| `src/speculators/models/fast_mtp/mimo_config.py` | `MiMoConfig` AutoConfig shim |
| `src/speculators/models/fast_mtp/__init__.py` | Package exports |
| `src/speculators/models/__init__.py` | Auto-import for registry |
| `src/speculators/model.py` | Handle `speculators_config=None` edge case |
| `tests/integration/models/test_fast_mtp_model.py` | Parametrized integration tests |