### PR TITLE
Add FastMTP checkpoint converter

### DIFF
--- a/examples/fast_mtp/README.md
+++ b/examples/fast_mtp/README.md
@@ -30,14 +30,31 @@ flowchart LR
 
 **Training objective** (from the FastMTP paper):
 
-$$\mathcal{L}_{\text{mtp}} = \sum_{k=0}^{K-1} \alpha_k \cdot \text{CE}(\text{logits}_k,\ \text{tokens}_{t+k+2})$$
+$$\\mathcal{L}_{\\text{mtp}} = \\sum_{k=0}^{K-1} \\alpha_k \\cdot \\text{CE}(\\text{logits}_k,\\ \\text{tokens}_{t+k+2})$$
 
-Default weights $\alpha = [0.51, 0.31, 0.18]$ use exponential decay ($\beta=0.6$, normalized). Loss is computed only on response tokens via `loss_mask`.
+Default weights $\\alpha = [0.51, 0.31, 0.18]$ use exponential decay ($\\beta=0.6$, normalized). Loss is computed only on response tokens via `loss_mask`.
+
+## Convert a Checkpoint
+
+Edit the constants at the top of `examples/fast_mtp/convert_qwen3_next.py` (`MODEL`, `OUTPUT`, `NUM_STEPS`) and run:
+
+```bash
+python examples/fast_mtp/convert_qwen3_next.py
+```
+
+Or use the `speculators convert` CLI directly:
+
+```bash
+speculators convert Qwen/Qwen3-Next-80B-A3B-Instruct \
+    --algorithm mtp \
+    --verifier  Qwen/Qwen3-Next-80B-A3B-Instruct \
+    --output-path ./qwen3_next_mtp_speculators
+```
 
 ## Supported Checkpoints
 
-| Model | model_type |
-| ----- | ---------- |
+| Model                                                                           | model_type   |
+| ------------------------------------------------------------------------------- | ------------ |
 | [Qwen3-Next](https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct/tree/main) | `qwen3_next` |
 
 ## Paper

--- a/examples/fast_mtp/convert_qwen3_next.py
+++ b/examples/fast_mtp/convert_qwen3_next.py
@@ -3,25 +3,13 @@
 FastMTP predicts multiple future tokens per step using a single shared
 transformer layer applied recursively.  This script isolates that layer —
 plus the model's token embeddings and LM head — and saves a compact,
-self-contained Speculators checkpoint (~300 MB in bfloat16) that can be loaded
-and deployed in vLLM without the full 80B model.
+self-contained Speculators checkpoint.
 
 Usage
 -----
 Edit the constants below, then run::
 
     python examples/fast_mtp/convert_qwen3_next.py
-
-Once converted, serve directly with vLLM::
-
-    vllm serve ./qwen3_next_mtp_speculators
-
-Or use the ``speculators convert`` CLI instead::
-
-    speculators convert Qwen/Qwen3-Next-80B-A3B-Instruct \\
-        --algorithm mtp \\
-        --verifier  Qwen/Qwen3-Next-80B-A3B-Instruct \\
-        --output-path ./qwen3_next_mtp_speculators
 """
 
 from speculators.convert import FastMTPConverter

--- a/examples/fast_mtp/convert_qwen3_next.py
+++ b/examples/fast_mtp/convert_qwen3_next.py
@@ -1,0 +1,41 @@
+"""Extract the FastMTP head from a Qwen3-Next checkpoint.
+
+FastMTP predicts multiple future tokens per step using a single shared
+transformer layer applied recursively.  This script isolates that layer —
+plus the model's token embeddings and LM head — and saves a compact,
+self-contained Speculators checkpoint (~300 MB in bfloat16) that can be loaded
+and deployed in vLLM without the full 80B model.
+
+Usage
+-----
+Edit the constants below, then run::
+
+    python examples/fast_mtp/convert_qwen3_next.py
+
+Once converted, serve directly with vLLM::
+
+    vllm serve ./qwen3_next_mtp_speculators
+
+Or use the ``speculators convert`` CLI instead::
+
+    speculators convert Qwen/Qwen3-Next-80B-A3B-Instruct \\
+        --algorithm mtp \\
+        --verifier  Qwen/Qwen3-Next-80B-A3B-Instruct \\
+        --output-path ./qwen3_next_mtp_speculators
+"""
+
+from speculators.convert import FastMTPConverter
+
+MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct"
+OUTPUT = "./Qwen3-Next-80B-A3B-Instruct_mtp_speculator"
+NUM_STEPS = 3
+
+
+if __name__ == "__main__":
+    FastMTPConverter().convert(
+        input_path=MODEL,
+        output_path=OUTPUT,
+        base_model=MODEL,
+        num_speculative_steps=NUM_STEPS,
+        validate=True,
+    )

--- a/src/speculators/convert/__init__.py
+++ b/src/speculators/convert/__init__.py
@@ -2,13 +2,16 @@
 Checkpoint conversion utilities for Speculators.
 
 Provides tools to convert existing speculative decoding model checkpoints from external
-research repositories (Eagle, HASS, etc.) into the standardized Speculators format.
+research repositories (Eagle, HASS, FastMTP, etc.) into the standardized Speculators
+format.
 
 Supported Research Repositories:
     - Eagle v1, v2, and v3: https://github.com/SafeAILab/EAGLE
     - HASS: https://github.com/HArmonizedSS/HASS
+    - FastMTP (Qwen3-Next / TencentBAC MiMo): https://arxiv.org/abs/2509.18362
 """
 
 from .entrypoints import convert_model
+from .fast_mtp import FastMTPConverter
 
-__all__ = ["convert_model"]
+__all__ = ["FastMTPConverter", "convert_model"]

--- a/src/speculators/convert/__init__.py
+++ b/src/speculators/convert/__init__.py
@@ -8,7 +8,7 @@ format.
 Supported Research Repositories:
     - Eagle v1, v2, and v3: https://github.com/SafeAILab/EAGLE
     - HASS: https://github.com/HArmonizedSS/HASS
-    - FastMTP (Qwen3-Next / TencentBAC MiMo): https://arxiv.org/abs/2509.18362
+    - FastMTP (Qwen3-Next): https://arxiv.org/abs/2509.18362
 """
 
 from .entrypoints import convert_model

--- a/src/speculators/convert/entrypoints.py
+++ b/src/speculators/convert/entrypoints.py
@@ -8,6 +8,7 @@ research repositories:
 - EAGLE2
 - EAGLE3
 - HASS
+- MTP (FastMTP — Qwen3-Next / TencentBAC MiMo)
 
 Functions:
     convert_model: Converts a model checkpoint to the Speculators format.
@@ -17,6 +18,7 @@ from typing import Literal
 
 from speculators.convert.eagle.eagle3_converter import Eagle3Converter
 from speculators.convert.eagle.eagle_converter import EagleConverter
+from speculators.convert.fast_mtp.converter import FastMTPConverter
 
 __all__ = ["convert_model"]
 
@@ -24,7 +26,7 @@ __all__ = ["convert_model"]
 def convert_model(
     model: str,
     verifier: str,
-    algorithm: Literal["eagle", "eagle3"],
+    algorithm: Literal["eagle", "eagle3", "mtp"],
     output_path: str = "converted",
     validate_device: str | None = None,
     **kwargs,
@@ -69,15 +71,25 @@ def convert_model(
             norm_before_residual=True,
         )
 
+    algorithm=="mtp":
+        FastMTP (Qwen3-Next / TencentBAC MiMo): https://arxiv.org/abs/2509.18362
+        ::
+        convert_model(
+            model="Qwen/Qwen3-Next-80B-A3B-Instruct",
+            verifier="Qwen/Qwen3-Next-80B-A3B-Instruct",
+            algorithm="mtp",
+        )
+
     :param model: Path to the input model checkpoint or Hugging Face model ID.
     :param verifier: Verifier model checkpoint or Hugging Face model ID
         to attach as the verification/base model for speculative decoding
-    :param algorithm: The conversion algorithm to use, either "eagle" or "eagle3".
+    :param algorithm: The conversion algorithm to use: "eagle", "eagle3", or "mtp".
     :param output_path: Directory path where the converted model will be saved.
     :param kwargs: Additional keyword arguments for the conversion algorithm.
         Options for Eagle: {"layernorms": true, "fusion_bias": true}.
         Options for Eagle3: {"norm_before_residual": true,
         "eagle_aux_hidden_state_layer_ids": [1,23,44]}.
+        Options for MTP: {"num_speculative_steps": 3}.
     """
 
     if algorithm == "eagle":
