### PR TITLE
Fix mergify check-failure condition

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -37,7 +37,7 @@ pull_request_rules:
       label:
         remove:
           - needs-rebase
-  
+
   - name: add quality-failed label
     conditions:
       - label != stale
@@ -57,7 +57,7 @@ pull_request_rules:
   - name: remove quality-failed label
     conditions:
       - label != stale
-      - -check-failure = quality-check
+      - -check-failure ~= ^quality-check
       - -closed
     actions:
       label:


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Currently, mergify is repeatedly labeling and unlabeling prs with failing quality checks.

The issue is in this logic
```yaml
  - name: add quality-failed label
    conditions:
      - label != stale
      - check-failure ~= ^quality-checks   # LINE 1
      - -closed
     ...

  - name: remove quality-failed label
    conditions:
      - label != stale
      - -check-failure = quality-check       # LINE 2
      - -closed
    ...

```
In line 1 (+the other conditions) we see that if a pr is not labeled stale, not closed and **has a check failure that REGEX MATCHES `^quality-checks`**, it will be labeled and commented on.

In line 2 (+ other conditions) if a pr is not labeled stale, not closed, and **does not have a check-failure that EXACTLY EQUALS `quality-check`**, it will be unlabeled.

The issue is that the check (I believe) is labeled something like `quality-checks (3.10)`. So if it fails, the first condition on line 1 is triggered because the regex matches.

Then the check on line 2 immediately passes because `quality-checks != quality-checks (3.10` and the pr is immediately unlabeled.

The fix is to update the line 2 condition so that it also checks for a regex match instead of an exact match.





<!--- Why your changes are needed -->

## Description

<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests

<!--- Please describe in detail how you tested your changes. -->

Not thoroughly tested, but this is broken on main

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
