### PR TITLE
docs: add algorithm documentation for EAGLE-3 and FastMTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ The following table summarizes the models that have been trained end-to-end by o
 
 ✅ = Supported, ⏳ = In Progress, ❌ = Not Yet Supported
 
+## Supported Algorithms
+
+| Algorithm | Description | Training | vLLM Inference | Reference |
+|-----------|-------------|----------|----------------|-----------|
+| **EAGLE-3** | Lightweight decoder with TTT steps for autoregressive draft generation | ✅ | ✅ | [Paper](https://arxiv.org/abs/2401.15077) |
+| **FastMTP** | Multi-token prediction with independent MTP layers per step | ⏳ | ⏳ | [Paper](https://arxiv.org/abs/2509.18362) |
+| **P-EAGLE** | Parallel EAGLE with COD sampling for multi-token prediction | ⏳ | ⏳ | [Paper](https://arxiv.org/abs/2602.01469) |
+
 ## Examples
 
 End-To-End Training Examples:

--- a/docs/algorithms/eagle3.md
+++ b/docs/algorithms/eagle3.md
@@ -1,0 +1,166 @@
+# EAGLE-3
+
+EAGLE-3 is the primary speculative decoding algorithm in Speculators. It uses a lightweight decoder with test-time training (TTT) steps to autoregressively generate multiple draft tokens, achieving high acceptance rates with minimal overhead.
+
+## Overview
+
+EAGLE-3 builds on the EAGLE family of speculative decoding methods. It uses a compact transformer decoder that predicts the next token from concatenated hidden states extracted from the verifier model. During inference, it performs multiple test-time training (TTT) steps to generate a sequence of draft tokens, which are then verified in a single forward pass of the full verifier model.
+
+**Key features:**
+
+- **High acceptance rates**: Achieves strong token acceptance across multiple prediction steps
+- **Lightweight architecture**: Single decoder layer with a linear projection, keeping parameter count low
+- **Flexible vocabulary mapping**: Supports full or reduced vocabulary via `d2t`/`t2d` mappings
+- **Broad verifier support**: Compatible with Llama, Qwen3, MoE models, and Vision-Language models
+
+## Architecture
+
+### Model Components
+
+The EAGLE-3 draft model consists of:
+
+1. **Linear projection** (`fc`): Projects concatenated hidden states $[h_1, h_2, h_3]$ of shape $3 \times \text{hidden\_size}$ to $\text{hidden\_size}$
+2. **Transformer decoder layer(s)**: One or more decoder layers matching the verifier architecture
+3. **Rotary embeddings**: Position encoding using RoPE with $2\times$ hidden size
+4. **LM head**: Draft-vocabulary-sized output projection for token prediction
+5. **Verifier components**: Frozen copies of verifier embedding, LM head, and final norm (used for target computation during training)
+
+### Forward Pass
+
+The forward pass implements autoregressive TTT steps:
+
+```
+For each TTT step k (0 to ttt_steps-1):
+    1. Embed the input token IDs using verifier embeddings
+    2. Concatenate embeddings with hidden states → shape [1, seq_len, 2 * hidden_size]
+    3. Apply rotary position embeddings
+    4. Pass through decoder layer(s) with cached KV states
+    5. Apply normalization and LM head to produce logits
+    6. Compute loss against verifier targets (KL divergence)
+    7. Select predicted tokens via argmax for next TTT step
+    8. Map draft token IDs back to verifier vocabulary space via d2t
+```
+
+### Vocabulary Mapping
+
+EAGLE-3 supports optional vocabulary reduction:
+
+- **`t2d` (target-to-draft)**: Boolean mask of shape `[verifier_vocab_size]` indicating which verifier tokens are included in the draft vocabulary
+- **`d2t` (draft-to-target)**: Offset tensor of shape `[draft_vocab_size]` mapping draft token indices back to verifier token indices
+
+When vocabulary mapping is not provided, the full verifier vocabulary is used.
+
+## Configuration
+
+EAGLE-3 models use the `Eagle3SpeculatorConfig` configuration class:
+
+```python
+from speculators.models.eagle3 import Eagle3SpeculatorConfig
+
+config = Eagle3SpeculatorConfig(
+    transformer_layer_config=verifier_config,
+    draft_vocab_size=32000,
+    norm_before_residual=True,
+    embed_requires_grad=False,
+)
+```
+
+### Configuration Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `transformer_layer_config` | `PretrainedConfig` | required | Decoder layer configuration (derived from verifier) |
+| `draft_vocab_size` | `int` | required | Size of the draft vocabulary |
+| `norm_before_residual` | `bool` | `True` | Apply normalization before residual connection |
+| `embed_requires_grad` | `bool` | `False` | Whether to train the embedding layer |
+
+## Training
+
+### Data Generation
+
+Generate training data using the verifier model:
+
+```bash
+python scripts/data_generation_offline.py \
+    --target-model-path meta-llama/Llama-3.1-8B-Instruct \
+    --train-data-path sharegpt \
+    --output-dir ./training_data \
+    --max-samples 5000
+```
+
+### Vocabulary Mapping
+
+Build vocabulary mappings from the generated data:
+
+```bash
+python scripts/build_vocab_mapping.py \
+    --data-path ./training_data \
+    --output-dir ./training_data
+```
+
+### Training Command
+
+```bash
+torchrun --nnodes=1 --nproc_per_node=8 scripts/train.py \
+    --verifier-name-or-path meta-llama/Llama-3.1-8B-Instruct \
+    --data-path ./training_data \
+    --save-path ./checkpoints/eagle3 \
+    --epochs 10 \
+    --lr 1e-4 \
+    --d2t-path ./training_data/d2t.npy \
+    --t2d-path ./training_data/t2d.npy \
+    --ttt-steps 3
+```
+
+### Training Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--ttt-steps` | `3` | Number of test-time training steps |
+| `--ttt-step-loss-decay` | `1.0` | Loss decay factor per TTT step |
+| `--num-layers` | `1` | Number of decoder layers |
+| `--norm-before-residual` | `True` | Toggle normalization before residual |
+| `--embed-requires-grad` | `False` | Train embedding layer weights |
+| `--use-off-policy-tokens` | `False` | Use off-policy tokens (for regenerated data) |
+
+### Loss Function
+
+EAGLE-3 uses KL divergence loss between draft and verifier logits:
+
+$$
+\mathcal{L} = \sum_{k=0}^{K-1} \gamma^k \cdot D_{KL}(\text{softmax}(\hat{y}_k) \| \text{softmax}(y_k))
+$$
+
+Where:
+
+- $K$ is the number of TTT steps
+- $\gamma$ is the step loss decay factor
+- $\hat{y}_k$ are the draft logits
+- $y_k$ are the verifier target logits
+
+## Inference
+
+### vLLM Deployment
+
+Trained EAGLE-3 models can be served directly with vLLM:
+
+```bash
+vllm serve RedHatAI/Qwen3-8B-speculator.eagle3
+```
+
+### Pre-trained Models
+
+Pre-trained EAGLE-3 models are available on HuggingFace:
+
+| Model | Verifier | Link |
+|-------|----------|------|
+| Llama 3.1 8B | meta-llama/Llama-3.1-8B-Instruct | [RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3](https://huggingface.co/RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3) |
+| Llama 3.3 70B | meta-llama/Llama-3.3-70B-Instruct | [RedHatAI/Llama-3.3-70B-Instruct-speculator.eagle3](https://huggingface.co/RedHatAI/Llama-3.3-70B-Instruct-speculator.eagle3) |
+| Qwen3 8B | Qwen/Qwen3-8B | [RedHatAI/Qwen3-8B-speculator.eagle3](https://huggingface.co/RedHatAI/Qwen3-8B-speculator.eagle3) |
+| Qwen3 14B | Qwen/Qwen3-14B | [RedHatAI/Qwen3-14B-speculator.eagle3](https://huggingface.co/RedHatAI/Qwen3-14B-speculator.eagle3) |
+| Qwen3 32B | Qwen/Qwen3-32B | [RedHatAI/Qwen3-32B-speculator.eagle3](https://huggingface.co/RedHatAI/Qwen3-32B-speculator.eagle3) |
+
+## References
+
+- **EAGLE Paper**: [EAGLE: Speculative Sampling Requires Rethinking Feature Uncertainty](https://arxiv.org/abs/2401.15077)
+- **EAGLE-2 Paper**: [EAGLE-2: Faster Inference of Language Models with Dynamic Draft Trees](https://arxiv.org/abs/2406.16858)

--- a/docs/algorithms/fast_mtp.md
+++ b/docs/algorithms/fast_mtp.md
@@ -1,0 +1,140 @@
+# FastMTP (Multi-Token Prediction)
+
+FastMTP is a speculative decoding algorithm that extends the multi-token prediction (MTP) approach for accelerated LLM inference. It uses a series of dedicated MTP layers that share verifier hidden states and predict multiple tokens ahead in parallel.
+
+## Overview
+
+FastMTP is based on the Multi-Token Prediction approach from DeepSeek-V3 / R1, adapted for speculative decoding. Unlike EAGLE-3's sequential test-time training (TTT) steps, FastMTP uses independent prediction layers — one per speculative step — that each predict the next token from shared hidden state representations.
+
+**Key advantages:**
+
+- **Simpler architecture**: Each speculative step uses an independent MTP layer, avoiding sequential dependencies during inference
+- **Efficient training**: Weighted cross-entropy loss across speculative steps with configurable step weights
+- **Flexible depth**: Configurable number of speculative steps (typically 3)
+
+**Paper**: [FastMTP: Harnessing Fast Multi-Token Prediction for Speculative Decoding (arXiv:2509.18362)](https://arxiv.org/abs/2509.18362)
+
+## Architecture
+
+### MTP Layer Structure
+
+Each MTP layer in FastMTP consists of:
+
+1. **Input Projection** (`input_proj`): A linear layer that projects the concatenated hidden state into the model's hidden dimension
+2. **Self-Attention**: A transformer self-attention mechanism (based on verifier architecture)
+3. **MLP**: A feed-forward network matching the verifier's MLP architecture
+4. **Layer Normalization**: Five RMSNorm layers for input, post-attention, post-MLP, and shared hidden state processing
+
+### Forward Pass
+
+The FastMTP forward pass processes multiple speculative steps in a single pass:
+
+```
+For each speculative step k (0 to num_speculative_steps-1):
+    1. Concatenate the shared hidden state with token embeddings
+    2. Project through input_proj to model dimension
+    3. Apply self-attention with causal mask
+    4. Apply MLP feed-forward
+    5. Predict logits via LM head
+    6. Compute weighted cross-entropy loss against target tokens
+```
+
+### Key Differences from EAGLE-3
+
+| Feature | EAGLE-3 | FastMTP |
+|---------|---------|---------|
+| Prediction approach | Sequential TTT steps | Independent MTP layers |
+| Hidden state usage | Concatenation of 3 hidden states | Shared verifier hidden state |
+| Loss function | KL divergence | Weighted cross-entropy |
+| Token generation | Autoregressive within TTT | Independent per layer |
+
+## Configuration
+
+FastMTP models use the `FastMTPConfig` configuration class:
+
+```python
+from speculators.models.fast_mtp import FastMTPConfig
+
+config = FastMTPConfig(
+    transformer_config=verifier_transformer_config,
+    num_speculative_steps=3,           # Number of MTP prediction layers
+    mtp_loss_step_weights=[0.51, 0.31, 0.18],  # Per-step loss weights
+    hidden_size=4096,                  # Must match verifier hidden size
+    vocab_size=128256,                 # Must match verifier vocab size
+)
+```
+
+### Configuration Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `transformer_config` | `PretrainedConfig` | required | Verifier model transformer configuration |
+| `num_speculative_steps` | `int` | `3` | Number of speculative prediction steps |
+| `mtp_loss_step_weights` | `list[float]` | `[0.51, 0.31, 0.18]` | Per-step cross-entropy loss weights |
+| `hidden_size` | `int` | required | Hidden dimension (must match verifier) |
+| `vocab_size` | `int` | required | Vocabulary size (must match verifier) |
+
+## Training
+
+### Data Generation
+
+FastMTP training uses the same data generation pipeline as EAGLE-3. Generate training data using:
+
+```bash
+python scripts/data_generation_offline.py \
+    --target-model-path <verifier_model> \
+    --train-data-path <dataset> \
+    --output-dir ./training_data \
+    --max-samples 5000
+```
+
+### Training Command
+
+!!! note "Status"
+    FastMTP training support is currently in development. Check the [speculators repository](https://github.com/vllm-project/speculators) for the latest updates.
+
+Once available, training will follow the standard training script pattern:
+
+```bash
+torchrun --nnodes=1 --nproc_per_node=<num_gpus> scripts/train.py \
+    --speculator-type mtp \
+    --verifier-name-or-path <verifier_model> \
+    --data-path ./training_data \
+    --save-path ./checkpoints/fastmtp \
+    --epochs 10 \
+    --lr 1e-4
+```
+
+### Loss Function
+
+FastMTP uses weighted cross-entropy loss across speculative steps:
+
+$$
+\mathcal{L} = \sum_{k=0}^{K-1} w_k \cdot \text{CE}(\hat{y}_k, y_{k+1})
+$$
+
+Where:
+
+- $K$ is the number of speculative steps
+- $w_k$ is the weight for step $k$ (default: `[0.51, 0.31, 0.18]`)
+- $\hat{y}_k$ are the predicted logits at step $k$
+- $y_{k+1}$ are the target token labels shifted by $k+1$ positions
+
+The decreasing weights reflect decreasing prediction accuracy at farther steps.
+
+## Inference with vLLM
+
+!!! note "Status"
+    FastMTP inference support in vLLM is under development. Check the [vLLM documentation](https://docs.vllm.ai/) for deployment instructions once available.
+
+Once supported, FastMTP models can be served using vLLM:
+
+```bash
+vllm serve <path_or_hub_id_to_fastmtp_model>
+```
+
+## References
+
+- **FastMTP Paper**: [FastMTP: Harnessing Fast Multi-Token Prediction for Speculative Decoding](https://arxiv.org/abs/2509.18362)
+- **DeepSeek-V3**: [DeepSeek-V3 Technical Report](https://arxiv.org/abs/2412.19437) — Original multi-token prediction architecture
+- **Reference Implementation**: [Tencent-BAC/FastMTP](https://github.com/Tencent-BAC/FastMTP)

--- a/docs/algorithms/index.md
+++ b/docs/algorithms/index.md
@@ -1,0 +1,21 @@
+# Algorithms
+
+Speculators supports multiple speculative decoding algorithms. Each algorithm provides a different approach to generating draft tokens for verification by the base model.
+
+## Supported Algorithms
+
+### [EAGLE-3](eagle3.md)
+
+The primary speculative decoding algorithm in Speculators. EAGLE-3 uses a lightweight transformer decoder with test-time training (TTT) steps to autoregressively generate draft tokens. It achieves high acceptance rates with minimal parameter overhead.
+
+**Status**: Fully supported — training, inference (vLLM), and pre-trained models available.
+
+### [FastMTP](fast_mtp.md)
+
+A multi-token prediction approach based on DeepSeek-V3's MTP architecture, adapted for speculative decoding. FastMTP uses independent prediction layers for each speculative step, offering a simpler alternative to EAGLE-3's sequential TTT approach.
+
+**Status**: Under development — model definition and training support in progress.
+
+## Adding New Algorithms
+
+See the [Adding New Algorithms](add_new_algorithms.md) guide for instructions on implementing and registering new speculative decoding algorithms in Speculators.


### PR DESCRIPTION
## Summary

Adds algorithm documentation for EAGLE-3 and FastMTP, plus an algorithms index page and a Supported Algorithms table in the main README.

Partially addresses #276

## Changes

### New Algorithm Documentation
- **`docs/algorithms/index.md`**: Algorithms overview page listing all supported and in-development algorithms with status badges
- **`docs/algorithms/eagle3.md`**: Comprehensive EAGLE-3 documentation covering:
  - Architecture overview (model components, forward pass, vocabulary mapping)
  - Configuration parameters
  - Training guide (data generation, vocab mapping, training command, parameters)
  - Loss function (KL divergence with step decay)
  - vLLM inference deployment
  - Pre-trained models reference table
- **`docs/algorithms/fast_mtp.md`**: FastMTP documentation covering:
  - Architecture overview (MTP layer structure, forward pass)
  - Comparison table with EAGLE-3
  - Configuration parameters
  - Training guide with weighted cross-entropy loss function
  - References to paper and reference implementation

### README Updates
- **`README.md`**: Added "Supported Algorithms" table with EAGLE-3, FastMTP, and P-EAGLE showing current status (supported/in-progress) and paper references

## Notes

This is an incremental contribution to #276. Full integration tests and performance benchmarks will follow once the FastMTP model definition (PR #301) is merged into main.
