### PR TITLE
fix(datagen): fix VllmHiddenStatesGenerator for hybrid KV cache models and large datasets

### DIFF
--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -22,6 +22,12 @@ DATASET_CONFIGS = {
         "prompt_field": "prompt",
         "default_split": "train_sft",
     },
+    "gsm8k": {
+        "id": "openai/gsm8k",
+        "subset": "main",
+        "prompt_field": "question",
+        "default_split": "train",
+    },
 }
 
 
@@ -43,8 +49,8 @@ def parse_args():
     parser.add_argument(
         "--dataset",
         default="ultrachat",
-        choices=["magpie", "ultrachat"],
-        help="Dataset to process (magpie or ultrachat)",
+        choices=list(DATASET_CONFIGS),
+        help="Dataset to process",
     )
     parser.add_argument(
         "--split",
@@ -54,7 +60,7 @@ def parse_args():
     parser.add_argument(
         "--subset",
         default=None,
-        help="(unused) kept for symmetry with other scripts",
+        help="Dataset subset/config name (overrides dataset default if set)",
     )
     parser.add_argument("--limit", type=int, default=None, help="Stop after N rows")
     parser.add_argument(
@@ -227,6 +233,7 @@ async def main():
     dataset_config = DATASET_CONFIGS[args.dataset]
     dataset_id = dataset_config["id"]
     prompt_field = dataset_config["prompt_field"]
+    subset = args.subset or dataset_config.get("subset")
 
     # Use dataset-specific default split if not provided
     split = args.split if args.split is not None else dataset_config["default_split"]
@@ -245,7 +252,10 @@ async def main():
     print()
 
     seen_ids = load_seen(args.outfile) if args.resume else set()
-    dataset = load_dataset(dataset_id, split=split, streaming=True)
+    load_kwargs: dict[str, Any] = {"split": split, "streaming": True}
+    if subset:
+        load_kwargs["name"] = subset
+    dataset = load_dataset(dataset_id, **load_kwargs)
 
     queue: asyncio.Queue = asyncio.Queue(maxsize=args.concurrency * 4)
     semaphore = asyncio.Semaphore(args.concurrency)

--- a/src/speculators/data_generation/custom_worker.py
+++ b/src/speculators/data_generation/custom_worker.py
@@ -24,12 +24,8 @@ def _patched_forward(
 ):
     """Patched forward pass that captures hidden states from specified layers.
 
-    This function is bound to base_model instances via types.MethodType.
-    It expects base_model to have an _extension attribute pointing to the
-    HiddenStatesWorkerExtension instance.
-
-    Args:
-        deepstack_input_embeds: For multimodal models with deepstack (Qwen3VL)
+    Bound to base_model instances via types.MethodType. Expects base_model to
+    have an _extension attribute pointing to HiddenStatesWorkerExtension.
     """
     if get_pp_group().is_first_rank:
         hidden_states = (

--- a/src/speculators/data_generation/custom_worker.py
+++ b/src/speculators/data_generation/custom_worker.py
@@ -102,6 +102,7 @@ class HiddenStatesWorkerExtension:
 
         metadata = getattr(self, "_current_request_metadata", None)
         if metadata is not None:
+            self._current_request_metadata = None  # type: ignore[assignment]
             # Sort by vLLM's actual batch position (vLLM reorders requests internally)
             input_batch = self.model_runner.input_batch  # type: ignore[attr-defined]
             sorted_metadata = sorted(

--- a/src/speculators/data_generation/vllm_hidden_states_generator.py
+++ b/src/speculators/data_generation/vllm_hidden_states_generator.py
@@ -186,7 +186,7 @@ class VllmHiddenStatesGenerator:
     ) -> VllmConfig:
         """Create VllmConfig with hidden states worker extension"""
         cache_config = CacheConfig(
-            block_size=VLLM_BLOCK_SIZE,
+            block_size=VLLM_BLOCK_SIZE,  # type: ignore[arg-type]
             gpu_memory_utilization=gpu_memory_utilization,
             # disable to prevent cache state leakage
             enable_prefix_caching=False,
@@ -322,7 +322,7 @@ class VllmHiddenStatesGenerator:
                 )
 
             model_output = self.executor.execute_model(scheduler_output)
-            self.executor.sample_tokens(model_output)
+            self.executor.sample_tokens(model_output)  # type: ignore[arg-type]
 
         # Abort all requests (prefill complete, don't need decode)
         self.scheduler.finish_requests(
@@ -381,9 +381,7 @@ class VllmHiddenStatesGenerator:
             except Exception:
                 # Use the underlying stdlib logger so exc_info is supported
                 # (PipelineLogger.warning accepts only a plain message string).
-                log.logger.warning(
-                    "Exception during executor shutdown", exc_info=True
-                )
+                log.logger.warning("Exception during executor shutdown", exc_info=True)
 
     def __del__(self) -> None:
         """Fallback cleanup when the object is garbage collected."""

--- a/src/speculators/data_generation/vllm_hidden_states_generator.py
+++ b/src/speculators/data_generation/vllm_hidden_states_generator.py
@@ -17,11 +17,10 @@ from vllm.config import (
 from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import get_hash_fn_by_name
 from vllm.v1.core.kv_cache_utils import (
-    _get_kv_cache_groups_uniform_spec,
-    get_kv_cache_config_from_groups,
+    generate_scheduler_kv_cache_config,
+    get_kv_cache_configs,
     get_request_block_hasher,
     init_none_hash,
-    unify_hybrid_kv_cache_specs,
 )
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.executor.multiproc_executor import MultiprocExecutor
@@ -142,20 +141,13 @@ class VllmHiddenStatesGenerator:
 
         log.info("Creating scheduler...")
         kv_cache_spec_list = self.executor.collective_rpc("get_kv_cache_spec")
-        kv_cache_spec = kv_cache_spec_list[0]
-        # Normalize hybrid KV cache specs for models with non-uniform attention
-        # (e.g., GPT-OSS with sliding/full attention layers)
-        unify_hybrid_kv_cache_specs(kv_cache_spec)
-        kv_cache_groups = _get_kv_cache_groups_uniform_spec(kv_cache_spec)
-
         free_memory, _ = mem_get_info()
         cache_memory = int(free_memory * gpu_memory_utilization * CACHE_MEMORY_FRACTION)
-
-        kv_cache_config = get_kv_cache_config_from_groups(
-            vllm_config=self.vllm_config,
-            kv_cache_groups=kv_cache_groups,
-            available_memory=cache_memory,
+        available_memory = [cache_memory] * len(kv_cache_spec_list)
+        kv_cache_configs = get_kv_cache_configs(
+            self.vllm_config, kv_cache_spec_list, available_memory
         )
+        kv_cache_config = generate_scheduler_kv_cache_config(kv_cache_configs)
 
         self.vllm_config.cache_config.num_gpu_blocks = kv_cache_config.num_blocks
         structured_output_manager = StructuredOutputManager(
@@ -170,7 +162,6 @@ class VllmHiddenStatesGenerator:
         )
 
         log.info("Initializing KV cache on all workers...")
-        kv_cache_configs = [kv_cache_config] * tensor_parallel_size
         self.executor.initialize_from_config(kv_cache_configs)
 
         # Create block hasher for request KV cache management

--- a/src/speculators/data_generation/vllm_hidden_states_generator.py
+++ b/src/speculators/data_generation/vllm_hidden_states_generator.py
@@ -369,10 +369,9 @@ class VllmHiddenStatesGenerator:
         """Support use as a context manager for guaranteed cleanup."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """Shut down the executor on context manager exit."""
         self._cleanup()
-        return False  # do not suppress exceptions
 
     def _cleanup(self) -> None:
         """Shut down the vLLM executor and release GPU resources."""
@@ -380,7 +379,11 @@ class VllmHiddenStatesGenerator:
             try:
                 self.executor.shutdown()
             except Exception:
-                log.warning("Exception during executor shutdown", exc_info=True)
+                # Use the underlying stdlib logger so exc_info is supported
+                # (PipelineLogger.warning accepts only a plain message string).
+                log.logger.warning(
+                    "Exception during executor shutdown", exc_info=True
+                )
 
     def __del__(self) -> None:
         """Fallback cleanup when the object is garbage collected."""

--- a/src/speculators/data_generation/vllm_hidden_states_generator.py
+++ b/src/speculators/data_generation/vllm_hidden_states_generator.py
@@ -342,7 +342,9 @@ class VllmHiddenStatesGenerator:
 
         # Map results back to original input order
         results = []
-        for req_id in sorted(request_id_to_idx.keys()):
+        for req_id in sorted(
+            request_id_to_idx.keys(), key=lambda r: request_id_to_idx[r]
+        ):
             i = request_id_to_idx[req_id]
 
             if req_id not in request_states_dict:
@@ -375,9 +377,11 @@ class VllmHiddenStatesGenerator:
 
     def _cleanup(self) -> None:
         """Shut down the vLLM executor and release GPU resources."""
-        if hasattr(self, "executor"):
+        executor = getattr(self, "executor", None)
+        if executor is not None:
+            self.executor = None  # type: ignore[assignment]  # Guard against double-cleanup
             try:
-                self.executor.shutdown()
+                executor.shutdown()
             except Exception:
                 # Use the underlying stdlib logger so exc_info is supported
                 # (PipelineLogger.warning accepts only a plain message string).

--- a/src/speculators/data_generation/vllm_hidden_states_generator.py
+++ b/src/speculators/data_generation/vllm_hidden_states_generator.py
@@ -351,7 +351,7 @@ class VllmHiddenStatesGenerator:
                     f"Available: {list(request_states_dict.keys())}"
                 )
 
-            layer_states = [h.clone().cpu() for h in request_states_dict[req_id]]
+            layer_states = [h.cpu() for h in request_states_dict[req_id]]
             input_ids_tensor = torch.as_tensor(input_ids_list[i], dtype=torch.long)
 
             results.append(
@@ -365,9 +365,26 @@ class VllmHiddenStatesGenerator:
         empty_cache()
         return results
 
-    def __del__(self):
+    def __enter__(self) -> "VllmHiddenStatesGenerator":
+        """Support use as a context manager for guaranteed cleanup."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        """Shut down the executor on context manager exit."""
+        self._cleanup()
+        return False  # do not suppress exceptions
+
+    def _cleanup(self) -> None:
+        """Shut down the vLLM executor and release GPU resources."""
         if hasattr(self, "executor"):
             try:
                 self.executor.shutdown()
             except Exception:
-                log.warning("Exception during executor shutdown")
+                log.warning("Exception during executor shutdown", exc_info=True)
+
+    def __del__(self) -> None:
+        """Fallback cleanup when the object is garbage collected."""
+        try:
+            self._cleanup()
+        except Exception:  # noqa: BLE001
+            pass  # suppress all exceptions in __del__ to avoid interpreter warnings

--- a/src/speculators/data_generation/vllm_hidden_states_generator.py
+++ b/src/speculators/data_generation/vllm_hidden_states_generator.py
@@ -86,7 +86,7 @@ class VllmHiddenStatesGenerator:
     ):
         warnings.warn(
             "VllmHiddenStatesGenerator and the associated data_generation_offline.py"
-            " script are deprecatd and will be removed shortly.",
+            " script are deprecated and will be removed shortly.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -302,6 +302,8 @@ class VllmHiddenStatesGenerator:
             # Calculate prefill tokens for each request (ignore decode tokens)
             prefill_metadata = {}
             for req_id, num_tokens in scheduler_output.num_scheduled_tokens.items():
+                if req_id not in request_num_computed:
+                    continue  # stale ID from a previous chunk; ignore
                 num_already_computed = request_num_computed[req_id]
                 num_prompt = request_id_to_prompt_len[req_id]
                 num_prefill = max(0, min(num_tokens, num_prompt - num_already_computed))

--- a/src/speculators/data_generation/vllm_hidden_states_generator.py
+++ b/src/speculators/data_generation/vllm_hidden_states_generator.py
@@ -230,7 +230,7 @@ class VllmHiddenStatesGenerator:
             args=(self.layer_ids,),
         )
 
-    def generate(self, token_ids: list[list[int]] | torch.Tensor) -> list[dict]:  # noqa: PLR0912, PLR0915
+    def generate(self, token_ids: list[list[int]] | torch.Tensor) -> list[dict]:
         """Extract hidden states from prefill phase only.
 
         Args:
@@ -252,12 +252,23 @@ class VllmHiddenStatesGenerator:
         max_len = self.vllm_config.model_config.max_model_len - MAX_DECODE_TOKENS
         input_ids_list = [ids[:max_len] for ids in input_ids_list]
 
-        # Track request IDs and prompt lengths for proper token attribution
-        request_id_to_idx = {}
-        request_id_to_prompt_len = {}
+        # Process in chunks: the scheduler can only run MAX_NUM_SEQS requests
+        # concurrently. Once a batch finishes its single decode step, finished
+        # requests still occupy slots until explicitly aborted, preventing new
+        # requests from being admitted. Processing in chunks and aborting after
+        # each chunk avoids this starvation.
+        results = []
+        for chunk_start in range(0, len(input_ids_list), MAX_NUM_SEQS):
+            chunk = input_ids_list[chunk_start : chunk_start + MAX_NUM_SEQS]
+            results.extend(self._generate_chunk(chunk))
+        return results
+
+    def _generate_chunk(self, input_ids_list: list[list[int]]) -> list[dict]:  # noqa: PLR0912, PLR0915
+        """Process one chunk (≤ MAX_NUM_SEQS) through the scheduling loop."""
+        request_id_to_idx: dict[str, int] = {}
+        request_id_to_prompt_len: dict[str, int] = {}
 
         for i, ids in enumerate(input_ids_list):
-            # Ensure ids is a list (not tensor) for vLLM Request
             ids_list = ids.tolist() if isinstance(ids, torch.Tensor) else ids
             req_id = f"req_{self._request_counter}_{i}"
             request_id_to_idx[req_id] = i
@@ -283,14 +294,11 @@ class VllmHiddenStatesGenerator:
 
         # Track progress for each request to distinguish prefill from decode
         request_num_computed = dict.fromkeys(request_id_to_idx, 0)
-        schedule_iterations = 0
         all_prefill_complete = False
 
         while (
             scheduler_output := self.scheduler.schedule()
         ).total_num_scheduled_tokens > 0 and not all_prefill_complete:
-            schedule_iterations += 1
-
             # Calculate prefill tokens for each request (ignore decode tokens)
             prefill_metadata = {}
             for req_id, num_tokens in scheduler_output.num_scheduled_tokens.items():

--- a/src/speculators/utils/pydantic_utils.py
+++ b/src/speculators/utils/pydantic_utils.py
@@ -32,7 +32,9 @@ class ReloadableBaseModel(BaseModel):
         This method is useful when the registry has been modified or when the
         class needs to be re-validated with the latest schema.
         """
-        cls.model_rebuild(force=True)
+        import torch  # noqa: PLC0415
+
+        cls.model_rebuild(force=True, _types_namespace={"torch": torch})
 
 
 class PydanticClassRegistryMixin(ReloadableBaseModel, ABC, ClassRegistryMixin):


### PR DESCRIPTION
## Purpose

The offline data generation pipeline (`VllmHiddenStatesGenerator`) does not work with hybrid attention models such as Qwen3. This PR fixes that, along with several other bugs discovered in the process.

## Problem

Qwen3 uses a hybrid attention architecture that mixes full attention layers (`FullAttentionSpec`) and sliding-window attention layers (`ChunkedLocalAttentionSpec`). The KV cache initialization in `VllmHiddenStatesGenerator` assumed all layers share a single uniform attention spec — valid for dense models like Llama, but not for hybrid models. Attempting to run data generation with a Qwen3 model failed immediately on startup:

```
TypeError: unify_hybrid_kv_cache_specs() does not support heterogeneous specs
```

Beyond the hybrid KV cache crash, the generator had additional bugs that surfaced during investigation:

**Scheduler starvation on large datasets.** The scheduler accepted the first 32 requests and completed them, but never marked them as finished — so their slots were never freed and no further requests were ever admitted. On a dataset of 7,000+ samples, only 32 hidden states were captured and the rest were silently dropped. No error was raised.

**Wrong result ordering for batches of 11+ sequences.** Request IDs were formatted as `req_0_N` and sorted lexicographically. For N ≥ 10, `"req_0_10"` sorted before `"req_0_2"`, returning results in the wrong order relative to the input — silently producing misaligned training data.

**Stale request metadata between scheduler steps.** `_current_request_metadata` was only reset between chunks, not after each forward pass. In a step with no prefill tokens, the stale dict from the previous step was reused, mapping the wrong tokens to the wrong requests.

**No GPU resource cleanup guarantee.** The vLLM executor was only shut down if the caller explicitly deleted the object. An exception mid-generation left GPU memory held until process exit.

**Package import error.** `reload_schemas()` called Pydantic's `model_rebuild()` without providing `torch` to the type evaluation namespace, causing:

```
NameError: name 'torch' is not defined
```

This made the `speculators` package unimportable in any context where the Pydantic schema rebuild ran before torch types were resolved.

## Changes

- **`vllm_hidden_states_generator.py`:** Replace `unify_hybrid_kv_cache_specs()` + `_get_kv_cache_groups_uniform_spec()` with `get_kv_cache_configs()` + `generate_scheduler_kv_cache_config()`, matching vLLM's own `EngineCore._initialize_kv_caches()`. Split `generate()` into `MAX_NUM_SEQS=32`-sized chunks processed by a new `_generate_chunk()` method so the scheduler slot is freed between batches. Sort results by integer index instead of string. Add `__enter__`/`__exit__`/`__del__` for guaranteed executor cleanup with a double-call guard.
- **`custom_worker.py`:** Clear `_current_request_metadata` immediately after consuming it in `_store_captured_states`.
- **`utils/pydantic_utils.py`:** Pass `_types_namespace={"torch": torch}` to `model_rebuild()`.
- **`scripts/response_regeneration/script.py`:** Add `gsm8k` dataset, wire `--subset` into `load_dataset` (was previously a no-op), make `--dataset` choices auto-derived from `DATASET_CONFIGS`.

## Testing

Verified on 4× H100 80GB (GPUs 2,5,6,7) with `Qwen/Qwen3-Next-80B-A3B-Instruct`.

**Data generation:**
```bash
CUDA_VISIBLE_DEVICES=2,5,6,7 python scripts/data_generation_offline.py \
    --target-model-path Qwen/Qwen3-Next-80B-A3B-Instruct \
    --train-data-path <path-to-jsonl> \
    --output-dir <output-dir> \
    --tensor-parallel-size 4
```

**Response regeneration — gsm8k:**
```bash
CUDA_VISIBLE_DEVICES=2,5,6,7 bash scripts/response_regeneration/run_all.sh \
    --model Qwen/Qwen3-Next-80B-A3B-Instruct \
    --gpus 2,5,6,7 \
    --tp-size 4 \
    --dataset gsm8k \
    --outfile gsm8k_qwen3next.jsonl
```

**Response regeneration — existing datasets:**
```bash
CUDA_VISIBLE_DEVICES=2,5,6,7 bash scripts/response_regeneration/run_all.sh \
    --model Qwen/Qwen3-Next-80B-A3B-Instruct \
    --gpus 2,5,6,7 \
    --tp-size 4 \
    --dataset magpie \
    --limit 1000
```