### PR TITLE
Fix AdamW optimizer init to use parameters()

### DIFF
--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -114,7 +114,7 @@ class Trainer:
 
     def setup_optimizer(self):
         # Setup optimizer
-        self.opt = torch.optim.AdamW(self.model.named_parameters(), lr=self.config.lr)
+        self.opt = torch.optim.AdamW(self.model.parameters(), lr=self.config.lr)
         last_epoch = -1
         if self.resume_from_checkpoint and self.checkpointer.previous_epoch != -1:
             self.checkpointer.load_optimizer_state_dict(self.model, self.opt)


### PR DESCRIPTION
## Why                                                                                                                                                          
  
named_parameters() yields (name, param) tuples, but AdamW expects bare parameter tensors.                                                                    
                                                                
## How

- Replace named_parameters() with parameters() in trainer optimizer setup