### PR TITLE
add multimodal preprocessing support

### DIFF
--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -174,6 +174,12 @@ def parse_args():
         default=8,
         help="Number of CPU processes for dataset preprocessing (default: 8)",
     )
+    parser.add_argument(
+        "--multimodal",
+        action="store_true",
+        default=False,
+        help="Enable multimodal mode (uses AutoProcessor instead of AutoTokenizer)",
+    )
     return parser.parse_args()
 
 
@@ -349,6 +355,7 @@ def main():
         token_freq_path=args.token_freq_path,
         assistant_pattern=args.assistant_pattern,
         turn_dropout=args.turn_dropout,
+        is_multimodal=args.multimodal,
     )
     num_saved = generate_and_save_hidden_states(args, dataset)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -271,6 +271,7 @@ def main(args: argparse.Namespace):
             on_missing=args.on_missing,
             on_generate=args.on_generate,
             transform=noise_transform,
+            hidden_states_dtype=hidden_states_dtype,
             split_ratio=0.9,
             model=args.verifier_name_or_path,
         )
@@ -281,6 +282,7 @@ def main(args: argparse.Namespace):
             vllm_endpoint=args.vllm_endpoint,
             on_missing=args.on_missing,
             on_generate=args.on_generate,
+            hidden_states_dtype=hidden_states_dtype,
             split_ratio=-0.1,
             model=args.verifier_name_or_path,
         )

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -2,13 +2,14 @@ import bisect
 import random
 import re
 from pathlib import Path
+from functools import partial
 from re import Pattern
 from typing import Any, cast
 
 import torch
 from datasets import Dataset as HFDataset
 from datasets import concatenate_datasets, load_dataset
-from transformers import AutoTokenizer, PreTrainedTokenizerBase
+from transformers import AutoProcessor, AutoTokenizer, PreTrainedTokenizerBase
 
 from speculators.data_generation.configs import DATASET_CONFIGS
 from speculators.data_generation.logging_utils import PipelineLogger
@@ -58,6 +59,101 @@ def _visualize_sample(preprocessed, tokenizer, idx: int = 0):
     log.info(highlighted)
 
 
