### PR TITLE
Eagle3: wire norm_before_fc into training scripts and gpt-oss example

### DIFF
--- a/examples/data_generation_and_training/gpt_oss_20b_ultrachat_5k.py
+++ b/examples/data_generation_and_training/gpt_oss_20b_ultrachat_5k.py
@@ -56,13 +56,14 @@ if __name__ == "__main__":
         target_vocab_size=201088,  # From https://huggingface.co/openai/gpt-oss-20b/blob/main/config.json
     )
 
-    # Training
+    # Training (norm_before_fc=True for gpt-oss to stabilize draft path)
     train_args = TrainArgs(
         logger="tensorboard",
         lr=3e-5,
         total_seq_len=TOTAL_SEQ_LEN,
         run_name="gpt_oss_20b_ultrachat_5k",
         epochs=10,
+        norm_before_fc=True,
     )
 
     run_e2e(

--- a/scripts/gen_and_train.py
+++ b/scripts/gen_and_train.py
@@ -132,6 +132,7 @@ class TrainArgs(NamedTuple):
     scheduler_warmup_steps: int | _NS = _NOTSET
     scheduler_total_steps: int | _NS = _NOTSET
     scheduler_num_cosine_cycles: float | _NS = _NOTSET
+    norm_before_fc: bool | _NS = _NOTSET
 
 
 ### END OF SCRIPT ARGUMENTS ###

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -312,6 +312,12 @@ def parse_args():
         default=False,
         help="Whether to train embedding layer weights (default: False)",
     )
+    parser.add_argument(
+        "--norm-before-fc",
+        action="store_true",
+        help="Use RMSNorm before fc in Eagle3 draft path "
+        "(e.g. for gpt-oss). Omit for other models.",
+    )
     # Dataloader parameters
     parser.add_argument(
         "--num-workers", type=int, default=12, help="Number of dataloader workers"

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -547,6 +547,7 @@ class Eagle3DraftModel(SpeculatorModel):
             transformer_layer_config=verifier_config,
             draft_vocab_size=kwargs["draft_vocab_size"],
             norm_before_residual=kwargs["norm_before_residual"],
+            norm_before_fc=kwargs.get("norm_before_fc", False),
             embed_requires_grad=kwargs.get("embed_requires_grad", False),
             speculators_config=SpeculatorsConfig(
                 algorithm="eagle3",


### PR DESCRIPTION
Follow-up to [#337](https://github.com/vllm-project/speculators/pull/337), which added config + core support for `norm_before_fc` but did not expose it in the training CLI or the combined pipeline. Without this, users running `train.py` or `gen_and_train.py` had no way to enable the pre-FC norm, so gpt-oss models could not be trained correctly via the standard scripts.

## Changes

- **train.py:** Add `--norm-before-fc` flag so the training script can pass `norm_before_fc=True` into the Eagle3 config.
- **gen_and_train.py:** Add `norm_before_fc` to `TrainArgs` so the combined pipeline forwards the flag to `train.py`.
- **gpt_oss_20b_ultrachat_5k.py:** Set `norm_before_fc=True` in the gpt-oss example so it trains with the stabilizing norm out of the box.

With these changes, gpt-oss models train correctly (`--norm-before-fc`), and all other models continue to train as before (flag defaults to off).

## Tests

- `train.py --norm-before-fc` creates the draft model with `input_norm`; omitting the flag matches pre-#337 behavior.
- gpt-oss example runs end-to-end with the norm enabled.

## Related

- Core + config: [#337](https://github.com/vllm-project/speculators/pull/337)
- Inference support in vLLM: [vllm-project/vllm#36545](https://github.com/vllm-project/vllm/pull/36545)
