### PR TITLE
feat: P-EAGLE Phase 1 - COD sampling, model, config, and loss utilities

### DIFF
--- a/src/speculators/models/__init__.py
+++ b/src/speculators/models/__init__.py
@@ -2,6 +2,7 @@ from .eagle import EagleSpeculator, EagleSpeculatorConfig
 from .eagle3 import Eagle3DraftModel, Eagle3SpeculatorConfig
 from .independent import IndependentSpeculatorConfig
 from .mlp import MLPSpeculatorConfig
+from .peagle import PEagleDraftModel, PEagleSpeculatorConfig
 
 __all__ = [
     "Eagle3DraftModel",
@@ -10,4 +11,6 @@ __all__ = [
     "EagleSpeculatorConfig",
     "IndependentSpeculatorConfig",
     "MLPSpeculatorConfig",
+    "PEagleDraftModel",
+    "PEagleSpeculatorConfig",
 ]

--- a/src/speculators/models/peagle/__init__.py
+++ b/src/speculators/models/peagle/__init__.py
@@ -1,0 +1,7 @@
+from speculators.models.peagle.config import PEagleSpeculatorConfig
+from speculators.models.peagle.core import PEagleDraftModel
+
+__all__ = [
+    "PEagleDraftModel",
+    "PEagleSpeculatorConfig",
+]

--- a/src/speculators/models/peagle/cod_sampling.py
+++ b/src/speculators/models/peagle/cod_sampling.py
@@ -1,0 +1,175 @@
+"""
+Conditional-On-Distribution (COD) sampling for P-EAGLE.
+
+This module implements the COD sampling algorithm from the P-EAGLE paper
+(arXiv:2602.01469). COD reduces the number of positions at each prediction
+depth through geometric decay, making parallel multi-token prediction
+training tractable.
+
+At depth 0, all valid positions (where loss_mask == 1) are retained.
+At depth k, n_valid × r^k positions are randomly retained, where r is the
+retention rate (down_sample_ratio). This reduces total positions from n×K
+to n×(1 + r + r² + ... + r^(K-1)), significantly reducing attention
+memory from O((nK)²) to O((nΣr^i)²).
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def cod_sample(
+    loss_mask: torch.Tensor,
+    down_sample_ratio: float,
+    num_depths: int,
+    down_sample_ratio_min: float = 0.0,
+    generator: torch.Generator | None = None,
+) -> list[torch.Tensor]:
+    """Perform COD sampling for P-EAGLE parallel group generation.
+
+    Generates index sets for each prediction depth using geometric decay-based
+    position retention. Only positions where loss_mask is True are candidates
+    for sampling. Positions are returned in sorted (causal) order.
+
+    Args:
+        loss_mask: Boolean tensor of shape [seq_len] indicating valid training
+            positions. Only positions with True values are candidates for sampling.
+        down_sample_ratio: Retention rate r ∈ (0, 1) for geometric decay.
+            Depth k retains n_valid × r^k positions.
+        num_depths: Number of parallel prediction depths K (including depth 0).
+            Must be >= 1.
+        down_sample_ratio_min: Minimum retention ratio to ensure at least
+            floor(n_valid × down_sample_ratio_min) positions at each depth.
+            Defaults to 0.0 (no minimum).
+        generator: Optional random generator for reproducible sampling.
+
+    Returns:
+        List of K tensors, where depth_indices[k] contains sorted indices of
+        retained positions for depth k. depth_indices[0] always contains all
+        valid positions.
+
+    Raises:
+        ValueError: If down_sample_ratio is not in (0, 1), num_depths < 1,
+            or down_sample_ratio_min is not in [0, 1].
+
+    Example:
+        >>> loss_mask = torch.tensor([True, False, True, True, True, False, True])
+        >>> indices = cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=3)
+        >>> len(indices)
+        3
+        >>> indices[0]  # All valid positions
+        tensor([0, 2, 3, 4, 6])
+        >>> len(indices[1])  # ~50% of valid positions
+        2
+        >>> len(indices[2])  # ~25% of valid positions
+        1
+    """
+    if not 0 < down_sample_ratio < 1:
+        raise ValueError(
+            f"down_sample_ratio must be in (0, 1), got {down_sample_ratio}"
+        )
+    if num_depths < 1:
+        raise ValueError(f"num_depths must be >= 1, got {num_depths}")
+    if not 0 <= down_sample_ratio_min <= 1:
+        raise ValueError(
+            f"down_sample_ratio_min must be in [0, 1], got {down_sample_ratio_min}"
+        )
+
+    # Get indices of valid positions
+    valid_indices = torch.nonzero(loss_mask, as_tuple=False).squeeze(-1)
+    n_valid = valid_indices.shape[0]
+
+    depth_indices: list[torch.Tensor] = []
+
+    for k in range(num_depths):
+        if k == 0:
+            # Depth 0 retains all valid positions
+            depth_indices.append(valid_indices.clone())
+        else:
+            # Compute retention count with geometric decay
+            retain_ratio = max(down_sample_ratio**k, down_sample_ratio_min)
+            n_retain = max(int(n_valid * retain_ratio), 0)
+
+            if n_retain == 0 or n_valid == 0:
+                depth_indices.append(
+                    torch.tensor([], dtype=valid_indices.dtype, device=loss_mask.device)
+                )
+            elif n_retain >= n_valid:
+                # Retain all if computed count exceeds available
+                depth_indices.append(valid_indices.clone())
+            else:
+                # Random sampling without replacement
+                perm = torch.randperm(n_valid, generator=generator, device="cpu")
+                sampled = perm[:n_retain]
+                # Sort to maintain causal order
+                sampled_sorted, _ = sampled.sort()
+                sampled_indices = valid_indices[sampled_sorted.to(valid_indices.device)]
+                depth_indices.append(sampled_indices)
+
+    return depth_indices
+
+
+def compute_cod_statistics(
+    depth_indices: list[torch.Tensor],
+    seq_len: int,
+) -> dict[str, int | float | list[int]]:
+    """Compute statistics for a COD sampling result.
+
+    Args:
+        depth_indices: Output from cod_sample(), list of index tensors per depth.
+        seq_len: Original sequence length.
+
+    Returns:
+        Dictionary with statistics including total positions, per-depth counts,
+        compression ratio, and effective sequence length.
+    """
+    per_depth_counts = [idx.shape[0] for idx in depth_indices]
+    total_positions = sum(per_depth_counts)
+    num_depths = len(depth_indices)
+
+    return {
+        "num_depths": num_depths,
+        "seq_len": seq_len,
+        "per_depth_counts": per_depth_counts,
+        "total_positions": total_positions,
+        "naive_total": per_depth_counts[0] * num_depths if num_depths > 0 else 0,
+        "compression_ratio": (
+            total_positions / (per_depth_counts[0] * num_depths)
+            if num_depths > 0 and per_depth_counts[0] > 0
+            else 0.0
+        ),
+    }
+
+
+def build_depth_position_ids(
+    depth_indices: list[torch.Tensor],
+    seq_len: int,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    """Build position IDs that track original sequence positions across depths.
+
+    Creates a concatenated position ID tensor where each element records the
+    original sequence position of the corresponding token, maintaining
+    positional information across COD-sampled parallel groups.
+
+    Args:
+        depth_indices: Output from cod_sample(), list of index tensors per depth.
+        seq_len: Original sequence length (unused, reserved for validation).
+        device: Target device for the output tensor.
+
+    Returns:
+        1D tensor of shape [total_positions] containing original position IDs
+        for each retained position across all depths.
+    """
+    if not depth_indices:
+        return torch.tensor([], dtype=torch.long, device=device)
+
+    position_ids = []
+    for indices in depth_indices:
+        if indices.numel() > 0:
+            position_ids.append(indices.to(device=device))
+
+    if not position_ids:
+        return torch.tensor([], dtype=torch.long, device=device)
+
+    return torch.cat(position_ids, dim=0)

--- a/src/speculators/models/peagle/config.py
+++ b/src/speculators/models/peagle/config.py
@@ -1,0 +1,95 @@
+"""
+Configuration for P-EAGLE (Parallel EAGLE) speculator model.
+
+P-EAGLE extends EAGLE-3 with multi-token prediction through Conditional-On-Distribution
+(COD) sampling, enabling 2-3x speedups over sequential EAGLE-3 drafting.
+
+This configuration adds P-EAGLE-specific parameters on top of the EAGLE-3 config:
+- para_num: Number of parallel prediction depths
+- down_sample_ratio: COD geometric decay retention rate
+- down_sample_ratio_min: Minimum retention rate
+- ptd_token_id: Padding token ID for MTP positions
+"""
+
+from typing import Literal
+
+from pydantic import Field
+
+from speculators import SpeculatorModelConfig
+from speculators.models.eagle3.config import Eagle3SpeculatorConfig
+
+__all__ = [
+    "PEagleSpeculatorConfig",
+]
+
+
+@SpeculatorModelConfig.register("peagle")
+class PEagleSpeculatorConfig(Eagle3SpeculatorConfig):
+    """
+    Configuration for P-EAGLE speculator with parallel multi-token prediction.
+
+    P-EAGLE extends EAGLE-3 with parallel prediction groups generated via
+    COD (Conditional-On-Distribution) sampling. Each depth k predicts the
+    token k+1 positions ahead, all processed in a single forward pass.
+
+    :param para_num: Number of parallel prediction depths (K)
+    :param down_sample_ratio: COD retention rate r for geometric decay
+    :param down_sample_ratio_min: Minimum retention rate at deepest depths
+    :param ptd_token_id: Token ID used for MTP padding positions
+    :param loss_type: Loss function type ('kl_div' or 'cross_entropy')
+    """
+
+    speculators_model_type: Literal["peagle"] = "peagle"
+    architectures: list[str] = Field(
+        default_factory=lambda: ["PEagleSpeculator"],
+        description="Model architectures that can load these weights",
+    )
+
+    para_num: int = Field(
+        default=8,
+        ge=1,
+        description=(
+            "Number of parallel prediction depths (K). "
+            "Depth k predicts the token k+1 positions ahead. "
+            "All depths are processed in a single forward pass."
+        ),
+    )
+
+    down_sample_ratio: float = Field(
+        default=0.5,
+        gt=0.0,
+        lt=1.0,
+        description=(
+            "COD retention rate r ∈ (0, 1) for geometric decay. "
+            "Depth k retains n_valid × r^k positions from the training sequence. "
+            "Lower values reduce memory but may hurt prediction quality at deeper depths."
+        ),
+    )
+
+    down_sample_ratio_min: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Minimum retention ratio to ensure at least some positions are kept "
+            "at deeper prediction depths. Defaults to 0.0 (no minimum)."
+        ),
+    )
+
+    ptd_token_id: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Token ID used as padding for MTP positions that lack predicted tokens "
+            "from previous steps. Renamed from 'unused_token_id' in the original paper "
+            "for clarity (aligned with vLLM convention)."
+        ),
+    )
+
+    loss_type: Literal["kl_div", "cross_entropy"] = Field(
+        default="cross_entropy",
+        description=(
+            "Loss function type for training. P-EAGLE uses cross-entropy loss "
+            "by default, unlike EAGLE-3 which uses KL divergence."
+        ),
+    )

--- a/src/speculators/models/peagle/core.py
+++ b/src/speculators/models/peagle/core.py
@@ -1,0 +1,719 @@
+# ruff: noqa: ERA001
+"""
+P-EAGLE (Parallel EAGLE) draft model implementation.
+
+P-EAGLE extends EAGLE-3 with parallel multi-token prediction through
+Conditional-On-Distribution (COD) sampling. Instead of sequential TTT steps,
+P-EAGLE generates predictions for multiple future positions in a single
+forward pass using parallel prediction groups.
+
+Key differences from Eagle3DraftModel:
+- mask_hidden: Learnable hidden state parameter for MTP padding positions
+- mask_token_embedding: Learnable embedding for unknown predicted tokens
+- Parallel forward pass via COD-sampled position groups
+- Cross-entropy loss by default (instead of KL divergence)
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import ClassVar
+
+import torch
+from torch.nn.attention.flex_attention import create_block_mask
+from transformers import AutoConfig, DynamicCache, PretrainedConfig
+
+from speculators.config import SpeculatorsConfig, VerifierConfig
+from speculators.model import SpeculatorModel
+from speculators.models.eagle3.attention import (
+    create_combined_mask_mod,
+)
+from speculators.models.eagle3.model_definitions import model_classes
+from speculators.models.peagle.cod_sampling import cod_sample
+from speculators.models.peagle.config import PEagleSpeculatorConfig
+from speculators.models.peagle.loss import (
+    cross_entropy_loss,
+    kl_div_loss,
+    per_depth_accuracy,
+)
+from speculators.proposals.greedy import GreedyTokenProposalConfig
+from speculators.utils.loading import load_model_layers
+
+
+def build_parallel_group_mask_mod(
+    ntp_lengths: torch.Tensor,
+    depth_indices: list[torch.Tensor],
+    total_len: int,
+):
+    """Build a mask modification function for parallel group attention.
+
+    Creates an attention mask that allows:
+    1. Causal attention within NTP (depth-0) positions
+    2. Each MTP position attends to NTP positions before its original
+       sequence position AND to itself (diagonal)
+    3. MTP positions do NOT attend to other MTP positions (independence)
+
+    The combined sequence layout is:
+        [NTP positions (depth 0)] [MTP depth 1] [MTP depth 2] ... [MTP depth K-1]
+
+    Args:
+        ntp_lengths: Tensor of per-document NTP sequence lengths for
+            document-boundary masking.
+        depth_indices: COD-sampled indices per depth from cod_sample().
+        total_len: Total combined sequence length across all depths.
+
+    Returns:
+        A mask modification function compatible with flex_attention's
+        create_block_mask.
+    """
+    ntp_len = depth_indices[0].shape[0] if len(depth_indices) > 0 else 0
+
+    # Build a mapping from global position to original sequence position
+    # for all depths beyond 0
+    # Also track boundary offsets for each depth
+    depth_offsets = [0]
+    offset = ntp_len
+    for k in range(1, len(depth_indices)):
+        depth_offsets.append(offset)
+        offset += depth_indices[k].shape[0]
+
+    # Build document IDs for NTP positions
+    document_ids = torch.repeat_interleave(
+        torch.arange(ntp_lengths.shape[0], device=ntp_lengths.device, dtype=torch.long),
+        ntp_lengths,
+    )
+    # Pad to ntp_len
+    if document_ids.shape[0] < ntp_len:
+        document_ids = torch.cat([
+            document_ids,
+            -1 * torch.ones(
+                ntp_len - document_ids.shape[0],
+                device=ntp_lengths.device,
+                dtype=torch.long,
+            ),
+        ])
+
+    # Build original position mapping for MTP positions
+    mtp_original_positions = []
+    for k in range(1, len(depth_indices)):
+        if depth_indices[k].numel() > 0:
+            mtp_original_positions.append(depth_indices[k])
+        else:
+            mtp_original_positions.append(
+                torch.tensor([], dtype=torch.long, device=ntp_lengths.device)
+            )
+
+    if mtp_original_positions:
+        mtp_positions_cat = torch.cat(mtp_original_positions).contiguous()
+    else:
+        mtp_positions_cat = torch.tensor(
+            [], dtype=torch.long, device=ntp_lengths.device
+        )
+
+    def mask_mod(_b, _h, q_idx, kv_idx):
+        q_is_ntp = q_idx < ntp_len
+        kv_is_ntp = kv_idx < ntp_len
+
+        # Case 1: Both NTP - standard causal + document mask
+        both_ntp = torch.logical_and(q_is_ntp, kv_is_ntp)
+        ntp_causal = q_idx >= kv_idx
+        ntp_same_doc = document_ids[torch.clamp(q_idx, max=ntp_len - 1)] == \
+            document_ids[torch.clamp(kv_idx, max=ntp_len - 1)]
+        ntp_valid = torch.logical_and(
+            document_ids[torch.clamp(q_idx, max=ntp_len - 1)] != -1, ntp_same_doc
+        )
+        ntp_mask = torch.logical_and(ntp_causal, ntp_valid)
+
+        # Case 2: Query is MTP, KV is NTP - MTP attends to NTP positions
+        # before or at its original position
+        q_is_mtp = ~q_is_ntp
+        mtp_to_ntp = torch.logical_and(q_is_mtp, kv_is_ntp)
+        mtp_q_offset = q_idx - ntp_len
+        mtp_q_orig_pos = mtp_positions_cat[
+            torch.clamp(mtp_q_offset, min=0, max=max(mtp_positions_cat.shape[0] - 1, 0))
+        ]
+        mtp_attends_ntp = kv_idx <= mtp_q_orig_pos
+
+        # Case 3: Diagonal self-attention for MTP positions
+        diagonal = q_idx == kv_idx
+
+        # Combine: NTP-NTP causal OR MTP-to-NTP OR diagonal
+        return torch.logical_or(
+            torch.logical_and(both_ntp, ntp_mask),
+            torch.logical_or(
+                torch.logical_and(mtp_to_ntp, mtp_attends_ntp),
+                torch.logical_and(q_is_mtp, diagonal),
+            ),
+        )
+
+    return mask_mod
+
+
+@SpeculatorModel.register("peagle")
+class PEagleDraftModel(SpeculatorModel):
+    """P-EAGLE draft model with parallel multi-token prediction.
+
+    Extends the EAGLE-3 architecture with:
+    - mask_hidden: Learnable padding hidden state for MTP positions
+    - mask_token_embedding: Learnable embedding for unknown tokens at MTP positions
+    - Parallel prediction groups via COD sampling
+    - Single forward pass for all prediction depths
+    """
+
+    config_class: ClassVar[type[PEagleSpeculatorConfig]] = PEagleSpeculatorConfig  # type: ignore[misc]
+    _keys_to_ignore_on_load_missing: ClassVar[list[str]] = [  # type: ignore[misc]
+        "embed_tokens.weight",
+        "verifier_norm.weight",
+        "verifier_lm_head.weight",
+        "d2t",
+        "t2d",
+    ]
+    _keys_to_ignore_on_save: ClassVar[list[str]] = [  # type: ignore[misc,assignment]
+        "verifier_lm_head.weight",
+        "verifier_norm.weight",
+    ]
+
+    def __init__(
+        self,
+        config: PEagleSpeculatorConfig,
+        t2d: torch.Tensor | None,
+        d2t: torch.Tensor | None,
+    ):
+        # Initialize via SpeculatorModel.__init__ (not Eagle3DraftModel)
+        # to avoid complex MRO issues - we replicate needed setup
+        SpeculatorModel.__init__(
+            self,
+            config=config,
+            verifier=None,
+            verifier_attachment_mode="train_only",
+        )
+        self.hidden_size = config.transformer_layer_config.hidden_size
+        self.draft_vocab_size = config.draft_vocab_size
+        self.para_num = config.para_num
+        self.down_sample_ratio = config.down_sample_ratio
+        self.down_sample_ratio_min = config.down_sample_ratio_min
+        self.ptd_token_id = config.ptd_token_id
+        self.loss_type = config.loss_type
+
+        # Verify mapping tensors
+        if (t2d is None) != (d2t is None):
+            raise ValueError(
+                "Both t2d and d2t must be provided together, or both must be None. "
+                f"Got t2d={'provided' if t2d is not None else 'None'}, "
+                f"d2t={'provided' if d2t is not None else 'None'}"
+            )
+
+        if t2d is not None:
+            self.register_buffer("t2d", t2d)
+            if int(t2d.sum(dtype=torch.long).item()) != self.draft_vocab_size:
+                raise ValueError(
+                    f"t2d has {int(t2d.sum(dtype=torch.long).item())} non-zero values, "
+                    f"expected {self.draft_vocab_size}."
+                )
+        else:
+            self.register_buffer("t2d", None)
+
+        if d2t is not None:
+            self.register_buffer("d2t", d2t)
+            if d2t.shape[0] != self.draft_vocab_size:
+                raise ValueError(
+                    f"d2t.shape[0] ({d2t.shape[0]}) must match"
+                    f" draft_vocab_size ({self.draft_vocab_size})."
+                )
+        else:
+            self.register_buffer("d2t", None)
+
+        # === P-EAGLE specific: Learnable padding parameters ===
+        # mask_hidden substitutes for missing hidden vectors at MTP positions
+        # Shape: [1, 1, 3 * hidden_size]
+        self.mask_hidden = torch.nn.Parameter(
+            torch.zeros(1, 1, 3 * self.hidden_size)
+        )
+        torch.nn.init.normal_(self.mask_hidden, mean=0.0, std=0.02)
+
+        # mask_token_embedding substitutes for unknown predicted tokens at MTP positions
+        # Shape: [1, 1, hidden_size]
+        self.mask_token_embedding = torch.nn.Parameter(
+            torch.zeros(1, 1, self.hidden_size)
+        )
+        torch.nn.init.normal_(self.mask_token_embedding, mean=0.0, std=0.02)
+
+        # === Standard EAGLE-3 architecture components ===
+        self.fc = torch.nn.Linear(3 * self.hidden_size, self.hidden_size, bias=False)
+        self._model_definitions = model_classes[
+            config.transformer_layer_config.model_type
+        ]
+        self._setup_decoder_layers(
+            config.transformer_layer_config, config.norm_before_residual
+        )
+        self.norm = self._model_definitions.norm_class(
+            self.hidden_size, eps=config.transformer_layer_config.rms_norm_eps
+        )
+        self._setup_rotary_embedding(config.transformer_layer_config)
+        self._setup_embeddings_and_lm_heads(
+            config.speculators_config.verifier, t2d, config.embed_requires_grad
+        )
+
+    def _setup_decoder_layers(
+        self, transformer_layer_config: PretrainedConfig, norm_before_residual: bool
+    ):
+        """Setup decoder layers (same as EAGLE-3)."""
+        num_hidden_layers = transformer_layer_config.num_hidden_layers
+        layers = [
+            self._model_definitions.first_layer_class(
+                transformer_layer_config,
+                layer_idx=0,
+                norm_before_residual=norm_before_residual,
+            )
+        ]
+        layers.extend([
+            self._model_definitions.decoder_layer_class(
+                transformer_layer_config, layer_idx
+            )
+            for layer_idx in range(1, num_hidden_layers)
+        ])
+        self.layers = torch.nn.ModuleList(layers)
+
+    def _setup_rotary_embedding(self, transformer_layer_config: PretrainedConfig):
+        """Setup rotary embedding with 2x hidden size (same as EAGLE-3)."""
+        modified_config = copy.copy(transformer_layer_config)
+        modified_config.hidden_size = modified_config.hidden_size * 2
+        self.rotary_emb = self._model_definitions.rotary_emb_class(modified_config)
+
+    def _setup_embeddings_and_lm_heads(
+        self,
+        config: VerifierConfig,
+        t2d: torch.Tensor | None,
+        embed_requires_grad: bool,
+    ):
+        """Setup embeddings and LM heads (same as EAGLE-3 but embed unfrozen by default)."""
+        if config.name_or_path is None:
+            raise ValueError("VerifierConfig `name_or_path` value is required.")
+        verifier_model_config = AutoConfig.from_pretrained(config.name_or_path)
+
+        if hasattr(verifier_model_config, "text_config"):
+            verifier_model_config = verifier_model_config.text_config
+
+        if verifier_model_config.hidden_size != self.hidden_size:
+            raise ValueError(
+                f"Verifier hidden size {verifier_model_config.hidden_size} does not"
+                f" match draft hidden size {self.hidden_size}."
+            )
+
+        verifier_weights = load_model_layers(
+            ["embed_tokens.weight", "lm_head.weight", "model.norm.weight"],
+            config.name_or_path,
+        )
+
+        if "embed_tokens.weight" not in verifier_weights:
+            raise KeyError(
+                f"Could not find embedding weights in {config.name_or_path}. "
+                "Expected a key ending with 'embed_tokens.weight'."
+            )
+
+        embed_tokens_weight = verifier_weights["embed_tokens.weight"]
+        lm_head_weight = verifier_weights.get("lm_head.weight", embed_tokens_weight)
+
+        self.verifier_norm = self._model_definitions.norm_class(
+            self.hidden_size, eps=verifier_model_config.rms_norm_eps,
+        )
+
+        # EMBEDDINGS
+        self.embed_tokens = torch.nn.Embedding(
+            verifier_model_config.vocab_size,
+            self.hidden_size,
+            padding_idx=verifier_model_config.pad_token_id,
+        )
+        default_dtype = self.embed_tokens.weight.dtype
+        self.embed_tokens.load_state_dict(
+            {"weight": embed_tokens_weight.to(default_dtype)}
+        )
+        # P-EAGLE: embeddings trainable by default
+        self.embed_tokens.weight.requires_grad = embed_requires_grad
+
+        # LM HEADS
+        self.lm_head = torch.nn.Linear(
+            self.hidden_size, self.draft_vocab_size, bias=False
+        )
+        self.verifier_lm_head = torch.nn.Linear(
+            self.hidden_size, self.draft_vocab_size, bias=False
+        )
+
+        if t2d is not None:
+            lm_head_weight = lm_head_weight.to(
+                device=t2d.device, dtype=default_dtype
+            )[t2d.to(torch.bool), :]
+        else:
+            lm_head_weight = lm_head_weight.to(dtype=default_dtype)
+
+        if lm_head_weight.shape != self.lm_head.weight.shape:
+            raise ValueError(
+                f"Verifier lm head data shape {lm_head_weight.shape} does not match "
+                f"draft lm head shape {self.lm_head.weight.shape}"
+            )
+        self.lm_head.weight.data = lm_head_weight.detach().clone()
+        self.verifier_lm_head.weight.data = lm_head_weight.detach().clone()
+        self.verifier_lm_head.weight.requires_grad = False
+
+        if "model.norm.weight" in verifier_weights:
+            verifier_norm_weight = verifier_weights["model.norm.weight"]
+            self.verifier_norm.load_state_dict(
+                {"weight": verifier_norm_weight.to(default_dtype)}
+            )
+        self.verifier_norm.weight.requires_grad = False
+
+    def _build_parallel_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+        depth_indices: list[torch.Tensor],
+    ) -> torch.Tensor:
+        """Build combined hidden states for parallel group processing.
+
+        Concatenates NTP hidden states with mask_hidden for MTP positions.
+
+        Args:
+            hidden_states: NTP hidden states [1, ntp_len, 3 * hidden_size].
+            depth_indices: COD-sampled indices per depth.
+
+        Returns:
+            Combined hidden states [1, total_positions, 3 * hidden_size]
+            where MTP positions use mask_hidden.
+        """
+        parts = [hidden_states]  # Start with depth 0 (NTP)
+
+        for k in range(1, len(depth_indices)):
+            n_positions = depth_indices[k].shape[0]
+            if n_positions > 0:
+                # Use learnable mask_hidden for MTP positions
+                mtp_hidden = self.mask_hidden.expand(1, n_positions, -1)
+                parts.append(mtp_hidden)
+
+        return torch.cat(parts, dim=1)
+
+    def _build_parallel_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        depth_indices: list[torch.Tensor],
+    ) -> torch.Tensor:
+        """Build input IDs for parallel group processing.
+
+        NTP positions use actual input IDs. MTP positions use ptd_token_id
+        as placeholder.
+
+        Args:
+            input_ids: NTP input IDs [1, ntp_len].
+            depth_indices: COD-sampled indices per depth.
+
+        Returns:
+            Combined input IDs [1, total_positions].
+        """
+        device = input_ids.device
+        parts = [input_ids]  # Start with depth 0 (NTP)
+
+        for k in range(1, len(depth_indices)):
+            n_positions = depth_indices[k].shape[0]
+            if n_positions > 0:
+                # MTP positions get ptd_token_id
+                mtp_ids = torch.full(
+                    (1, n_positions), self.ptd_token_id,
+                    dtype=input_ids.dtype, device=device,
+                )
+                parts.append(mtp_ids)
+
+        return torch.cat(parts, dim=1)
+
+    def _build_parallel_position_ids(
+        self,
+        position_ids: torch.Tensor,
+        depth_indices: list[torch.Tensor],
+    ) -> torch.Tensor:
+        """Build position IDs for parallel group processing.
+
+        MTP positions use their original sequence positions (shifted by depth k)
+        to maintain proper positional encoding.
+
+        Args:
+            position_ids: NTP position IDs [1, ntp_len].
+            depth_indices: COD-sampled indices per depth.
+
+        Returns:
+            Combined position IDs [1, total_positions].
+        """
+        device = position_ids.device
+        parts = [position_ids]  # Start with depth 0 (NTP)
+
+        for k in range(1, len(depth_indices)):
+            if depth_indices[k].numel() > 0:
+                # MTP position IDs: original positions shifted by depth
+                # depth k predicts token k+1 positions ahead
+                mtp_pos = depth_indices[k].unsqueeze(0) + k + 1
+                parts.append(mtp_pos.to(device))
+
+        return torch.cat(parts, dim=1)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,  # [1, seq_len, 3 * hidden_size]
+        input_ids: torch.Tensor,  # [1, seq_len]
+        lengths: torch.Tensor | None = None,  # [batch_size]
+        loss_mask: torch.Tensor | None = None,  # [1, seq_len]
+        position_ids: torch.Tensor | None = None,  # [1, seq_len]
+        verifier_last_hidden_states: torch.Tensor | None = None,
+        para_num: int | None = None,
+        down_sample_ratio: float | None = None,
+        **kwargs,
+    ):
+        """Forward pass with parallel multi-token prediction.
+
+        Performs COD sampling to generate parallel prediction groups, then
+        processes all groups in a single forward pass through the decoder.
+
+        Args:
+            hidden_states: Concatenated verifier hidden states [1, seq_len, 3*H].
+            input_ids: Input token IDs [1, seq_len].
+            lengths: Per-document sequence lengths for attention masking.
+            loss_mask: Boolean mask for valid training positions [1, seq_len].
+            position_ids: Token position IDs [1, seq_len].
+            verifier_last_hidden_states: Verifier output for loss computation.
+            para_num: Override for number of parallel depths.
+            down_sample_ratio: Override for COD retention rate.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            If verifier_last_hidden_states is provided (training):
+                Tuple of (draft_tokens_list, loss, metrics_dict)
+            Otherwise (inference):
+                List of draft token predictions per depth.
+        """
+        device = hidden_states.device
+        total_seq_len = hidden_states.shape[1]
+        _para_num = para_num if para_num is not None else self.para_num
+        _down_sample_ratio = (
+            down_sample_ratio if down_sample_ratio is not None else
+            self.down_sample_ratio
+        )
+
+        if lengths is None:
+            lengths = torch.tensor([total_seq_len], dtype=torch.long, device=device)
+        if position_ids is None:
+            position_ids = 1 + torch.arange(
+                total_seq_len, dtype=torch.long, device=device
+            ).unsqueeze(0)
+
+        # === COD Sampling ===
+        sample_mask = (
+            loss_mask.squeeze(0).bool()
+            if loss_mask is not None
+            else torch.ones(total_seq_len, dtype=torch.bool, device=device)
+        )
+        depth_indices = cod_sample(
+            sample_mask,
+            down_sample_ratio=_down_sample_ratio,
+            num_depths=_para_num,
+            down_sample_ratio_min=self.down_sample_ratio_min,
+        )
+
+        # === Build parallel inputs ===
+        parallel_hidden = self._build_parallel_hidden_states(
+            hidden_states, depth_indices
+        )
+        parallel_ids = self._build_parallel_input_ids(input_ids, depth_indices)
+        parallel_pos = self._build_parallel_position_ids(position_ids, depth_indices)
+
+        combined_len = parallel_hidden.shape[1]
+
+        # === Attention mask ===
+        mask_mod = build_parallel_group_mask_mod(
+            lengths.to(device), depth_indices, combined_len,
+        )
+        attention_mask = create_block_mask(
+            mask_mod,
+            B=None, H=None,
+            Q_LEN=combined_len,
+            KV_LEN=combined_len,
+            device=device,
+        )
+
+        # === Forward through decoder ===
+        past_key_values = DynamicCache(
+            config=self.config.transformer_layer_config
+        )
+
+        combined_hidden = self.fc(parallel_hidden)
+        # [1, combined_len, hidden_size]
+
+        with torch.no_grad():
+            # For MTP positions, use mask_token_embedding instead of actual embeddings
+            ntp_len = depth_indices[0].shape[0]
+            input_embeds_ntp = self.embed_tokens(parallel_ids[:, :ntp_len])
+            mtp_len = combined_len - ntp_len
+            if mtp_len > 0:
+                input_embeds_mtp = self.mask_token_embedding.expand(1, mtp_len, -1)
+                input_embeds = torch.cat([input_embeds_ntp, input_embeds_mtp], dim=1)
+            else:
+                input_embeds = input_embeds_ntp
+
+        combined_hidden = torch.cat([input_embeds, combined_hidden], dim=-1)
+        # [1, combined_len, 2 * hidden_size]
+
+        position_embeddings = self.rotary_emb(combined_hidden, parallel_pos)
+
+        cache_position = torch.arange(
+            combined_len, dtype=torch.long, device=device
+        )
+
+        for decoder_layer in self.layers:
+            combined_hidden = decoder_layer(
+                combined_hidden,
+                attention_mask=attention_mask,
+                position_ids=parallel_pos,
+                past_key_values=past_key_values,
+                cache_position=cache_position,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+
+        logits = self.lm_head(self.norm(combined_hidden))
+        # [1, combined_len, draft_vocab_size]
+
+        # === Split logits by depth and compute loss ===
+        return_loss = verifier_last_hidden_states is not None
+        draft_tokens = []
+        offset = 0
+
+        if return_loss:
+            with torch.no_grad():
+                targets = self.verifier_lm_head(
+                    self.verifier_norm(verifier_last_hidden_states)
+                )
+
+            loss = torch.tensor(0.0, device=device)
+            metrics: dict[str, torch.Tensor] = {}
+
+        for k in range(len(depth_indices)):
+            n_k = depth_indices[k].shape[0]
+            depth_logits = logits[:, offset:offset + n_k, :]
+            draft_tokens.append(torch.argmax(depth_logits, dim=-1).detach().clone())
+
+            if return_loss and n_k > 0:
+                # Get targets at appropriate positions for this depth
+                # Depth k predicts token at position i + k + 1
+                idx = depth_indices[k]
+                if k == 0:
+                    # NTP: predict next token (shift by 1)
+                    valid = idx < total_seq_len - 1
+                    shifted_idx = torch.clamp(idx + 1, max=total_seq_len - 1)
+                else:
+                    # MTP depth k: predict token k+1 ahead
+                    valid = idx + k + 1 < total_seq_len
+                    shifted_idx = torch.clamp(idx + k + 1, max=total_seq_len - 1)
+
+                if self.loss_type == "cross_entropy":
+                    # Cross-entropy with target token IDs
+                    depth_targets = torch.argmax(
+                        targets[:, shifted_idx, :], dim=-1
+                    )
+                    depth_mask = valid.unsqueeze(0).float()
+                    depth_loss = cross_entropy_loss(
+                        depth_logits, depth_targets, depth_mask
+                    )
+                else:
+                    # KL divergence with target distributions
+                    depth_target_dist = targets[:, shifted_idx, :]
+                    depth_mask = valid.unsqueeze(0).float()
+                    depth_loss = kl_div_loss(
+                        depth_logits, depth_target_dist, depth_mask
+                    )
+
+                loss = loss + depth_loss
+                metrics[f"loss_depth_{k}"] = depth_loss.detach().clone()
+
+                # Accuracy for this depth
+                pred_ids = torch.argmax(depth_logits, dim=-1)
+                target_ids = torch.argmax(targets[:, shifted_idx, :], dim=-1)
+                correct = (pred_ids == target_ids).float()
+                if valid.any():
+                    acc = (correct * valid.unsqueeze(0).float()).sum() / (
+                        valid.float().sum() + 1e-5
+                    )
+                else:
+                    acc = torch.tensor(0.0, device=device)
+                metrics[f"acc_depth_{k}"] = acc
+
+            offset += n_k
+
+        if return_loss:
+            metrics["loss"] = loss.detach().clone()
+            return draft_tokens, loss, metrics
+        else:
+            return draft_tokens
+
+    @classmethod
+    def from_training_args(
+        cls,
+        verifier_config: PretrainedConfig,
+        **kwargs,
+    ) -> "PEagleDraftModel":
+        """Create P-EAGLE model from training arguments.
+
+        Args:
+            verifier_config: Verifier model configuration.
+            **kwargs: Training arguments including P-EAGLE-specific params:
+                - num_layers: Number of decoder layers
+                - norm_before_residual: Whether to normalize before residual
+                - t2d/d2t: Vocabulary mapping tensors
+                - para_num: Number of parallel prediction depths
+                - down_sample_ratio: COD retention rate
+                - down_sample_ratio_min: Minimum retention rate
+                - ptd_token_id: Padding token ID for MTP
+                - loss_type: Loss function type
+                - verifier_name_or_path: Path to verifier model
+
+        Returns:
+            Initialized PEagleDraftModel.
+        """
+        config = PEagleSpeculatorConfig(
+            transformer_layer_config=verifier_config,
+            draft_vocab_size=kwargs["draft_vocab_size"],
+            norm_before_residual=kwargs["norm_before_residual"],
+            embed_requires_grad=kwargs.get("embed_requires_grad", True),
+            para_num=kwargs.get("para_num", 8),
+            down_sample_ratio=kwargs.get("down_sample_ratio", 0.5),
+            down_sample_ratio_min=kwargs.get("down_sample_ratio_min", 0.0),
+            ptd_token_id=kwargs.get("ptd_token_id", 0),
+            loss_type=kwargs.get("loss_type", "cross_entropy"),
+            speculators_config=SpeculatorsConfig(
+                algorithm="peagle",
+                proposal_methods=[
+                    GreedyTokenProposalConfig(
+                        speculative_tokens=kwargs.get("para_num", 8),
+                    )
+                ],
+                default_proposal_method="greedy",
+                verifier=VerifierConfig.from_config(
+                    verifier_config, name_or_path=kwargs["verifier_name_or_path"]
+                ),
+            ),
+        )
+
+        return cls(config=config, t2d=kwargs.get("t2d"), d2t=kwargs.get("d2t"))
+
+    @staticmethod
+    def get_trainer_kwargs(**kwargs) -> tuple[dict, dict]:
+        """Get training and validation kwargs for P-EAGLE.
+
+        Args:
+            **kwargs: Training arguments.
+
+        Returns:
+            Tuple of (train_call_kwargs, val_call_kwargs).
+        """
+        train_kwargs = {
+            "para_num": kwargs.get("para_num", 8),
+            "down_sample_ratio": kwargs.get("down_sample_ratio", 0.5),
+        }
+        val_kwargs = {
+            "para_num": kwargs.get("para_num", 8),
+            "down_sample_ratio": kwargs.get("down_sample_ratio", 0.5),
+        }
+        return train_kwargs, val_kwargs

--- a/src/speculators/models/peagle/loss.py
+++ b/src/speculators/models/peagle/loss.py
@@ -1,0 +1,190 @@
+"""
+Loss functions for P-EAGLE training.
+
+This module provides loss computation utilities for P-EAGLE, including
+cross-entropy loss (default for P-EAGLE) and per-depth loss aggregation
+for parallel multi-token prediction training.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def cross_entropy_loss(
+    logits: torch.Tensor,
+    target_ids: torch.Tensor,
+    loss_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute cross-entropy loss for P-EAGLE training.
+
+    Unlike EAGLE-3's KL divergence loss which operates on probability
+    distributions, P-EAGLE uses standard cross-entropy loss with target
+    token IDs.
+
+    Args:
+        logits: Model output logits of shape [batch, seq_len, vocab_size].
+        target_ids: Target token IDs of shape [batch, seq_len].
+        loss_mask: Optional boolean mask of shape [batch, seq_len] indicating
+            which positions to include in loss computation.
+
+    Returns:
+        Scalar loss value averaged over valid positions.
+    """
+    # Reshape for cross_entropy: [batch * seq_len, vocab_size] and [batch * seq_len]
+    batch, seq_len, vocab_size = logits.shape
+
+    logits_flat = logits.reshape(-1, vocab_size)
+    targets_flat = target_ids.reshape(-1)
+
+    # Compute per-token cross-entropy loss
+    per_token_loss = F.cross_entropy(logits_flat, targets_flat, reduction="none")
+    # shape: [batch * seq_len]
+
+    per_token_loss = per_token_loss.reshape(batch, seq_len)
+
+    if loss_mask is not None:
+        # Apply mask and average over valid positions
+        per_token_loss = per_token_loss * loss_mask.float()
+        denominator = loss_mask.float().sum() + 1e-5
+        return per_token_loss.sum() / denominator
+    else:
+        return per_token_loss.mean()
+
+
+def kl_div_loss(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    loss_mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute KL divergence loss (same as EAGLE-3).
+
+    This is kept for compatibility with EAGLE-3's loss computation pattern.
+    P-EAGLE defaults to cross_entropy_loss but can optionally use KL divergence.
+
+    Args:
+        logits: Model output logits of shape [batch, seq_len, vocab_size].
+        targets: Target logits/probabilities of shape [batch, seq_len, vocab_size].
+        loss_mask: Optional boolean mask of shape [batch, seq_len].
+
+    Returns:
+        Scalar loss value averaged over valid positions.
+    """
+    log_probs = F.log_softmax(logits, dim=-1)
+    target_probs = F.softmax(targets, dim=-1)
+    elementwise_loss = F.kl_div(
+        log_probs, target_probs, reduction="none", log_target=False
+    )
+
+    if loss_mask is not None:
+        elementwise_loss = elementwise_loss * loss_mask.unsqueeze(-1)
+        denominator = loss_mask.sum(dim=1) + 1e-5
+    else:
+        denominator = logits.shape[1]
+
+    batch_loss = torch.sum(elementwise_loss, dim=(1, 2)) / denominator
+    return batch_loss.mean()
+
+
+def per_depth_loss(
+    all_logits: list[torch.Tensor],
+    all_targets: list[torch.Tensor],
+    all_masks: list[torch.Tensor | None],
+    loss_fn: str = "cross_entropy",
+    depth_loss_weights: list[float] | None = None,
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """Compute aggregate loss across parallel prediction depths.
+
+    Computes loss for each depth independently and returns the weighted sum
+    along with per-depth metrics.
+
+    Args:
+        all_logits: List of K tensors, one per depth. Shape varies by depth
+            due to COD sampling: [batch, n_positions_k, vocab_size].
+        all_targets: List of K target tensors matching all_logits shapes.
+            For cross_entropy: [batch, n_positions_k] (token IDs).
+            For kl_div: [batch, n_positions_k, vocab_size] (distributions).
+        all_masks: List of K optional mask tensors, [batch, n_positions_k].
+        loss_fn: Loss function type, one of 'cross_entropy' or 'kl_div'.
+        depth_loss_weights: Optional per-depth loss weights. If None,
+            all depths are weighted equally.
+
+    Returns:
+        Tuple of (total_loss, metrics_dict) where metrics_dict contains
+        per-depth loss values keyed as 'loss_depth_{k}'.
+
+    Raises:
+        ValueError: If loss_fn is not a recognized type.
+    """
+    if loss_fn == "cross_entropy":
+        _loss_fn = cross_entropy_loss
+    elif loss_fn == "kl_div":
+        _loss_fn = kl_div_loss
+    else:
+        raise ValueError(f"Unknown loss function: {loss_fn}. Use 'cross_entropy' or 'kl_div'.")
+
+    num_depths = len(all_logits)
+    if depth_loss_weights is None:
+        depth_loss_weights = [1.0] * num_depths
+
+    if len(depth_loss_weights) != num_depths:
+        raise ValueError(
+            f"depth_loss_weights length ({len(depth_loss_weights)}) "
+            f"must match num_depths ({num_depths})"
+        )
+
+    device = all_logits[0].device
+    total_loss = torch.tensor(0.0, device=device)
+    metrics: dict[str, torch.Tensor] = {}
+
+    for k in range(num_depths):
+        if all_logits[k].numel() == 0:
+            metrics[f"loss_depth_{k}"] = torch.tensor(0.0, device=device)
+            continue
+
+        depth_loss = _loss_fn(all_logits[k], all_targets[k], all_masks[k])
+        weighted_loss = depth_loss_weights[k] * depth_loss
+        total_loss = total_loss + weighted_loss
+        metrics[f"loss_depth_{k}"] = depth_loss.detach().clone()
+
+    metrics["loss"] = total_loss.detach().clone()
+    return total_loss, metrics
+
+
+@torch.no_grad()
+def per_depth_accuracy(
+    all_logits: list[torch.Tensor],
+    all_target_ids: list[torch.Tensor],
+    all_masks: list[torch.Tensor | None],
+) -> dict[str, torch.Tensor]:
+    """Compute top-1 accuracy for each prediction depth.
+
+    Args:
+        all_logits: List of K logit tensors per depth.
+        all_target_ids: List of K target token ID tensors per depth.
+        all_masks: List of K optional mask tensors per depth.
+
+    Returns:
+        Dictionary with per-depth accuracy keyed as 'acc_depth_{k}'.
+    """
+    metrics: dict[str, torch.Tensor] = {}
+    device = all_logits[0].device
+
+    for k in range(len(all_logits)):
+        if all_logits[k].numel() == 0:
+            metrics[f"acc_depth_{k}"] = torch.tensor(0.0, device=device)
+            continue
+
+        predicted = torch.argmax(all_logits[k], dim=-1)
+        correct = predicted == all_target_ids[k]
+
+        if all_masks[k] is not None:
+            correct = correct * all_masks[k].bool()
+            denom = all_masks[k].float().sum() + 1e-5
+        else:
+            denom = torch.tensor(correct.numel(), dtype=torch.float, device=device)
+
+        metrics[f"acc_depth_{k}"] = correct.float().sum() / denom
+
+    return metrics

--- a/tests/unit/models/test_peagle_cod_sampling.py
+++ b/tests/unit/models/test_peagle_cod_sampling.py
@@ -1,0 +1,297 @@
+"""Unit tests for P-EAGLE COD sampling utilities."""
+
+import pytest
+import torch
+
+from speculators.models.peagle.cod_sampling import (
+    build_depth_position_ids,
+    cod_sample,
+    compute_cod_statistics,
+)
+
+
+class TestCodSample:
+    """Tests for the cod_sample function."""
+
+    def test_basic_sampling(self):
+        """Test basic COD sampling with a simple loss mask."""
+        loss_mask = torch.tensor([True, False, True, True, True, False, True])
+        indices = cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=3)
+
+        assert len(indices) == 3
+        # Depth 0 should retain all valid positions
+        assert torch.equal(indices[0], torch.tensor([0, 2, 3, 4, 6]))
+        # Deeper depths should have fewer positions
+        assert len(indices[1]) <= len(indices[0])
+        assert len(indices[2]) <= len(indices[1])
+
+    def test_depth_0_retains_all_valid(self):
+        """Depth 0 should always retain all valid positions."""
+        loss_mask = torch.tensor([True, True, False, True, False, True])
+        indices = cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=4)
+
+        expected = torch.tensor([0, 1, 3, 5])
+        assert torch.equal(indices[0], expected)
+
+    def test_geometric_decay_count(self):
+        """Verify geometric decay in position counts."""
+        # Use a large sequence to make statistics reliable
+        n = 1000
+        loss_mask = torch.ones(n, dtype=torch.bool)
+        r = 0.5
+        K = 4
+
+        generator = torch.Generator().manual_seed(42)
+        indices = cod_sample(
+            loss_mask, down_sample_ratio=r, num_depths=K, generator=generator
+        )
+
+        # Depth k should retain approximately n * r^k positions
+        for k in range(K):
+            expected = int(n * r**k)
+            actual = len(indices[k])
+            if k == 0:
+                assert actual == n
+            else:
+                assert actual == expected
+
+    def test_single_depth(self):
+        """num_depths=1 should only return depth 0 (all valid positions)."""
+        loss_mask = torch.tensor([True, False, True, True])
+        indices = cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=1)
+
+        assert len(indices) == 1
+        assert torch.equal(indices[0], torch.tensor([0, 2, 3]))
+
+    def test_empty_loss_mask(self):
+        """Test with no valid positions."""
+        loss_mask = torch.zeros(10, dtype=torch.bool)
+        indices = cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=3)
+
+        assert len(indices) == 3
+        for k in range(3):
+            assert indices[k].numel() == 0
+
+    def test_all_valid_positions(self):
+        """Test with all positions valid."""
+        loss_mask = torch.ones(10, dtype=torch.bool)
+        indices = cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=2)
+
+        assert len(indices) == 2
+        assert len(indices[0]) == 10
+        assert len(indices[1]) == 5  # floor(10 * 0.5)
+
+    def test_sorted_order(self):
+        """Sampled indices should be in sorted (causal) order."""
+        loss_mask = torch.ones(100, dtype=torch.bool)
+        indices = cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=5)
+
+        for k in range(5):
+            if indices[k].numel() > 1:
+                diffs = indices[k][1:] - indices[k][:-1]
+                assert (diffs > 0).all(), f"Depth {k} indices not sorted"
+
+    def test_indices_are_valid_positions(self):
+        """All returned indices should be positions where loss_mask is True."""
+        loss_mask = torch.tensor(
+            [True, False, True, False, True, True, False, True, True, False]
+        )
+        valid = torch.nonzero(loss_mask, as_tuple=False).squeeze(-1)
+        valid_set = set(valid.tolist())
+
+        indices = cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=4)
+
+        for k in range(4):
+            for idx in indices[k].tolist():
+                assert idx in valid_set, f"Index {idx} at depth {k} is not valid"
+
+    def test_reproducibility_with_generator(self):
+        """Same generator seed should produce same results."""
+        loss_mask = torch.ones(50, dtype=torch.bool)
+
+        gen1 = torch.Generator().manual_seed(123)
+        indices1 = cod_sample(
+            loss_mask, down_sample_ratio=0.5, num_depths=4, generator=gen1
+        )
+
+        gen2 = torch.Generator().manual_seed(123)
+        indices2 = cod_sample(
+            loss_mask, down_sample_ratio=0.5, num_depths=4, generator=gen2
+        )
+
+        for k in range(4):
+            assert torch.equal(indices1[k], indices2[k])
+
+    def test_down_sample_ratio_min(self):
+        """Minimum retention rate should prevent zero positions at deep depths."""
+        loss_mask = torch.ones(100, dtype=torch.bool)
+        # With r=0.1 and K=10, depth 9 would have 100 * 0.1^9 ≈ 0
+        # but with min=0.05, depth 9 should have at least 100 * 0.05 = 5
+        indices = cod_sample(
+            loss_mask,
+            down_sample_ratio=0.1,
+            num_depths=10,
+            down_sample_ratio_min=0.05,
+        )
+
+        for k in range(10):
+            expected_min = int(100 * 0.05)
+            if k == 0:
+                assert len(indices[k]) == 100
+            else:
+                # With min, should have at least floor(100 * 0.05) = 5
+                actual_ratio = max(0.1**k, 0.05)
+                expected = int(100 * actual_ratio)
+                assert len(indices[k]) == expected
+
+    def test_invalid_down_sample_ratio(self):
+        """Should raise ValueError for invalid ratio values."""
+        loss_mask = torch.ones(10, dtype=torch.bool)
+
+        with pytest.raises(ValueError, match="down_sample_ratio must be in"):
+            cod_sample(loss_mask, down_sample_ratio=0.0, num_depths=2)
+
+        with pytest.raises(ValueError, match="down_sample_ratio must be in"):
+            cod_sample(loss_mask, down_sample_ratio=1.0, num_depths=2)
+
+        with pytest.raises(ValueError, match="down_sample_ratio must be in"):
+            cod_sample(loss_mask, down_sample_ratio=-0.5, num_depths=2)
+
+        with pytest.raises(ValueError, match="down_sample_ratio must be in"):
+            cod_sample(loss_mask, down_sample_ratio=1.5, num_depths=2)
+
+    def test_invalid_num_depths(self):
+        """Should raise ValueError for num_depths < 1."""
+        loss_mask = torch.ones(10, dtype=torch.bool)
+
+        with pytest.raises(ValueError, match="num_depths must be >= 1"):
+            cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=0)
+
+    def test_invalid_min_ratio(self):
+        """Should raise ValueError for invalid min ratio."""
+        loss_mask = torch.ones(10, dtype=torch.bool)
+
+        with pytest.raises(ValueError, match="down_sample_ratio_min must be in"):
+            cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=2,
+                       down_sample_ratio_min=-0.1)
+
+        with pytest.raises(ValueError, match="down_sample_ratio_min must be in"):
+            cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=2,
+                       down_sample_ratio_min=1.5)
+
+    def test_very_small_sequence(self):
+        """Test with single-element sequence."""
+        loss_mask = torch.tensor([True])
+        indices = cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=3)
+
+        assert len(indices) == 3
+        assert torch.equal(indices[0], torch.tensor([0]))
+        # floor(1 * 0.5) = 0, so deeper depths should be empty
+        assert indices[1].numel() == 0
+        assert indices[2].numel() == 0
+
+    def test_high_retention_rate(self):
+        """Test with retention rate close to 1."""
+        loss_mask = torch.ones(20, dtype=torch.bool)
+        indices = cod_sample(loss_mask, down_sample_ratio=0.9, num_depths=3)
+
+        # All depths should retain most positions
+        assert len(indices[0]) == 20
+        assert len(indices[1]) == 18  # floor(20 * 0.9)
+        assert len(indices[2]) == 16  # floor(20 * 0.81)
+
+    def test_low_retention_rate(self):
+        """Test with very low retention rate."""
+        loss_mask = torch.ones(100, dtype=torch.bool)
+        indices = cod_sample(loss_mask, down_sample_ratio=0.1, num_depths=4)
+
+        assert len(indices[0]) == 100
+        assert len(indices[1]) == 10  # floor(100 * 0.1)
+        assert len(indices[2]) == 1   # floor(100 * 0.01)
+        assert len(indices[3]) == 0   # floor(100 * 0.001) = 0
+
+    def test_no_duplicate_indices(self):
+        """Each depth should have unique indices."""
+        loss_mask = torch.ones(50, dtype=torch.bool)
+        indices = cod_sample(loss_mask, down_sample_ratio=0.5, num_depths=5)
+
+        for k in range(5):
+            unique = torch.unique(indices[k])
+            assert len(unique) == len(indices[k]), f"Duplicates at depth {k}"
+
+
+class TestComputeCodStatistics:
+    """Tests for compute_cod_statistics."""
+
+    def test_basic_statistics(self):
+        """Test basic statistics computation."""
+        indices = [
+            torch.tensor([0, 1, 2, 3, 4]),
+            torch.tensor([1, 3]),
+            torch.tensor([2]),
+        ]
+        stats = compute_cod_statistics(indices, seq_len=10)
+
+        assert stats["num_depths"] == 3
+        assert stats["seq_len"] == 10
+        assert stats["per_depth_counts"] == [5, 2, 1]
+        assert stats["total_positions"] == 8
+        assert stats["naive_total"] == 15
+        assert abs(stats["compression_ratio"] - 8 / 15) < 1e-5
+
+    def test_empty_indices(self):
+        """Test with empty depth indices."""
+        indices = [torch.tensor([0, 1, 2]), torch.tensor([])]
+        stats = compute_cod_statistics(indices, seq_len=5)
+
+        assert stats["total_positions"] == 3
+        assert stats["per_depth_counts"] == [3, 0]
+
+    def test_single_depth(self):
+        """Test with single depth."""
+        indices = [torch.tensor([0, 1, 2, 3])]
+        stats = compute_cod_statistics(indices, seq_len=5)
+
+        assert stats["compression_ratio"] == 1.0
+
+
+class TestBuildDepthPositionIds:
+    """Tests for build_depth_position_ids."""
+
+    def test_basic_position_ids(self):
+        """Test basic position ID building."""
+        indices = [
+            torch.tensor([0, 1, 2, 3]),
+            torch.tensor([1, 3]),
+            torch.tensor([2]),
+        ]
+        pos_ids = build_depth_position_ids(indices, seq_len=5)
+
+        expected = torch.tensor([0, 1, 2, 3, 1, 3, 2])
+        assert torch.equal(pos_ids, expected)
+
+    def test_empty_depths(self):
+        """Test with some empty depths."""
+        indices = [
+            torch.tensor([0, 1]),
+            torch.tensor([], dtype=torch.long),
+            torch.tensor([0]),
+        ]
+        pos_ids = build_depth_position_ids(indices, seq_len=3)
+
+        expected = torch.tensor([0, 1, 0])
+        assert torch.equal(pos_ids, expected)
+
+    def test_all_empty(self):
+        """Test with all empty indices."""
+        indices = []
+        pos_ids = build_depth_position_ids(indices, seq_len=0)
+
+        assert pos_ids.numel() == 0
+
+    def test_device_placement(self):
+        """Test that output respects device parameter."""
+        indices = [torch.tensor([0, 1, 2])]
+        pos_ids = build_depth_position_ids(indices, seq_len=3, device=torch.device("cpu"))
+
+        assert pos_ids.device == torch.device("cpu")

--- a/tests/unit/models/test_peagle_config.py
+++ b/tests/unit/models/test_peagle_config.py
@@ -1,0 +1,128 @@
+"""Unit tests for P-EAGLE configuration."""
+
+import pytest
+from pydantic import ValidationError
+from transformers.models.llama.configuration_llama import LlamaConfig
+
+from speculators.config import SpeculatorModelConfig, SpeculatorsConfig, VerifierConfig
+from speculators.models.peagle.config import PEagleSpeculatorConfig
+from speculators.proposals.greedy import GreedyTokenProposalConfig
+
+
+def _make_speculators_config():
+    """Helper to create a minimal SpeculatorsConfig."""
+    return SpeculatorsConfig(
+        algorithm="peagle",
+        proposal_methods=[GreedyTokenProposalConfig(speculative_tokens=8)],
+        default_proposal_method="greedy",
+        verifier=VerifierConfig(
+            name_or_path="test-model",
+            architectures=["LlamaForCausalLM"],
+        ),
+    )
+
+
+class TestPEagleSpeculatorConfig:
+    """Tests for PEagleSpeculatorConfig."""
+
+    def test_default_values(self):
+        """Test default configuration values."""
+        config = PEagleSpeculatorConfig(
+            speculators_config=_make_speculators_config(),
+        )
+        assert config.speculators_model_type == "peagle"
+        assert config.para_num == 8
+        assert config.down_sample_ratio == 0.5
+        assert config.down_sample_ratio_min == 0.0
+        assert config.ptd_token_id == 0
+        assert config.loss_type == "cross_entropy"
+        assert config.architectures == ["PEagleSpeculator"]
+
+    def test_custom_values(self):
+        """Test with custom configuration values."""
+        config = PEagleSpeculatorConfig(
+            speculators_config=_make_speculators_config(),
+            para_num=4,
+            down_sample_ratio=0.7,
+            down_sample_ratio_min=0.1,
+            ptd_token_id=128255,
+            loss_type="kl_div",
+        )
+        assert config.para_num == 4
+        assert config.down_sample_ratio == 0.7
+        assert config.down_sample_ratio_min == 0.1
+        assert config.ptd_token_id == 128255
+        assert config.loss_type == "kl_div"
+
+    def test_inherits_eagle3_fields(self):
+        """Config should inherit EAGLE-3 fields."""
+        llama_config = LlamaConfig(
+            hidden_size=256,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            intermediate_size=512,
+        )
+        config = PEagleSpeculatorConfig(
+            speculators_config=_make_speculators_config(),
+            transformer_layer_config=llama_config,
+            draft_vocab_size=1000,
+            norm_before_residual=True,
+        )
+        assert config.draft_vocab_size == 1000
+        assert config.norm_before_residual is True
+        assert config.transformer_layer_config.hidden_size == 256
+
+    def test_invalid_para_num(self):
+        """para_num must be >= 1."""
+        with pytest.raises(ValidationError):
+            PEagleSpeculatorConfig(
+                speculators_config=_make_speculators_config(),
+                para_num=0,
+            )
+
+    def test_invalid_down_sample_ratio(self):
+        """down_sample_ratio must be in (0, 1)."""
+        with pytest.raises(ValidationError):
+            PEagleSpeculatorConfig(
+                speculators_config=_make_speculators_config(),
+                down_sample_ratio=0.0,
+            )
+        with pytest.raises(ValidationError):
+            PEagleSpeculatorConfig(
+                speculators_config=_make_speculators_config(),
+                down_sample_ratio=1.0,
+            )
+
+    def test_invalid_down_sample_ratio_min(self):
+        """down_sample_ratio_min must be in [0, 1]."""
+        with pytest.raises(ValidationError):
+            PEagleSpeculatorConfig(
+                speculators_config=_make_speculators_config(),
+                down_sample_ratio_min=-0.1,
+            )
+
+    def test_invalid_loss_type(self):
+        """loss_type must be 'kl_div' or 'cross_entropy'."""
+        with pytest.raises(ValidationError):
+            PEagleSpeculatorConfig(
+                speculators_config=_make_speculators_config(),
+                loss_type="mse",
+            )
+
+    def test_registry_registration(self):
+        """PEagleSpeculatorConfig should be registered as 'peagle'."""
+        SpeculatorModelConfig.auto_populate_registry()
+        assert "peagle" in SpeculatorModelConfig.registry
+
+    def test_serialization(self):
+        """Config should serialize and deserialize correctly."""
+        config = PEagleSpeculatorConfig(
+            speculators_config=_make_speculators_config(),
+            para_num=6,
+            down_sample_ratio=0.6,
+        )
+        config_dict = config.to_dict()
+        assert config_dict["para_num"] == 6
+        assert config_dict["down_sample_ratio"] == 0.6
+        assert config_dict["speculators_model_type"] == "peagle"

--- a/tests/unit/models/test_peagle_loss.py
+++ b/tests/unit/models/test_peagle_loss.py
@@ -1,0 +1,291 @@
+"""Unit tests for P-EAGLE loss functions."""
+
+import pytest
+import torch
+
+from speculators.models.peagle.loss import (
+    cross_entropy_loss,
+    kl_div_loss,
+    per_depth_accuracy,
+    per_depth_loss,
+)
+
+
+class TestCrossEntropyLoss:
+    """Tests for cross_entropy_loss."""
+
+    def test_basic_loss(self):
+        """Test basic cross-entropy computation."""
+        batch, seq_len, vocab_size = 1, 4, 10
+        logits = torch.randn(batch, seq_len, vocab_size)
+        targets = torch.randint(0, vocab_size, (batch, seq_len))
+
+        loss = cross_entropy_loss(logits, targets)
+        assert loss.ndim == 0  # scalar
+        assert loss.item() > 0
+
+    def test_perfect_predictions_low_loss(self):
+        """Perfect predictions should give very low loss."""
+        batch, seq_len, vocab_size = 1, 5, 10
+        targets = torch.randint(0, vocab_size, (batch, seq_len))
+
+        # Create logits that strongly predict the targets
+        logits = torch.full((batch, seq_len, vocab_size), -10.0)
+        for b in range(batch):
+            for s in range(seq_len):
+                logits[b, s, targets[b, s]] = 10.0
+
+        loss = cross_entropy_loss(logits, targets)
+        assert loss.item() < 0.01
+
+    def test_with_loss_mask(self):
+        """Test that loss mask correctly excludes positions."""
+        batch, seq_len, vocab_size = 1, 6, 5
+        logits = torch.randn(batch, seq_len, vocab_size)
+        targets = torch.randint(0, vocab_size, (batch, seq_len))
+
+        # All positions
+        loss_all = cross_entropy_loss(logits, targets)
+
+        # Only first 3 positions
+        mask = torch.tensor([[1, 1, 1, 0, 0, 0]], dtype=torch.float32)
+        loss_masked = cross_entropy_loss(logits, targets, mask)
+
+        # Losses should be different since they use different positions
+        assert loss_masked.item() != loss_all.item()
+
+    def test_zero_mask(self):
+        """All-zero mask should give near-zero loss."""
+        batch, seq_len, vocab_size = 1, 4, 10
+        logits = torch.randn(batch, seq_len, vocab_size)
+        targets = torch.randint(0, vocab_size, (batch, seq_len))
+        mask = torch.zeros(batch, seq_len)
+
+        loss = cross_entropy_loss(logits, targets, mask)
+        assert abs(loss.item()) < 0.01
+
+    def test_batch_dimension(self):
+        """Test with batch_size > 1."""
+        batch, seq_len, vocab_size = 4, 8, 20
+        logits = torch.randn(batch, seq_len, vocab_size)
+        targets = torch.randint(0, vocab_size, (batch, seq_len))
+
+        loss = cross_entropy_loss(logits, targets)
+        assert loss.ndim == 0
+        assert loss.item() > 0
+
+
+class TestKlDivLoss:
+    """Tests for kl_div_loss."""
+
+    def test_basic_loss(self):
+        """Test basic KL divergence computation."""
+        batch, seq_len, vocab_size = 1, 4, 10
+        logits = torch.randn(batch, seq_len, vocab_size)
+        targets = torch.randn(batch, seq_len, vocab_size)
+
+        loss = kl_div_loss(logits, targets)
+        assert loss.ndim == 0
+        assert loss.item() >= 0
+
+    def test_identical_distributions_zero_loss(self):
+        """Same distributions should give zero KL divergence."""
+        batch, seq_len, vocab_size = 1, 5, 10
+        logits = torch.randn(batch, seq_len, vocab_size)
+
+        loss = kl_div_loss(logits, logits)
+        assert loss.item() < 0.01
+
+    def test_with_loss_mask(self):
+        """Test KL divergence with loss mask."""
+        batch, seq_len, vocab_size = 1, 6, 5
+        logits = torch.randn(batch, seq_len, vocab_size)
+        targets = torch.randn(batch, seq_len, vocab_size)
+
+        mask = torch.tensor([[1, 1, 1, 0, 0, 0]], dtype=torch.float32)
+        loss = kl_div_loss(logits, targets, mask)
+        assert loss.ndim == 0
+
+
+class TestPerDepthLoss:
+    """Tests for per_depth_loss."""
+
+    def test_basic_cross_entropy(self):
+        """Test per-depth cross-entropy loss aggregation."""
+        vocab_size = 10
+        all_logits = [
+            torch.randn(1, 8, vocab_size),
+            torch.randn(1, 4, vocab_size),
+            torch.randn(1, 2, vocab_size),
+        ]
+        all_targets = [
+            torch.randint(0, vocab_size, (1, 8)),
+            torch.randint(0, vocab_size, (1, 4)),
+            torch.randint(0, vocab_size, (1, 2)),
+        ]
+        all_masks = [None, None, None]
+
+        total_loss, metrics = per_depth_loss(
+            all_logits, all_targets, all_masks, loss_fn="cross_entropy"
+        )
+
+        assert total_loss.ndim == 0
+        assert total_loss.item() > 0
+        assert "loss" in metrics
+        assert "loss_depth_0" in metrics
+        assert "loss_depth_1" in metrics
+        assert "loss_depth_2" in metrics
+
+    def test_kl_div_loss_fn(self):
+        """Test per-depth KL divergence loss."""
+        vocab_size = 10
+        all_logits = [
+            torch.randn(1, 8, vocab_size),
+            torch.randn(1, 4, vocab_size),
+        ]
+        all_targets = [
+            torch.randn(1, 8, vocab_size),
+            torch.randn(1, 4, vocab_size),
+        ]
+        all_masks = [None, None]
+
+        total_loss, metrics = per_depth_loss(
+            all_logits, all_targets, all_masks, loss_fn="kl_div"
+        )
+
+        assert total_loss.ndim == 0
+        assert "loss_depth_0" in metrics
+        assert "loss_depth_1" in metrics
+
+    def test_depth_weights(self):
+        """Test custom depth loss weights."""
+        vocab_size = 10
+        all_logits = [
+            torch.randn(1, 5, vocab_size),
+            torch.randn(1, 5, vocab_size),
+        ]
+        all_targets = [
+            torch.randint(0, vocab_size, (1, 5)),
+            torch.randint(0, vocab_size, (1, 5)),
+        ]
+        all_masks = [None, None]
+
+        # Equal weights
+        loss_equal, _ = per_depth_loss(
+            all_logits, all_targets, all_masks,
+            loss_fn="cross_entropy",
+            depth_loss_weights=[1.0, 1.0],
+        )
+
+        # Zero weight for depth 1
+        loss_weighted, _ = per_depth_loss(
+            all_logits, all_targets, all_masks,
+            loss_fn="cross_entropy",
+            depth_loss_weights=[1.0, 0.0],
+        )
+
+        # Weighted should be less (only depth 0)
+        assert loss_weighted.item() < loss_equal.item()
+
+    def test_invalid_loss_fn(self):
+        """Should raise ValueError for unknown loss function."""
+        all_logits = [torch.randn(1, 4, 10)]
+        all_targets = [torch.randint(0, 10, (1, 4))]
+        all_masks = [None]
+
+        with pytest.raises(ValueError, match="Unknown loss function"):
+            per_depth_loss(all_logits, all_targets, all_masks, loss_fn="invalid")
+
+    def test_mismatched_weights_length(self):
+        """Should raise ValueError for mismatched weights."""
+        all_logits = [torch.randn(1, 4, 10)]
+        all_targets = [torch.randint(0, 10, (1, 4))]
+        all_masks = [None]
+
+        with pytest.raises(ValueError, match="depth_loss_weights length"):
+            per_depth_loss(
+                all_logits, all_targets, all_masks,
+                depth_loss_weights=[1.0, 2.0],
+            )
+
+    def test_empty_logits(self):
+        """Test with empty logit tensors (from COD sampling with 0 positions)."""
+        vocab_size = 10
+        all_logits = [
+            torch.randn(1, 5, vocab_size),
+            torch.empty(0, 0, vocab_size),  # Empty depth
+        ]
+        all_targets = [
+            torch.randint(0, vocab_size, (1, 5)),
+            torch.empty(0, 0, dtype=torch.long),
+        ]
+        all_masks = [None, None]
+
+        total_loss, metrics = per_depth_loss(
+            all_logits, all_targets, all_masks, loss_fn="cross_entropy"
+        )
+
+        assert total_loss.item() > 0
+        assert metrics["loss_depth_1"].item() == 0.0
+
+
+class TestPerDepthAccuracy:
+    """Tests for per_depth_accuracy."""
+
+    def test_perfect_accuracy(self):
+        """Perfect predictions should give 100% accuracy."""
+        vocab_size = 10
+        target_ids = [torch.randint(0, vocab_size, (1, 5))]
+
+        # Create logits that predict the target
+        logits = [torch.full((1, 5, vocab_size), -10.0)]
+        for s in range(5):
+            logits[0][0, s, target_ids[0][0, s]] = 10.0
+
+        metrics = per_depth_accuracy(logits, target_ids, [None])
+        assert abs(metrics["acc_depth_0"].item() - 1.0) < 0.01
+
+    def test_random_accuracy(self):
+        """Random predictions should give well below 100%."""
+        vocab_size = 100
+        target_ids = [torch.randint(0, vocab_size, (1, 100))]
+        logits = [torch.randn(1, 100, vocab_size)]
+
+        metrics = per_depth_accuracy(logits, target_ids, [None])
+        # Random accuracy should be around 1%
+        assert metrics["acc_depth_0"].item() < 0.2
+
+    def test_with_mask(self):
+        """Masks should filter positions for accuracy."""
+        vocab_size = 5
+        target_ids = [torch.tensor([[0, 1, 2, 3, 4]])]
+
+        logits = [torch.full((1, 5, vocab_size), -10.0)]
+        # Only first 2 correct
+        logits[0][0, 0, 0] = 10.0
+        logits[0][0, 1, 1] = 10.0
+        logits[0][0, 2, 0] = 10.0  # wrong
+        logits[0][0, 3, 0] = 10.0  # wrong
+        logits[0][0, 4, 0] = 10.0  # wrong
+
+        # Mask only first 2 positions
+        mask = torch.tensor([[1, 1, 0, 0, 0]], dtype=torch.float32)
+        metrics = per_depth_accuracy(logits, target_ids, [mask])
+
+        assert abs(metrics["acc_depth_0"].item() - 1.0) < 0.01
+
+    def test_multi_depth(self):
+        """Test accuracy across multiple depths."""
+        vocab_size = 10
+        logits = [
+            torch.randn(1, 5, vocab_size),
+            torch.randn(1, 3, vocab_size),
+        ]
+        targets = [
+            torch.randint(0, vocab_size, (1, 5)),
+            torch.randint(0, vocab_size, (1, 3)),
+        ]
+
+        metrics = per_depth_accuracy(logits, targets, [None, None])
+        assert "acc_depth_0" in metrics
+        assert "acc_depth_1" in metrics


### PR DESCRIPTION
## Summary

Implements Phase 1 components for P-EAGLE (Parallel EAGLE) support as described in RFC #292.

P-EAGLE extends EAGLE-3 with parallel multi-token prediction through Conditional-On-Distribution (COD) sampling, enabling 2-3x speedups over sequential EAGLE-3 drafting.

## Changes

### New Module: `src/speculators/models/peagle/`

**`cod_sampling.py`** - COD Sampling Utility
- `cod_sample()`: Core algorithm implementing geometric decay-based position retention
  - Depth 0 retains all valid positions (where `loss_mask == 1`)
  - Depth k retains `n_valid × r^k` positions with random sampling
  - Supports `down_sample_ratio_min` to prevent zero positions at deep depths
  - Returns sorted indices to maintain causal order
- `compute_cod_statistics()`: Compression ratio and per-depth count analysis
- `build_depth_position_ids()`: Position ID tracking across sampled depths

**`config.py`** - P-EAGLE Configuration
- `PEagleSpeculatorConfig`: Extends `Eagle3SpeculatorConfig` with:
  - `para_num`: Number of parallel prediction depths (K), default 8
  - `down_sample_ratio`: COD retention rate r ∈ (0, 1), default 0.5
  - `down_sample_ratio_min`: Minimum retention rate, default 0.0
  - `ptd_token_id`: Padding token ID for MTP positions (renamed from `unused_token_id` per discussion)
  - `loss_type`: `'cross_entropy'` (default) or `'kl_div'`
- Registered as `"peagle"` in the model registry

**`loss.py`** - Loss Functions
- `cross_entropy_loss()`: Standard CE loss with mask support (P-EAGLE default)
- `kl_div_loss()`: KL divergence loss for compatibility with EAGLE-3
- `per_depth_loss()`: Aggregate loss across parallel prediction depths with configurable weights
- `per_depth_accuracy()`: Per-depth top-1 accuracy metrics

**`core.py`** - P-EAGLE Draft Model
- `PEagleDraftModel`: Registered as `"peagle"`, extends `SpeculatorModel` with:
  - `mask_hidden` parameter `[1, 1, 3×hidden_size]`: Learnable padding hidden state for MTP positions
  - `mask_token_embedding` parameter `[1, 1, hidden_size]`: Learnable embedding for unknown tokens
  - Parallel forward pass: COD sampling → combined hidden states → single decoder pass → per-depth loss
  - `build_parallel_group_mask_mod()`: Flex attention mask construction for parallel prediction groups
  - `from_training_args()` factory method
  - `get_trainer_kwargs()` for training integration

### Modified
- `src/speculators/models/__init__.py`: Added P-EAGLE exports

### Tests (51 new tests, all passing)
- `test_peagle_cod_sampling.py` (24 tests): COD sampling correctness, boundary cases, reproducibility
- `test_peagle_loss.py` (18 tests): Cross-entropy, KL divergence, per-depth aggregation, accuracy
- `test_peagle_config.py` (9 tests): Config validation, registry, serialization, inheritance

## Relationship to RFC #292

This PR implements Phase 1 components as outlined in the RFC:
- ✅ COD sampling implementation (loss mask aware)
- ✅ P-EAGLE model with `mask_hidden` parameter
- ✅ Configuration class with `para_num`, `down_sample_ratio`, `ptd_token_id`
- ✅ Cross-entropy loss function option
- ✅ Attention mask construction for parallel patterns
- ✅ Model registration with `SpeculatorModel` registry

Remaining items for Phase 1 (future PRs):
- Sequence splitting for gradient accumulation
- Full training loop integration validation with actual data
- Alignment verification with reference implementation

## Testing

All 51 new unit tests pass. No regressions in existing tests (274 pass; 3 pre-existing Windows path separator failures unrelated to this PR).

Closes #292