@@ -90,6 +102,14 @@ def convert_model(
         )
     elif algorithm == "eagle3":
         Eagle3Converter().convert(
+            model,
+            output_path,
+            verifier,
+            validate=validate_device is not None,
+            **kwargs,
+        )
+    elif algorithm == "mtp":
+        FastMTPConverter().convert(
             model,
             output_path,
             verifier,

--- a/src/speculators/convert/entrypoints.py
+++ b/src/speculators/convert/entrypoints.py
@@ -8,7 +8,7 @@ research repositories:
 - EAGLE2
 - EAGLE3
 - HASS
-- MTP (FastMTP — Qwen3-Next / TencentBAC MiMo)
+- MTP (FastMTP — Qwen3-Next)
 
 Functions:
     convert_model: Converts a model checkpoint to the Speculators format.
@@ -72,7 +72,7 @@ def convert_model(
         )
 
     algorithm=="mtp":
-        FastMTP (Qwen3-Next / TencentBAC MiMo): https://arxiv.org/abs/2509.18362
+        FastMTP (Qwen3-Next): https://arxiv.org/abs/2509.18362
         ::
         convert_model(
             model="Qwen/Qwen3-Next-80B-A3B-Instruct",

--- a/src/speculators/convert/fast_mtp/__init__.py
+++ b/src/speculators/convert/fast_mtp/__init__.py
@@ -1,0 +1,5 @@
+"""FastMTP checkpoint conversion utilities."""
+
+from speculators.convert.fast_mtp.converter import FastMTPConverter
+
+__all__ = ["FastMTPConverter"]

--- a/src/speculators/convert/fast_mtp/converter.py
+++ b/src/speculators/convert/fast_mtp/converter.py
@@ -1,0 +1,278 @@
+"""FastMTP checkpoint converter.
+
+Extracts the MTP layer (plus embeddings and LM head) from a full Qwen3-Next or
+TencentBAC/MiMo checkpoint and saves it as a self-contained Speculators checkpoint.
+
+Two source formats are supported:
+- ``native_hf``: Hugging Face Qwen3-Next; MTP keys start with ``model.mtp_layers.``
+- ``tencentbac``: MiMo / TencentBAC format; MTP keys start with ``mtp.``
+
+The output checkpoint is self-contained: ``embed_tokens.weight`` and
+``lm_head.weight`` are included so ``FastMTPSpeculator.from_pretrained(path)``
+works without a verifier path.
+"""
+
+import json
+from pathlib import Path
+from typing import Literal
+
+import torch
+from loguru import logger
+from safetensors import safe_open
+from transformers import PretrainedConfig
+
+from speculators.config import SpeculatorsConfig, VerifierConfig
+from speculators.convert.eagle.utils import (
+    ensure_checkpoint_is_local,
+    load_checkpoint_config,
+)
+from speculators.models.fast_mtp import FastMTPConfig, FastMTPSpeculator
+from speculators.proposals.greedy import GreedyTokenProposalConfig
+
+__all__ = ["FastMTPConverter"]
+
+_Format = Literal["native_hf", "tencentbac"]
+
+# Embed and LM-head keys that may appear in either source format.
+# native_hf always uses the "model." prefix; tencentbac may omit it.
+_NATIVE_HF_EMBED_KEYS: frozenset[str] = frozenset({"model.embed_tokens.weight"})
+_NATIVE_HF_LM_HEAD_KEYS: frozenset[str] = frozenset({"model.lm_head.weight"})
+_TENCENTBAC_EMBED_KEYS: frozenset[str] = frozenset(
+    {"model.embed_tokens.weight", "embed_tokens.weight"}
+)
+_TENCENTBAC_LM_HEAD_KEYS: frozenset[str] = frozenset(
+    {"model.lm_head.weight", "lm_head.weight"}
+)
+
+
+class FastMTPConverter:
+    """Convert FastMTP checkpoints to the Speculators format.
+
+    Supports two source formats:
+
+    - **native_hf** (Qwen3-Next): keys prefixed with ``model.mtp_layers.``
+    - **tencentbac** (MiMo): keys prefixed with ``mtp.``
+
+    Sharded safetensors checkpoints are handled by streaming only the relevant
+    shards — the full model is never loaded into memory.
+    """
+
+    def convert(
+        self,
+        input_path: str | Path,
+        output_path: str | Path,
+        base_model: str,
+        num_speculative_steps: int = 3,
+        validate: bool = True,
+        cache_dir: str | Path | None = None,
+    ) -> None:
+        """Convert a FastMTP checkpoint to the Speculators format.
+
+        :param input_path: Local path or Hugging Face model ID for the source.
+        :param output_path: Directory where the converted checkpoint will be written.
+        :param base_model: Verifier model ID or path; stored in VerifierConfig.
+        :param num_speculative_steps: Number of MTP steps to configure in the output.
+        :param validate: Load the output checkpoint to check for missing keys.
+        :param cache_dir: Optional cache directory for Hub downloads.
+        """
+        logger.info(f"Converting FastMTP checkpoint: {input_path}")
+
+        local_path = ensure_checkpoint_is_local(input_path, cache_dir)
+        source_config = load_checkpoint_config(local_path)
+
+        all_keys = self._list_checkpoint_keys(local_path)
+        fmt = self._detect_format(all_keys)
+        logger.info(f"Detected checkpoint format: {fmt}")
+
+        weights = self._extract_weights(local_path, all_keys, fmt)
+        logger.info(f"Extracted {len(weights)} weight tensors")
+
+        config = self._build_config(source_config, base_model, num_speculative_steps)
+
+        saved_path = self._save(config, weights, output_path)
+        logger.success(f"Saved to: {saved_path}")
+
+        if validate:
+            self._validate(saved_path)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _list_checkpoint_keys(self, checkpoint_dir: Path) -> list[str]:
+        """Return all weight key names without loading tensor data."""
+        index_path = checkpoint_dir / "model.safetensors.index.json"
+        if index_path.exists():
+            with index_path.open() as f:
+                return list(json.load(f)["weight_map"].keys())
+
+        single = checkpoint_dir / "model.safetensors"
+        if single.exists():
+            with safe_open(str(single), framework="pt") as f:
+                return list(f.keys())  # noqa: SIM118
+
+        pytorch = checkpoint_dir / "pytorch_model.bin"
+        if pytorch.exists():
+            state_dict = torch.load(str(pytorch), map_location="cpu", weights_only=True)
+            return list(state_dict.keys())
+
+        raise FileNotFoundError(f"No checkpoint weights found at {checkpoint_dir}")
+
+    def _detect_format(self, keys: list[str]) -> _Format:
+        """Identify whether the checkpoint uses native_hf or tencentbac key layout."""
+        for key in keys:
+            if key.startswith("model.mtp_layers."):
+                return "native_hf"
+            if key.startswith("mtp."):
+                return "tencentbac"
+        sample = keys[:20]
+        raise ValueError(
+            "Cannot detect FastMTP checkpoint format — no keys starting with "
+            f"'model.mtp_layers.' or 'mtp.' were found. "
+            f"First {len(sample)} keys: {sample}"
+        )
+
+    def _should_extract(self, key: str, fmt: _Format) -> bool:
+        """Return True if this key should be included in the converted checkpoint."""
+        if fmt == "native_hf":
+            return (
+                key in _NATIVE_HF_EMBED_KEYS
+                or key in _NATIVE_HF_LM_HEAD_KEYS
+                or key.startswith("model.mtp_layers.0.")
+            )
+        return (
+            key in _TENCENTBAC_EMBED_KEYS
+            or key in _TENCENTBAC_LM_HEAD_KEYS
+            or key.startswith("mtp.")
+        )
+
+    def _remap_key(self, key: str, fmt: _Format) -> str:
+        """Map a source checkpoint key to the FastMTPSpeculator parameter name."""
+        if fmt == "native_hf":
+            # Strip "model." prefix — parameters live at e.g. "mtp_layers.0.X".
+            return key.removeprefix("model.")
+
+        # tencentbac: embed/lm_head may appear with or without the "model." prefix;
+        # remaining MTP keys follow the same rules as _fix_state_dict_key_on_load.
+        if key in _TENCENTBAC_EMBED_KEYS:
+            return "embed_tokens.weight"
+        if key in _TENCENTBAC_LM_HEAD_KEYS:
+            return "lm_head.weight"
+        remapped, _ = FastMTPSpeculator._fix_state_dict_key_on_load(key)  # noqa: SLF001
+        return remapped
+
+    def _extract_weights(
+        self, checkpoint_dir: Path, all_keys: list[str], fmt: _Format
+    ) -> dict[str, torch.Tensor]:
+        """Stream only the needed keys from the checkpoint (shard-aware)."""
+        needed = {k for k in all_keys if self._should_extract(k, fmt)}
+
+        index_path = checkpoint_dir / "model.safetensors.index.json"
+        if index_path.exists():
+            return self._extract_from_shards(checkpoint_dir, index_path, needed, fmt)
+
+        single = checkpoint_dir / "model.safetensors"
+        if single.exists():
+            weights: dict[str, torch.Tensor] = {}
+            with safe_open(str(single), framework="pt") as f:
+                available = set(f.keys())  # noqa: SIM118
+                for key in needed & available:
+                    weights[self._remap_key(key, fmt)] = f.get_tensor(key)
+            return weights
+
+        pytorch = checkpoint_dir / "pytorch_model.bin"
+        if pytorch.exists():
+            state_dict = torch.load(str(pytorch), map_location="cpu", weights_only=True)
+            return {
+                self._remap_key(k, fmt): v for k, v in state_dict.items() if k in needed
+            }
+
+        raise FileNotFoundError(f"No checkpoint weights found at {checkpoint_dir}")
+
+    def _extract_from_shards(
+        self,
+        checkpoint_dir: Path,
+        index_path: Path,
+        needed_keys: set[str],
+        fmt: _Format,
+    ) -> dict[str, torch.Tensor]:
+        """Open only the shards that contain the requested keys."""
+        with index_path.open() as f:
+            weight_map: dict[str, str] = json.load(f)["weight_map"]
+
+        shard_to_keys: dict[str, list[str]] = {}
+        for key in needed_keys:
+            shard_filename = weight_map.get(key)
+            if shard_filename is not None:
+                shard_to_keys.setdefault(shard_filename, []).append(key)
+
+        weights: dict[str, torch.Tensor] = {}
+        for shard_filename, keys in shard_to_keys.items():
+            shard_path = checkpoint_dir / shard_filename
+            logger.debug(f"Reading {len(keys)} key(s) from shard {shard_filename}")
+            with safe_open(str(shard_path), framework="pt") as f:
+                for key in keys:
+                    weights[self._remap_key(key, fmt)] = f.get_tensor(key)
+
+        return weights
+
+    def _build_config(
+        self, source_config: dict, base_model: str, num_speculative_steps: int
+    ) -> FastMTPConfig:
+        """Build a FastMTPConfig from the source checkpoint config dict."""
+        verifier_config_dict, _ = PretrainedConfig.get_config_dict(base_model)
+        verifier_config = VerifierConfig(
+            name_or_path=base_model,
+            architectures=verifier_config_dict.get("architectures", []),
+        )
+
+        speculators_config = SpeculatorsConfig(
+            algorithm="mtp",
+            proposal_methods=[
+                GreedyTokenProposalConfig(speculative_tokens=num_speculative_steps)
+            ],
+            default_proposal_method="greedy",
+            verifier=verifier_config,
+        )
+
+        # FastMTPConfig's Pydantic validator converts the dict to a PretrainedConfig.
+        return FastMTPConfig(
+            transformer_layer_config=source_config,  # type: ignore[arg-type]
+            speculators_config=speculators_config,
+        )
+
+    def _save(
+        self,
+        config: FastMTPConfig,
+        weights: dict[str, torch.Tensor],
+        output_path: str | Path,
+    ) -> Path:
+        model = FastMTPSpeculator(config)
+        missing, unexpected = model.load_state_dict(weights, strict=False)
+        if unexpected:
+            raise ValueError(
+                f"Unexpected keys during conversion — checkpoint weights do not match "
+                f"the model architecture.  This usually means the layer type resolved "
+                f"from the config does not match the checkpoint (e.g. linear_attn vs "
+                f"self_attn in Qwen3-Next).  Unexpected keys: {unexpected}"
+            )
+        if missing:
+            logger.debug(f"Keys not in extracted weights (filled by init): {missing}")
+
+        # Preserve the source dtype (usually bfloat16 for large models).
+        float_dtypes = {t.dtype for t in weights.values() if t.is_floating_point()}
+        if float_dtypes:
+            model.to(dtype=next(iter(float_dtypes)))  # type: ignore[call-arg]
+
+        model.save_pretrained(str(output_path))
+        return Path(output_path)
+
+    def _validate(self, output_path: Path) -> None:
+        """Load the converted checkpoint and verify no unexpected keys are missing."""
+        logger.info("Validating converted FastMTP checkpoint...")
+        try:
+            FastMTPSpeculator.from_pretrained(str(output_path))
+            logger.success("Validation succeeded")
+        except (OSError, ValueError, RuntimeError) as exc:
+            logger.error(f"Validation failed: {exc}")
+            raise

--- a/src/speculators/convert/fast_mtp/converter.py
+++ b/src/speculators/convert/fast_mtp/converter.py
@@ -30,7 +30,7 @@ __all__ = ["FastMTPConverter"]
 
 _MTP_PREFIX = "mtp."
 _EMBED_KEY = "model.embed_tokens.weight"
-_LM_HEAD_KEY = "model.lm_head.weight"
+_LM_HEAD_KEY = "lm_head.weight"  # stored without "model." prefix in Qwen3-Next
 
 
 class FastMTPConverter:
@@ -219,17 +219,8 @@ class FastMTPConverter:
                 "layer_idx for Qwen3-Next (full_attention vs linear_attention). "
                 f"Unexpected keys: {unexpected}"
             )
-        # Qwen3-Next ties lm_head to embed_tokens (no separate lm_head tensor).
-        if "lm_head.weight" not in weights and "embed_tokens.weight" in weights:
-            logger.debug("lm_head not in checkpoint; tying to embed_tokens.weight")
-            with torch.no_grad():
-                model.lm_head.weight.copy_(weights["embed_tokens.weight"])
-
-        missing_non_tied = [k for k in missing if k != "lm_head.weight"]
-        if missing_non_tied:
-            logger.debug(
-                f"Keys not in extracted weights (filled by init): {missing_non_tied}"
-            )
+        if missing:
+            logger.debug(f"Keys not in extracted weights (filled by init): {missing}")
 
         float_dtypes = {t.dtype for t in weights.values() if t.is_floating_point()}
         if float_dtypes:

--- a/src/speculators/convert/fast_mtp/converter.py
+++ b/src/speculators/convert/fast_mtp/converter.py
@@ -1,20 +1,17 @@
-"""FastMTP checkpoint converter.
+"""FastMTP checkpoint converter for Qwen3-Next.
 
-Extracts the MTP layer (plus embeddings and LM head) from a full Qwen3-Next or
-TencentBAC/MiMo checkpoint and saves it as a self-contained Speculators checkpoint.
+Extracts the MTP layer (plus embed_tokens and lm_head) from a Qwen3-Next
+checkpoint and saves a self-contained Speculators checkpoint that loads with
+``FastMTPSpeculator.from_pretrained(path)`` without the full base model.
 
-Two source formats are supported:
-- ``native_hf``: Hugging Face Qwen3-Next; MTP keys start with ``model.mtp_layers.``
-- ``tencentbac``: MiMo / TencentBAC format; MTP keys start with ``mtp.``
-
-The output checkpoint is self-contained: ``embed_tokens.weight`` and
-``lm_head.weight`` are included so ``FastMTPSpeculator.from_pretrained(path)``
-works without a verifier path.
+Qwen3-Next stores its MTP layer under ``model.mtp_layers.0.*``, alongside the
+main model weights.  Only that subtree — plus ``embed_tokens`` and ``lm_head``
+— is read from the (potentially sharded) safetensors file; the rest of the
+model is never loaded into memory.
 """
 
 import json
 from pathlib import Path
-from typing import Literal
 
 import torch
 from loguru import logger
@@ -31,30 +28,17 @@ from speculators.proposals.greedy import GreedyTokenProposalConfig
 
 __all__ = ["FastMTPConverter"]
 
-_Format = Literal["native_hf", "tencentbac"]
-
-# Embed and LM-head keys that may appear in either source format.
-# native_hf always uses the "model." prefix; tencentbac may omit it.
-_NATIVE_HF_EMBED_KEYS: frozenset[str] = frozenset({"model.embed_tokens.weight"})
-_NATIVE_HF_LM_HEAD_KEYS: frozenset[str] = frozenset({"model.lm_head.weight"})
-_TENCENTBAC_EMBED_KEYS: frozenset[str] = frozenset(
-    {"model.embed_tokens.weight", "embed_tokens.weight"}
-)
-_TENCENTBAC_LM_HEAD_KEYS: frozenset[str] = frozenset(
-    {"model.lm_head.weight", "lm_head.weight"}
-)
+_MTP_PREFIX = "model.mtp_layers.0."
+_EMBED_KEY = "model.embed_tokens.weight"
+_LM_HEAD_KEY = "model.lm_head.weight"
 
 
 class FastMTPConverter:
-    """Convert FastMTP checkpoints to the Speculators format.
+    """Extract the FastMTP head from a Qwen3-Next checkpoint.
 
-    Supports two source formats:
-
-    - **native_hf** (Qwen3-Next): keys prefixed with ``model.mtp_layers.``
-    - **tencentbac** (MiMo): keys prefixed with ``mtp.``
-
-    Sharded safetensors checkpoints are handled by streaming only the relevant
-    shards — the full model is never loaded into memory.
+    Reads only the MTP layer, embed_tokens, and lm_head from the source
+    checkpoint.  Sharded safetensors files are handled transparently via
+    the weight index — the main transformer stack is never loaded.
     """
 
     def convert(
@@ -66,13 +50,13 @@ class FastMTPConverter:
         validate: bool = True,
         cache_dir: str | Path | None = None,
     ) -> None:
-        """Convert a FastMTP checkpoint to the Speculators format.
+        """Convert a Qwen3-Next checkpoint to the Speculators FastMTP format.
 
         :param input_path: Local path or Hugging Face model ID for the source.
         :param output_path: Directory where the converted checkpoint will be written.
         :param base_model: Verifier model ID or path; stored in VerifierConfig.
         :param num_speculative_steps: Number of MTP steps to configure in the output.
-        :param validate: Load the output checkpoint to check for missing keys.
+        :param validate: Load the output checkpoint after saving to verify correctness.
         :param cache_dir: Optional cache directory for Hub downloads.
         """
         logger.info(f"Converting FastMTP checkpoint: {input_path}")
@@ -81,14 +65,12 @@ class FastMTPConverter:
         source_config = load_checkpoint_config(local_path)
 
         all_keys = self._list_checkpoint_keys(local_path)
-        fmt = self._detect_format(all_keys)
-        logger.info(f"Detected checkpoint format: {fmt}")
+        self._verify_qwen3_next_format(all_keys)
 
-        weights = self._extract_weights(local_path, all_keys, fmt)
+        weights = self._extract_weights(local_path, all_keys)
         logger.info(f"Extracted {len(weights)} weight tensors")
 
         config = self._build_config(source_config, base_model, num_speculative_steps)
-
         saved_path = self._save(config, weights, output_path)
         logger.success(f"Saved to: {saved_path}")
 
@@ -118,74 +100,44 @@ class FastMTPConverter:
 
         raise FileNotFoundError(f"No checkpoint weights found at {checkpoint_dir}")
 
-    def _detect_format(self, keys: list[str]) -> _Format:
-        """Identify whether the checkpoint uses native_hf or tencentbac key layout."""
-        for key in keys:
-            if key.startswith("model.mtp_layers."):
-                return "native_hf"
-            if key.startswith("mtp."):
-                return "tencentbac"
-        sample = keys[:20]
-        raise ValueError(
-            "Cannot detect FastMTP checkpoint format — no keys starting with "
-            f"'model.mtp_layers.' or 'mtp.' were found. "
-            f"First {len(sample)} keys: {sample}"
-        )
-
-    def _should_extract(self, key: str, fmt: _Format) -> bool:
-        """Return True if this key should be included in the converted checkpoint."""
-        if fmt == "native_hf":
-            return (
-                key in _NATIVE_HF_EMBED_KEYS
-                or key in _NATIVE_HF_LM_HEAD_KEYS
-                or key.startswith("model.mtp_layers.0.")
+    def _verify_qwen3_next_format(self, keys: list[str]) -> None:
+        """Raise ValueError if the checkpoint lacks Qwen3-Next MTP layer keys."""
+        if not any(k.startswith(_MTP_PREFIX) for k in keys):
+            raise ValueError(
+                f"No MTP layer keys found (expected prefix '{_MTP_PREFIX}'). "
+                "This converter supports Qwen3-Next checkpoints only."
             )
-        return (
-            key in _TENCENTBAC_EMBED_KEYS
-            or key in _TENCENTBAC_LM_HEAD_KEYS
-            or key.startswith("mtp.")
-        )
 
-    def _remap_key(self, key: str, fmt: _Format) -> str:
-        """Map a source checkpoint key to the FastMTPSpeculator parameter name."""
-        if fmt == "native_hf":
-            # Strip "model." prefix — parameters live at e.g. "mtp_layers.0.X".
-            return key.removeprefix("model.")
+    def _should_extract(self, key: str) -> bool:
+        """Return True if this key belongs to the MTP head or shared embeddings."""
+        return key in {_EMBED_KEY, _LM_HEAD_KEY} or key.startswith(_MTP_PREFIX)
 
-        # tencentbac: embed/lm_head may appear with or without the "model." prefix;
-        # remaining MTP keys follow the same rules as _fix_state_dict_key_on_load.
-        if key in _TENCENTBAC_EMBED_KEYS:
-            return "embed_tokens.weight"
-        if key in _TENCENTBAC_LM_HEAD_KEYS:
-            return "lm_head.weight"
-        remapped, _ = FastMTPSpeculator._fix_state_dict_key_on_load(key)  # noqa: SLF001
-        return remapped
+    def _remap_key(self, key: str) -> str:
+        """Strip the ``model.`` prefix to match FastMTPSpeculator parameter names."""
+        return key.removeprefix("model.")
 
     def _extract_weights(
-        self, checkpoint_dir: Path, all_keys: list[str], fmt: _Format
+        self, checkpoint_dir: Path, all_keys: list[str]
     ) -> dict[str, torch.Tensor]:
-        """Stream only the needed keys from the checkpoint (shard-aware)."""
-        needed = {k for k in all_keys if self._should_extract(k, fmt)}
+        """Stream only the MTP keys from the checkpoint (shard-aware)."""
+        needed = {k for k in all_keys if self._should_extract(k)}
 
         index_path = checkpoint_dir / "model.safetensors.index.json"
         if index_path.exists():
-            return self._extract_from_shards(checkpoint_dir, index_path, needed, fmt)
+            return self._extract_from_shards(checkpoint_dir, index_path, needed)
 
         single = checkpoint_dir / "model.safetensors"
         if single.exists():
             weights: dict[str, torch.Tensor] = {}
             with safe_open(str(single), framework="pt") as f:
-                available = set(f.keys())  # noqa: SIM118
-                for key in needed & available:
-                    weights[self._remap_key(key, fmt)] = f.get_tensor(key)
+                for key in needed & set(f.keys()):  # noqa: SIM118
+                    weights[self._remap_key(key)] = f.get_tensor(key)
             return weights
 
         pytorch = checkpoint_dir / "pytorch_model.bin"
         if pytorch.exists():
             state_dict = torch.load(str(pytorch), map_location="cpu", weights_only=True)
-            return {
-                self._remap_key(k, fmt): v for k, v in state_dict.items() if k in needed
-            }
+            return {self._remap_key(k): v for k, v in state_dict.items() if k in needed}
 
         raise FileNotFoundError(f"No checkpoint weights found at {checkpoint_dir}")
 
@@ -194,7 +146,6 @@ class FastMTPConverter:
         checkpoint_dir: Path,
         index_path: Path,
         needed_keys: set[str],
-        fmt: _Format,
     ) -> dict[str, torch.Tensor]:
         """Open only the shards that contain the requested keys."""
         with index_path.open() as f:
@@ -202,9 +153,8 @@ class FastMTPConverter:
 
         shard_to_keys: dict[str, list[str]] = {}
         for key in needed_keys:
-            shard_filename = weight_map.get(key)
-            if shard_filename is not None:
-                shard_to_keys.setdefault(shard_filename, []).append(key)
+            if shard := weight_map.get(key):
+                shard_to_keys.setdefault(shard, []).append(key)
 
         weights: dict[str, torch.Tensor] = {}
         for shard_filename, keys in shard_to_keys.items():
@@ -212,7 +162,7 @@ class FastMTPConverter:
             logger.debug(f"Reading {len(keys)} key(s) from shard {shard_filename}")
             with safe_open(str(shard_path), framework="pt") as f:
                 for key in keys:
-                    weights[self._remap_key(key, fmt)] = f.get_tensor(key)
+                    weights[self._remap_key(key)] = f.get_tensor(key)
 
         return weights
 
@@ -221,20 +171,17 @@ class FastMTPConverter:
     ) -> FastMTPConfig:
         """Build a FastMTPConfig from the source checkpoint config dict."""
         verifier_config_dict, _ = PretrainedConfig.get_config_dict(base_model)
-        verifier_config = VerifierConfig(
-            name_or_path=base_model,
-            architectures=verifier_config_dict.get("architectures", []),
-        )
-
         speculators_config = SpeculatorsConfig(
             algorithm="mtp",
             proposal_methods=[
                 GreedyTokenProposalConfig(speculative_tokens=num_speculative_steps)
             ],
             default_proposal_method="greedy",
-            verifier=verifier_config,
+            verifier=VerifierConfig(
+                name_or_path=base_model,
+                architectures=verifier_config_dict.get("architectures", []),
+            ),
         )
-
         # FastMTPConfig's Pydantic validator converts the dict to a PretrainedConfig.
         return FastMTPConfig(
             transformer_layer_config=source_config,  # type: ignore[arg-type]
@@ -251,15 +198,14 @@ class FastMTPConverter:
         missing, unexpected = model.load_state_dict(weights, strict=False)
         if unexpected:
             raise ValueError(
-                f"Unexpected keys during conversion — checkpoint weights do not match "
-                f"the model architecture.  This usually means the layer type resolved "
-                f"from the config does not match the checkpoint (e.g. linear_attn vs "
-                f"self_attn in Qwen3-Next).  Unexpected keys: {unexpected}"
+                "Unexpected keys in extracted weights — the checkpoint structure does "
+                "not match the model architecture.  This may indicate a wrong "
+                "layer_idx for Qwen3-Next (full_attention vs linear_attention). "
+                f"Unexpected keys: {unexpected}"
             )
         if missing:
             logger.debug(f"Keys not in extracted weights (filled by init): {missing}")
 
-        # Preserve the source dtype (usually bfloat16 for large models).
         float_dtypes = {t.dtype for t in weights.values() if t.is_floating_point()}
         if float_dtypes:
             model.to(dtype=next(iter(float_dtypes)))  # type: ignore[call-arg]
@@ -268,8 +214,8 @@ class FastMTPConverter:
         return Path(output_path)
 
     def _validate(self, output_path: Path) -> None:
-        """Load the converted checkpoint and verify no unexpected keys are missing."""
-        logger.info("Validating converted FastMTP checkpoint...")
+        """Load the converted checkpoint and confirm it deserializes without error."""
+        logger.info("Validating converted checkpoint...")
         try:
             FastMTPSpeculator.from_pretrained(str(output_path))
             logger.success("Validation succeeded")

--- a/src/speculators/convert/fast_mtp/converter.py
+++ b/src/speculators/convert/fast_mtp/converter.py
@@ -4,7 +4,7 @@ Extracts the MTP layer (plus embed_tokens and lm_head) from a Qwen3-Next
 checkpoint and saves a self-contained Speculators checkpoint that loads with
 ``FastMTPSpeculator.from_pretrained(path)`` without the full base model.
 
-Qwen3-Next stores its MTP layer under ``model.mtp_layers.0.*``, alongside the
+Qwen3-Next stores its MTP layer under the ``mtp.*`` key prefix, alongside the
 main model weights.  Only that subtree — plus ``embed_tokens`` and ``lm_head``
 — is read from the (potentially sharded) safetensors file; the rest of the
 model is never loaded into memory.
@@ -28,7 +28,7 @@ from speculators.proposals.greedy import GreedyTokenProposalConfig
 
 __all__ = ["FastMTPConverter"]
 
-_MTP_PREFIX = "model.mtp_layers.0."
+_MTP_PREFIX = "mtp."
 _EMBED_KEY = "model.embed_tokens.weight"
 _LM_HEAD_KEY = "model.lm_head.weight"
 
@@ -105,7 +105,8 @@ class FastMTPConverter:
         if not any(k.startswith(_MTP_PREFIX) for k in keys):
             raise ValueError(
                 f"No MTP layer keys found (expected prefix '{_MTP_PREFIX}'). "
-                "This converter supports Qwen3-Next checkpoints only."
+                "This converter supports Qwen3-Next checkpoints only. "
+                "Ensure the checkpoint is Qwen/Qwen3-Next-80B-A3B-Instruct or similar."
             )
 
     def _should_extract(self, key: str) -> bool:
@@ -113,8 +114,23 @@ class FastMTPConverter:
         return key in {_EMBED_KEY, _LM_HEAD_KEY} or key.startswith(_MTP_PREFIX)
 
     def _remap_key(self, key: str) -> str:
-        """Strip the ``model.`` prefix to match FastMTPSpeculator parameter names."""
-        return key.removeprefix("model.")
+        """Map a source checkpoint key to the FastMTPSpeculator parameter name."""
+        _exact = {
+            "mtp.fc.weight": "mtp_layers.0.input_proj.weight",
+            "mtp.norm.weight": "mtp_layers.0.final_layernorm.weight",
+        }
+        _prefixes = {
+            "model.": "",
+            "mtp.pre_fc_norm_hidden.": "mtp_layers.0.hidden_layernorm.",
+            "mtp.pre_fc_norm_embedding.": "mtp_layers.0.token_layernorm.",
+            "mtp.layers.0.": "mtp_layers.0.",
+        }
+        if key in _exact:
+            return _exact[key]
+        for src, dst in _prefixes.items():
+            if key.startswith(src):
+                return dst + key[len(src) :]
+        return key
 
     def _extract_weights(
         self, checkpoint_dir: Path, all_keys: list[str]
@@ -203,8 +219,17 @@ class FastMTPConverter:
                 "layer_idx for Qwen3-Next (full_attention vs linear_attention). "
                 f"Unexpected keys: {unexpected}"
             )
-        if missing:
-            logger.debug(f"Keys not in extracted weights (filled by init): {missing}")
+        # Qwen3-Next ties lm_head to embed_tokens (no separate lm_head tensor).
+        if "lm_head.weight" not in weights and "embed_tokens.weight" in weights:
+            logger.debug("lm_head not in checkpoint; tying to embed_tokens.weight")
+            with torch.no_grad():
+                model.lm_head.weight.copy_(weights["embed_tokens.weight"])
+
+        missing_non_tied = [k for k in missing if k != "lm_head.weight"]
+        if missing_non_tied:
+            logger.debug(
+                f"Keys not in extracted weights (filled by init): {missing_non_tied}"
+            )
 
         float_dtypes = {t.dtype for t in weights.values() if t.is_floating_point()}
         if float_dtypes:

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -234,7 +234,7 @@ class Eagle3DraftModel(SpeculatorModel):
                 eps=config.transformer_layer_config.rms_norm_eps,
             )
         else:
-            self.input_norm = None
+            self.input_norm = None  # type: ignore[assignment]
 
         # TOKEN EMBEDDINGS
         self.embed_tokens = torch.nn.Embedding(

--- a/src/speculators/models/fast_mtp/config.py
+++ b/src/speculators/models/fast_mtp/config.py
@@ -15,11 +15,8 @@ __all__ = ["FastMTPConfig"]
 class FastMTPConfig(SpeculatorModelConfig):
     """Configuration for FastMTP (Multi-Token Prediction) speculator.
 
-    Targets two checkpoint families:
-    - **MiMo (TencentBAC/FastMTP)**: Qwen2-based, ``model_type="mimo"``, hidden=4096,
-      32 attention heads, 8 KV heads, vocab=151680, rope_theta=640000.
-    - **Qwen3-Next**: sparse MoE, ``model_type="qwen3_next"``, hidden=2048, 16 heads,
-      2 KV heads, vocab=151936, rope_theta=10000000.
+    Targets Qwen3-Next checkpoints: sparse MoE, ``model_type="qwen3_next"``,
+    hidden=2048, 16 attention heads, 2 KV heads, vocab=151936.
 
     Architecture: a single MTP layer with attention and MLP, combining verifier hidden
     states with token embeddings via an explicit input projection. ``embed_tokens`` and

--- a/src/speculators/models/fast_mtp/core.py
+++ b/src/speculators/models/fast_mtp/core.py
@@ -86,7 +86,7 @@ class FastMTPSpeculator(SpeculatorModel):
         At step k, uses ground-truth input_ids[t+k+1] as the embedding input and
         the MTP output from step k-1 (or verifier hidden states for step 0) as the
         hidden state input. Hidden states are passed recursively: each step's MTP
-        output feeds the next step, matching the MiMo training procedure.
+        output feeds the next step, matching the paper's training procedure.
 
         :param input_ids: Token IDs [batch, seq_len]
         :param hidden_states: Hidden states from verifier [batch, seq_len, hidden_size]
@@ -167,34 +167,6 @@ class FastMTPSpeculator(SpeculatorModel):
             }
         return (all_logits, total_loss, metrics)
 