+def _normalize_content(content: Any) -> Any:
+    # Normalize multimodal content into list-of-items when applicable.
+    def _strip_image_tokens(text: str) -> str:
+        # Remove inline image markers to avoid duplicate placeholders.
+        return re.sub(r"<image\s*/?>", "", text, flags=re.IGNORECASE).strip()
+
+    if isinstance(content, list):
+        normalized_items = []
+        for item in content:
+            if isinstance(item, str):
+                normalized_items.append(
+                    {"type": "text", "text": _strip_image_tokens(item)}
+                )
+                continue
+            if isinstance(item, dict):
+                image_ref = _get_image_ref(item)
+                if image_ref is not None:
+                    normalized_items.append({"type": "image", "image": image_ref})
+                    continue
+                text_val = item.get("text")
+                if text_val is not None:
+                    normalized_items.append(
+                        {"type": "text", "text": _strip_image_tokens(text_val)}
+                    )
+                    continue
+                normalized_items.append(item)
+                continue
+            normalized_items.append({"type": "text", "text": str(item)})
+        return normalized_items
+    return content
+
+
+def _get_conversations_from_examples(examples: dict) -> list:
+    # Extract batched conversations/messages from dataset examples.
+    if "conversations" in examples:
+        return examples.get("conversations", [])
+    if "messages" in examples:
+        return examples.get("messages", [])
+    return []
+
+
+def _flatten_singleton_batch(value: Any, *, field_name: str) -> Any:
+    # Collapse singleton batch dimension; fail fast on true batched outputs.
+    if isinstance(value, torch.Tensor):
+        value = value.tolist()
+    if isinstance(value, list) and value and isinstance(value[0], list):
+        if len(value) != 1:
+            raise ValueError(
+                f"{field_name} returned non-singleton batch: batch_size={len(value)}"
+            )
+        return value[0]
+    return value
+
+
+def _get_tokenizer_from_processor(processor: Any) -> PreTrainedTokenizer:
+    # Extract tokenizer from a processor for offset-based tokenization.
+    tokenizer = getattr(processor, "tokenizer", None)
+    if tokenizer is None:
+        raise ValueError("Processor does not provide a tokenizer attribute.")
+    return tokenizer
+
+
+def _get_image_ref(item: dict) -> Any | None:
+    if item.get("type") not in ("image", "image_url"):
+        return None
+
+    image_ref = item.get("image")
+    if image_ref is not None:
+        return image_ref
+
+    image_url = item.get("image_url")
+    if isinstance(image_url, dict):
+        return image_url.get("url")
+    return image_url
+
+
+def _extract_multimodal_data_from_conversation(
+    conv: list[dict],
+) -> dict[str, list[Any]]:
+    mm_data: dict[str, list[Any]] = {}
+    for turn in conv:
+        content = turn.get("content")
+        if not isinstance(content, list):
+            continue
+
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            image_ref = _get_image_ref(item)
+            if image_ref is not None:
+                mm_data.setdefault("image", []).append(image_ref)
+    return mm_data
+
+
+
 def _normalize_conversation(
     conv: list[dict],
     turn_dropout: bool = False,
@@ -78,6 +174,7 @@ def _normalize_conversation(
     for i, turn in enumerate(conv):
         role = turn.get("from", turn.get("role", ""))
         content = turn.get("value") or turn.get("content") or ""
+        content = _normalize_content(content)
 
         # Map various role names to standard user/assistant
         if role in ("human", "user"):
@@ -107,13 +204,14 @@ def _normalize_conversation(
     return normalized
 
 
-def _supports_assistant_mask(tokenizer: PreTrainedTokenizerBase) -> bool:
-    """Check if tokenizer truly supports HF assistant token mask.
+def _supports_assistant_mask(caller: Any) -> bool:
+    """Check if tokenizer/processor truly supports HF assistant token mask.
 
     Must return a non-zero mask for a conversation containing an assistant message.
+    Works for both tokenizers and processors.
     """
     try:
-        res_any = tokenizer.apply_chat_template(
+        res_any = caller.apply_chat_template(
             [{"role": "assistant", "content": "test"}],
             tokenize=True,
             return_assistant_tokens_mask=True,
@@ -131,11 +229,11 @@ def _supports_assistant_mask(tokenizer: PreTrainedTokenizerBase) -> bool:
         return False
 
 
-def _detect_assistant_pattern(tokenizer: PreTrainedTokenizerBase) -> str:
-    """Auto-detect the assistant message pattern from the tokenizer's chat template.
+def _detect_assistant_pattern_from_template(caller: Any) -> str:
+    """Auto-detect the assistant message pattern from a chat template caller.
 
     Uses multi-turn conversation but extracts pattern from the LAST assistant
-    message only.
+    message only. Works for both tokenizers and processors.
     """
     test_conv = [
         {"role": "user", "content": "USER_MSG_1"},
@@ -144,7 +242,7 @@ def _detect_assistant_pattern(tokenizer: PreTrainedTokenizerBase) -> str:
         {"role": "assistant", "content": "ASSISTANT_MSG_2"},
     ]
 
-    formatted = tokenizer.apply_chat_template(
+    formatted = caller.apply_chat_template(
         test_conv, tokenize=False, add_generation_prompt=False
     )
     assert isinstance(formatted, str), "Expected string from apply_chat_template"
@@ -255,17 +353,20 @@ def _create_loss_mask_from_offsets(
     return loss_mask
 
 
-def _preprocess_batch(
+def _preprocess_batch_text(  # noqa: PLR0912, PLR0915
     examples: dict,
     tokenizer: PreTrainedTokenizerBase,
     max_length: int,
     assistant_pattern: str | Pattern[str] | None,
     turn_dropout: bool = False,
 ) -> dict[str, list]:
-    """Process a batch of conversations into tokenized format with loss masks."""
+    """Process a batch of text-only conversations into tokenized format.
+
+    Builds input IDs and loss masks for each conversation.
+    """
 
     results: dict[str, list] = {"input_ids": [], "loss_mask": [], "seq_len": []}
-    conversations = examples.get("conversations", [])
+    conversations = _get_conversations_from_examples(examples)
 
     if not conversations:
         log.warning(f"No conversations key found. Keys: {list(examples.keys())}")
@@ -293,14 +394,21 @@ def _preprocess_batch(
                 encoded = cast("dict[str, Any]", encoded_any)
 
                 # input IDs and loss mask
-                input_ids = encoded["input_ids"]
+                input_ids = _flatten_singleton_batch(
+                    encoded["input_ids"],
+                    field_name="Text apply_chat_template input_ids",
+                )
                 # HF uses 'assistant_masks' in recent versions
                 mask_key = (
                     "assistant_masks"
                     if "assistant_masks" in encoded
                     else "assistant_mask"
                 )
-                loss_mask = torch.tensor(encoded[mask_key], dtype=torch.long)
+                loss_mask_raw = _flatten_singleton_batch(
+                    encoded[mask_key],
+                    field_name="Text apply_chat_template assistant mask",
+                )
+                loss_mask = torch.tensor(loss_mask_raw, dtype=torch.long)
 
             else:
                 # Fallback: regex-based detection
@@ -324,8 +432,14 @@ def _preprocess_batch(
                 )
 
                 # input IDs and loss mask
-                input_ids = encoding["input_ids"]
-                offsets = encoding["offset_mapping"]
+                input_ids = _flatten_singleton_batch(
+                    encoding["input_ids"],
+                    field_name="Text tokenizer input_ids",
+                )
+                offsets = _flatten_singleton_batch(
+                    encoding["offset_mapping"],
+                    field_name="Text tokenizer offset_mapping",
+                )
 
                 loss_mask = _create_loss_mask_from_offsets(
                     formatted_raw, offsets, assistant_pattern
@@ -352,6 +466,112 @@ def _preprocess_batch(
     return results
 
 
+def _preprocess_batch_multimodal(  # noqa: PLR0912, PLR0915
+    examples: dict,
+    processor: Any,
+    max_length: int,
+    assistant_pattern: str | Pattern[str] | None,
+    turn_dropout: bool = False,
+) -> dict[str, list]:
+    # Preprocess a batch of multimodal conversations into token IDs and loss masks.
+
+    results: dict[str, list] = {
+        "input_ids": [],
+        "loss_mask": [],
+        "multi_modal_data": [],
+        "prompt": [],
+    }
+    conversations = _get_conversations_from_examples(examples)
+
+    if not conversations:
+        log.warning(f"No conversations key found. Keys: {list(examples.keys())}")
+        return results
+
+    tokenizer = _get_tokenizer_from_processor(processor)
+
+    for idx, conv in enumerate(conversations):
+        if not conv or not isinstance(conv, list):
+            continue
+
+        normalized_conv = _normalize_conversation(conv, turn_dropout)
+        if not normalized_conv:
+            continue
+
+        try:
+            formatted_raw = processor.apply_chat_template(
+                normalized_conv,
+                tokenize=False,
+                add_generation_prompt=False,
+            )
+            assert isinstance(formatted_raw, str)
+
+            if assistant_pattern is None:
+                encoded_any = processor.apply_chat_template(
+                    normalized_conv,
+                    tokenize=True,
+                    add_generation_prompt=False,
+                    return_assistant_tokens_mask=True,
+                    return_dict=True,
+                )
+                encoded = cast("dict[str, Any]", encoded_any)
+
+                input_ids = _flatten_singleton_batch(
+                    encoded["input_ids"],
+                    field_name="Multimodal apply_chat_template input_ids",
+                )
+                mask_key = (
+                    "assistant_masks"
+                    if "assistant_masks" in encoded
+                    else "assistant_mask"
+                )
+                loss_mask_raw = _flatten_singleton_batch(
+                    encoded[mask_key],
+                    field_name="Multimodal apply_chat_template assistant mask",
+                )
+                loss_mask = torch.tensor(loss_mask_raw, dtype=torch.long)
+            else:
+                encoding = tokenizer(
+                    formatted_raw,
+                    return_offsets_mapping=True,
+                    max_length=max_length,
+                    truncation=True,
+                    add_special_tokens=False,
+                )
+
+                input_ids = _flatten_singleton_batch(
+                    encoding["input_ids"],
+                    field_name="Multimodal tokenizer input_ids",
+                )
+                offsets = _flatten_singleton_batch(
+                    encoding["offset_mapping"],
+                    field_name="Multimodal tokenizer offset_mapping",
+                )
+                loss_mask = _create_loss_mask_from_offsets(
+                    formatted_raw, offsets, assistant_pattern
+                )
+
+            assert len(input_ids) == len(loss_mask), (
+                f"Shape mismatch: input_ids={len(input_ids)}, "
+                f"loss_mask={len(loss_mask)}"
+            )
+
+            results["input_ids"].append(torch.tensor(input_ids, dtype=torch.long))
+            results["loss_mask"].append(loss_mask)
+            results["multi_modal_data"].append(
+                _extract_multimodal_data_from_conversation(normalized_conv)
+            )
+            results["prompt"].append(formatted_raw)
+
+        except (TypeError, ValueError, KeyError, AttributeError, RuntimeError) as e:
+            log.error(
+                f"Failed to process conversation {idx} "
+                f"(assistant_pattern={assistant_pattern is not None}): {e}"
+            )
+            continue
+
+    return results
+
+
 def build_eagle3_dataset(
     dataset: HFDataset,
     tokenizer: PreTrainedTokenizerBase,
@@ -359,6 +579,7 @@ def build_eagle3_dataset(
     num_proc: int = 8,
     assistant_pattern: str | Pattern[str] | None = None,
     turn_dropout: bool = False,
+    processor: Any | None = None,
 ) -> HFDataset:
     """Build EAGLE3 dataset by tokenizing conversations and creating loss masks.
 
@@ -375,22 +596,43 @@ def build_eagle3_dataset(
         turn_dropout: If True, randomly keeps first N consecutive turns per
                      conversation
     """
+    is_multimodal = processor is not None
+    caller = processor if is_multimodal else tokenizer
+
     # Detect and use provided assistant message pattern
     if assistant_pattern is not None:
         log.info(f"Using custom assistant pattern: {str(assistant_pattern)[:80]}...")
-    elif _supports_assistant_mask(tokenizer):
-        assistant_pattern = None  # Signal to use HF mask in _preprocess_batch
-        log.info("Using HF assistant token mask for loss masking")
+    elif _supports_assistant_mask(caller):
+        assistant_pattern = None
+        log.info(
+            f"Using HF assistant token mask for loss masking"
+            f"{' (multimodal)' if is_multimodal else ''}"
+        )
     else:
-        assistant_pattern = _detect_assistant_pattern(tokenizer)
+        assistant_pattern = _detect_assistant_pattern_from_template(caller)
         log.info(f"Detected assistant pattern: {str(assistant_pattern)[:80]}...")
 
     original_cols = dataset.column_names
 
+    if is_multimodal:
+        map_fn = partial(
+            _preprocess_batch_multimodal,
+            processor=processor,
+            max_length=max_length,
+            assistant_pattern=assistant_pattern,
+            turn_dropout=turn_dropout,
+        )
+    else:
+        map_fn = partial(
+            _preprocess_batch_text,
+            tokenizer=tokenizer,
+            max_length=max_length,
+            assistant_pattern=assistant_pattern,
+            turn_dropout=turn_dropout,
+        )
+
     dataset = dataset.map(
-        lambda examples: _preprocess_batch(
-            examples, tokenizer, max_length, assistant_pattern, turn_dropout
-        ),
+        map_fn,
         batched=True,
         num_proc=num_proc,
         batch_size=1000,
@@ -398,7 +640,12 @@ def build_eagle3_dataset(
         keep_in_memory=True,  # skip caching
     )
 
-    dataset.set_format(type="torch")
+    if is_multimodal:
+        dataset.set_format(
+            type="torch", columns=["input_ids", "loss_mask"], output_all_columns=True
+        )
+    else:
+        dataset.set_format(type="torch")
     return dataset
 
 
@@ -432,7 +679,8 @@ def load_and_preprocess_dataset(
     token_freq_path: Path | str = "./token_freq.pt",  # noqa: S107
     assistant_pattern: str | None = None,
     turn_dropout: bool = False,
-) -> tuple[HFDataset, PreTrainedTokenizerBase]:
+    is_multimodal: bool | None = None,
+) -> tuple[HFDataset, PreTrainedTokenizer]:
     """Load, tokenize, and preprocess a dataset for EAGLE3 training.
 
     Uses the tokenizer's built-in chat template via apply_chat_template.
@@ -452,18 +700,41 @@ def load_and_preprocess_dataset(
                           chat template.
         turn_dropout: If True, randomly keeps first N consecutive turns per
                      conversation
+        is_multimodal: Multimodal mode flag. Defaults to text-only when omitted.
 
     Returns:
         Tuple of (preprocessed_dataset, tokenizer)
     """
     log.section("Starting dataset preprocessing")
 
-    log.subsection("Loading tokenizer")
-    tokenizer = AutoTokenizer.from_pretrained(target_model_path, trust_remote_code=True)
+    if is_multimodal is None:
+        is_multimodal = False
+    log.info(f"Using multimodal mode: {is_multimodal}")
+
+    if is_multimodal:
+        processor = AutoProcessor.from_pretrained(
+            target_model_path, trust_remote_code=True
+        )
+        tokenizer = _get_tokenizer_from_processor(processor)
+    else:
+        processor = None
+        tokenizer = AutoTokenizer.from_pretrained(
+            target_model_path, trust_remote_code=True
+        )
+
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token
 
-    if not hasattr(tokenizer, "apply_chat_template") or tokenizer.chat_template is None:
+    if is_multimodal:
+        if not hasattr(processor, "apply_chat_template"):
+            raise ValueError(
+                f"Processor for {target_model_path} does not support "
+                "apply_chat_template. Please use a model with a pre-configured "
+                "chat template."
+            )
+    elif (
+        not hasattr(tokenizer, "apply_chat_template") or tokenizer.chat_template is None
+    ):
         raise ValueError(
             f"Tokenizer for {target_model_path} does not support chat templates. "
             "Please use a model with a pre-configured chat template."
@@ -493,12 +764,13 @@ def load_and_preprocess_dataset(
             num_proc=build_dataset_num_proc,
             assistant_pattern=assistant_pattern,
             turn_dropout=turn_dropout,
+            processor=processor,
         )
         processed_datasets.append(preprocessed_dataset)
 
     combined_dataset = concatenate_datasets(processed_datasets)
-    combined_dataset.shuffle(seed=seed)
-    if max_samples is not None and len(raw_dataset) > max_samples:
+    combined_dataset = combined_dataset.shuffle(seed=seed)
+    if max_samples is not None and len(combined_dataset) > max_samples:
         combined_dataset = combined_dataset.select(range(max_samples))
 
     log.subsection("Computing token frequency distribution")

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -1,15 +1,15 @@
 import bisect
 import random
 import re
-from pathlib import Path
 from functools import partial
+from pathlib import Path
 from re import Pattern
 from typing import Any, cast
 
 import torch
 from datasets import Dataset as HFDataset
 from datasets import concatenate_datasets, load_dataset
-from transformers import AutoProcessor, AutoTokenizer, PreTrainedTokenizerBase
+from transformers import AutoProcessor, AutoTokenizer, PreTrainedTokenizer
 
 from speculators.data_generation.configs import DATASET_CONFIGS
 from speculators.data_generation.logging_utils import PipelineLogger
@@ -151,7 +151,6 @@ def _extract_multimodal_data_from_conversation(
             if image_ref is not None:
                 mm_data.setdefault("image", []).append(image_ref)
     return mm_data
-
 
 
 def _normalize_conversation(
@@ -355,7 +354,7 @@ def _create_loss_mask_from_offsets(
 
 def _preprocess_batch_text(  # noqa: PLR0912, PLR0915
     examples: dict,
-    tokenizer: PreTrainedTokenizerBase,
+    tokenizer: PreTrainedTokenizer,
     max_length: int,
     assistant_pattern: str | Pattern[str] | None,
     turn_dropout: bool = False,
@@ -574,7 +573,7 @@ def _preprocess_batch_multimodal(  # noqa: PLR0912, PLR0915
 
 def build_eagle3_dataset(
     dataset: HFDataset,
-    tokenizer: PreTrainedTokenizerBase,
+    tokenizer: PreTrainedTokenizer,
     max_length: int = 2048,
     num_proc: int = 8,
     assistant_pattern: str | Pattern[str] | None = None,

--- a/tests/datagen/test_preprocessing.py
+++ b/tests/datagen/test_preprocessing.py
@@ -9,7 +9,7 @@ import torch
 from datasets import Dataset as HFDataset
 from transformers import AutoTokenizer
 
-import speculators.data_generation.preprocessing as preprocessing
+from speculators.data_generation import preprocessing
 from speculators.data_generation.preprocessing import (
     _create_loss_mask_from_offsets,
     _detect_assistant_pattern_from_template,
@@ -105,7 +105,11 @@ def test_load_and_preprocess_dataset_defaults_to_text_mode(monkeypatch):
     dummy_tokenizer = DummyTokenizer()
     captured: dict[str, object] = {}
 
-    monkeypatch.setattr(preprocessing, "load_raw_dataset", lambda *args, **kwargs: raw_dataset)
+    monkeypatch.setattr(
+        preprocessing,
+        "load_raw_dataset",
+        lambda *args, **kwargs: raw_dataset,
+    )
     monkeypatch.setattr(
         preprocessing.AutoTokenizer,
         "from_pretrained",
@@ -114,14 +118,20 @@ def test_load_and_preprocess_dataset_defaults_to_text_mode(monkeypatch):
     monkeypatch.setattr(
         preprocessing,
         "build_eagle3_dataset",
-        lambda *args, **kwargs: captured.setdefault("processor", kwargs.get("processor")) or raw_dataset,
+        lambda *args, **kwargs: (
+            captured.setdefault("processor", kwargs.get("processor")) or raw_dataset
+        ),
     )
     monkeypatch.setattr(
         preprocessing,
         "save_token_frequency_distribution",
         lambda *args, **kwargs: None,
     )
-    monkeypatch.setattr(preprocessing, "_visualize_sample", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        preprocessing,
+        "_visualize_sample",
+        lambda *args, **kwargs: None,
+    )
 
     dataset, tokenizer = preprocessing.load_and_preprocess_dataset(
         target_model_path="dummy-model",
@@ -682,7 +692,7 @@ def test_detect_assistant_pattern_thinking_model():
     contains substantial content.
     """
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B", trust_remote_code=True)
-    pattern = _detect_assistant_pattern(tokenizer)
+    pattern = _detect_assistant_pattern_from_template(tokenizer)
 
     # Format a multi-turn conversation with thinking content injected
     # directly into the formatted string (as it would appear in real data)
@@ -742,7 +752,7 @@ def test_create_loss_mask_thinking_model(thinking_content):
     <think> block.
     """
     tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B", trust_remote_code=True)
-    pattern = _detect_assistant_pattern(tokenizer)
+    pattern = _detect_assistant_pattern_from_template(tokenizer)
 
     # Build formatted text using the real chat template
     conv = [

--- a/tests/datagen/test_preprocessing.py
+++ b/tests/datagen/test_preprocessing.py
@@ -9,11 +9,12 @@ import torch
 from datasets import Dataset as HFDataset
 from transformers import AutoTokenizer
 
+import speculators.data_generation.preprocessing as preprocessing
 from speculators.data_generation.preprocessing import (
     _create_loss_mask_from_offsets,
-    _detect_assistant_pattern,
+    _detect_assistant_pattern_from_template,
     _normalize_conversation,
-    _preprocess_batch,
+    _preprocess_batch_text,
     _supports_assistant_mask,
     build_eagle3_dataset,
 )
@@ -77,6 +78,65 @@ def test_normalize_conversation_unknown_role():
     assert result[1]["role"] == "assistant"
 
 
+@pytest.mark.sanity
+def test_load_and_preprocess_dataset_defaults_to_text_mode(monkeypatch):
+    """Test that omitted multimodal flag falls back to text-only processing."""
+
+    raw_dataset = HFDataset.from_dict(
+        {
+            "conversations": [
+                [
+                    {"role": "user", "content": "Hello"},
+                    {"role": "assistant", "content": "Hi!"},
+                ]
+            ]
+        }
+    )
+
+    class DummyTokenizer:
+        def __init__(self):
+            self.pad_token = None
+            self.eos_token = "<eos>"
+            self.chat_template = "dummy-template"
+
+        def apply_chat_template(self, *args, **kwargs):
+            return "formatted"
+
+    dummy_tokenizer = DummyTokenizer()
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(preprocessing, "load_raw_dataset", lambda *args, **kwargs: raw_dataset)
+    monkeypatch.setattr(
+        preprocessing.AutoTokenizer,
+        "from_pretrained",
+        lambda *args, **kwargs: dummy_tokenizer,
+    )
+    monkeypatch.setattr(
+        preprocessing,
+        "build_eagle3_dataset",
+        lambda *args, **kwargs: captured.setdefault("processor", kwargs.get("processor")) or raw_dataset,
+    )
+    monkeypatch.setattr(
+        preprocessing,
+        "save_token_frequency_distribution",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(preprocessing, "_visualize_sample", lambda *args, **kwargs: None)
+
+    dataset, tokenizer = preprocessing.load_and_preprocess_dataset(
+        target_model_path="dummy-model",
+        train_data_path="dummy-data",
+        seq_length=128,
+        build_dataset_num_proc=1,
+        is_multimodal=None,
+    )
+
+    assert dataset is raw_dataset
+    assert tokenizer is dummy_tokenizer
+    assert captured["processor"] is None
+    assert dummy_tokenizer.pad_token == dummy_tokenizer.eos_token
+
+
 # Tests for _detect_assistant_pattern
 @pytest.mark.sanity
 def test_detect_assistant_pattern_structure():
@@ -86,7 +146,7 @@ def test_detect_assistant_pattern_structure():
     if not hasattr(tokenizer, "apply_chat_template") or tokenizer.chat_template is None:
         pytest.skip("Tokenizer does not support chat templates")
 
-    pattern = _detect_assistant_pattern(tokenizer)
+    pattern = _detect_assistant_pattern_from_template(tokenizer)
 
     # Pattern should be a valid regex string
     assert isinstance(pattern, str)
@@ -111,7 +171,7 @@ def test_detect_assistant_pattern_correctly_identifies_assistant_vs_user():
         pytest.skip("Tokenizer does not support chat templates")
 
     # Get the pattern
-    pattern = _detect_assistant_pattern(tokenizer)
+    pattern = _detect_assistant_pattern_from_template(tokenizer)
 
     # Format a conversation manually to test the pattern
     test_conv = [
@@ -146,7 +206,7 @@ def test_detect_assistant_pattern_extracts_correct_content():
     if not hasattr(tokenizer, "apply_chat_template") or tokenizer.chat_template is None:
         pytest.skip("Tokenizer does not support chat templates")
 
-    pattern = _detect_assistant_pattern(tokenizer)
+    pattern = _detect_assistant_pattern_from_template(tokenizer)
 
     # Test with a multi-turn conversation
     test_conv = [
@@ -282,8 +342,8 @@ def test_preprocess_batch_basic():
         ]
     }
 
-    assistant_pattern = _detect_assistant_pattern(tokenizer)
-    results = _preprocess_batch(
+    assistant_pattern = _detect_assistant_pattern_from_template(tokenizer)
+    results = _preprocess_batch_text(
         examples, tokenizer, max_length=512, assistant_pattern=assistant_pattern
     )
 
@@ -308,8 +368,8 @@ def test_preprocess_batch_empty_conversations():
         pytest.skip("Tokenizer does not support chat templates")
 
     examples: dict[str, list] = {"conversations": []}
-    assistant_pattern = _detect_assistant_pattern(tokenizer)
-    results = _preprocess_batch(
+    assistant_pattern = _detect_assistant_pattern_from_template(tokenizer)
+    results = _preprocess_batch_text(
         examples, tokenizer, max_length=512, assistant_pattern=assistant_pattern
     )
 
@@ -336,8 +396,8 @@ def test_preprocess_batch_invalid_conversation():
         ]
     }
 
-    assistant_pattern = _detect_assistant_pattern(tokenizer)
-    results = _preprocess_batch(
+    assistant_pattern = _detect_assistant_pattern_from_template(tokenizer)
+    results = _preprocess_batch_text(
         examples, tokenizer, max_length=512, assistant_pattern=assistant_pattern
     )
 
@@ -370,8 +430,8 @@ def test_preprocess_batch_truncation():
     }
 
     max_length = 100
-    assistant_pattern = _detect_assistant_pattern(tokenizer)
-    results = _preprocess_batch(
+    assistant_pattern = _detect_assistant_pattern_from_template(tokenizer)
+    results = _preprocess_batch_text(
         examples, tokenizer, max_length=max_length, assistant_pattern=assistant_pattern
     )
 
@@ -406,7 +466,7 @@ def test_preprocess_batch_uses_hf_assistant_mask():
     }
 
     # Pass None to trigger masking path
-    results = _preprocess_batch(
+    results = _preprocess_batch_text(
         examples,
         tokenizer,
         max_length=128,
@@ -454,9 +514,9 @@ def test_preprocess_batch_falls_back_to_regex():
         ]
     }
 
-    assistant_pattern = _detect_assistant_pattern(tokenizer)
+    assistant_pattern = _detect_assistant_pattern_from_template(tokenizer)
 
-    results = _preprocess_batch(
+    results = _preprocess_batch_text(
         examples,
         tokenizer,
         max_length=128,
@@ -594,8 +654,8 @@ def test_preprocess_batch_with_turn_dropout():
         ]
     }
 
-    assistant_pattern = _detect_assistant_pattern(tokenizer)
-    results = _preprocess_batch(
+    assistant_pattern = _detect_assistant_pattern_from_template(tokenizer)
+    results = _preprocess_batch_text(
         examples,
         tokenizer,
         max_length=512,

--- a/tests/datagen/test_regex_patterns.py
+++ b/tests/datagen/test_regex_patterns.py
@@ -9,8 +9,8 @@ from loguru import logger as log
 from transformers import AutoTokenizer
 
 from speculators.data_generation.preprocessing import (
-    _detect_assistant_pattern,
-    _preprocess_batch,
+    _detect_assistant_pattern_from_template,
+    _preprocess_batch_text,
 )
 
 # Test models covering major template families
@@ -42,7 +42,7 @@ def tokenizer(request):
 
 def test_regex_detection_across_models(tokenizer):
     """
-    Verify that _detect_assistant_pattern and _preprocess_batch (regex path)
+    Verify that _detect_assistant_pattern_text and _preprocess_batch_text (regex path)
     work correctly for a variety of model families.
     """
     model_name = tokenizer.name_or_path
@@ -50,7 +50,7 @@ def test_regex_detection_across_models(tokenizer):
 
     # 1. Detect pattern
     try:
-        pattern = _detect_assistant_pattern(tokenizer)
+        pattern = _detect_assistant_pattern_from_template(tokenizer)
     except (ValueError, RuntimeError) as e:
         pytest.fail(f"Failed to detect assistant pattern for {model_name}: {e}")
 
@@ -70,7 +70,7 @@ def test_regex_detection_across_models(tokenizer):
     }
 
     # Regex path by passing the explicit pattern
-    results = _preprocess_batch(
+    results = _preprocess_batch_text(
         examples, tokenizer, max_length=512, assistant_pattern=pattern
     )
 


### PR DESCRIPTION
<!-- markdownlint-disable -->


## Purpose

Enable multimodal-aware(currently single image-text pair) preprocessing for the EAGLE offline data-generation pipeline while preserving backward compatibility for existing text-only workflows.

## Description
This PR adds multimodal preprocessing support and refactors related preprocessing internals:

- Added `--multimodal` flag to offline generation entrypoint and passed it through to preprocessing.
- Added helpers for:
  - multimodal content normalization,
  - image reference extraction,
  - singleton batch flattening with clearer error context.
- Generalized assistant-mask/pattern logic to work with either tokenizer or processor callers.
- Kept compatibility for existing callers:
  - `is_multimodal=None` defaults to text mode.
- Updated tests to new helper/function names and added a regression test for default text fallback behavior.


## Related Issue

https://github.com/vllm-project/speculators/issues/290

## Tests

- Ran an existing pure-text Qwen example end-to-end to ensure this change does not affect the original text-only path.
- Ran training in my adapted VL code path to verify multimodal preprocessing outputs are consumable and behavior is correct.

Notes:

- The data generation and training workflow in speculators will be updated soon and this PR intentionally focuses on organizing and stabilizing the preprocessing part only.

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
