### PR TITLE
feat: add warm-start/fine-tuning support for pretrained EAGLE3 models

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -266,6 +266,7 @@ The scripts has the following optional arguments:
 - `--num-layers`: The number of layers to use. Defaults to 1.
 - `--d2t-path`: The path to the d2t tensor. Defaults to `d2t.npy`.
 - `--t2d-path`: The path to the t2d tensor. Defaults to `t2d.npy`.
+- `--pretrained-model-path`: Path to a pretrained speculator model directory or HuggingFace Hub ID for warm-start/fine-tuning. When provided, d2t/t2d mappings, model config, and weights are loaded from this model. Overrides `--d2t-path` and `--t2d-path`.
 - `--ttt-steps`: The number of TTT steps to use. Defaults to 3.
 - `--ttt-step-loss-decay`: The loss decay factor to use for the TTT steps. Defaults to 1.0.
 
@@ -289,6 +290,26 @@ torchrun --nnodes=1 --nproc_per_node=8 scripts/train.py \
     --ttt-steps 3 \
     --ttt-step-loss-decay 1.0
 ```
+
+### Fine-tuning from Pretrained
+
+To fine-tune an existing speculator model (e.g., from HuggingFace Hub) on new domain-specific data:
+
+```bash
+python scripts/train.py \
+    --verifier-name-or-path meta-llama/Llama-3.1-8B-Instruct \
+    --pretrained-model-path RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3 \
+    --data-path ./new_domain_data \
+    --save-path ./checkpoints/finetuned \
+    --epochs 5 \
+    --lr 5e-5
+```
+
+When `--pretrained-model-path` is provided:
+- Vocabulary mappings (`d2t`/`t2d`) are automatically extracted from the pretrained model
+- The model architecture config is preserved from the pretrained model
+- Model weights are loaded for warm-start, while optimizer/scheduler states start fresh
+- `--d2t-path` and `--t2d-path` are not needed (and will be rejected if also specified)
 
 ## E2E Pipeline
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import random
 import warnings
 
@@ -9,6 +10,7 @@ from transformers import LlamaConfig, PretrainedConfig
 from transformers.models.auto.configuration_auto import AutoConfig
 from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 
+from speculators.config import SpeculatorModelConfig
 from speculators.model import SpeculatorModel
 from speculators.train.data import (
     Eagle3SampleFileDataset,
@@ -23,6 +25,13 @@ from speculators.train.logger import setup_metric_logger, setup_root_logger
 from speculators.train.noise_transforms import AddUniformNoise
 from speculators.train.trainer import Trainer, TrainerConfig
 from speculators.train.utils import maybe_destroy_distributed, maybe_setup_distributed
+from speculators.utils.loading import (
+    extract_vocab_mappings,
+    load_full_state_dict,
+    load_pretrained_weights,
+)
+
+logger = logging.getLogger(__name__)
 
 DRAFT_ARCH_CONFIGS: dict[str, type] = {
     "llama": LlamaConfig,
@@ -41,6 +50,104 @@ def set_seed(seed: int, deterministic: bool = False):
         # For deterministic behavior (may impact performance)
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
+
+
+def load_pretrained_model(
+    pretrained_path: str, device: torch.device
+) -> tuple[dict[str, torch.Tensor], torch.Tensor, torch.Tensor, int]:
+    """Load pretrained speculator model and extract components.
+
+    :param pretrained_path: Path to local directory or HuggingFace Hub model ID
+    :param device: Device to move vocab mapping tensors to
+    :return: Tuple of (state_dict, d2t, t2d, draft_vocab_size)
+    """
+    logger.info(f"Loading pretrained model from {pretrained_path}")
+
+    # Load full state dict
+    state_dict = load_full_state_dict(pretrained_path)
+
+    # Extract vocab mappings (removes d2t/t2d from state_dict in-place)
+    d2t, t2d = extract_vocab_mappings(state_dict, device)
+
+    # Derive draft_vocab_size
+    draft_vocab_size = d2t.shape[0]
+    logger.info(f"Derived draft_vocab_size={draft_vocab_size}")
+
+    return state_dict, d2t, t2d, draft_vocab_size
+
+
+def load_vocab_mappings(
+    d2t_path: str, t2d_path: str, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Load vocabulary mappings from numpy files.
+
+    :param d2t_path: Path to draft-to-target mapping numpy file
+    :param t2d_path: Path to target-to-draft mapping numpy file
+    :param device: Device to move tensors to
+    :return: Tuple of (d2t, t2d, draft_vocab_size)
+    :raises ValueError: If both paths are not provided
+    """
+    if not (d2t_path and t2d_path):
+        raise ValueError(
+            "Both d2t and t2d paths must be provided together. "
+            f"Got d2t={'provided' if d2t_path else 'missing'}, "
+            f"t2d={'provided' if t2d_path else 'missing'}"
+        )
+
+    d2t = torch.from_numpy(np.load(d2t_path)).to(device)
+    t2d = torch.from_numpy(np.load(t2d_path)).to(device)
+    draft_vocab_size = d2t.shape[0]
+
+    return d2t, t2d, draft_vocab_size
+
+
+def initialize_vocab_config(
+    args: argparse.Namespace, device: torch.device
+) -> tuple[
+    torch.Tensor | None,
+    torch.Tensor | None,
+    int,
+    dict[str, torch.Tensor] | None,
+]:
+    """Initialize vocabulary configuration from args.
+
+    Handles three modes:
+    1. From pretrained model (--pretrained-model-path): loads d2t/t2d + weights
+    2. From numpy files (--d2t-path, --t2d-path): loads d2t/t2d only
+    3. No vocab mapping: uses full verifier vocab
+
+    :param args: Parsed command-line arguments
+    :param device: Device to move tensors to
+    :return: Tuple of (d2t, t2d, draft_vocab_size, pretrained_state_dict)
+    :raises ValueError: If conflicting arguments are provided
+    """
+    # Check for conflicting args
+    if args.pretrained_model_path and (args.d2t_path or args.t2d_path):
+        raise ValueError(
+            "--pretrained-model-path overrides --d2t-path and "
+            "--t2d-path. Please remove --d2t-path and --t2d-path."
+        )
+
+    # Load from pretrained model
+    if args.pretrained_model_path:
+        state_dict, d2t, t2d, vocab_size = load_pretrained_model(
+            args.pretrained_model_path, device
+        )
+        return d2t, t2d, vocab_size, state_dict
+
+    # Load from numpy files
+    if args.d2t_path or args.t2d_path:
+        d2t, t2d, vocab_size = load_vocab_mappings(
+            args.d2t_path, args.t2d_path, device
+        )
+        return d2t, t2d, vocab_size, None
+
+    # No vocab mapping provided — use full verifier vocab
+    verifier_config = AutoConfig.from_pretrained(args.verifier_name_or_path)
+    if hasattr(verifier_config, "text_config"):
+        verifier_config = verifier_config.text_config
+
+    return None, None, verifier_config.vocab_size, None
 
 
 def setup_dataloader(
@@ -151,30 +258,24 @@ def main(args: argparse.Namespace):
     local_rank, world_size, rank, is_distributed = maybe_setup_distributed()
     device = torch.device(local_rank)
 
-    # Load t2d and d2t tensors if provided
-    if args.d2t_path or args.t2d_path:
-        if not (args.d2t_path and args.t2d_path):
-            raise ValueError(
-                "Both t2d and d2t must be provided together, or both must be omitted. "
-                f"Got t2d={'provided' if args.t2d_path is not None else 'not provided'}"
-                f"d2t={'provided' if args.d2t_path is not None else 'not provided'}"
-            )
-        d2t = torch.from_numpy(np.load(args.d2t_path)).to(device)
-        t2d = torch.from_numpy(np.load(args.t2d_path)).to(device)
-        draft_vocab_size = d2t.shape[0]
-    else:
-        d2t = None
-        t2d = None
-        # When vocab mapping is not provided, use the full verifier vocab
-        verifier_config = AutoConfig.from_pretrained(args.verifier_name_or_path)
-        if hasattr(verifier_config, "text_config"):
-            verifier_config = verifier_config.text_config
-        draft_vocab_size = verifier_config.vocab_size
+    # Initialize vocabulary configuration
+    d2t, t2d, draft_vocab_size, pretrained_state_dict = initialize_vocab_config(
+        args, device
+    )
 
     # Setup speculator config
-    transformer_layer_config = create_transformer_layer_config(
-        args.verifier_name_or_path, args.num_layers, draft_arch=args.draft_arch
-    )
+    # If fine-tuning, preserve the transformer_layer_config from pretrained model
+    if args.pretrained_model_path:
+        pretrained_config = SpeculatorModelConfig.from_pretrained(
+            args.pretrained_model_path
+        )
+        transformer_layer_config = pretrained_config.transformer_layer_config
+        transformer_layer_config._attn_implementation = "simple_flex_attention"  # noqa: SLF001
+        logger.info("Using transformer_layer_config from pretrained model")
+    else:
+        transformer_layer_config = create_transformer_layer_config(
+            args.verifier_name_or_path, args.num_layers, draft_arch=args.draft_arch
+        )
 
     # Get model class from registry and create model using its factory method
     if SpeculatorModel.registry_auto_discovery:
@@ -194,6 +295,12 @@ def main(args: argparse.Namespace):
         draft_vocab_size=draft_vocab_size,
         **vars(args),
     )
+
+    # Load pretrained weights if provided (for fine-tuning)
+    if pretrained_state_dict is not None:
+        load_pretrained_weights(
+            draft_model, pretrained_state_dict, args.pretrained_model_path
+        )
 
     # Setup dataloaders
     train_files, val_files = split_files(args.data_path, ratio=0.9)
@@ -276,6 +383,18 @@ def parse_args():
     )
     parser.add_argument("--d2t-path", type=str, default=None)
     parser.add_argument("--t2d-path", type=str, default=None)
+    parser.add_argument(
+        "--pretrained-model-path",
+        type=str,
+        default=None,
+        help=(
+            "Path to pretrained speculator model directory or HuggingFace Hub ID "
+            "(e.g., RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3). "
+            "When provided, d2t/t2d mappings, model config, and weights "
+            "are loaded from this model, enabling warm-start/fine-tuning. "
+            "Overrides --d2t-path and --t2d-path."
+        ),
+    )
     parser.add_argument("--ttt-steps", type=int, default=3)
     parser.add_argument("--ttt-step-loss-decay", type=float, default=1.0)
     parser.add_argument(

--- a/src/speculators/utils/loading.py
+++ b/src/speculators/utils/loading.py
@@ -1,12 +1,20 @@
+from __future__ import annotations
+
 import json
+import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
-from huggingface_hub import hf_hub_download
-from huggingface_hub.errors import EntryNotFoundError
+from huggingface_hub import hf_hub_download, snapshot_download
+from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
 from loguru import logger
 from safetensors import safe_open
+
+if TYPE_CHECKING:
+    from speculators import SpeculatorModel
+
+std_logger = logging.getLogger(__name__)
 
 
 def load_model_layers(
@@ -88,3 +96,196 @@ def _resolve_file(model_path: str, file_name: str) -> Path:
     # Treat as repo_id on the Hub
     logger.info(f"Loading from huggingface directory: {model_path}: {file_name}")
     return Path(hf_hub_download(repo_id=model_path, filename=file_name))
+
+
+def load_full_state_dict(model_path: str) -> dict[str, torch.Tensor]:
+    """Load complete state dict from safetensors format (single or sharded).
+
+    Supports both local paths and HuggingFace Hub model IDs.
+
+    :param model_path: Path to local directory OR HuggingFace Hub model ID
+    :return: Dictionary mapping parameter names to tensors (on CPU)
+    :raises FileNotFoundError: If no safetensors files found
+    """
+    resolved_path = _resolve_model_path(model_path)
+
+    # Try loading as single file first
+    single_file = resolved_path / "model.safetensors"
+    if single_file.exists():
+        return _load_single_safetensors(single_file)
+
+    # Try loading as sharded
+    index_file = resolved_path / "model.safetensors.index.json"
+    if index_file.exists():
+        return _load_sharded_safetensors(resolved_path, index_file)
+
+    raise FileNotFoundError(
+        f"No safetensors files found in {model_path}. "
+        "Expected 'model.safetensors' or 'model.safetensors.index.json'"
+    )
+
+
+def _resolve_model_path(model_path: str) -> Path:
+    """Resolve model path from local directory or HF Hub."""
+    path = Path(model_path)
+
+    if path.exists():
+        return path
+
+    # Try to download from HF Hub
+    try:
+        std_logger.info(f"Downloading from HuggingFace Hub: {model_path}")
+        local_dir = snapshot_download(
+            repo_id=model_path,
+            allow_patterns=["*.safetensors", "*.json"],
+            ignore_patterns=["*.msgpack", "*.h5", "*.bin"],
+        )
+        return Path(local_dir)
+    except RepositoryNotFoundError as e:
+        raise FileNotFoundError(
+            f"Model not found at local path '{model_path}' "
+            f"and not found on HuggingFace Hub"
+        ) from e
+
+
+def _load_single_safetensors(file_path: Path) -> dict[str, torch.Tensor]:
+    """Load tensors from a single safetensors file."""
+    std_logger.info(f"Loading single safetensors file: {file_path}")
+    state_dict: dict[str, torch.Tensor] = {}
+    with safe_open(str(file_path), framework="pt", device="cpu") as f:
+        for key in f.keys():  # noqa: SIM118
+            state_dict[key] = f.get_tensor(key)
+    return state_dict
+
+
+def _load_sharded_safetensors(
+    model_dir: Path, index_file: Path
+) -> dict[str, torch.Tensor]:
+    """Load tensors from sharded safetensors files."""
+    std_logger.info(f"Loading sharded safetensors from {model_dir}")
+
+    with index_file.open() as f:
+        index = json.load(f)
+
+    weight_map = index.get("weight_map", {})
+    if not weight_map:
+        raise ValueError(f"index.json contains no weight_map: {index_file}")
+
+    # Collect unique shard files
+    shard_files = set(weight_map.values())
+
+    # Load tensors from all shards
+    state_dict: dict[str, torch.Tensor] = {}
+    for shard_file in sorted(shard_files):
+        shard_path = model_dir / shard_file
+        if not shard_path.exists():
+            raise FileNotFoundError(f"Shard file not found: {shard_path}")
+
+        std_logger.info(f"  Loading shard: {shard_file}")
+        with safe_open(str(shard_path), framework="pt", device="cpu") as f:
+            for key in f.keys():  # noqa: SIM118
+                if weight_map.get(key) == shard_file:
+                    state_dict[key] = f.get_tensor(key)
+
+    return state_dict
+
+
+def extract_vocab_mappings(
+    state_dict: dict[str, torch.Tensor], device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Extract d2t and t2d vocabulary mappings from a speculator state dict.
+
+    The mappings are removed from the state dict in-place so that the remaining
+    keys can be loaded directly into a model without conflicts.
+
+    :param state_dict: Model state dictionary (modified in-place)
+    :param device: Device to move tensors to
+    :return: Tuple of (d2t, t2d) tensors
+    :raises ValueError: If d2t or t2d not found in state dict
+    """
+    d2t_key = _find_exact_key(state_dict, "d2t")
+    t2d_key = _find_exact_key(state_dict, "t2d")
+
+    std_logger.info(f"Extracting d2t from: {d2t_key}")
+    std_logger.info(f"Extracting t2d from: {t2d_key}")
+
+    d2t = state_dict.pop(d2t_key).to(device)
+    t2d = state_dict.pop(t2d_key).to(device)
+
+    _validate_mapping_tensor(d2t, "d2t")
+    _validate_mapping_tensor(t2d, "t2d")
+
+    std_logger.info(f"d2t shape: {d2t.shape}, t2d shape: {t2d.shape}")
+
+    return d2t, t2d
+
+
+def _find_exact_key(state_dict: dict[str, torch.Tensor], target: str) -> str:
+    """Find exact match for key in state dict (case-insensitive).
+
+    :param state_dict: Model state dictionary
+    :param target: Target key name to find
+    :return: Matching key from state dict
+    :raises ValueError: If exact match not found
+    """
+    for key in state_dict:
+        if key.lower() == target.lower():
+            return key
+
+    available_keys = list(state_dict.keys())[:20]
+    raise ValueError(
+        f"Key '{target}' not found in state dict. "
+        f"Available keys sample: {available_keys}..."
+    )
+
+
+def _validate_mapping_tensor(tensor: torch.Tensor, name: str) -> None:
+    """Validate vocabulary mapping tensor shape.
+
+    :param tensor: Tensor to validate
+    :param name: Name for error messages
+    :raises ValueError: If tensor is not 1D
+    """
+    if tensor.dim() != 1:
+        raise ValueError(
+            f"Unexpected {name} shape: {tensor.shape}. Expected 1D tensor."
+        )
+
+
+def load_pretrained_weights(
+    model: SpeculatorModel,
+    state_dict: dict[str, torch.Tensor],
+    model_path: str,
+) -> None:
+    """Load pretrained weights into model with validation.
+
+    :param model: Model to load weights into
+    :param state_dict: State dictionary from pretrained model
+    :param model_path: Path or identifier of the pretrained model (for logging)
+    """
+    std_logger.info(f"Loading pretrained weights from {model_path}")
+    std_logger.info(f"Parameters to load: {len(state_dict)}")
+
+    # Load with strict=False (d2t/t2d already passed to constructor)
+    missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
+
+    # Build set of legitimately missing keys
+    expected_missing = {"t2d", "d2t", "verifier_lm_head.weight"}
+    model_ignored = getattr(model, "_keys_to_ignore_on_load_missing", [])
+    expected_missing.update(model_ignored)
+
+    # Filter problematic missing keys
+    problematic = [k for k in missing_keys if k not in expected_missing]
+
+    if problematic:
+        std_logger.warning(f"Unexpected missing keys: {problematic}")
+    if unexpected_keys:
+        std_logger.warning(f"Unexpected keys in checkpoint: {unexpected_keys}")
+
+    if problematic or unexpected_keys:
+        std_logger.warning(
+            "Weight loading completed with warnings. "
+            "May indicate architecture mismatch."
+        )
+    else:
+        std_logger.info("Successfully loaded all pretrained weights")

--- a/tests/unit/train/test_pretrained_loading.py
+++ b/tests/unit/train/test_pretrained_loading.py
@@ -1,0 +1,225 @@
+"""Unit tests for pretrained model loading in scripts/train.py."""
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from scripts.train import (
+    initialize_vocab_config,
+    load_pretrained_model,
+    load_vocab_mappings,
+)
+
+
+# --- load_vocab_mappings ---
+
+
+class TestLoadVocabMappings:
+    def test_success(self, tmp_path):
+        """Loads d2t/t2d from numpy files with correct shapes and values."""
+        d2t_path = tmp_path / "d2t.npy"
+        t2d_path = tmp_path / "t2d.npy"
+        np.save(d2t_path, np.arange(100))
+        np.save(t2d_path, np.arange(128))
+
+        device = torch.device("cpu")
+        d2t, t2d, vocab_size = load_vocab_mappings(
+            str(d2t_path), str(t2d_path), device
+        )
+
+        assert d2t.shape == (100,)
+        assert t2d.shape == (128,)
+        assert vocab_size == 100
+        assert d2t.device == device
+        assert t2d.device == device
+        assert torch.equal(d2t, torch.arange(100))
+        assert torch.equal(t2d, torch.arange(128))
+
+    @pytest.mark.parametrize(
+        ("d2t_path", "t2d_path"),
+        [
+            (None, "/path/to/t2d.npy"),
+            ("/path/to/d2t.npy", None),
+            (None, None),
+            ("", "/path/to/t2d.npy"),
+        ],
+        ids=["missing_d2t", "missing_t2d", "both_missing", "empty_d2t"],
+    )
+    def test_requires_both_paths(self, d2t_path, t2d_path):
+        """Rejects when d2t or t2d path is missing or empty."""
+        with pytest.raises(ValueError, match="Both d2t and t2d paths must be provided"):
+            load_vocab_mappings(d2t_path, t2d_path, torch.device("cpu"))  # type: ignore[arg-type]
+
+    def test_file_not_found(self, tmp_path):
+        """Rejects when numpy files do not exist."""
+        with pytest.raises(FileNotFoundError):
+            load_vocab_mappings(
+                str(tmp_path / "no_d2t.npy"),
+                str(tmp_path / "no_t2d.npy"),
+                torch.device("cpu"),
+            )
+
+    def test_2d_arrays(self, tmp_path):
+        """Supports 2D arrays; vocab_size is first dimension."""
+        np.save(tmp_path / "d2t.npy", np.arange(200).reshape(100, 2))
+        np.save(tmp_path / "t2d.npy", np.arange(256).reshape(128, 2))
+        d2t, t2d, vocab_size = load_vocab_mappings(
+            str(tmp_path / "d2t.npy"), str(tmp_path / "t2d.npy"), torch.device("cpu")
+        )
+        assert d2t.shape == (100, 2)
+        assert t2d.shape == (128, 2)
+        assert vocab_size == 100
+
+
+# --- load_pretrained_model ---
+
+
+class TestLoadPretrainedModel:
+    @patch("scripts.train.load_full_state_dict")
+    @patch("scripts.train.extract_vocab_mappings")
+    def test_success(self, mock_extract, mock_load_state):
+        """Loads pretrained model; returns state_dict, d2t, t2d, vocab_size."""
+        mock_load_state.return_value = {"layer.weight": torch.randn(10, 10)}
+        mock_d2t, mock_t2d = torch.arange(100), torch.arange(128)
+        mock_extract.return_value = (mock_d2t, mock_t2d)
+
+        device = torch.device("cpu")
+        state_dict, d2t, t2d, vocab_size = load_pretrained_model(
+            "/path/to/model", device
+        )
+
+        mock_load_state.assert_called_once_with("/path/to/model")
+        mock_extract.assert_called_once()
+        assert torch.equal(d2t, mock_d2t)
+        assert torch.equal(t2d, mock_t2d)
+        assert vocab_size == 100
+
+    @patch("scripts.train.load_full_state_dict")
+    @patch("scripts.train.extract_vocab_mappings")
+    def test_vocab_size_from_d2t(self, mock_extract, mock_load_state):
+        """vocab_size is derived from d2t.shape[0]."""
+        mock_load_state.return_value = {}
+        for size in [100, 256, 1024]:
+            mock_extract.return_value = (torch.arange(size), torch.arange(size * 2))
+            _, _, _, vocab_size = load_pretrained_model(
+                "/path/to/model", torch.device("cpu")
+            )
+            assert vocab_size == size
+
+
+# --- initialize_vocab_config ---
+
+
+class TestInitializeVocabConfig:
+    @pytest.mark.parametrize(
+        ("d2t_path", "t2d_path"),
+        [
+            ("/path/to/d2t.npy", "/path/to/t2d.npy"),
+            ("/path/to/d2t.npy", None),
+            (None, "/path/to/t2d.npy"),
+        ],
+        ids=["both_paths", "d2t_only", "t2d_only"],
+    )
+    def test_rejects_pretrained_plus_paths(self, d2t_path, t2d_path):
+        """Rejects when pretrained_model_path and d2t/t2d paths are both set."""
+        args = argparse.Namespace(
+            pretrained_model_path="/path/to/model",
+            d2t_path=d2t_path,
+            t2d_path=t2d_path,
+            verifier_name_or_path="meta-llama/Llama-2-7b",
+        )
+        with pytest.raises(ValueError, match="--pretrained-model-path overrides"):
+            initialize_vocab_config(args, torch.device("cpu"))
+
+    @patch("scripts.train.load_pretrained_model")
+    def test_from_pretrained(self, mock_load):
+        """Initializes from pretrained: returns d2t, t2d, vocab_size, state_dict."""
+        mock_state = {"layer": torch.randn(10, 10)}
+        mock_d2t, mock_t2d = torch.arange(100), torch.arange(128)
+        mock_load.return_value = (mock_state, mock_d2t, mock_t2d, 100)
+
+        args = argparse.Namespace(
+            pretrained_model_path="/path/to/model",
+            d2t_path=None,
+            t2d_path=None,
+            verifier_name_or_path="meta-llama/Llama-2-7b",
+        )
+        d2t, t2d, vocab_size, state_dict = initialize_vocab_config(
+            args, torch.device("cpu")
+        )
+
+        assert vocab_size == 100
+        assert state_dict == mock_state
+        assert d2t is not None
+        assert t2d is not None
+        assert torch.equal(d2t, mock_d2t)
+        assert torch.equal(t2d, mock_t2d)
+        mock_load.assert_called_once_with("/path/to/model", torch.device("cpu"))
+
+    @patch("scripts.train.load_vocab_mappings")
+    def test_from_numpy(self, mock_load_vocab):
+        """Initializes from numpy paths; state_dict is None."""
+        mock_d2t, mock_t2d = torch.arange(100), torch.arange(128)
+        mock_load_vocab.return_value = (mock_d2t, mock_t2d, 100)
+
+        args = argparse.Namespace(
+            pretrained_model_path=None,
+            d2t_path="/path/to/d2t.npy",
+            t2d_path="/path/to/t2d.npy",
+            verifier_name_or_path="meta-llama/Llama-2-7b",
+        )
+        d2t, t2d, vocab_size, state_dict = initialize_vocab_config(
+            args, torch.device("cpu")
+        )
+
+        assert vocab_size == 100
+        assert state_dict is None
+        assert d2t is not None
+        assert t2d is not None
+        assert torch.equal(d2t, mock_d2t)
+        assert torch.equal(t2d, mock_t2d)
+        mock_load_vocab.assert_called_once_with(
+            "/path/to/d2t.npy", "/path/to/t2d.npy", torch.device("cpu")
+        )
+
+    @patch("scripts.train.AutoConfig")
+    def test_no_vocab_mapping(self, mock_config_class):
+        """Without d2t/t2d, uses verifier vocab_size."""
+        mock_config_class.from_pretrained.return_value = type(
+            "VerifierConfig", (), {"vocab_size": 32000}
+        )()
+
+        args = argparse.Namespace(
+            pretrained_model_path=None,
+            d2t_path=None,
+            t2d_path=None,
+            verifier_name_or_path="meta-llama/Llama-2-7b",
+        )
+        d2t, t2d, vocab_size, state_dict = initialize_vocab_config(
+            args, torch.device("cpu")
+        )
+
+        assert d2t is None
+        assert t2d is None
+        assert vocab_size == 32000
+        assert state_dict is None
+        mock_config_class.from_pretrained.assert_called_once_with("meta-llama/Llama-2-7b")
+
+    @patch("scripts.train.AutoConfig")
+    def test_multimodal_verifier(self, mock_config_class):
+        """Multimodal verifier: uses text_config.vocab_size."""
+        mock_config_class.from_pretrained.return_value = MagicMock(
+            text_config=MagicMock(vocab_size=32000)
+        )
+
+        args = argparse.Namespace(
+            pretrained_model_path=None,
+            d2t_path=None,
+            t2d_path=None,
+            verifier_name_or_path="Qwen/Qwen2-VL-7B",
+        )
+        _, _, vocab_size, _ = initialize_vocab_config(args, torch.device("cpu"))
+        assert vocab_size == 32000

--- a/tests/unit/utils/test_loading_pretrained.py
+++ b/tests/unit/utils/test_loading_pretrained.py
@@ -1,0 +1,213 @@
+"""Unit tests for pretrained model loading utilities in speculators.utils.loading."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from speculators.utils.loading import (
+    _find_exact_key,
+    _validate_mapping_tensor,
+    extract_vocab_mappings,
+    load_full_state_dict,
+    load_pretrained_weights,
+)
+
+
+# --- extract_vocab_mappings ---
+
+
+class TestExtractVocabMappings:
+    def test_success(self):
+        """Extracts d2t/t2d and removes them from state_dict."""
+        state_dict = {
+            "model.layer1.weight": torch.randn(10, 10),
+            "d2t": torch.randn(100),
+            "t2d": torch.randn(128),
+        }
+
+        device = torch.device("cpu")
+        d2t, t2d = extract_vocab_mappings(state_dict, device)
+
+        assert d2t.shape == (100,)
+        assert t2d.shape == (128,)
+        assert d2t.device == device
+        assert t2d.device == device
+        assert "d2t" not in state_dict
+        assert "t2d" not in state_dict
+        assert "model.layer1.weight" in state_dict
+
+    @pytest.mark.parametrize(
+        ("state_dict", "missing_key"),
+        [
+            ({"layer.weight": torch.randn(10, 10), "t2d": torch.randn(100)}, "d2t"),
+            ({"layer.weight": torch.randn(10, 10), "d2t": torch.randn(100)}, "t2d"),
+        ],
+    )
+    def test_missing_key(self, state_dict, missing_key):
+        """Errors when d2t or t2d is missing."""
+        with pytest.raises(ValueError, match=f"Key '{missing_key}' not found"):
+            extract_vocab_mappings(state_dict, torch.device("cpu"))
+
+    def test_invalid_shape_3d(self):
+        """Errors on non-1D d2t."""
+        state_dict = {"d2t": torch.randn(10, 10, 10), "t2d": torch.randn(128)}
+        with pytest.raises(ValueError, match="Unexpected d2t shape"):
+            extract_vocab_mappings(state_dict, torch.device("cpu"))
+
+    def test_case_insensitive(self):
+        """Matches keys case-insensitively."""
+        state_dict = {"D2T": torch.randn(100), "T2D": torch.randn(128)}
+        device = torch.device("cpu")
+        d2t, t2d = extract_vocab_mappings(state_dict, device)
+
+        assert d2t.shape == (100,)
+        assert t2d.shape == (128,)
+        assert "D2T" not in state_dict
+        assert "T2D" not in state_dict
+
+
+# --- _find_exact_key ---
+
+
+class TestFindExactKey:
+    @pytest.mark.parametrize(
+        ("state_dict", "lookup_key", "expected_key"),
+        [
+            ({"d2t": torch.randn(10)}, "d2t", "d2t"),
+            ({"D2T": torch.randn(10)}, "d2t", "D2T"),
+        ],
+    )
+    def test_match(self, state_dict, lookup_key, expected_key):
+        result = _find_exact_key(state_dict, lookup_key)
+        assert result == expected_key
+
+    def test_not_found(self):
+        state_dict = {"model.layer.weight": torch.randn(10, 10)}
+        with pytest.raises(ValueError, match="Key 'd2t' not found"):
+            _find_exact_key(state_dict, "d2t")
+
+    def test_error_shows_available_keys(self):
+        state_dict = {
+            "model.layer1.weight": torch.randn(10, 10),
+            "model.layer2.weight": torch.randn(10, 10),
+        }
+        with pytest.raises(ValueError, match="Available keys"):
+            _find_exact_key(state_dict, "missing_key")
+
+
+# --- _validate_mapping_tensor ---
+
+
+class TestValidateMappingTensor:
+    def test_1d_valid(self):
+        """1D tensors pass validation."""
+        _validate_mapping_tensor(torch.randn(100), "test")
+
+    @pytest.mark.parametrize(
+        "tensor",
+        [
+            torch.randn(100, 128),  # 2D
+            torch.randn(10, 10, 10),  # 3D
+            torch.tensor(5.0),  # 0D scalar
+        ],
+    )
+    def test_invalid_ndim(self, tensor):
+        """Non-1D tensors are rejected."""
+        with pytest.raises(ValueError, match="Unexpected test shape"):
+            _validate_mapping_tensor(tensor, "test")
+
+
+# --- load_full_state_dict ---
+
+
+class TestLoadFullStateDict:
+    def test_single_file(self, tmp_path):
+        """Loads from a single model.safetensors file."""
+        state_dict = {
+            "layer1.weight": torch.randn(10, 10),
+            "layer2.bias": torch.randn(10),
+            "d2t": torch.randn(100),
+            "t2d": torch.randn(128),
+        }
+        save_file(state_dict, str(tmp_path / "model.safetensors"))
+
+        loaded = load_full_state_dict(str(tmp_path))
+        assert len(loaded) == len(state_dict)
+        for key, value in state_dict.items():
+            assert key in loaded
+            assert torch.equal(loaded[key], value)
+
+    def test_sharded(self, tmp_path):
+        """Loads from sharded safetensors files."""
+        shard1 = {"layer1.weight": torch.randn(10, 10), "d2t": torch.randn(100)}
+        shard2 = {"layer2.weight": torch.randn(20, 20), "t2d": torch.randn(128)}
+
+        save_file(shard1, str(tmp_path / "model-00001-of-00002.safetensors"))
+        save_file(shard2, str(tmp_path / "model-00002-of-00002.safetensors"))
+
+        index = {
+            "metadata": {"total_size": 12345},
+            "weight_map": {
+                "layer1.weight": "model-00001-of-00002.safetensors",
+                "d2t": "model-00001-of-00002.safetensors",
+                "layer2.weight": "model-00002-of-00002.safetensors",
+                "t2d": "model-00002-of-00002.safetensors",
+            },
+        }
+        with (tmp_path / "model.safetensors.index.json").open("w") as f:
+            json.dump(index, f)
+
+        loaded = load_full_state_dict(str(tmp_path))
+        assert len(loaded) == 4
+        assert torch.equal(loaded["layer1.weight"], shard1["layer1.weight"])
+        assert torch.equal(loaded["d2t"], shard1["d2t"])
+        assert torch.equal(loaded["layer2.weight"], shard2["layer2.weight"])
+        assert torch.equal(loaded["t2d"], shard2["t2d"])
+
+    def test_file_not_found(self, tmp_path):
+        """Errors when no model files exist."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        with pytest.raises(FileNotFoundError):
+            load_full_state_dict(str(empty_dir))
+
+
+# --- load_pretrained_weights ---
+
+
+class TestLoadPretrainedWeights:
+    def test_success(self):
+        """Loads weights into model via load_state_dict."""
+        mock_model = MagicMock()
+        mock_model.load_state_dict.return_value = ([], [])
+        state_dict = {"layer.weight": torch.randn(10, 10)}
+
+        load_pretrained_weights(mock_model, state_dict, "/path/to/model")
+        mock_model.load_state_dict.assert_called_once()
+
+    def test_with_expected_missing(self):
+        """Expected missing keys (d2t, t2d, verifier_lm_head) don't warn."""
+        mock_model = MagicMock()
+        expected_missing = ["d2t", "t2d", "verifier_lm_head.weight"]
+        mock_model.load_state_dict.return_value = (expected_missing, [])
+
+        # Should not raise
+        load_pretrained_weights(
+            mock_model, {"layer.weight": torch.randn(10, 10)}, "/test"
+        )
+
+    def test_strict_false(self):
+        """Passes strict=False to load_state_dict."""
+        mock_model = MagicMock()
+        mock_model.load_state_dict.return_value = ([], [])
+        state_dict = {"layer.weight": torch.randn(10, 10)}
+
+        load_pretrained_weights(mock_model, state_dict, "/path")
+
+        call_kwargs = mock_model.load_state_dict.call_args
+        assert call_kwargs[1].get("strict") is False or (
+            len(call_kwargs[0]) >= 2 and call_kwargs[0][1] is False
+        )


### PR DESCRIPTION
## Summary

Adds support for warm-start/fine-tuning from pretrained speculator models, enabling users to initialize training from existing models stored locally or on HuggingFace Hub.

Closes #269

## Changes

### `src/speculators/utils/loading.py`
- **`load_full_state_dict()`**: Load complete state dict from safetensors format (single or sharded), supporting both local paths and HuggingFace Hub model IDs
- **`extract_vocab_mappings()`**: Extract `d2t`/`t2d` vocab mappings from state dict, removing them in-place
- **`load_pretrained_weights()`**: Load pretrained weights into a model with validation and expected-missing-key handling
- Supporting utilities: `_resolve_model_path()`, `_load_single_safetensors()`, `_load_sharded_safetensors()`, `_find_exact_key()`, `_validate_mapping_tensor()`

### `scripts/train.py`
- Added `--pretrained-model-path` CLI argument (mutually exclusive with `--d2t-path`/`--t2d-path`)
- Refactored vocab/model initialization into modular functions:
  - `load_pretrained_model()`: loads state dict and extracts vocab mappings
  - `load_vocab_mappings()`: loads d2t/t2d from numpy files
  - `initialize_vocab_config()`: unified entry point handling all three modes (pretrained, numpy, no-mapping)
- When fine-tuning, `transformer_layer_config` is preserved from the pretrained model
- Pretrained weights are loaded after model creation, keeping optimizer/scheduler states fresh

### `scripts/README.md`
- Added `--pretrained-model-path` argument documentation
- Added Fine-tuning from Pretrained section with example command

### Tests (35 new tests, all passing)
- `tests/unit/utils/test_loading_pretrained.py`: 19 tests for loading utilities
- `tests/unit/train/test_pretrained_loading.py`: 16 tests for train script functions

## Usage

```bash
python scripts/train.py \
    --verifier-name-or-path meta-llama/Llama-3.1-8B-Instruct \
    --pretrained-model-path RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3 \
    --data-path ./new_domain_data \
    --epochs 5 \
    --lr 5e-5
```

## Use Cases
- **Domain adaptation**: Fine-tune a general EAGLE3 model on domain-specific data
- **Continued training**: Resume training with new data without full checkpoint state
- **Model iteration**: Start from a community model and adapt to specific requirements

## Test Results
All 133 unit tests pass (including 35 new tests):
```
====================== 133 passed, 2 warnings in 12.31s =======================
```
