### PR TITLE
Add FastMTP data generation and dataset utilities

### DIFF
--- a/examples/fast_mtp/README.md
+++ b/examples/fast_mtp/README.md
@@ -51,6 +51,45 @@ speculators convert Qwen/Qwen3-Next-80B-A3B-Instruct \
     --output-path ./qwen3_next_mtp_speculators
 ```
 
+## Generate Training Data
+
+Before finetuning you need to generate hidden-state training data from the verifier. Edit the constants at the top of `examples/fast_mtp/generate_data_qwen3_next.py` and run:
+
+```bash
+# 4 GPUs — adjust CUDA_VISIBLE_DEVICES and TENSOR_PARALLEL_SIZE to match your setup
+CUDA_VISIBLE_DEVICES=0,1,2,3 python examples/fast_mtp/generate_data_qwen3_next.py
+```
+
+The script will:
+
+1. Load `HuggingFaceH4/ultrachat_200k` (`train_sft` split) and tokenize it with `build_eagle3_dataset`, which computes the `loss_mask` (1 on response tokens, 0 on prompt/system tokens).
+2. Run prefill-only inference on `Qwen/Qwen3-Next-80B-A3B-Instruct` via vLLM and capture the **last verifier hidden layer** (`[seq_len, H]`) for each sequence — half the storage of Eagle3's multi-layer capture.
+3. Save one `.pt` file per sequence to `OUTPUT_DIR`:
+
+```python
+{
+    "input_ids":     Tensor[seq_len],      # long
+    "hidden_states": Tensor[seq_len, H],   # float32, last verifier layer
+    "loss_mask":     Tensor[seq_len],      # 1 = compute loss here
+}
+```
+
+4. Write a `sample_lengths.json` index for fast length look-ups during training.
+
+**Hardware requirements:** ~81 GB VRAM per GPU (4 × H100 80 GB recommended for `Qwen3-Next-80B-A3B-Instruct`).
+
+Configurable constants at the top of the script:
+
+| Constant                 | Default                            | Description                             |
+| ------------------------ | ---------------------------------- | --------------------------------------- |
+| `MODEL`                  | `Qwen/Qwen3-Next-80B-A3B-Instruct` | Verifier model (Hub ID or local path)   |
+| `OUTPUT_DIR`             | `./output/…_ultrachat`             | Destination for `.pt` files             |
+| `DATASET`                | `HuggingFaceH4/ultrachat_200k`     | HuggingFace dataset to tokenize         |
+| `NUM_SAMPLES`            | `5_000`                            | Number of sequences to generate         |
+| `MAX_SEQ_LEN`            | `4096`                             | Maximum sequence length                 |
+| `TENSOR_PARALLEL_SIZE`   | `4`                                | Must match `CUDA_VISIBLE_DEVICES` count |
+| `GPU_MEMORY_UTILIZATION` | `0.85`                             | Fraction of GPU memory vLLM may use     |
+
 ## Supported Checkpoints
 
 | Model                                                                           | model_type   |

--- a/examples/fast_mtp/generate_data_qwen3_next.py
+++ b/examples/fast_mtp/generate_data_qwen3_next.py
@@ -29,12 +29,16 @@ from speculators.data_generation.preprocessing import tokenize_conversations
 # ── Configuration ─────────────────────────────────────────────────────────────
 
 MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct"
-OUTPUT_DIR = Path("./output/Qwen3-Next-80B-A3B-Instruct_ultrachat")
+OUTPUT_DIR = Path("/mnt/data/rahul-tuli/datasets/Qwen3-Next-80B-A3B-Instruct_ultrachat")
 DATASET = "HuggingFaceH4/ultrachat_200k"
-NUM_SAMPLES = 100
+NUM_SAMPLES = 50_000
 MAX_SEQ_LEN = 4096
 TENSOR_PARALLEL_SIZE = 4  # match the number of GPUs in CUDA_VISIBLE_DEVICES
-GPU_MEMORY_UTILIZATION = 0.85
+GPU_MEMORY_UTILIZATION = 0.7
+# Qwen3-Next's GDN linear attention allocates activation memory proportional to
+# this value. Reducing it from the default (max(8192, MAX_SEQ_LEN)) prevents
+# CUDA OOM on H100s where the 80B model shard already uses ~37 GiB per GPU.
+MAX_NUM_BATCHED_TOKENS = 2048
 
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -84,6 +88,7 @@ if __name__ == "__main__":
         max_model_len=MAX_SEQ_LEN,
         gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
         tensor_parallel_size=TENSOR_PARALLEL_SIZE,
+        max_num_batched_tokens=MAX_NUM_BATCHED_TOKENS,
     )
 
     print(f"\nDone. {NUM_SAMPLES} samples saved to {OUTPUT_DIR}")

--- a/examples/fast_mtp/generate_data_qwen3_next.py
+++ b/examples/fast_mtp/generate_data_qwen3_next.py
@@ -39,6 +39,9 @@ GPU_MEMORY_UTILIZATION = 0.7
 # this value. Reducing it from the default (max(8192, MAX_SEQ_LEN)) prevents
 # CUDA OOM on H100s where the 80B model shard already uses ~37 GiB per GPU.
 MAX_NUM_BATCHED_TOKENS = 2048
+# Hidden states are collected, saved, and freed between batches to keep memory
+# bounded. At mean seq_len ~1184 and hidden_dim 7168, 500 seqs ≈ 8.5 GB CPU RAM.
+GENERATE_BATCH_SIZE = 500
 
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -89,6 +92,7 @@ if __name__ == "__main__":
         gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
         tensor_parallel_size=TENSOR_PARALLEL_SIZE,
         max_num_batched_tokens=MAX_NUM_BATCHED_TOKENS,
+        generate_batch_size=GENERATE_BATCH_SIZE,
     )
 
     print(f"\nDone. {NUM_SAMPLES} samples saved to {OUTPUT_DIR}")

--- a/examples/fast_mtp/generate_data_qwen3_next.py
+++ b/examples/fast_mtp/generate_data_qwen3_next.py
@@ -1,0 +1,89 @@
+"""Generate FastMTP training data from Qwen3-Next-80B-A3B-Instruct.
+
+Runs prefill on Qwen3-Next-80B-A3B-Instruct, captures the last verifier hidden
+state for each token, and saves one ``.pt`` file per sequence to OUTPUT_DIR.
+
+Each file contains::
+
+    {
+        "input_ids":     Tensor[seq_len],        # long
+        "hidden_states": Tensor[seq_len, H],     # float32, last verifier layer
+        "loss_mask":     Tensor[seq_len],        # 1 = train on this token
+    }
+
+Usage
+-----
+Edit the constants below, then run::
+
+    CUDA_VISIBLE_DEVICES=0,1,2,3 python examples/fast_mtp/generate_data_qwen3_next.py
+"""
+
+from pathlib import Path
+
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+from speculators.data_generation.fast_mtp_generator import generate_and_save_fast_mtp
+from speculators.data_generation.preprocessing import tokenize_conversations
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+MODEL = "Qwen/Qwen3-Next-80B-A3B-Instruct"
+OUTPUT_DIR = Path("./output/Qwen3-Next-80B-A3B-Instruct_ultrachat")
+DATASET = "HuggingFaceH4/ultrachat_200k"
+NUM_SAMPLES = 100
+MAX_SEQ_LEN = 4096
+TENSOR_PARALLEL_SIZE = 4  # match the number of GPUs in CUDA_VISIBLE_DEVICES
+GPU_MEMORY_UTILIZATION = 0.85
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+if __name__ == "__main__":
+    # ── Tokenize ──────────────────────────────────────────────────────────────
+    print(f"Loading tokenizer from {MODEL}")
+    tokenizer = AutoTokenizer.from_pretrained(MODEL, trust_remote_code=True)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    print(f"Loading {DATASET} (train_sft split, {NUM_SAMPLES} samples)")
+    raw = load_dataset(DATASET, split="train_sft")
+    raw = raw.shuffle(seed=42).select(range(NUM_SAMPLES))
+    # ultrachat_200k stores turns under "messages"; tokenize_conversations expects
+    # the standard "conversations" key used by ShareGPT-format datasets.
+    raw = raw.map(
+        lambda ex: {"conversations": ex["messages"]},
+        remove_columns=raw.column_names,
+    )
+
+    print(f"Tokenizing {NUM_SAMPLES} samples (max_len={MAX_SEQ_LEN})")
+    dataset = tokenize_conversations(
+        dataset=raw,
+        tokenizer=tokenizer,
+        max_length=MAX_SEQ_LEN,
+        num_proc=4,
+    )
+
+    token_ids = [s["input_ids"].tolist() for s in dataset]
+    loss_masks = [s["loss_mask"].tolist() for s in dataset]
+
+    lengths = [len(t) for t in token_ids]
+    print(
+        f"Sequence lengths — min: {min(lengths)}, "
+        f"max: {max(lengths)}, "
+        f"mean: {sum(lengths) / len(lengths):.0f}"
+    )
+
+    # ── Generate and save ─────────────────────────────────────────────────────
+    print(f"Generating hidden states and saving to {OUTPUT_DIR}")
+    generate_and_save_fast_mtp(
+        model_path=MODEL,
+        token_ids=token_ids,
+        loss_masks=loss_masks,
+        output_dir=OUTPUT_DIR,
+        max_model_len=MAX_SEQ_LEN,
+        gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
+        tensor_parallel_size=TENSOR_PARALLEL_SIZE,
+    )
+
+    print(f"\nDone. {NUM_SAMPLES} samples saved to {OUTPUT_DIR}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ ignore_missing_imports=true
 [tool.ruff]
 line-length = 88
 indent-width = 4
-exclude = ["build", "dist", "env", ".venv"]
+exclude = ["build", "dist", "env", ".venv", "local", "*_speculator", "*_speculators"]
 
 [tool.ruff.format]
 quote-style = "double"
@@ -254,6 +254,7 @@ select = [
 
 "examples/**/*.py" = [
     "INP001", # allow implicit namespace packages in examples
+    "T201",   # print statements are acceptable in examples
 ]
 
 "scripts/gen_and_train.py" = [

--- a/src/speculators/data_generation/__init__.py
+++ b/src/speculators/data_generation/__init__.py
@@ -1,7 +1,10 @@
-"""Data generation utilities for EAGLE-style speculative decoding training."""
+"""Data generation utilities for speculative decoding training."""
 
+from speculators.data_generation.fast_mtp_generator import (
+    generate_and_save_fast_mtp,
+)
 from speculators.data_generation.vllm_hidden_states_generator import (
     VllmHiddenStatesGenerator,
 )
 
-__all__ = ["VllmHiddenStatesGenerator"]
+__all__ = ["VllmHiddenStatesGenerator", "generate_and_save_fast_mtp"]

--- a/src/speculators/data_generation/_model_utils.py
+++ b/src/speculators/data_generation/_model_utils.py
@@ -1,0 +1,28 @@
+"""Lightweight model-config helpers shared across data-generation modules.
+
+These utilities have **no vLLM dependency** and may be imported in any
+environment (training, datagen, or test).
+"""
+
+from transformers import AutoConfig
+
+__all__: list[str] = []  # internal — not part of the public API
+
+
+def num_hidden_layers(model_path: str) -> int:
+    """Return the number of transformer hidden layers for *model_path*.
+
+    Handles both flat configs (``config.num_hidden_layers``) and nested
+    multimodal configs (``config.text_config.num_hidden_layers``).
+
+    :raises ValueError: if the layer count cannot be determined.
+    """
+    config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    if hasattr(config, "num_hidden_layers"):
+        return config.num_hidden_layers  # type: ignore[return-value]
+    if hasattr(config, "text_config"):
+        return config.text_config.num_hidden_layers  # type: ignore[return-value]
+    raise ValueError(
+        f"Cannot determine num_hidden_layers from config for {model_path!r}. "
+        "Expected config.num_hidden_layers or config.text_config.num_hidden_layers."
+    )

--- a/src/speculators/data_generation/custom_worker.py
+++ b/src/speculators/data_generation/custom_worker.py
@@ -94,10 +94,15 @@ class HiddenStatesWorkerExtension:
     """
 
     def _store_captured_states(self, aux_hidden_states):
+        # Move to CPU immediately to avoid accumulating GPU tensors across many
+        # forward passes. For large runs (e.g. 50k sequences) keeping the tensors
+        # on GPU until _get_captured_states is called would grow GPU memory
+        # continuously until OOM.
+        cpu_states = [h.cpu() for h in aux_hidden_states]
         if self._captured_states is None:  # type: ignore[has-type]
-            self._captured_states = [[h] for h in aux_hidden_states]
+            self._captured_states = [[h] for h in cpu_states]
         else:
-            for i, h in enumerate(aux_hidden_states):
+            for i, h in enumerate(cpu_states):
                 self._captured_states[i].append(h)
 
         metadata = getattr(self, "_current_request_metadata", None)
@@ -165,25 +170,28 @@ class HiddenStatesWorkerExtension:
         if self._captured_states is None:
             return None
 
-        # Concatenate captured states from all scheduler iterations
-        concatenated_layers = [
-            torch.cat(layer_tensors, dim=0) for layer_tensors in self._captured_states
-        ]
+        num_layers = len(self._captured_states)
 
-        # Slice and group by request
+        # Slice directly from per-iteration tensors rather than concatenating
+        # everything first. This avoids allocating a second full-sized buffer
+        # equal to the total token count × hidden_dim before we even start
+        # distributing tokens to requests.
         request_chunks: defaultdict[str, list[list[torch.Tensor]]] = defaultdict(
-            lambda: [[] for _ in range(len(concatenated_layers))]
+            lambda: [[] for _ in range(num_layers)]
         )
-        current_idx = 0
 
-        for metadata in self._request_metadata:  # type: ignore[has-type]
+        for iter_idx, metadata in enumerate(self._request_metadata):  # type: ignore[has-type]
+            current_idx = 0
             for req_id, num_tok in metadata:
-                for layer_idx, layer_tensor in enumerate(concatenated_layers):
-                    chunk = layer_tensor[current_idx : current_idx + num_tok].clone()
+                for layer_idx in range(num_layers):
+                    # Slice is a view — no allocation; torch.cat below creates
+                    # the final contiguous tensor for this request.
+                    iter_tensor = self._captured_states[layer_idx][iter_idx]  # type: ignore[index]
+                    chunk = iter_tensor[current_idx : current_idx + num_tok]
                     request_chunks[req_id][layer_idx].append(chunk)
                 current_idx += num_tok
 
-        # Concatenate chunks for each request
+        # Concatenate per-request chunks (one allocation per request per layer)
         result: dict[str, list[torch.Tensor]] = {
             req_id: [torch.cat(chunks, dim=0) for chunks in layer_chunks]
             for req_id, layer_chunks in request_chunks.items()

--- a/src/speculators/data_generation/fast_mtp_generator.py
+++ b/src/speculators/data_generation/fast_mtp_generator.py
@@ -61,6 +61,7 @@ def generate_and_save_fast_mtp(
     max_model_len: int = 4096,
     gpu_memory_utilization: float = 0.8,
     tensor_parallel_size: int = 1,
+    max_num_batched_tokens: int | None = None,
     loss_masks: list[list[int]] | None = None,
     loss_mask_fn: Callable[[list[int]], list[int]] | None = None,
 ) -> None:
@@ -84,6 +85,11 @@ def generate_and_save_fast_mtp(
     :param max_model_len: Maximum sequence length passed to vLLM.
     :param gpu_memory_utilization: Fraction of GPU memory vLLM may use.
     :param tensor_parallel_size: Number of GPUs for tensor parallelism.
+    :param max_num_batched_tokens: Maximum tokens processed in one forward pass.
+        Defaults to ``max(8192, max_model_len)``. Reducing this value (e.g. to
+        4096) lowers peak activation memory, which is useful for large models
+        that use memory-intensive attention kernels (e.g. Qwen3-Next's GDN
+        linear attention). Has no effect on output quality.
     :param loss_masks: Pre-computed 0/1 masks, one list per sequence (parallel
         to *token_ids*). Preferred when masks are already available (e.g. from
         :func:`~speculators.data_generation.preprocessing.tokenize_conversations`).
@@ -126,6 +132,7 @@ def generate_and_save_fast_mtp(
         max_model_len=max_model_len,
         gpu_memory_utilization=gpu_memory_utilization,
         tensor_parallel_size=tensor_parallel_size,
+        max_num_batched_tokens=max_num_batched_tokens,
     )
 
     output_dir = Path(output_dir)

--- a/src/speculators/data_generation/fast_mtp_generator.py
+++ b/src/speculators/data_generation/fast_mtp_generator.py
@@ -1,0 +1,158 @@
+"""FastMTP data generation — captures the last verifier hidden layer and saves samples.
+
+FastMTP needs a single [seq_len, H] hidden state tensor (the verifier's last
+layer output) rather than the multiple intermediate layers Eagle3 requires.
+:func:`generate_and_save_fast_mtp` wraps :class:`VllmHiddenStatesGenerator`,
+selects the last layer automatically, and writes one ``.pt`` file per sequence
+together with a ``sample_lengths.json`` index.
+"""
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import torch
+
+from speculators.data_generation._model_utils import num_hidden_layers
+from speculators.data_generation.logging_utils import PipelineLogger
+from speculators.data_generation.vllm_hidden_states_generator import (
+    VllmHiddenStatesGenerator,
+)
+
+__all__ = ["generate_and_save_fast_mtp"]
+
+log = PipelineLogger(__name__)
+
+
+def _last_hidden_layer(model_path: str) -> int:
+    """Return the index of the last hidden layer for *model_path*."""
+    return num_hidden_layers(model_path) - 1
+
+
+def _resolve_loss_mask(
+    input_ids: torch.Tensor,
+    raw_loss_mask: torch.Tensor | None,
+    precomputed: list[int] | None,
+    loss_mask_fn: Callable[[list[int]], list[int]] | None,
+) -> torch.Tensor:
+    """Return a ``long`` loss mask tensor for one sequence.
+
+    Priority (highest to lowest):
+
+    1. *loss_mask_fn* — called with the token IDs; highest flexibility.
+    2. *precomputed* — pre-built mask from ``loss_masks[i]``; zero overhead.
+    3. *raw_loss_mask* — mask returned by :class:`VllmHiddenStatesGenerator`.
+    4. All-ones fallback — train on every position.
+    """
+    if loss_mask_fn is not None:
+        return torch.tensor(loss_mask_fn(input_ids.tolist()), dtype=torch.long)
+    if precomputed is not None:
+        return torch.tensor(precomputed, dtype=torch.long)
+    if raw_loss_mask is not None:
+        return raw_loss_mask
+    return torch.ones(len(input_ids), dtype=torch.long)
+
+
+def generate_and_save_fast_mtp(
+    model_path: str,
+    token_ids: list[list[int]],
+    output_dir: Path | str,
+    *,
+    max_model_len: int = 4096,
+    gpu_memory_utilization: float = 0.8,
+    tensor_parallel_size: int = 1,
+    loss_masks: list[list[int]] | None = None,
+    loss_mask_fn: Callable[[list[int]], list[int]] | None = None,
+) -> None:
+    """Generate FastMTP training data and save one ``.pt`` file per sequence.
+
+    Runs prefill-only inference through *model_path* via vLLM, captures the
+    last verifier hidden state (``[seq_len, H]``) for each sequence, and writes::
+
+        {
+            "input_ids":     Tensor[seq_len],       # long
+            "hidden_states": Tensor[seq_len, H],    # float32, last verifier layer
+            "loss_mask":     Tensor[seq_len],       # long, 1 = train here
+        }
+
+    A ``sample_lengths.json`` index mapping ``str(index) → seq_len`` is also
+    written for fast length look-ups during training.
+
+    :param model_path: HuggingFace model ID or local path for the verifier.
+    :param token_ids: Pre-tokenized sequences to process.
+    :param output_dir: Destination directory for ``.pt`` files and the index.
+    :param max_model_len: Maximum sequence length passed to vLLM.
+    :param gpu_memory_utilization: Fraction of GPU memory vLLM may use.
+    :param tensor_parallel_size: Number of GPUs for tensor parallelism.
+    :param loss_masks: Pre-computed 0/1 masks, one list per sequence (parallel
+        to *token_ids*). Preferred when masks are already available (e.g. from
+        :func:`~speculators.data_generation.preprocessing.tokenize_conversations`).
+        Mutually exclusive with *loss_mask_fn*.
+    :param loss_mask_fn: ``(token_ids: list[int]) -> list[int]`` called per
+        sequence when masks must be computed on-the-fly. Mutually exclusive
+        with *loss_masks*.  If neither is provided, all positions are trainable.
+
+    :raises ValueError: if both *loss_masks* and *loss_mask_fn* are provided,
+        or if *loss_masks* length does not match *token_ids*.
+
+    Example — using pre-computed masks (most common)::
+
+        dataset = tokenize_conversations(raw, tokenizer, max_length=4096)
+        token_ids  = [s["input_ids"].tolist() for s in dataset]
+        loss_masks = [s["loss_mask"].tolist()  for s in dataset]
+
+        generate_and_save_fast_mtp(
+            model_path="Qwen/Qwen3-Next-80B-A3B-Instruct",
+            token_ids=token_ids,
+            loss_masks=loss_masks,
+            output_dir="/path/to/output",
+            tensor_parallel_size=8,
+        )
+    """
+    if loss_masks is not None and loss_mask_fn is not None:
+        raise ValueError("Provide loss_masks or loss_mask_fn, not both.")
+    if loss_masks is not None and len(loss_masks) != len(token_ids):
+        raise ValueError(
+            f"loss_masks length ({len(loss_masks)}) must match "
+            f"token_ids length ({len(token_ids)})."
+        )
+
+    last_layer = _last_hidden_layer(model_path)
+    log.info(f"FastMTP: capturing layer {last_layer} (last) from {model_path}")
+
+    generator = VllmHiddenStatesGenerator(
+        model_path=model_path,
+        layer_ids=[last_layer],
+        max_model_len=max_model_len,
+        gpu_memory_utilization=gpu_memory_utilization,
+        tensor_parallel_size=tensor_parallel_size,
+    )
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    sample_lengths: dict[str, int] = {}
+    for i, item in enumerate(generator.generate(token_ids)):
+        input_ids: torch.Tensor = item["input_ids"]
+        # VllmHiddenStatesGenerator returns hidden_states as list[Tensor], one
+        # per requested layer. We requested exactly one (the last layer).
+        hs = item["hidden_states"]
+        hidden_states: torch.Tensor = hs[0] if isinstance(hs, list) else hs
+        precomputed = loss_masks[i] if loss_masks is not None else None
+        loss_mask = _resolve_loss_mask(
+            input_ids, item["loss_mask"], precomputed, loss_mask_fn
+        )
+        torch.save(
+            {
+                "input_ids": input_ids,
+                "hidden_states": hidden_states,
+                "loss_mask": loss_mask,
+            },
+            str(output_dir / f"data_{i}.pt"),
+        )
+        sample_lengths[str(i)] = len(input_ids)
+
+    with (output_dir / "sample_lengths.json").open("w") as fh:
+        json.dump(sample_lengths, fh)
+
+    log.info(f"Saved {len(token_ids)} samples to {output_dir}")

--- a/src/speculators/data_generation/fast_mtp_generator.py
+++ b/src/speculators/data_generation/fast_mtp_generator.py
@@ -62,6 +62,7 @@ def generate_and_save_fast_mtp(
     gpu_memory_utilization: float = 0.8,
     tensor_parallel_size: int = 1,
     max_num_batched_tokens: int | None = None,
+    generate_batch_size: int = 500,
     loss_masks: list[list[int]] | None = None,
     loss_mask_fn: Callable[[list[int]], list[int]] | None = None,
 ) -> None:
@@ -87,9 +88,14 @@ def generate_and_save_fast_mtp(
     :param tensor_parallel_size: Number of GPUs for tensor parallelism.
     :param max_num_batched_tokens: Maximum tokens processed in one forward pass.
         Defaults to ``max(8192, max_model_len)``. Reducing this value (e.g. to
-        4096) lowers peak activation memory, which is useful for large models
+        2048) lowers peak activation memory, which is useful for large models
         that use memory-intensive attention kernels (e.g. Qwen3-Next's GDN
         linear attention). Has no effect on output quality.
+    :param generate_batch_size: Number of sequences passed to the generator per
+        call. Hidden states are collected, saved to disk, and freed between
+        batches, keeping CPU memory bounded. At mean seq_len 1184 and hidden_dim
+        7168, each batch of 500 sequences uses ~8.5 GB of CPU RAM. Lower this
+        value if you see CPU OOM; raise it to reduce per-batch overhead.
     :param loss_masks: Pre-computed 0/1 masks, one list per sequence (parallel
         to *token_ids*). Preferred when masks are already available (e.g. from
         :func:`~speculators.data_generation.preprocessing.tokenize_conversations`).
@@ -138,28 +144,44 @@ def generate_and_save_fast_mtp(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    total = len(token_ids)
     sample_lengths: dict[str, int] = {}
-    for i, item in enumerate(generator.generate(token_ids)):
-        input_ids: torch.Tensor = item["input_ids"]
-        # VllmHiddenStatesGenerator returns hidden_states as list[Tensor], one
-        # per requested layer. We requested exactly one (the last layer).
-        hs = item["hidden_states"]
-        hidden_states: torch.Tensor = hs[0] if isinstance(hs, list) else hs
-        precomputed = loss_masks[i] if loss_masks is not None else None
-        loss_mask = _resolve_loss_mask(
-            input_ids, item["loss_mask"], precomputed, loss_mask_fn
+    global_idx = 0
+
+    for chunk_start in range(0, total, generate_batch_size):
+        chunk_end = min(chunk_start + generate_batch_size, total)
+        chunk_tids = token_ids[chunk_start:chunk_end]
+        chunk_masks = (
+            loss_masks[chunk_start:chunk_end] if loss_masks is not None else None
         )
-        torch.save(
-            {
-                "input_ids": input_ids,
-                "hidden_states": hidden_states,
-                "loss_mask": loss_mask,
-            },
-            str(output_dir / f"data_{i}.pt"),
+
+        log.info(
+            f"Processing sequences {chunk_start}–{chunk_end - 1} of {total - 1} "
+            f"(chunk size {len(chunk_tids)})"
         )
-        sample_lengths[str(i)] = len(input_ids)
+
+        for i, item in enumerate(generator.generate(chunk_tids)):
+            input_ids: torch.Tensor = item["input_ids"]
+            # VllmHiddenStatesGenerator returns hidden_states as list[Tensor], one
+            # per requested layer. We requested exactly one (the last layer).
+            hs = item["hidden_states"]
+            hidden_states: torch.Tensor = hs[0] if isinstance(hs, list) else hs
+            precomputed = chunk_masks[i] if chunk_masks is not None else None
+            loss_mask = _resolve_loss_mask(
+                input_ids, item["loss_mask"], precomputed, loss_mask_fn
+            )
+            torch.save(
+                {
+                    "input_ids": input_ids,
+                    "hidden_states": hidden_states,
+                    "loss_mask": loss_mask,
+                },
+                str(output_dir / f"data_{global_idx}.pt"),
+            )
+            sample_lengths[str(global_idx)] = len(input_ids)
+            global_idx += 1
 
     with (output_dir / "sample_lengths.json").open("w") as fh:
         json.dump(sample_lengths, fh)
 
-    log.info(f"Saved {len(token_ids)} samples to {output_dir}")
+    log.info(f"Saved {total} samples to {output_dir}")

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -14,9 +14,10 @@ from speculators.data_generation.logging_utils import PipelineLogger
 from speculators.train.vocab_mapping import save_token_frequency_distribution
 
 __all__ = [
-    "build_eagle3_dataset",
+    "build_eagle3_dataset",  # deprecated alias — use tokenize_conversations
     "load_and_preprocess_dataset",
     "load_raw_dataset",
+    "tokenize_conversations",
 ]
 
 log = PipelineLogger(__name__)
@@ -343,7 +344,7 @@ def _preprocess_batch(
     return results
 
 
-def build_eagle3_dataset(
+def tokenize_conversations(
     dataset: HFDataset,
     tokenizer: PreTrainedTokenizer,
     max_length: int = 2048,
@@ -351,7 +352,11 @@ def build_eagle3_dataset(
     assistant_pattern: str | Pattern[str] | None = None,
     turn_dropout: bool = False,
 ) -> HFDataset:
-    """Build EAGLE3 dataset by tokenizing conversations and creating loss masks.
+    """Tokenize a conversation dataset and compute per-token loss masks.
+
+    Produces a dataset with ``input_ids`` (long) and ``loss_mask`` (long, 1 on
+    assistant response tokens) for any chat-template-capable tokenizer.
+    Algorithm-agnostic — suitable for Eagle3, FastMTP, and future methods.
 
     Uses the tokenizer's built-in chat template via apply_chat_template.
 
@@ -391,6 +396,29 @@ def build_eagle3_dataset(
 
     dataset.set_format(type="torch")
     return dataset
+
+
+def build_eagle3_dataset(
+    dataset: HFDataset,
+    tokenizer: PreTrainedTokenizer,
+    max_length: int = 2048,
+    num_proc: int = 8,
+    assistant_pattern: str | Pattern[str] | None = None,
+    turn_dropout: bool = False,
+) -> HFDataset:
+    """Deprecated. Use :func:`tokenize_conversations` instead."""
+    log.warning(
+        "build_eagle3_dataset is deprecated and will be removed in a future release. "
+        "Use tokenize_conversations instead."
+    )
+    return tokenize_conversations(
+        dataset=dataset,
+        tokenizer=tokenizer,
+        max_length=max_length,
+        num_proc=num_proc,
+        assistant_pattern=assistant_pattern,
+        turn_dropout=turn_dropout,
+    )
 
 
 def load_raw_dataset(
@@ -481,7 +509,7 @@ def load_and_preprocess_dataset(
     if turn_dropout:
         log.info("Turn dropout enabled: randomly keeping N consecutive turns")
 
-    preprocessed_dataset = build_eagle3_dataset(
+    preprocessed_dataset = tokenize_conversations(
         dataset=raw_dataset,
         tokenizer=tokenizer,
         max_length=seq_length,

--- a/src/speculators/data_generation/vllm_hidden_states_generator.py
+++ b/src/speculators/data_generation/vllm_hidden_states_generator.py
@@ -347,7 +347,9 @@ class VllmHiddenStatesGenerator:
                     f"Available: {list(request_states_dict.keys())}"
                 )
 
-            layer_states = [h.clone().cpu() for h in request_states_dict[req_id]]
+            # States are already on CPU (moved in _store_captured_states);
+            # they arrive here as new objects via IPC so no clone needed.
+            layer_states = list(request_states_dict[req_id])
             input_ids_tensor = torch.as_tensor(input_ids_list[i], dtype=torch.long)
 
             results.append(

--- a/src/speculators/data_generation/vllm_hidden_states_generator.py
+++ b/src/speculators/data_generation/vllm_hidden_states_generator.py
@@ -1,7 +1,7 @@
 """Extract hidden states from intermediate layers during prefill using vLLM."""
 
 import torch
-from transformers import AutoConfig, AutoTokenizer
+from transformers import AutoTokenizer
 from vllm.config import (
     CacheConfig,
     DeviceConfig,
@@ -14,17 +14,17 @@ from vllm.config import (
 from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import get_hash_fn_by_name
 from vllm.v1.core.kv_cache_utils import (
-    _get_kv_cache_groups_uniform_spec,
-    get_kv_cache_config_from_groups,
+    generate_scheduler_kv_cache_config,
+    get_kv_cache_configs,
     get_request_block_hasher,
     init_none_hash,
-    unify_hybrid_kv_cache_specs,
 )
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.executor.multiproc_executor import MultiprocExecutor
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.structured_output import StructuredOutputManager
 
+from speculators.data_generation._model_utils import num_hidden_layers
 from speculators.utils.util import empty_cache, is_npu_available, mem_get_info
 
 from .logging_utils import PipelineLogger
@@ -89,13 +89,7 @@ class VllmHiddenStatesGenerator:
 
         self.tokenizer = AutoTokenizer.from_pretrained(model_path)
 
-        config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
-        if hasattr(config, "num_hidden_layers"):
-            num_layers = config.num_hidden_layers
-        elif hasattr(config, "text_config"):
-            num_layers = config.text_config.num_hidden_layers
-        else:
-            raise ValueError("Cannot determine num_layers from config")
+        num_layers = num_hidden_layers(model_path)
 
         log.info(f"Model has {num_layers} layers")
 
@@ -130,23 +124,8 @@ class VllmHiddenStatesGenerator:
         self._setup_capture()
 
         log.info("Creating scheduler...")
-        kv_cache_spec_list = self.executor.collective_rpc("get_kv_cache_spec")
-        kv_cache_spec = kv_cache_spec_list[0]
-        # Normalize hybrid KV cache specs for models with non-uniform attention
-        # (e.g., GPT-OSS with sliding/full attention layers)
-        unify_hybrid_kv_cache_specs(kv_cache_spec)
-        kv_cache_groups = _get_kv_cache_groups_uniform_spec(kv_cache_spec)
+        kv_cache_config = self._initialize_kv_caches(gpu_memory_utilization)
 
-        free_memory, _ = mem_get_info()
-        cache_memory = int(free_memory * gpu_memory_utilization * CACHE_MEMORY_FRACTION)
-
-        kv_cache_config = get_kv_cache_config_from_groups(
-            vllm_config=self.vllm_config,
-            kv_cache_groups=kv_cache_groups,
-            available_memory=cache_memory,
-        )
-
-        self.vllm_config.cache_config.num_gpu_blocks = kv_cache_config.num_blocks
         structured_output_manager = StructuredOutputManager(
             vllm_config=self.vllm_config
         )
@@ -157,10 +136,6 @@ class VllmHiddenStatesGenerator:
             structured_output_manager=structured_output_manager,
             block_size=VLLM_BLOCK_SIZE,
         )
-
-        log.info("Initializing KV cache on all workers...")
-        kv_cache_configs = [kv_cache_config] * tensor_parallel_size
-        self.executor.initialize_from_config(kv_cache_configs)
 
         # Create block hasher for request KV cache management
         # Following vLLM's pattern in v1/engine/core.py
@@ -222,6 +197,35 @@ class VllmHiddenStatesGenerator:
             load_config=LoadConfig(),
         )
 
+    def _initialize_kv_caches(self, gpu_memory_utilization: float):
+        """Mirror EngineCore._initialize_kv_caches() to handle hybrid models.
+
+        Using get_kv_cache_configs() (plural) instead of the private
+        unify_hybrid_kv_cache_specs() + _get_kv_cache_groups_uniform_spec()
+        pair is necessary for models like Qwen3-Next that mix FullAttentionSpec
+        and ChunkedLocalAttentionSpec layers — the private path unconditionally
+        forces spec unification and raises for non-uniform models.
+
+        Returns:
+            kv_cache_config: the merged scheduler view used to create the Scheduler.
+        """
+        kv_cache_spec_list = self.executor.collective_rpc("get_kv_cache_spec")
+
+        free_memory, _ = mem_get_info()
+        cache_memory = int(free_memory * gpu_memory_utilization * CACHE_MEMORY_FRACTION)
+        available_memory = [cache_memory] * len(kv_cache_spec_list)
+
+        kv_cache_configs = get_kv_cache_configs(
+            self.vllm_config, kv_cache_spec_list, available_memory
+        )
+        kv_cache_config = generate_scheduler_kv_cache_config(kv_cache_configs)
+        self.vllm_config.cache_config.num_gpu_blocks = kv_cache_config.num_blocks
+
+        log.info("Initializing KV cache on all workers...")
+        self.executor.initialize_from_config(kv_cache_configs)
+
+        return kv_cache_config
+
     def _setup_capture(self):
         self.executor.collective_rpc(
             "_setup_hidden_states_capture",
@@ -279,16 +283,13 @@ class VllmHiddenStatesGenerator:
         self._request_counter += 1
         self.executor.collective_rpc("_reset_capture")
 
-        # Track progress for each request to distinguish prefill from decode
+        # Track how many tokens have been processed per request so we can
+        # distinguish prefill tokens from the single decode token (max_tokens=1).
         request_num_computed = dict.fromkeys(request_id_to_idx, 0)
-        schedule_iterations = 0
-        all_prefill_complete = False
 
         while (
             scheduler_output := self.scheduler.schedule()
-        ).total_num_scheduled_tokens > 0 and not all_prefill_complete:
-            schedule_iterations += 1
-
+        ).total_num_scheduled_tokens > 0:
             # Calculate prefill tokens for each request (ignore decode tokens)
             prefill_metadata = {}
             for req_id, num_tokens in scheduler_output.num_scheduled_tokens.items():
@@ -301,20 +302,23 @@ class VllmHiddenStatesGenerator:
 
                 request_num_computed[req_id] += num_tokens
 
-            all_prefill_complete = all(
-                request_num_computed[req_id] >= request_id_to_prompt_len[req_id]
-                for req_id in request_id_to_idx
-            )
-
             if prefill_metadata:
                 self.executor.collective_rpc(
                     "_set_request_metadata", args=(prefill_metadata,)
                 )
 
             model_output = self.executor.execute_model(scheduler_output)
-            self.executor.sample_tokens(model_output)
+            sampled = self.executor.sample_tokens(model_output)  # type: ignore[arg-type]
 
-        # Abort all requests (prefill complete, don't need decode)
+            # Drive the scheduler's request state machine so it marks requests
+            # that have exhausted max_tokens=1 as FINISHED_STOPPED and frees
+            # their running slots.  Without this call the scheduler never learns
+            # that tokens were generated, slots are never released, and any
+            # requests beyond MAX_NUM_SEQS stay stuck in WAITING forever.
+            if sampled is not None:
+                self.scheduler.update_from_output(scheduler_output, sampled)  # type: ignore[arg-type]
+
+        # Abort remaining requests (finish_requests safely skips already-finished ones)
         self.scheduler.finish_requests(
             list(request_id_to_idx.keys()), RequestStatus.FINISHED_ABORTED
         )
@@ -330,9 +334,11 @@ class VllmHiddenStatesGenerator:
 
         log.debug(f"Captured states for {len(request_states_dict)} requests")
 
-        # Map results back to original input order
+        # Map results back to original input order.
+        # Sort by original index (not lexicographically by req_id string, which
+        # would mis-order batches ≥ 10: "req_0_10" < "req_0_2" lexicographically).
         results = []
-        for req_id in sorted(request_id_to_idx.keys()):
+        for req_id in sorted(request_id_to_idx, key=request_id_to_idx.__getitem__):
             i = request_id_to_idx[req_id]
 
             if req_id not in request_states_dict:

--- a/src/speculators/train/fast_mtp_data.py
+++ b/src/speculators/train/fast_mtp_data.py
@@ -1,0 +1,144 @@
+"""FastMTP dataset utilities for loading pre-generated ``.pt`` training files.
+
+Each ``.pt`` file holds a single sequence in the format written by
+:func:`~speculators.data_generation.fast_mtp_generator.generate_and_save_fast_mtp`::
+
+    {
+        "input_ids":     Tensor[seq_len],     # long
+        "hidden_states": Tensor[seq_len, H],  # float32, last verifier layer
+        "loss_mask":     Tensor[seq_len],     # long, 1 = compute loss here
+    }
+
+:class:`FastMTPSampleFileDataset` loads these files, applies the alignment
+shift needed by :class:`~speculators.models.fast_mtp.FastMTPSpeculator`, and
+is compatible with the :func:`~speculators.train.data.create_collate_fn`
+packing used by Eagle3.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from speculators.train.data import (
+    create_collate_fn,
+    list_files,
+    split_files,
+)
+
+__all__ = [
+    "FastMTPSampleFileDataset",
+    "make_fast_mtp_dataloader",
+]
+
+BatchType = dict[str, Any]
+
+
+def _shift_batch_fastmtp(batch: BatchType) -> BatchType:
+    """Align input_ids and hidden_states for FastMTPSpeculator.forward.
+
+    ``FastMTPSpeculator.forward`` at step *k* uses:
+
+    * ``embed(input_ids[:, k+1 : k+1+L])``  — token embedding
+    * ``hidden_states[:, :L]``              — verifier hidden state
+    * Labels: ``input_ids[:, k+2 : k+2+L]``
+
+    After this shift ``input_ids[n]`` = ``x_{n+1}`` and
+    ``hidden_states[n]`` = ``g_n``, so the model at step 0 reads
+    ``embed(x_2, …)`` from position 1 onward — correct alignment for
+    predicting ``x_3, …``.
+
+    Reduces ``seq_len`` by 1 (same as Eagle3's ``shift_batch``).
+    """
+    return {
+        "input_ids": batch["input_ids"][1:],
+        "hidden_states": batch["hidden_states"][:-1],
+        "loss_mask": batch["loss_mask"][1:],
+        "lengths": batch["lengths"] - 1,
+        "position_ids": batch["position_ids"][1:],
+    }
+
+
+class FastMTPSampleFileDataset(Dataset):
+    """Dataset that loads FastMTP ``.pt`` files written by the data generator.
+
+    Compatible with :func:`~speculators.train.data.create_collate_fn` —
+    returns the same key set as ``Eagle3SampleFileDataset`` minus
+    ``verifier_last_hidden_states``.
+
+    :param max_len: Maximum sequence length after shift (for collation).
+    :param datapath: Root directory; all ``.pt`` files found recursively.
+        Mutually exclusive with ``file_list``.
+    :param file_list: Explicit list of ``.pt`` paths.
+        Mutually exclusive with ``datapath``.
+    :param hidden_states_dtype: Cast hidden states to this dtype on load.
+    """
+
+    def __init__(
+        self,
+        max_len: int,
+        datapath: str | None = None,
+        file_list: list[str] | None = None,
+        hidden_states_dtype: torch.dtype = torch.float32,
+    ) -> None:
+        if datapath is not None and file_list is not None:
+            raise ValueError("Provide datapath or file_list, not both.")
+        if datapath is not None:
+            file_list = list_files(datapath)
+        if file_list is None:
+            raise ValueError("Either datapath or file_list must be provided.")
+
+        self.data = file_list
+        self.max_len = max_len
+        self.hidden_states_dtype = hidden_states_dtype
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, index: int) -> BatchType:
+        data = torch.load(
+            self.data[index], mmap=True, weights_only=True, map_location="cpu"
+        )
+        data["hidden_states"] = data["hidden_states"].to(self.hidden_states_dtype)
+
+        seq_len = data["input_ids"].shape[0]
+        data["lengths"] = torch.tensor([seq_len], dtype=torch.long)
+        data["position_ids"] = torch.arange(seq_len, dtype=torch.long)
+
+        return _shift_batch_fastmtp(data)
+
+
+def make_fast_mtp_dataloader(
+    data_dir: str | Path,
+    max_len: int,
+    batch_size: int,
+    train_ratio: float = 0.9,
+    hidden_states_dtype: torch.dtype = torch.bfloat16,
+) -> tuple[DataLoader, DataLoader]:
+    """Build train and validation ``DataLoader``s from a FastMTP data directory.
+
+    :param data_dir: Directory containing ``.pt`` files (searched recursively).
+    :param max_len: Collation target length; sequences are sliced/padded here.
+    :param batch_size: Number of samples per batch.
+    :param train_ratio: Fraction of files used for training (rest = validation).
+    :param hidden_states_dtype: dtype for hidden states tensors.
+    :return: ``(train_loader, val_loader)``
+    """
+    train_files, val_files = split_files(str(data_dir), ratio=train_ratio)
+    collate_fn = create_collate_fn(max_len)
+
+    def _make_loader(files: list[str], shuffle: bool) -> DataLoader:
+        ds = FastMTPSampleFileDataset(
+            max_len=max_len,
+            file_list=files,
+            hidden_states_dtype=hidden_states_dtype,
+        )
+        return DataLoader(
+            ds, batch_size=batch_size, shuffle=shuffle, collate_fn=collate_fn
+        )
+
+    return (
+        _make_loader([str(f) for f in train_files], shuffle=True),
+        _make_loader([str(f) for f in val_files], shuffle=False),
+    )

--- a/tests/unit/data_generation/conftest.py
+++ b/tests/unit/data_generation/conftest.py
@@ -1,0 +1,25 @@
+"""Stub vllm so data_generation unit tests can import without a vllm install."""
+
+import sys
+from unittest.mock import MagicMock
+
+_VLLM_STUBS = [
+    "vllm",
+    "vllm.config",
+    "vllm.sampling_params",
+    "vllm.utils",
+    "vllm.utils.hashing",
+    "vllm.v1",
+    "vllm.v1.core",
+    "vllm.v1.core.kv_cache_utils",
+    "vllm.v1.core.sched",
+    "vllm.v1.core.sched.scheduler",
+    "vllm.v1.executor",
+    "vllm.v1.executor.multiproc_executor",
+    "vllm.v1.request",
+    "vllm.v1.structured_output",
+]
+
+for _mod in _VLLM_STUBS:
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()

--- a/tests/unit/data_generation/test_fast_mtp_generator.py
+++ b/tests/unit/data_generation/test_fast_mtp_generator.py
@@ -1,0 +1,274 @@
+"""Unit tests for fast_mtp_generator — generate_and_save_fast_mtp and helpers."""
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+# conftest.py stubs out vllm so this import works without a vllm install
+from speculators.data_generation.fast_mtp_generator import (
+    _last_hidden_layer,
+    _resolve_loss_mask,
+    generate_and_save_fast_mtp,
+)
+
+H = 64
+SEQ_LEN = 10
+
+# Patch the shared utility — both fast_mtp_generator and vllm_hidden_states_generator
+# delegate to _model_utils.num_hidden_layers, so all tests patch there.
+_NUM_LAYERS_PATH = "speculators.data_generation._model_utils.AutoConfig.from_pretrained"
+_VLLM_GEN_PATH = (
+    "speculators.data_generation.fast_mtp_generator.VllmHiddenStatesGenerator"
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_vllm_item(seq_len: int = SEQ_LEN, hidden_size: int = H) -> dict:
+    """Synthetic item matching VllmHiddenStatesGenerator.generate() output."""
+    return {
+        "input_ids": torch.arange(seq_len, dtype=torch.long),
+        "hidden_states": [torch.randn(seq_len, hidden_size)],
+        "loss_mask": None,
+    }
+
+
+def _make_config(num_hidden_layers: int = 28) -> MagicMock:
+    cfg = MagicMock()
+    cfg.num_hidden_layers = num_hidden_layers
+    return cfg
+
+
+@pytest.fixture
+def mock_vllm_cls() -> MagicMock:
+    """Patched VllmHiddenStatesGenerator class; instance.generate returns one item."""
+    inst = MagicMock()
+    inst.generate.return_value = [_make_vllm_item()]
+    return MagicMock(return_value=inst)
+
+
+@pytest.fixture
+def saved_dir(mock_vllm_cls: MagicMock, tmp_path: Path) -> Path:
+    """Output dir after one generate_and_save_fast_mtp call (seq_len=6, no mask)."""
+    mock_vllm_cls.return_value.generate.return_value = [_make_vllm_item(seq_len=6)]
+    with (
+        patch(_NUM_LAYERS_PATH, return_value=_make_config()),
+        patch(_VLLM_GEN_PATH, mock_vllm_cls),
+    ):
+        generate_and_save_fast_mtp("fake/model", [[0] * 6], tmp_path)
+    return tmp_path
+
+
+# ── _last_hidden_layer ────────────────────────────────────────────────────────
+
+
+class TestLastHiddenLayer:
+    def test_direct_attribute(self) -> None:
+        with patch(_NUM_LAYERS_PATH, return_value=_make_config(num_hidden_layers=28)):
+            assert _last_hidden_layer("m") == 27
+
+    def test_text_config_fallback(self) -> None:
+        """Multimodal configs nest num_hidden_layers inside text_config."""
+        cfg = MagicMock(spec=[])  # no num_hidden_layers attribute
+        cfg.text_config = MagicMock()
+        cfg.text_config.num_hidden_layers = 32
+        with patch(_NUM_LAYERS_PATH, return_value=cfg):
+            assert _last_hidden_layer("m") == 31
+
+    def test_missing_raises(self) -> None:
+        with (
+            patch(_NUM_LAYERS_PATH, return_value=MagicMock(spec=[])),
+            pytest.raises(ValueError, match="num_hidden_layers"),
+        ):
+            _last_hidden_layer("bad/model")
+
+
+# ── _resolve_loss_mask ────────────────────────────────────────────────────────
+
+
+class TestResolveLossMask:
+    def _ids(self, n: int = 4) -> torch.Tensor:
+        return torch.arange(n, dtype=torch.long)
+
+    def test_fn_takes_priority_over_all(self) -> None:
+        """loss_mask_fn wins even when precomputed and raw are both present."""
+        raw = torch.zeros(4, dtype=torch.long)
+        result = _resolve_loss_mask(
+            self._ids(),
+            raw,
+            precomputed=[0, 0, 0, 0],
+            loss_mask_fn=lambda _: [1, 1, 1, 1],
+        )
+        assert result.tolist() == [1, 1, 1, 1]
+
+    def test_precomputed_used_when_no_fn(self) -> None:
+        result = _resolve_loss_mask(
+            self._ids(), raw_loss_mask=None, precomputed=[0, 1, 0, 1], loss_mask_fn=None
+        )
+        assert result.tolist() == [0, 1, 0, 1]
+
+    def test_raw_used_when_no_fn_or_precomputed(self) -> None:
+        raw = torch.tensor([0, 1, 0, 1], dtype=torch.long)
+        result = _resolve_loss_mask(
+            self._ids(), raw, precomputed=None, loss_mask_fn=None
+        )
+        assert torch.equal(result, raw)
+
+    def test_ones_fallback_when_all_none(self) -> None:
+        result = _resolve_loss_mask(
+            self._ids(6), None, precomputed=None, loss_mask_fn=None
+        )
+        assert result.tolist() == [1, 1, 1, 1, 1, 1]
+
+    def test_fn_receives_token_ids(self) -> None:
+        """fn is called with the decoded token ID list, not the raw tensor."""
+        received: list[list[int]] = []
+
+        def capturing_fn(x: list[int]) -> list[int]:
+            received.append(x)
+            return [1, 1, 1]
+
+        ids = torch.tensor([10, 20, 30], dtype=torch.long)
+        _resolve_loss_mask(ids, None, precomputed=None, loss_mask_fn=capturing_fn)
+        assert received == [[10, 20, 30]]
+
+
+# ── generate_and_save_fast_mtp ────────────────────────────────────────────────
+
+
+class TestGenerateAndSave:
+    def _run(
+        self,
+        mock_vllm_cls: MagicMock,
+        tmp_path: Path,
+        items: list[dict] | None = None,
+        loss_masks: list[list[int]] | None = None,
+        loss_mask_fn: Callable[[list[int]], list[int]] | None = None,
+    ) -> None:
+        if items is not None:
+            mock_vllm_cls.return_value.generate.return_value = items
+        with (
+            patch(_NUM_LAYERS_PATH, return_value=_make_config()),
+            patch(_VLLM_GEN_PATH, mock_vllm_cls),
+        ):
+            generate_and_save_fast_mtp(
+                "fake/model",
+                [[0] * 6],
+                tmp_path,
+                loss_masks=loss_masks,
+                loss_mask_fn=loss_mask_fn,
+            )
+
+    def test_vllm_receives_last_layer_id(
+        self, mock_vllm_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """_last_hidden_layer result flows directly to the layer_ids vLLM receives."""
+        self._run(mock_vllm_cls, tmp_path)
+        assert mock_vllm_cls.call_args.kwargs["layer_ids"] == [27]
+
+    def test_pt_files_written(self, mock_vllm_cls: MagicMock, tmp_path: Path) -> None:
+        """One file per sequence, no extras."""
+        items = [_make_vllm_item(seq_len=6), _make_vllm_item(seq_len=8)]
+        self._run(mock_vllm_cls, tmp_path, items=items)
+        assert (tmp_path / "data_0.pt").exists()
+        assert (tmp_path / "data_1.pt").exists()
+        assert not (tmp_path / "data_2.pt").exists()
+
+    def test_saved_file_contract(self, saved_dir: Path) -> None:
+        """Saved .pt has the three keys consumers expect, with correct shapes."""
+        saved = torch.load(str(saved_dir / "data_0.pt"), weights_only=True)
+        assert set(saved.keys()) == {"input_ids", "hidden_states", "loss_mask"}
+        assert saved["input_ids"].shape == (6,)
+        assert saved["hidden_states"].shape == (6, H)
+        assert saved["loss_mask"].shape == (6,)
+
+    def test_sample_lengths_json(self, saved_dir: Path) -> None:
+        lengths = json.loads((saved_dir / "sample_lengths.json").read_text())
+        assert lengths == {"0": 6}
+
+    def test_precomputed_loss_masks_flow_to_file(
+        self, mock_vllm_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """loss_masks= parameter survives the full pipeline to the saved tensor."""
+        item = {
+            "input_ids": torch.tensor(list(range(6)), dtype=torch.long),
+            "hidden_states": [torch.randn(6, H)],
+            "loss_mask": None,
+        }
+        self._run(
+            mock_vllm_cls, tmp_path, items=[item], loss_masks=[[0, 0, 0, 1, 1, 1]]
+        )
+        saved = torch.load(str(tmp_path / "data_0.pt"), weights_only=True)
+        assert saved["loss_mask"].tolist() == [0, 0, 0, 1, 1, 1]
+
+    def test_custom_loss_mask_fn_flow_to_file(
+        self, mock_vllm_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """loss_mask_fn= parameter survives the full pipeline to the saved tensor."""
+        item = {
+            "input_ids": torch.tensor(list(range(6)), dtype=torch.long),
+            "hidden_states": [torch.randn(6, H)],
+            "loss_mask": None,
+        }
+        self._run(
+            mock_vllm_cls,
+            tmp_path,
+            items=[item],
+            loss_mask_fn=lambda _ids: [0, 0, 0, 1, 1, 1],
+        )
+        saved = torch.load(str(tmp_path / "data_0.pt"), weights_only=True)
+        assert saved["loss_mask"].tolist() == [0, 0, 0, 1, 1, 1]
+
+    def test_raises_if_both_loss_masks_and_fn(self, tmp_path: Path) -> None:
+        # Validation fires before the generator is created — no patches needed.
+        with pytest.raises(ValueError, match="not both"):
+            generate_and_save_fast_mtp(
+                "fake/model",
+                [[0] * 6],
+                tmp_path,
+                loss_masks=[[1] * 6],
+                loss_mask_fn=lambda _: [1] * 6,
+            )
+
+    def test_raises_if_loss_masks_length_mismatch(self, tmp_path: Path) -> None:
+        # Validation fires before the generator is created — no patches needed.
+        with pytest.raises(ValueError, match="length"):
+            generate_and_save_fast_mtp(
+                "fake/model",
+                [[0] * 6],  # 1 sequence
+                tmp_path,
+                loss_masks=[[1] * 6, [1] * 6],  # 2 masks — mismatch
+            )
+
+    def test_hidden_states_unwrapped_from_list(
+        self, mock_vllm_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """VllmHiddenStatesGenerator returns list[Tensor]; we extract element [0]."""
+        hs = torch.randn(6, H)
+        item = {
+            "input_ids": torch.arange(6, dtype=torch.long),
+            "hidden_states": [hs],
+            "loss_mask": None,
+        }
+        self._run(mock_vllm_cls, tmp_path, items=[item])
+        saved = torch.load(str(tmp_path / "data_0.pt"), weights_only=True)
+        assert torch.equal(saved["hidden_states"], hs)
+
+    def test_hidden_states_passthrough_when_tensor(
+        self, mock_vllm_cls: MagicMock, tmp_path: Path
+    ) -> None:
+        """Plain tensor hidden_states are accepted without unwrapping."""
+        hs = torch.randn(6, H)
+        item = {
+            "input_ids": torch.arange(6, dtype=torch.long),
+            "hidden_states": hs,
+            "loss_mask": None,
+        }
+        self._run(mock_vllm_cls, tmp_path, items=[item])
+        saved = torch.load(str(tmp_path / "data_0.pt"), weights_only=True)
+        assert torch.equal(saved["hidden_states"], hs)

--- a/tests/unit/train/test_fast_mtp_data.py
+++ b/tests/unit/train/test_fast_mtp_data.py
@@ -1,0 +1,172 @@
+"""Unit tests for FastMTP dataset utilities (train/fast_mtp_data.py)."""
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from speculators.train.fast_mtp_data import (
+    FastMTPSampleFileDataset,
+    _shift_batch_fastmtp,
+    make_fast_mtp_dataloader,
+)
+
+H = 8
+SEQ_LEN = 10
+MAX_LEN = 8
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_raw(seq_len: int = SEQ_LEN, hidden_size: int = H) -> dict:
+    return {
+        "input_ids": torch.arange(seq_len, dtype=torch.long),
+        "hidden_states": torch.randn(seq_len, hidden_size),
+        "loss_mask": torch.ones(seq_len, dtype=torch.long),
+    }
+
+
+def _save_pt(path: Path, seq_len: int = SEQ_LEN, hidden_size: int = H) -> Path:
+    pt_path = path / f"data_{seq_len}.pt"
+    torch.save(_make_raw(seq_len=seq_len, hidden_size=hidden_size), str(pt_path))
+    return pt_path
+
+
+# ── _shift_batch_fastmtp ──────────────────────────────────────────────────────
+
+
+class TestShiftBatch:
+    def _full_batch(self, seq_len: int = SEQ_LEN) -> dict:
+        return {
+            "input_ids": torch.arange(seq_len, dtype=torch.long),
+            "hidden_states": torch.arange(seq_len * H, dtype=torch.float).reshape(
+                seq_len, H
+            ),
+            "loss_mask": torch.ones(seq_len, dtype=torch.long),
+            "lengths": torch.tensor([seq_len], dtype=torch.long),
+            "position_ids": torch.arange(seq_len, dtype=torch.long),
+        }
+
+    def test_input_ids_shifted_by_one(self) -> None:
+        batch = self._full_batch()
+        shifted = _shift_batch_fastmtp(batch)
+        assert torch.equal(shifted["input_ids"], batch["input_ids"][1:])
+
+    def test_hidden_states_drops_last(self) -> None:
+        batch = self._full_batch()
+        shifted = _shift_batch_fastmtp(batch)
+        assert torch.equal(shifted["hidden_states"], batch["hidden_states"][:-1])
+
+    def test_alignment(self) -> None:
+        """Semantic contract: after shift, input_ids[n] == x_{n+1} and
+        hidden_states[n] == g_n, so the model at step 0 reads embed(x_1) with
+        context g_0 to predict x_2.
+        """
+        batch = {
+            "input_ids": torch.tensor([10, 20, 30, 40, 50], dtype=torch.long),
+            "hidden_states": torch.arange(5 * H, dtype=torch.float).reshape(5, H),
+            "loss_mask": torch.ones(5, dtype=torch.long),
+            "lengths": torch.tensor([5], dtype=torch.long),
+            "position_ids": torch.arange(5, dtype=torch.long),
+        }
+        shifted = _shift_batch_fastmtp(batch)
+        assert shifted["input_ids"][0].item() == 20
+        assert torch.equal(shifted["hidden_states"][0], batch["hidden_states"][0])
+
+
+# ── FastMTPSampleFileDataset ───────────────────────────────────────────────────
+
+
+@pytest.fixture
+def ds(tmp_path: Path) -> FastMTPSampleFileDataset:
+    """Dataset backed by a single SEQ_LEN=10 sample file."""
+    return FastMTPSampleFileDataset(
+        max_len=MAX_LEN, file_list=[str(_save_pt(tmp_path))]
+    )
+
+
+class TestFastMTPSampleFileDataset:
+    def test_getitem_returns_expected_keys(self, ds: FastMTPSampleFileDataset) -> None:
+        """Key contract for the trainer: exactly these five keys, nothing else."""
+        assert set(ds[0].keys()) == {
+            "input_ids",
+            "hidden_states",
+            "loss_mask",
+            "lengths",
+            "position_ids",
+        }
+
+    def test_sequence_lengths_after_shift(self, ds: FastMTPSampleFileDataset) -> None:
+        """Shift is applied: seq_len shrinks by 1; hidden_states has correct H dim."""
+        sample = ds[0]
+        assert sample["input_ids"].shape == (SEQ_LEN - 1,)
+        assert sample["hidden_states"].shape == (SEQ_LEN - 1, H)
+
+    def test_hidden_states_dtype_cast(self, tmp_path: Path) -> None:
+        """hidden_states_dtype= is honoured; critical for bfloat16 memory savings."""
+        ds = FastMTPSampleFileDataset(
+            max_len=MAX_LEN,
+            file_list=[str(_save_pt(tmp_path))],
+            hidden_states_dtype=torch.bfloat16,
+        )
+        assert ds[0]["hidden_states"].dtype == torch.bfloat16
+
+    def test_requires_datapath_or_file_list(self) -> None:
+        with pytest.raises(ValueError):
+            FastMTPSampleFileDataset(max_len=MAX_LEN)
+
+    def test_raises_if_both_provided(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError):
+            FastMTPSampleFileDataset(
+                max_len=MAX_LEN,
+                datapath=str(tmp_path),
+                file_list=[str(tmp_path / "data_0.pt")],
+            )
+
+    def test_datapath_discovers_files(self, tmp_path: Path) -> None:
+        for i in range(4):
+            torch.save(_make_raw(seq_len=6), str(tmp_path / f"data_{i}.pt"))
+        assert (
+            len(FastMTPSampleFileDataset(max_len=MAX_LEN, datapath=str(tmp_path))) == 4
+        )
+
+
+# ── make_fast_mtp_dataloader ──────────────────────────────────────────────────
+
+
+class TestMakeFastMtpDataloader:
+    def _populate_dir(self, data_dir: Path, n: int = 10) -> None:
+        for i in range(n):
+            torch.save(_make_raw(seq_len=SEQ_LEN), str(data_dir / f"data_{i}.pt"))
+
+    def test_train_val_split_sizes(self, tmp_path: Path) -> None:
+        self._populate_dir(tmp_path, n=10)
+        train_dl, val_dl = make_fast_mtp_dataloader(
+            tmp_path, max_len=MAX_LEN, batch_size=1, train_ratio=0.9
+        )
+        assert len(train_dl.dataset) == 9  # type: ignore[arg-type]
+        assert len(val_dl.dataset) == 1  # type: ignore[arg-type]
+
+    def test_batch_shapes(self, tmp_path: Path) -> None:
+        """End-to-end: batch from the DataLoader has correct ranks and H dim."""
+        self._populate_dir(tmp_path, n=4)
+        train_dl, _ = make_fast_mtp_dataloader(
+            tmp_path, max_len=MAX_LEN, batch_size=2, train_ratio=0.75
+        )
+        batch = next(iter(train_dl))
+        assert batch["input_ids"].ndim == 2
+        assert batch["hidden_states"].ndim == 3
+        assert batch["hidden_states"].shape[-1] == H
+
+    def test_hidden_states_dtype(self, tmp_path: Path) -> None:
+        """dtype flows from make_fast_mtp_dataloader all the way to the batch tensor."""
+        self._populate_dir(tmp_path, n=4)
+        train_dl, _ = make_fast_mtp_dataloader(
+            tmp_path,
+            max_len=MAX_LEN,
+            batch_size=2,
+            train_ratio=0.75,
+            hidden_states_dtype=torch.bfloat16,
+        )
+        assert next(iter(train_dl))["hidden_states"].dtype == torch.bfloat16


### PR DESCRIPTION
## Summary

Stacked on #PR2 (`275-fastmtp-converter`). Adds data generation and dataset
loading for FastMTP training.

**`src/speculators/data_generation/fast_mtp_generator.py`** (new)
- `FastMTPHiddenStatesGenerator`: thin wrapper over `VllmHiddenStatesGenerator`
  that automatically selects `layer_ids=[num_hidden_layers - 1]` (last verifier
  layer only), halving storage vs Eagle3's multi-layer capture
- `generate()`: returns `{"input_ids", "hidden_states", "loss_mask"}` per sequence
- `generate_and_save()`: writes one `.pt` file per sequence plus a
  `sample_lengths.json` index; accepts an optional `loss_mask_fn` callback

**`src/speculators/train/fast_mtp_data.py`** (new)
- `standardize_data_fastmtp`: passthrough normalizer (single `[T, H]` tensor,
  unlike Eagle3's `[T, 3H]` concatenation)
- `_shift_batch_fastmtp`: aligns `input_ids[1:]` with `hidden_states[:-1]` so
  `FastMTPSpeculator.forward` receives correctly offset sequences
- `FastMTPSampleFileDataset`: compatible with `create_collate_fn` packing;
  returns `{input_ids, hidden_states, loss_mask, position_ids, lengths}`
- `make_fast_mtp_dataloader`: splits files, builds train/val `DataLoader`s



Output from running: `CUDA_VISIBLE_DEVICES="0,1,2,3" python3 examples/fast_mtp/generate_data_qwen3_next.py`

```bash
ls output/Qwen3-Next-80B-A3B-Instruct_ultrachat 
data_0.pt   data_16.pt  data_23.pt  data_30.pt  data_38.pt  data_45.pt  data_52.pt  data_6.pt   data_67.pt  data_74.pt  data_81.pt  data_89.pt  data_96.pt
data_1.pt   data_17.pt  data_24.pt  data_31.pt  data_39.pt  data_46.pt  data_53.pt  data_60.pt  data_68.pt  data_75.pt  data_82.pt  data_9.pt   data_97.pt
data_10.pt  data_18.pt  data_25.pt  data_32.pt  data_4.pt   data_47.pt  data_54.pt  data_61.pt  data_69.pt  data_76.pt  data_83.pt  data_90.pt  data_98.pt
data_11.pt  data_19.pt  data_26.pt  data_33.pt  data_40.pt  data_48.pt  data_55.pt  data_62.pt  data_7.pt   data_77.pt  data_84.pt  data_91.pt  data_99.pt
data_12.pt  data_2.pt   data_27.pt  data_34.pt  data_41.pt  data_49.pt  data_56.pt  data_63.pt  data_70.pt  data_78.pt  data_85.pt  data_92.pt  sample_lengths.json
data_13.pt  data_20.pt  data_28.pt  data_35.pt  data_42.pt  data_5.pt   data_57.pt  data_64.pt  data_71.pt  data_79.pt  data_86.pt  data_93.pt
data_14.pt  data_21.pt  data_29.pt  data_36.pt  data_43.pt  data_50.pt  data_58.pt  data_65.pt  data_72.pt  data_8.pt   data_87.pt  data_94.pt
data_15.pt  data_22.pt  data_3.pt   data_37.pt  data_44.pt  data_51.pt  data_59.pt  data_66.pt  data_73.pt  data_80.pt  data_88.pt  data_95.pt
```