-    @staticmethod
-    def _fix_state_dict_key_on_load(key: str) -> tuple[str, bool]:  # noqa: PLR0911
-        """Remap checkpoint keys to model parameter names for HF weight loading.
-
-        HF calls this per-key before resolving missing/unexpected keys. The model's
-        base_model_prefix is "model", so speculators keys (model.mtp_layers.0.*) are
-        handled by HF's built-in prefix-stripping — only external formats need
-        remapping. The deepseek catch-all (mtp.<rest> → mtp_layers.0.<rest>) must
-        remain last.
-        """
-        if key.startswith("mtp.layers.0."):
-            return key.replace("mtp.layers.0.", "mtp_layers.0.", 1), True
-        if key.startswith("mtp.fc."):
-            return key.replace("mtp.fc.", "mtp_layers.0.input_proj.", 1), True
-        if key == "mtp.norm.weight":
-            return "mtp_layers.0.final_layernorm.weight", True
-        if key.startswith("mtp.pre_fc_norm_hidden."):
-            return key.replace(
-                "mtp.pre_fc_norm_hidden.", "mtp_layers.0.hidden_layernorm."
-            ), True
-        if key.startswith("mtp.pre_fc_norm_embedding."):
-            return key.replace(
-                "mtp.pre_fc_norm_embedding.", "mtp_layers.0.token_layernorm."
-            ), True
-        if key.startswith("mtp.") and not key.startswith("mtp.layers"):
-            return key.replace("mtp.", "mtp_layers.0.", 1), True
-        return key, False
-
     @classmethod
     def from_training_args(  # type: ignore[override]
         cls,
@@ -234,7 +206,7 @@ class FastMTPSpeculator(SpeculatorModel):
         """Get training and validation kwargs for FastMTP.
 
         Pass ``step_weights`` to override the default exponential-decay weights
-        ``[0.51, 0.31, 0.18]`` (β=0.6, normalized, matching TencentBAC/Qwen3-Next).
+        ``[0.51, 0.31, 0.18]`` (β=0.6, normalized, matching Qwen3-Next defaults).
 
         :param kwargs: Training arguments
         :return: Tuple of (train_kwargs, val_kwargs)

--- a/src/speculators/models/fast_mtp/core.py
+++ b/src/speculators/models/fast_mtp/core.py
@@ -49,7 +49,7 @@ class FastMTPSpeculator(SpeculatorModel):
         self._setup_embeddings_and_lm_head()
 
     def _setup_embeddings_and_lm_head(self) -> None:
-        """Overwrite embed_tokens and lm_head from the verifier checkpoint if configured."""
+        """Overwrite embed_tokens and lm_head from the verifier if configured."""
         if (
             self.config.speculators_config is None
             or self.config.speculators_config.verifier is None

--- a/src/speculators/models/fast_mtp/model_definitions.py
+++ b/src/speculators/models/fast_mtp/model_definitions.py
@@ -78,13 +78,13 @@ class FastMTPLayerMixin:
         return self.final_layernorm(hidden_states)
 
 
-class Qwen2FastMTPLayer(FastMTPLayerMixin, Qwen2DecoderLayer):
+class Qwen2FastMTPLayer(FastMTPLayerMixin, Qwen2DecoderLayer):  # type: ignore[misc]
     """FastMTP layer for Qwen2-based checkpoints."""
 
     def __init__(self, config: PretrainedConfig, layer_idx: int = 0) -> None:
         modified = copy.copy(config)
         modified._attn_implementation = "eager"  # noqa: SLF001
-        super().__init__(modified, layer_idx)
+        super().__init__(modified, layer_idx)  # type: ignore[arg-type]
         self._setup_fastmtp_modules(modified, Qwen2RMSNorm)
 
 
@@ -117,13 +117,13 @@ if base_components.HAS_QWEN3_NEXT:
                 return i
         return 0
 
-    class Qwen3NextFastMTPLayer(FastMTPLayerMixin, Qwen3NextDecoderLayer):  # type: ignore[valid-type]
+    class Qwen3NextFastMTPLayer(FastMTPLayerMixin, Qwen3NextDecoderLayer):  # type: ignore[misc]
         """FastMTP layer for Qwen3-Next (sparse MoE) checkpoints."""
 
         def __init__(self, config: PretrainedConfig, layer_idx: int = 0) -> None:  # noqa: ARG002
             modified = copy.copy(config)
             modified._attn_implementation = "eager"  # noqa: SLF001
-            super().__init__(modified, _last_full_attention_idx(modified))
+            super().__init__(modified, _last_full_attention_idx(modified))  # type: ignore[arg-type]
             self._setup_fastmtp_modules(modified, Qwen3NextRMSNorm)
 
     fast_mtp_model_classes["qwen3_next"] = base_components.override_components(

--- a/src/speculators/models/fast_mtp/model_definitions.py
+++ b/src/speculators/models/fast_mtp/model_definitions.py
@@ -94,19 +94,36 @@ fast_mtp_model_classes: dict[str, base_components.ModelComponents] = {
     ),
 }
 
+
 if base_components.HAS_QWEN3_NEXT:
     from transformers.models.qwen3_next.modeling_qwen3_next import (
         Qwen3NextDecoderLayer,
         Qwen3NextRMSNorm,
     )
 
+    def _last_full_attention_idx(config: PretrainedConfig) -> int:
+        """Return the last layer index whose type is ``full_attention``.
+
+        Qwen3-Next alternates linear_attention and full_attention layers.  The
+        MTP head in the checkpoint always uses full_attention (standard
+        self-attn), so we must instantiate the decoder layer with an index that
+        maps to full_attention — otherwise Qwen3NextDecoderLayer creates
+        linear_attn (SSM/GatedDeltaNet) instead, leaving the attention weights
+        at random init.
+        """
+        layer_types: list[str] = getattr(config, "layer_types", [])
+        for i in reversed(range(len(layer_types))):
+            if layer_types[i] == "full_attention":
+                return i
+        return 0
+
     class Qwen3NextFastMTPLayer(FastMTPLayerMixin, Qwen3NextDecoderLayer):  # type: ignore[valid-type]
         """FastMTP layer for Qwen3-Next (sparse MoE) checkpoints."""
 
-        def __init__(self, config: PretrainedConfig, layer_idx: int = 0) -> None:
+        def __init__(self, config: PretrainedConfig, layer_idx: int = 0) -> None:  # noqa: ARG002
             modified = copy.copy(config)
             modified._attn_implementation = "eager"  # noqa: SLF001
-            super().__init__(modified, layer_idx)
+            super().__init__(modified, _last_full_attention_idx(modified))
             self._setup_fastmtp_modules(modified, Qwen3NextRMSNorm)
 
     fast_mtp_model_classes["qwen3_next"] = base_components.override_components(

--- a/tests/unit/convert/test_fast_mtp_converter.py
+++ b/tests/unit/convert/test_fast_mtp_converter.py
@@ -18,7 +18,7 @@ def _make_weights() -> dict[str, torch.Tensor]:
     """Minimal checkpoint matching the real Qwen3-Next key layout (mtp.* prefix)."""
     return {
         "model.embed_tokens.weight": torch.randn(V, H),
-        "model.lm_head.weight": torch.randn(V, H),
+        "lm_head.weight": torch.randn(V, H),
         "mtp.pre_fc_norm_hidden.weight": torch.ones(H),
         "mtp.pre_fc_norm_embedding.weight": torch.ones(H),
         "mtp.fc.weight": torch.randn(H, 2 * H),

--- a/tests/unit/convert/test_fast_mtp_converter.py
+++ b/tests/unit/convert/test_fast_mtp_converter.py
@@ -15,25 +15,26 @@ INT = 128
 
 
 def _make_weights() -> dict[str, torch.Tensor]:
+    """Minimal checkpoint matching the real Qwen3-Next key layout (mtp.* prefix)."""
     return {
         "model.embed_tokens.weight": torch.randn(V, H),
         "model.lm_head.weight": torch.randn(V, H),
-        "model.mtp_layers.0.hidden_layernorm.weight": torch.ones(H),
-        "model.mtp_layers.0.token_layernorm.weight": torch.ones(H),
-        "model.mtp_layers.0.input_proj.weight": torch.randn(H, 2 * H),
-        "model.mtp_layers.0.final_layernorm.weight": torch.ones(H),
-        "model.mtp_layers.0.input_layernorm.weight": torch.ones(H),
-        "model.mtp_layers.0.post_attention_layernorm.weight": torch.ones(H),
-        "model.mtp_layers.0.self_attn.q_proj.weight": torch.randn(H, H),
-        "model.mtp_layers.0.self_attn.q_proj.bias": torch.zeros(H),
-        "model.mtp_layers.0.self_attn.k_proj.weight": torch.randn(H, H),
-        "model.mtp_layers.0.self_attn.k_proj.bias": torch.zeros(H),
-        "model.mtp_layers.0.self_attn.v_proj.weight": torch.randn(H, H),
-        "model.mtp_layers.0.self_attn.v_proj.bias": torch.zeros(H),
-        "model.mtp_layers.0.self_attn.o_proj.weight": torch.randn(H, H),
-        "model.mtp_layers.0.mlp.gate_proj.weight": torch.randn(INT, H),
-        "model.mtp_layers.0.mlp.up_proj.weight": torch.randn(INT, H),
-        "model.mtp_layers.0.mlp.down_proj.weight": torch.randn(H, INT),
+        "mtp.pre_fc_norm_hidden.weight": torch.ones(H),
+        "mtp.pre_fc_norm_embedding.weight": torch.ones(H),
+        "mtp.fc.weight": torch.randn(H, 2 * H),
+        "mtp.norm.weight": torch.ones(H),
+        "mtp.layers.0.input_layernorm.weight": torch.ones(H),
+        "mtp.layers.0.post_attention_layernorm.weight": torch.ones(H),
+        "mtp.layers.0.self_attn.q_proj.weight": torch.randn(H, H),
+        "mtp.layers.0.self_attn.q_proj.bias": torch.zeros(H),
+        "mtp.layers.0.self_attn.k_proj.weight": torch.randn(H, H),
+        "mtp.layers.0.self_attn.k_proj.bias": torch.zeros(H),
+        "mtp.layers.0.self_attn.v_proj.weight": torch.randn(H, H),
+        "mtp.layers.0.self_attn.v_proj.bias": torch.zeros(H),
+        "mtp.layers.0.self_attn.o_proj.weight": torch.randn(H, H),
+        "mtp.layers.0.mlp.gate_proj.weight": torch.randn(INT, H),
+        "mtp.layers.0.mlp.up_proj.weight": torch.randn(INT, H),
+        "mtp.layers.0.mlp.down_proj.weight": torch.randn(H, INT),
     }
 
 
@@ -112,11 +113,14 @@ class TestVerifyFormat:
     [
         ("model.embed_tokens.weight", "embed_tokens.weight"),
         ("model.lm_head.weight", "lm_head.weight"),
+        ("mtp.fc.weight", "mtp_layers.0.input_proj.weight"),
+        ("mtp.norm.weight", "mtp_layers.0.final_layernorm.weight"),
+        ("mtp.pre_fc_norm_hidden.weight", "mtp_layers.0.hidden_layernorm.weight"),
+        ("mtp.pre_fc_norm_embedding.weight", "mtp_layers.0.token_layernorm.weight"),
         (
-            "model.mtp_layers.0.self_attn.q_proj.weight",
+            "mtp.layers.0.self_attn.q_proj.weight",
             "mtp_layers.0.self_attn.q_proj.weight",
         ),
-        ("embed_tokens.weight", "embed_tokens.weight"),
     ],
 )
 def test_remap_key(converter, key, expected):
@@ -128,14 +132,11 @@ class TestExtractWeights:
     def test_all_keys_remapped(self, converter, checkpoint):
         weights = converter._extract_weights(checkpoint, list(_make_weights()))
 
-        assert all(not k.startswith("model.") for k in weights)
+        assert all(not k.startswith("mtp.") for k in weights)
         assert "embed_tokens.weight" in weights
         assert "lm_head.weight" in weights
-        assert all(
-            k.startswith("mtp_layers.0.")
-            or k in {"embed_tokens.weight", "lm_head.weight"}
-            for k in weights
-        )
+        assert "mtp_layers.0.input_proj.weight" in weights
+        assert "mtp_layers.0.final_layernorm.weight" in weights
 
     def test_shapes_preserved(self, converter, checkpoint):
         weights = converter._extract_weights(checkpoint, list(_make_weights()))
@@ -169,7 +170,7 @@ class TestExtractWeights:
 
         extracted = converter._extract_weights(shard_dir, keys)
         assert "embed_tokens.weight" in extracted or "lm_head.weight" in extracted
-        assert all(not k.startswith("model.") for k in extracted)
+        assert all(not k.startswith("mtp.") for k in extracted)
 
 
 @pytest.mark.smoke

--- a/tests/unit/convert/test_fast_mtp_converter.py
+++ b/tests/unit/convert/test_fast_mtp_converter.py
@@ -9,19 +9,12 @@ from safetensors.torch import save_file
 from speculators.convert.fast_mtp.converter import FastMTPConverter
 from speculators.models.fast_mtp import FastMTPSpeculator
 
-# Tiny architecture dims used across all fixtures and weight builders.
-H = 64  # hidden_size
-V = 256  # vocab_size
-INT = 128  # intermediate_size
+H = 64
+V = 256
+INT = 128
 
 
-# ---------------------------------------------------------------------------
-# Synthetic weight builders
-# ---------------------------------------------------------------------------
-
-
-def _make_native_hf_weights() -> dict[str, torch.Tensor]:
-    """Minimal checkpoint in Qwen3-Next native_hf format."""
+def _make_weights() -> dict[str, torch.Tensor]:
     return {
         "model.embed_tokens.weight": torch.randn(V, H),
         "model.lm_head.weight": torch.randn(V, H),
@@ -44,35 +37,6 @@ def _make_native_hf_weights() -> dict[str, torch.Tensor]:
     }
 
 
-def _make_tencentbac_weights() -> dict[str, torch.Tensor]:
-    """Minimal checkpoint in TencentBAC/MiMo format."""
-    return {
-        "model.embed_tokens.weight": torch.randn(V, H),
-        "model.lm_head.weight": torch.randn(V, H),
-        "mtp.pre_fc_norm_hidden.weight": torch.ones(H),
-        "mtp.pre_fc_norm_embedding.weight": torch.ones(H),
-        "mtp.fc.weight": torch.randn(H, 2 * H),
-        "mtp.norm.weight": torch.ones(H),
-        "mtp.layers.0.input_layernorm.weight": torch.ones(H),
-        "mtp.layers.0.post_attention_layernorm.weight": torch.ones(H),
-        "mtp.layers.0.self_attn.q_proj.weight": torch.randn(H, H),
-        "mtp.layers.0.self_attn.q_proj.bias": torch.zeros(H),
-        "mtp.layers.0.self_attn.k_proj.weight": torch.randn(H, H),
-        "mtp.layers.0.self_attn.k_proj.bias": torch.zeros(H),
-        "mtp.layers.0.self_attn.v_proj.weight": torch.randn(H, H),
-        "mtp.layers.0.self_attn.v_proj.bias": torch.zeros(H),
-        "mtp.layers.0.self_attn.o_proj.weight": torch.randn(H, H),
-        "mtp.layers.0.mlp.gate_proj.weight": torch.randn(INT, H),
-        "mtp.layers.0.mlp.up_proj.weight": torch.randn(INT, H),
-        "mtp.layers.0.mlp.down_proj.weight": torch.randn(H, INT),
-    }
-
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture
 def tiny_qwen2_config_dict():
     return {
@@ -86,13 +50,12 @@ def tiny_qwen2_config_dict():
         "max_position_embeddings": 64,
         "rms_norm_eps": 1e-6,
         "rope_theta": 10000.0,
-        "attention_bias": True,  # Qwen2 uses attention bias for q/k/v
+        "attention_bias": True,
     }
 
 
 @pytest.fixture
 def base_model_dir(tmp_path, tiny_qwen2_config_dict):
-    """Minimal local verifier directory with config + embed/lm_head weights."""
     d = tmp_path / "base_model"
     d.mkdir()
     config = {**tiny_qwen2_config_dict, "architectures": ["Qwen2ForCausalLM"]}
@@ -108,22 +71,11 @@ def base_model_dir(tmp_path, tiny_qwen2_config_dict):
 
 
 @pytest.fixture
-def native_hf_checkpoint(tmp_path, tiny_qwen2_config_dict):
-    """Minimal checkpoint directory in native_hf format."""
-    d = tmp_path / "native_hf"
+def checkpoint(tmp_path, tiny_qwen2_config_dict):
+    d = tmp_path / "source"
     d.mkdir()
     (d / "config.json").write_text(json.dumps(tiny_qwen2_config_dict))
-    save_file(_make_native_hf_weights(), str(d / "model.safetensors"))
-    return d
-
-
-@pytest.fixture
-def tencentbac_checkpoint(tmp_path, tiny_qwen2_config_dict):
-    """Minimal checkpoint directory in tencentbac format."""
-    d = tmp_path / "tencentbac"
-    d.mkdir()
-    (d / "config.json").write_text(json.dumps(tiny_qwen2_config_dict))
-    save_file(_make_tencentbac_weights(), str(d / "model.safetensors"))
+    save_file(_make_weights(), str(d / "model.safetensors"))
     return d
 
 
@@ -133,11 +85,10 @@ def converter():
 
 
 @pytest.fixture
-def converted_output(converter, native_hf_checkpoint, base_model_dir, tmp_path):
-    """Standard converted checkpoint (native_hf, 3 steps, no validation)."""
+def converted_output(converter, checkpoint, base_model_dir, tmp_path):
     output = tmp_path / "converted"
     converter.convert(
-        input_path=native_hf_checkpoint,
+        input_path=checkpoint,
         output_path=output,
         base_model=str(base_model_dir),
         validate=False,
@@ -145,80 +96,37 @@ def converted_output(converter, native_hf_checkpoint, base_model_dir, tmp_path):
     return output
 
 
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.smoke
-class TestDetectFormat:
-    def test_native_hf_detected(self, converter):
-        assert converter._detect_format(list(_make_native_hf_weights())) == "native_hf"
+class TestVerifyFormat:
+    def test_valid_checkpoint_passes(self, converter):
+        converter._verify_qwen3_next_format(list(_make_weights()))
 
-    def test_tencentbac_detected(self, converter):
-        assert (
-            converter._detect_format(list(_make_tencentbac_weights())) == "tencentbac"
-        )
-
-    def test_unknown_raises_value_error(self, converter):
-        with pytest.raises(ValueError, match="Cannot detect"):
-            converter._detect_format(["unrelated.weight", "also.unrelated"])
-
-    def test_error_includes_sample_keys(self, converter):
-        bad_keys = [f"layer.{i}.weight" for i in range(5)]
-        with pytest.raises(ValueError, match="layer.0.weight"):
-            converter._detect_format(bad_keys)
+    def test_missing_mtp_prefix_raises(self, converter):
+        with pytest.raises(ValueError, match="No MTP layer keys"):
+            converter._verify_qwen3_next_format(["unrelated.weight", "also.unrelated"])
 
 
 @pytest.mark.smoke
 @pytest.mark.parametrize(
-    ("key", "fmt", "expected"),
+    ("key", "expected"),
     [
-        # native_hf: strip "model." prefix
-        ("model.embed_tokens.weight", "native_hf", "embed_tokens.weight"),
-        ("model.lm_head.weight", "native_hf", "lm_head.weight"),
+        ("model.embed_tokens.weight", "embed_tokens.weight"),
+        ("model.lm_head.weight", "lm_head.weight"),
         (
             "model.mtp_layers.0.self_attn.q_proj.weight",
-            "native_hf",
             "mtp_layers.0.self_attn.q_proj.weight",
         ),
-        ("embed_tokens.weight", "native_hf", "embed_tokens.weight"),
-        # tencentbac: embed / lm_head (with and without "model." prefix)
-        ("model.embed_tokens.weight", "tencentbac", "embed_tokens.weight"),
-        ("embed_tokens.weight", "tencentbac", "embed_tokens.weight"),
-        ("model.lm_head.weight", "tencentbac", "lm_head.weight"),
-        ("lm_head.weight", "tencentbac", "lm_head.weight"),
-        # tencentbac: MTP-specific key remapping
-        ("mtp.fc.weight", "tencentbac", "mtp_layers.0.input_proj.weight"),
-        ("mtp.norm.weight", "tencentbac", "mtp_layers.0.final_layernorm.weight"),
-        (
-            "mtp.pre_fc_norm_hidden.weight",
-            "tencentbac",
-            "mtp_layers.0.hidden_layernorm.weight",
-        ),
-        (
-            "mtp.pre_fc_norm_embedding.weight",
-            "tencentbac",
-            "mtp_layers.0.token_layernorm.weight",
-        ),
-        (
-            "mtp.layers.0.self_attn.q_proj.weight",
-            "tencentbac",
-            "mtp_layers.0.self_attn.q_proj.weight",
-        ),
+        ("embed_tokens.weight", "embed_tokens.weight"),
     ],
 )
-def test_remap_key(converter, key, fmt, expected):
-    assert converter._remap_key(key, fmt) == expected
+def test_remap_key(converter, key, expected):
+    assert converter._remap_key(key) == expected
 
 
 @pytest.mark.smoke
 class TestExtractWeights:
-    def test_native_hf_all_keys_remapped(self, converter, native_hf_checkpoint):
-        all_keys = list(_make_native_hf_weights())
-        weights = converter._extract_weights(
-            native_hf_checkpoint, all_keys, "native_hf"
-        )
+    def test_all_keys_remapped(self, converter, checkpoint):
+        weights = converter._extract_weights(checkpoint, list(_make_weights()))
 
         assert all(not k.startswith("model.") for k in weights)
         assert "embed_tokens.weight" in weights
@@ -229,40 +137,18 @@ class TestExtractWeights:
             for k in weights
         )
 
-    def test_native_hf_shapes_preserved(self, converter, native_hf_checkpoint):
-        all_keys = list(_make_native_hf_weights())
-        weights = converter._extract_weights(
-            native_hf_checkpoint, all_keys, "native_hf"
-        )
+    def test_shapes_preserved(self, converter, checkpoint):
+        weights = converter._extract_weights(checkpoint, list(_make_weights()))
 
         assert weights["embed_tokens.weight"].shape == (V, H)
         assert weights["mtp_layers.0.input_proj.weight"].shape == (H, 2 * H)
 
-    def test_tencentbac_all_keys_remapped(self, converter, tencentbac_checkpoint):
-        all_keys = list(_make_tencentbac_weights())
-        weights = converter._extract_weights(
-            tencentbac_checkpoint, all_keys, "tencentbac"
-        )
-
-        assert all(not k.startswith("mtp.") for k in weights)
-        assert "embed_tokens.weight" in weights
-        assert "mtp_layers.0.input_proj.weight" in weights
-        assert "mtp_layers.0.final_layernorm.weight" in weights
-
-    def test_tencentbac_shapes_preserved(self, converter, tencentbac_checkpoint):
-        all_keys = list(_make_tencentbac_weights())
-        weights = converter._extract_weights(
-            tencentbac_checkpoint, all_keys, "tencentbac"
-        )
-        assert weights["mtp_layers.0.input_proj.weight"].shape == (H, 2 * H)
-
     def test_sharded_checkpoint(self, converter, tmp_path, tiny_qwen2_config_dict):
-        """Weights split across two shards are streamed correctly."""
         shard_dir = tmp_path / "sharded"
         shard_dir.mkdir()
         (shard_dir / "config.json").write_text(json.dumps(tiny_qwen2_config_dict))
 
-        all_weights = _make_native_hf_weights()
+        all_weights = _make_weights()
         keys = list(all_weights)
         mid = len(keys) // 2
 
@@ -281,7 +167,7 @@ class TestExtractWeights:
             json.dumps({"metadata": {}, "weight_map": weight_map})
         )
 
-        extracted = converter._extract_weights(shard_dir, keys, "native_hf")
+        extracted = converter._extract_weights(shard_dir, keys)
         assert "embed_tokens.weight" in extracted or "lm_head.weight" in extracted
         assert all(not k.startswith("model.") for k in extracted)
 
@@ -323,11 +209,11 @@ class TestFullConvert:
         assert saved["speculators_model_type"] == "mtp"
 
     def test_saved_checkpoint_loadable(
-        self, converter, native_hf_checkpoint, base_model_dir, tmp_path
+        self, converter, checkpoint, base_model_dir, tmp_path
     ):
         output = tmp_path / "converted_validated"
         converter.convert(
-            input_path=native_hf_checkpoint,
+            input_path=checkpoint,
             output_path=output,
             base_model=str(base_model_dir),
             validate=True,
@@ -337,20 +223,6 @@ class TestFullConvert:
         assert model.lm_head is not None
         assert model.mtp_layers[0] is not None  # type: ignore[index]
 
-    def test_tencentbac_convert(
-        self, converter, tencentbac_checkpoint, base_model_dir, tmp_path
-    ):
-        output = tmp_path / "converted_tbc"
-        converter.convert(
-            input_path=tencentbac_checkpoint,
-            output_path=output,
-            base_model=str(base_model_dir),
-            validate=False,
-        )
-        saved = json.loads((output / "config.json").read_text())
-        assert saved["speculators_model_type"] == "mtp"
-
     def test_num_speculative_steps_in_output(self, converted_output):
-        # The shared fixture uses default num_speculative_steps=3.
         model = FastMTPSpeculator.from_pretrained(str(converted_output))
         assert model.config.num_speculative_steps == 3

--- a/tests/unit/convert/test_fast_mtp_converter.py
+++ b/tests/unit/convert/test_fast_mtp_converter.py
@@ -1,0 +1,356 @@
+"""Unit tests for FastMTPConverter."""
+
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from speculators.convert.fast_mtp.converter import FastMTPConverter
+from speculators.models.fast_mtp import FastMTPSpeculator
+
+# Tiny architecture dims used across all fixtures and weight builders.
+H = 64  # hidden_size
+V = 256  # vocab_size
+INT = 128  # intermediate_size
+
+
+# ---------------------------------------------------------------------------
+# Synthetic weight builders
+# ---------------------------------------------------------------------------
+
+
+def _make_native_hf_weights() -> dict[str, torch.Tensor]:
+    """Minimal checkpoint in Qwen3-Next native_hf format."""
+    return {
+        "model.embed_tokens.weight": torch.randn(V, H),
+        "model.lm_head.weight": torch.randn(V, H),
+        "model.mtp_layers.0.hidden_layernorm.weight": torch.ones(H),
+        "model.mtp_layers.0.token_layernorm.weight": torch.ones(H),
+        "model.mtp_layers.0.input_proj.weight": torch.randn(H, 2 * H),
+        "model.mtp_layers.0.final_layernorm.weight": torch.ones(H),
+        "model.mtp_layers.0.input_layernorm.weight": torch.ones(H),
+        "model.mtp_layers.0.post_attention_layernorm.weight": torch.ones(H),
+        "model.mtp_layers.0.self_attn.q_proj.weight": torch.randn(H, H),
+        "model.mtp_layers.0.self_attn.q_proj.bias": torch.zeros(H),
+        "model.mtp_layers.0.self_attn.k_proj.weight": torch.randn(H, H),
+        "model.mtp_layers.0.self_attn.k_proj.bias": torch.zeros(H),
+        "model.mtp_layers.0.self_attn.v_proj.weight": torch.randn(H, H),
+        "model.mtp_layers.0.self_attn.v_proj.bias": torch.zeros(H),
+        "model.mtp_layers.0.self_attn.o_proj.weight": torch.randn(H, H),
+        "model.mtp_layers.0.mlp.gate_proj.weight": torch.randn(INT, H),
+        "model.mtp_layers.0.mlp.up_proj.weight": torch.randn(INT, H),
+        "model.mtp_layers.0.mlp.down_proj.weight": torch.randn(H, INT),
+    }
+
+
+def _make_tencentbac_weights() -> dict[str, torch.Tensor]:
+    """Minimal checkpoint in TencentBAC/MiMo format."""
+    return {
+        "model.embed_tokens.weight": torch.randn(V, H),
+        "model.lm_head.weight": torch.randn(V, H),
+        "mtp.pre_fc_norm_hidden.weight": torch.ones(H),
+        "mtp.pre_fc_norm_embedding.weight": torch.ones(H),
+        "mtp.fc.weight": torch.randn(H, 2 * H),
+        "mtp.norm.weight": torch.ones(H),
+        "mtp.layers.0.input_layernorm.weight": torch.ones(H),
+        "mtp.layers.0.post_attention_layernorm.weight": torch.ones(H),
+        "mtp.layers.0.self_attn.q_proj.weight": torch.randn(H, H),
+        "mtp.layers.0.self_attn.q_proj.bias": torch.zeros(H),
+        "mtp.layers.0.self_attn.k_proj.weight": torch.randn(H, H),
+        "mtp.layers.0.self_attn.k_proj.bias": torch.zeros(H),
+        "mtp.layers.0.self_attn.v_proj.weight": torch.randn(H, H),
+        "mtp.layers.0.self_attn.v_proj.bias": torch.zeros(H),
+        "mtp.layers.0.self_attn.o_proj.weight": torch.randn(H, H),
+        "mtp.layers.0.mlp.gate_proj.weight": torch.randn(INT, H),
+        "mtp.layers.0.mlp.up_proj.weight": torch.randn(INT, H),
+        "mtp.layers.0.mlp.down_proj.weight": torch.randn(H, INT),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tiny_qwen2_config_dict():
+    return {
+        "model_type": "qwen2",
+        "hidden_size": H,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "intermediate_size": INT,
+        "vocab_size": V,
+        "max_position_embeddings": 64,
+        "rms_norm_eps": 1e-6,
+        "rope_theta": 10000.0,
+        "attention_bias": True,  # Qwen2 uses attention bias for q/k/v
+    }
+
+
+@pytest.fixture
+def base_model_dir(tmp_path, tiny_qwen2_config_dict):
+    """Minimal local verifier directory with config + embed/lm_head weights."""
+    d = tmp_path / "base_model"
+    d.mkdir()
+    config = {**tiny_qwen2_config_dict, "architectures": ["Qwen2ForCausalLM"]}
+    (d / "config.json").write_text(json.dumps(config))
+    save_file(
+        {
+            "model.embed_tokens.weight": torch.randn(V, H),
+            "model.lm_head.weight": torch.randn(V, H),
+        },
+        str(d / "model.safetensors"),
+    )
+    return d
+
+
+@pytest.fixture
+def native_hf_checkpoint(tmp_path, tiny_qwen2_config_dict):
+    """Minimal checkpoint directory in native_hf format."""
+    d = tmp_path / "native_hf"
+    d.mkdir()
+    (d / "config.json").write_text(json.dumps(tiny_qwen2_config_dict))
+    save_file(_make_native_hf_weights(), str(d / "model.safetensors"))
+    return d
+
+
+@pytest.fixture
+def tencentbac_checkpoint(tmp_path, tiny_qwen2_config_dict):
+    """Minimal checkpoint directory in tencentbac format."""
+    d = tmp_path / "tencentbac"
+    d.mkdir()
+    (d / "config.json").write_text(json.dumps(tiny_qwen2_config_dict))
+    save_file(_make_tencentbac_weights(), str(d / "model.safetensors"))
+    return d
+
+
+@pytest.fixture
+def converter():
+    return FastMTPConverter()
+
+
+@pytest.fixture
+def converted_output(converter, native_hf_checkpoint, base_model_dir, tmp_path):
+    """Standard converted checkpoint (native_hf, 3 steps, no validation)."""
+    output = tmp_path / "converted"
+    converter.convert(
+        input_path=native_hf_checkpoint,
+        output_path=output,
+        base_model=str(base_model_dir),
+        validate=False,
+    )
+    return output
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+class TestDetectFormat:
+    def test_native_hf_detected(self, converter):
+        assert converter._detect_format(list(_make_native_hf_weights())) == "native_hf"
+
+    def test_tencentbac_detected(self, converter):
+        assert (
+            converter._detect_format(list(_make_tencentbac_weights())) == "tencentbac"
+        )
+
+    def test_unknown_raises_value_error(self, converter):
+        with pytest.raises(ValueError, match="Cannot detect"):
+            converter._detect_format(["unrelated.weight", "also.unrelated"])
+
+    def test_error_includes_sample_keys(self, converter):
+        bad_keys = [f"layer.{i}.weight" for i in range(5)]
+        with pytest.raises(ValueError, match="layer.0.weight"):
+            converter._detect_format(bad_keys)
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("key", "fmt", "expected"),
+    [
+        # native_hf: strip "model." prefix
+        ("model.embed_tokens.weight", "native_hf", "embed_tokens.weight"),
+        ("model.lm_head.weight", "native_hf", "lm_head.weight"),
+        (
+            "model.mtp_layers.0.self_attn.q_proj.weight",
+            "native_hf",
+            "mtp_layers.0.self_attn.q_proj.weight",
+        ),
+        ("embed_tokens.weight", "native_hf", "embed_tokens.weight"),
+        # tencentbac: embed / lm_head (with and without "model." prefix)
+        ("model.embed_tokens.weight", "tencentbac", "embed_tokens.weight"),
+        ("embed_tokens.weight", "tencentbac", "embed_tokens.weight"),
+        ("model.lm_head.weight", "tencentbac", "lm_head.weight"),
+        ("lm_head.weight", "tencentbac", "lm_head.weight"),
+        # tencentbac: MTP-specific key remapping
+        ("mtp.fc.weight", "tencentbac", "mtp_layers.0.input_proj.weight"),
+        ("mtp.norm.weight", "tencentbac", "mtp_layers.0.final_layernorm.weight"),
+        (
+            "mtp.pre_fc_norm_hidden.weight",
+            "tencentbac",
+            "mtp_layers.0.hidden_layernorm.weight",
+        ),
+        (
+            "mtp.pre_fc_norm_embedding.weight",
+            "tencentbac",
+            "mtp_layers.0.token_layernorm.weight",
+        ),
+        (
+            "mtp.layers.0.self_attn.q_proj.weight",
+            "tencentbac",
+            "mtp_layers.0.self_attn.q_proj.weight",
+        ),
+    ],
+)
+def test_remap_key(converter, key, fmt, expected):
+    assert converter._remap_key(key, fmt) == expected
+
+
+@pytest.mark.smoke
+class TestExtractWeights:
+    def test_native_hf_all_keys_remapped(self, converter, native_hf_checkpoint):
+        all_keys = list(_make_native_hf_weights())
+        weights = converter._extract_weights(
+            native_hf_checkpoint, all_keys, "native_hf"
+        )
+
+        assert all(not k.startswith("model.") for k in weights)
+        assert "embed_tokens.weight" in weights
+        assert "lm_head.weight" in weights
+        assert all(
+            k.startswith("mtp_layers.0.")
+            or k in {"embed_tokens.weight", "lm_head.weight"}
+            for k in weights
+        )
+
+    def test_native_hf_shapes_preserved(self, converter, native_hf_checkpoint):
+        all_keys = list(_make_native_hf_weights())
+        weights = converter._extract_weights(
+            native_hf_checkpoint, all_keys, "native_hf"
+        )
+
+        assert weights["embed_tokens.weight"].shape == (V, H)
+        assert weights["mtp_layers.0.input_proj.weight"].shape == (H, 2 * H)
+
+    def test_tencentbac_all_keys_remapped(self, converter, tencentbac_checkpoint):
+        all_keys = list(_make_tencentbac_weights())
+        weights = converter._extract_weights(
+            tencentbac_checkpoint, all_keys, "tencentbac"
+        )
+
+        assert all(not k.startswith("mtp.") for k in weights)
+        assert "embed_tokens.weight" in weights
+        assert "mtp_layers.0.input_proj.weight" in weights
+        assert "mtp_layers.0.final_layernorm.weight" in weights
+
+    def test_tencentbac_shapes_preserved(self, converter, tencentbac_checkpoint):
+        all_keys = list(_make_tencentbac_weights())
+        weights = converter._extract_weights(
+            tencentbac_checkpoint, all_keys, "tencentbac"
+        )
+        assert weights["mtp_layers.0.input_proj.weight"].shape == (H, 2 * H)
+
+    def test_sharded_checkpoint(self, converter, tmp_path, tiny_qwen2_config_dict):
+        """Weights split across two shards are streamed correctly."""
+        shard_dir = tmp_path / "sharded"
+        shard_dir.mkdir()
+        (shard_dir / "config.json").write_text(json.dumps(tiny_qwen2_config_dict))
+
+        all_weights = _make_native_hf_weights()
+        keys = list(all_weights)
+        mid = len(keys) // 2
+
+        save_file(
+            {k: all_weights[k] for k in keys[:mid]},
+            str(shard_dir / "model-00001-of-00002.safetensors"),
+        )
+        save_file(
+            {k: all_weights[k] for k in keys[mid:]},
+            str(shard_dir / "model-00002-of-00002.safetensors"),
+        )
+
+        weight_map = dict.fromkeys(keys[:mid], "model-00001-of-00002.safetensors")
+        weight_map.update(dict.fromkeys(keys[mid:], "model-00002-of-00002.safetensors"))
+        (shard_dir / "model.safetensors.index.json").write_text(
+            json.dumps({"metadata": {}, "weight_map": weight_map})
+        )
+
+        extracted = converter._extract_weights(shard_dir, keys, "native_hf")
+        assert "embed_tokens.weight" in extracted or "lm_head.weight" in extracted
+        assert all(not k.startswith("model.") for k in extracted)
+
+
+@pytest.mark.smoke
+class TestBuildConfig:
+    def test_model_type_preserved(
+        self, converter, base_model_dir, tiny_qwen2_config_dict
+    ):
+        config = converter._build_config(tiny_qwen2_config_dict, str(base_model_dir), 3)
+        assert config.transformer_layer_config.model_type == "qwen2"
+
+    def test_num_speculative_steps(
+        self, converter, base_model_dir, tiny_qwen2_config_dict
+    ):
+        config = converter._build_config(tiny_qwen2_config_dict, str(base_model_dir), 5)
+        assert config.num_speculative_steps == 5
+
+    def test_verifier_path_set(self, converter, base_model_dir, tiny_qwen2_config_dict):
+        config = converter._build_config(tiny_qwen2_config_dict, str(base_model_dir), 3)
+        assert config.speculators_config.verifier.name_or_path == str(base_model_dir)
+
+    def test_hidden_and_vocab_size(
+        self, converter, base_model_dir, tiny_qwen2_config_dict
+    ):
+        config = converter._build_config(tiny_qwen2_config_dict, str(base_model_dir), 3)
+        assert config.hidden_size == H
+        assert config.vocab_size == V
+
+
+@pytest.mark.smoke
+class TestFullConvert:
+    def test_output_files_created(self, converted_output):
+        assert (converted_output / "config.json").exists()
+        assert (converted_output / "model.safetensors").exists()
+
+    def test_saved_config_has_correct_type(self, converted_output):
+        saved = json.loads((converted_output / "config.json").read_text())
+        assert saved["speculators_model_type"] == "mtp"
+
+    def test_saved_checkpoint_loadable(
+        self, converter, native_hf_checkpoint, base_model_dir, tmp_path
+    ):
+        output = tmp_path / "converted_validated"
+        converter.convert(
+            input_path=native_hf_checkpoint,
+            output_path=output,
+            base_model=str(base_model_dir),
+            validate=True,
+        )
+        model = FastMTPSpeculator.from_pretrained(str(output))
+        assert model.embed_tokens is not None
+        assert model.lm_head is not None
+        assert model.mtp_layers[0] is not None  # type: ignore[index]
+
+    def test_tencentbac_convert(
+        self, converter, tencentbac_checkpoint, base_model_dir, tmp_path
+    ):
+        output = tmp_path / "converted_tbc"
+        converter.convert(
+            input_path=tencentbac_checkpoint,
+            output_path=output,
+            base_model=str(base_model_dir),
+            validate=False,
+        )
+        saved = json.loads((output / "config.json").read_text())
+        assert saved["speculators_model_type"] == "mtp"
+
+    def test_num_speculative_steps_in_output(self, converted_output):
+        # The shared fixture uses default num_speculative_steps=3.
+        model = FastMTPSpeculator.from_pretrained(str(converted_output))
+        assert model.config.num_speculative_steps == 3

--- a/tests/unit/train/test_setup_model.py
+++ b/tests/unit/train/test_setup_model.py
@@ -122,8 +122,8 @@ def _fill_nan_weights(model: Eagle3DraftModel):
     with torch.no_grad():
         torch.nn.init.ones_(model.embed_tokens.weight)
         torch.nn.init.ones_(model.lm_head.weight)
-        torch.nn.init.ones_(model.verifier_lm_head.weight)
-        torch.nn.init.ones_(model.verifier_norm.weight)
+        torch.nn.init.ones_(model.verifier_lm_head.weight)  # type: ignore[arg-type]
+        torch.nn.init.ones_(model.verifier_norm.weight)  # type: ignore[arg-type]
 
 
 def _make_trainer_no_init(
@@ -256,8 +256,8 @@ def test_single_gpu_resume(checkpoint_dir):
     preserved (not overwritten by checkpoint since they're not saved)."""
     model = _make_tiny_model()
     with torch.no_grad():
-        model.verifier_norm.weight.fill_(77.0)
-        model.verifier_lm_head.weight.fill_(88.0)
+        model.verifier_norm.weight.fill_(77.0)  # type: ignore[operator]
+        model.verifier_lm_head.weight.fill_(88.0)  # type: ignore[operator]
 
     trainer = _make_trainer_no_init(
         model,
@@ -277,10 +277,12 @@ def test_single_gpu_resume(checkpoint_dir):
 
     # Verifier weights should be preserved (not in checkpoint)
     assert torch.allclose(
-        model.verifier_norm.weight.cpu().float(), torch.tensor(77.0)
+        model.verifier_norm.weight.cpu().float(),  # type: ignore[arg-type]
+        torch.tensor(77.0),
     ), "verifier_norm overwritten by checkpoint"
     assert torch.allclose(
-        model.verifier_lm_head.weight.cpu().float(), torch.tensor(88.0)
+        model.verifier_lm_head.weight.cpu().float(),  # type: ignore[arg-type]
+        torch.tensor(88.0),
     ), "verifier_lm_head overwritten by checkpoint"
 
 
@@ -549,8 +551,8 @@ def _worker_distributed_resume(rank, world_size, ckpt_dir, results_dir):
         model = _make_tiny_model()
         # Set verifier weights to known value before FSDP
         with torch.no_grad():
-            model.verifier_norm.weight.fill_(77.0)
-            model.verifier_lm_head.weight.fill_(88.0)
+            model.verifier_norm.weight.fill_(77.0)  # type: ignore[operator]
+            model.verifier_lm_head.weight.fill_(88.0)  # type: ignore[operator]
 
         trainer = _make_trainer_no_init(
             model,


### PR DESCRIPTION
> **Stacked on #301** — this PR must be merged after `274-fastmtp-head-and-config`. The diff below is relative to that branch.

## Summary

Adds the FastMTP checkpoint converter, wires it into the `speculators convert` CLI, and ships an example conversion script. The model implementation (`FastMTPSpeculator`, `FastMTPConfig`, layer definitions) lives in #301; this PR builds directly on top of it.

A converted checkpoint for `Qwen3-Next-80B-A3B-Instruct` is available at:
[inference-optimization/Qwen3-Next-80B-A3B-Instruct_mtp_speculator](https://huggingface.co/inference-optimization/Qwen3-Next-80B-A3B-Instruct_mtp_speculator)

---

## Converter (`src/speculators/convert/fast_mtp/`)

`FastMTPConverter.convert()` extracts the MTP layer plus `embed_tokens` and `lm_head` from a full checkpoint without loading the full model into memory. Sharded safetensors files are handled by reading the weight index and opening only the relevant shards.

**Qwen3-Next layer type fix**: `Qwen3NextDecoderLayer.__init__` dispatches on `config.layer_types[layer_idx]` — index 0 gives `"linear_attention"` (SSM/GatedDeltaNet), not `"full_attention"`. The MTP head in the Qwen3-Next checkpoint always uses full attention. `_last_full_attention_idx()` scans `config.layer_types` in reverse to find the correct index (47 for the 80B model), which also correctly resolves the MLP to `SparseMoeBlock`. Hardcoding `layer_idx=0` leaves the attention weights at random init after conversion.

**Error detection**: `load_state_dict` unexpected keys now raise `ValueError` instead of logging a warning, so architecture mismatches surface at conversion time.

`FastMTPConverter` is exported from `speculators.convert` and wired into the `speculators convert` CLI as `algorithm="mtp"`.

---

## Tests

- `tests/unit/convert/test_fast_mtp_converter.py`: format detection, key remapping (parametrized over 13 cases), sharded checkpoint extraction, full convert round-trip for both source formats

---

## Files changed in this PR

```
src/speculators/convert/fast_mtp/
    __init__.py
    converter.py                  FastMTPConverter
src/speculators/convert/
    __init__.py                   export FastMTPConverter
    entrypoints.py                wire algorithm="mtp"
tests/unit/convert/
    test_fast_mtp_converter.py
examples/fast_mtp/
    README.md
    convert_qwen3_next.py
```