### PR TITLE
feat(eval): add MTP support to eval-guidellm framework

### DIFF
--- a/examples/evaluate/eval-guidellm/README.md
+++ b/examples/evaluate/eval-guidellm/README.md
@@ -29,6 +29,9 @@ bash setup.sh  # or: bash setup.sh --use-uv for faster installation
 
 # Qwen3-32B EAGLE3 on math_reasoning dataset
 ./run_evaluation.sh -c configs/qwen3-32b-eagle3.env
+
+# Qwen3-Next-80B with GSM8K-finetuned MTP head (built-in, no separate speculator)
+./run_evaluation.sh -c configs/qwen3-next-80b-mtp.env
 ```
 
 **Or run with custom parameters:**
@@ -47,8 +50,9 @@ Results will be in a timestamped directory like `eval_results_20251203_165432/`.
 This framework uses vLLM's speculative decoding feature to evaluate speculator models. The evaluation setup consists of:
 
 - **Base Model**: The main LLM that performs final token acceptance/rejection
-- **Speculator Model**: A smaller, faster model that generates speculative tokens
-- **Speculative Decoding**: The base model validates tokens proposed by the speculator, speeding up inference
+- **Speculator** (EAGLE3): A separate, smaller model that proposes speculative tokens — loaded via `SPECULATOR_MODEL`
+- **Built-in MTP head**: Some models (e.g. Qwen3-Next) ship the speculative head inside the base checkpoint; no separate speculator is needed
+- **Speculative Decoding**: The base model validates speculative tokens, speeding up inference
 
 The framework consists of modular scripts organized in a clean directory structure:
 
@@ -56,11 +60,12 @@ The framework consists of modular scripts organized in a clean directory structu
 eval-guidellm/
 ├── run_evaluation.sh              # Main controller
 ├── configs/                       # Pre-configured evaluations
-│   ├── llama-3.1-8b-eagle3.env    # Llama-3.1-8B
-│   ├── llama-3.3-70b-eagle3.env   # Llama-3.3-70B
-│   ├── gpt-oss-20b-eagle3.env     # GPT-OSS-20B
-│   ├── qwen3-8b-eagle3.env        # Qwen3-8B
-│   └── qwen3-32b-eagle3.env       # Qwen3-32B
+│   ├── llama-3.1-8b-eagle3.env    # Llama-3.1-8B (EAGLE3)
+│   ├── llama-3.3-70b-eagle3.env   # Llama-3.3-70B (EAGLE3)
+│   ├── gpt-oss-20b-eagle3.env     # GPT-OSS-20B (EAGLE3)
+│   ├── qwen3-8b-eagle3.env        # Qwen3-8B (EAGLE3)
+│   ├── qwen3-32b-eagle3.env       # Qwen3-32B (EAGLE3)
+│   └── qwen3-next-80b-mtp.env     # Qwen3-Next-80B (built-in MTP head)
 ├── scripts/                       # Utility scripts
 │   ├── vllm_serve.sh
 │   ├── vllm_stop.sh
@@ -76,20 +81,15 @@ eval-guidellm/
 The framework includes configs for common models:
 
 ```bash
-# Llama-3.1-8B EAGLE3 on math_reasoning
+# EAGLE3 (separate speculator)
 ./run_evaluation.sh -c configs/llama-3.1-8b-eagle3.env
-
-# Llama-3.3-70B EAGLE3 on math_reasoning
 ./run_evaluation.sh -c configs/llama-3.3-70b-eagle3.env
-
-# GPT-OSS-20B EAGLE3 on math_reasoning
 ./run_evaluation.sh -c configs/gpt-oss-20b-eagle3.env
-
-# Qwen3-8B EAGLE3 on math_reasoning
 ./run_evaluation.sh -c configs/qwen3-8b-eagle3.env
-
-# Qwen3-32B EAGLE3 on math_reasoning
 ./run_evaluation.sh -c configs/qwen3-32b-eagle3.env
+
+# MTP (built-in head — no separate speculator)
+./run_evaluation.sh -c configs/qwen3-next-80b-mtp.env
 ```
 
 ### Command Line Usage
@@ -148,14 +148,16 @@ Then run:
 | Option                   | Description                                                   | Default                  |
 | ------------------------ | ------------------------------------------------------------- | ------------------------ |
 | `BASE_MODEL`             | Base model path or HuggingFace ID                             | (required)               |
-| `SPECULATOR_MODEL`       | Speculator model path or HuggingFace ID                       | (required)               |
+| `SPECULATOR_MODEL`       | Speculator model path or HuggingFace ID (omit for MTP)        | (optional)               |
 | `NUM_SPEC_TOKENS`        | Number of speculative tokens to generate                      | 3                        |
-| `METHOD`                 | Speculative decoding method                                   | eagle3                   |
+| `METHOD`                 | Speculative decoding method (`eagle3` or `mtp`)               | eagle3                   |
 | `DATASET`                | Dataset for benchmarking (emulated, HF dataset, or file path) | (required)               |
 | `TENSOR_PARALLEL_SIZE`   | Number of GPUs for tensor parallelism                         | 2                        |
 | `GPU_MEMORY_UTILIZATION` | GPU memory fraction to use                                    | 0.8                      |
 | `PORT`                   | Server port                                                   | 8000                     |
 | `HEALTH_CHECK_TIMEOUT`   | Server startup timeout (seconds)                              | 300                      |
+| `TOKENIZER_MODE`         | vLLM tokenizer mode (set to `auto` for MTP models)            | (unset)                  |
+| `NO_CHUNKED_PREFILL`     | Set to `true` to disable chunked prefill (required for MTP)   | (unset)                  |
 | `TEMPERATURE`            | Sampling temperature                                          | 0.6                      |
 | `TOP_P`                  | Top-p (nucleus) sampling parameter                            | 0.95                     |
 | `TOP_K`                  | Top-k sampling parameter                                      | 20                       |
@@ -191,6 +193,26 @@ The framework supports five types of dataset inputs:
 
    - Runs benchmark on that specific file
    - Example: `DATASET="./my_data.jsonl"`
+
+## MTP (Built-in Head) Models
+
+Some models ship with a speculative head baked directly into the model checkpoint — there is no separate speculator to load. Qwen3-Next is one example: its MTP head is part of the verifier weights and driven by vLLM's native `--speculative-config '{"method": "mtp", ...}'`. See the Configuration Options table for the relevant settings (`METHOD`, `TOKENIZER_MODE`, `NO_CHUNKED_PREFILL`).
+
+### Reproducible benchmark: Qwen3-Next-80B finetuned MTP head
+
+The config `configs/qwen3-next-80b-mtp.env` points to a publicly available checkpoint finetuned on GSM8K math reasoning data. Anyone with 4× H100s can run this to reproduce the published results:
+
+```bash
+# Run on GPUs 0–3 (adjust CUDA_VISIBLE_DEVICES as needed)
+CUDA_VISIBLE_DEVICES=0,1,2,3 ./run_evaluation.sh -c configs/qwen3-next-80b-mtp.env
+```
+
+**Results** (benchmark: `RedHatAI/speculator_benchmarks:math_reasoning.jsonl`, `num_speculative_tokens=3`):
+
+| Checkpoint      | Pos0  | Pos1  | Pos2  | MeanAccepted  |
+| --------------- | ----- | ----- | ----- | ------------- |
+| Base MTP head   | 0.873 | 0.778 | 0.675 | 2.01          |
+| GSM8K finetuned | 0.934 | 0.891 | 0.838 | 2.46 (+22.5%) |
 
 ## Advanced Usage
 

--- a/examples/evaluate/eval-guidellm/README.md
+++ b/examples/evaluate/eval-guidellm/README.md
@@ -209,10 +209,10 @@ CUDA_VISIBLE_DEVICES=0,1,2,3 ./run_evaluation.sh -c configs/qwen3-next-80b-mtp.e
 
 **Results** (benchmark: `RedHatAI/speculator_benchmarks:math_reasoning.jsonl`, `num_speculative_tokens=3`):
 
-| Checkpoint      | Pos0  | Pos1  | Pos2  | MeanAccepted  |
-| --------------- | ----- | ----- | ----- | ------------- |
-| Base MTP head   | 0.873 | 0.778 | 0.675 | 2.01          |
-| GSM8K finetuned | 0.934 | 0.891 | 0.838 | 2.46 (+22.5%) |
+| Checkpoint      | Pos0  | Pos1  | Pos2  | MeanAccepted |
+| --------------- | ----- | ----- | ----- | ------------ |
+| Base MTP head   | 0.873 | 0.778 | 0.675 | 2.01         |
+| GSM8K finetuned | 0.934 | 0.891 | 0.838 | 2.46         |
 
 ## Advanced Usage
 

--- a/examples/evaluate/eval-guidellm/configs/qwen3-next-80b-mtp.env
+++ b/examples/evaluate/eval-guidellm/configs/qwen3-next-80b-mtp.env
@@ -1,0 +1,27 @@
+# Configuration for Qwen3-Next-80B with built-in MTP head (GSM8K finetuned)
+# Evaluation on math_reasoning dataset
+
+# Model configuration
+BASE_MODEL="inference-optimization/Qwen3-Next-80B-A3B-Instruct-GSM8K-MTP-finetuned"
+METHOD="mtp"
+NUM_SPEC_TOKENS=3
+
+# Dataset configuration
+DATASET="RedHatAI/speculator_benchmarks:math_reasoning.jsonl"
+
+# vLLM server settings
+TENSOR_PARALLEL_SIZE=4
+MAX_MODEL_LEN=24000
+GPU_MEMORY_UTILIZATION=0.8
+PORT=8000
+HEALTH_CHECK_TIMEOUT=600
+TOKENIZER_MODE="auto"
+NO_CHUNKED_PREFILL="true"
+
+# Sampling parameters
+TEMPERATURE=0.6
+TOP_P=0.95
+TOP_K=20
+
+# Output settings
+OUTPUT_DIR="eval_results_$(date +%Y%m%d_%H%M%S)"

--- a/examples/evaluate/eval-guidellm/run_evaluation.sh
+++ b/examples/evaluate/eval-guidellm/run_evaluation.sh
@@ -25,6 +25,8 @@ OUTPUT_DIR=""
 TEMPERATURE=""
 TOP_P=""
 TOP_K=""
+TOKENIZER_MODE=""
+NO_CHUNKED_PREFILL=""
 
 # ==============================================================================
 # Helper Functions
@@ -35,20 +37,22 @@ show_usage() {
 Usage: $0 [OPTIONS]
 
 Required (use one):
-  -c, --config FILE                    Config file (e.g., configs/llama-eagle3.env)
-  -b BASE_MODEL -s SPECULATOR_MODEL    Base model, speculator, and dataset via command line
-     -d DATASET
+  -c, --config FILE    Config file (e.g., configs/llama-eagle3.env)
+  -b BASE_MODEL        Base model path or HuggingFace ID
+     -d DATASET        Dataset for benchmarking
 
 Optional:
-  -o OUTPUT_DIR                        Output directory (default: eval_results_TIMESTAMP)
-  -h, --help                           Show this help message
+  -s SPECULATOR_MODEL  Speculator model (omit for built-in MTP heads)
+  -o OUTPUT_DIR        Output directory (default: eval_results_TIMESTAMP)
+  -h, --help           Show this help message
 
 Examples:
-  $0 -c configs/llama-3.3-70b-eagle3.env                      # Use config file
+  $0 -c configs/llama-3.3-70b-eagle3.env              # EAGLE3 via config file
+  $0 -c configs/qwen3-next-80b-mtp.env                 # MTP via config file
   $0 -b "RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic" \\
      -s "RedHatAI/Llama-3.3-70B-Instruct-speculator.eagle3" \\
-     -d "emulated"                                             # Use command line
-  $0 -c configs/llama-eagle3.env -d "different-dataset"       # Override dataset
+     -d "emulated"                                     # EAGLE3 via command line
+  $0 -c configs/llama-eagle3.env -d "other.jsonl"     # Override dataset
 EOF
 }
 
@@ -171,12 +175,6 @@ if [[ -z "${BASE_MODEL}" ]]; then
     exit 1
 fi
 
-if [[ -z "${SPECULATOR_MODEL}" ]]; then
-    echo "[ERROR] SPECULATOR_MODEL is required (set in config file or via -s)" >&2
-    show_usage
-    exit 1
-fi
-
 if [[ -z "${DATASET}" ]]; then
     echo "[ERROR] DATASET is required (set in config file or via -d)" >&2
     show_usage
@@ -214,18 +212,23 @@ ACCEPTANCE_RESULTS="${OUTPUT_DIR}/acceptance_analysis.txt"
 
 echo "[INFO] Starting vLLM server..."
 
-"${SCRIPT_DIR}/scripts/vllm_serve.sh" \
-    -b "${BASE_MODEL}" \
-    -s "${SPECULATOR_MODEL}" \
-    --num-spec-tokens "${NUM_SPEC_TOKENS}" \
-    --method "${METHOD}" \
-    --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}" \
-    --max-model-len "${MAX_MODEL_LEN}" \
-    --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
-    --port "${PORT}" \
-    --health-check-timeout "${HEALTH_CHECK_TIMEOUT}" \
-    --log-file "${SERVER_LOG}" \
+SERVE_ARGS=(
+    -b "${BASE_MODEL}"
+    --num-spec-tokens "${NUM_SPEC_TOKENS}"
+    --method "${METHOD}"
+    --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}"
+    --max-model-len "${MAX_MODEL_LEN}"
+    --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}"
+    --port "${PORT}"
+    --health-check-timeout "${HEALTH_CHECK_TIMEOUT}"
+    --log-file "${SERVER_LOG}"
     --pid-file "${SERVER_PID}"
+)
+[[ -n "${SPECULATOR_MODEL}" ]] && SERVE_ARGS+=(-s "${SPECULATOR_MODEL}")
+[[ -n "${TOKENIZER_MODE}" ]] && SERVE_ARGS+=(--tokenizer-mode "${TOKENIZER_MODE}")
+[[ "${NO_CHUNKED_PREFILL}" == "true" ]] && SERVE_ARGS+=(--no-enable-chunked-prefill)
+
+"${SCRIPT_DIR}/scripts/vllm_serve.sh" "${SERVE_ARGS[@]}"
 
 # ==============================================================================
 # Run GuideLLM Benchmark

--- a/examples/evaluate/eval-guidellm/run_evaluation.sh
+++ b/examples/evaluate/eval-guidellm/run_evaluation.sh
@@ -185,6 +185,12 @@ if ! check_dependencies; then
     exit 1
 fi
 
+# eagle3 requires an external speculator; mtp uses the built-in head
+if [[ "${METHOD}" == "eagle3" && -z "${SPECULATOR_MODEL}" ]]; then
+    echo "[ERROR] METHOD=eagle3 requires SPECULATOR_MODEL to be set (use -s or set it in the config file)" >&2
+    exit 1
+fi
+
 # Setup cleanup handler
 trap cleanup EXIT INT TERM
 

--- a/examples/evaluate/eval-guidellm/scripts/vllm_serve.sh
+++ b/examples/evaluate/eval-guidellm/scripts/vllm_serve.sh
@@ -18,6 +18,8 @@ PORT=""
 HEALTH_CHECK_TIMEOUT=""
 SERVER_LOG=""
 PID_FILE=""
+TOKENIZER_MODE=""
+NO_CHUNKED_PREFILL=""
 
 readonly SLEEP_INTERVAL=5
 
@@ -27,29 +29,37 @@ readonly SLEEP_INTERVAL=5
 
 show_usage() {
     cat << EOF
-Usage: $0 -b BASE_MODEL -s SPECULATOR_MODEL [OPTIONS]
+Usage: $0 -b BASE_MODEL [OPTIONS]
 
 Required:
   -b BASE_MODEL              Base model path or HuggingFace ID
-  -s SPECULATOR_MODEL        Speculator model path or HuggingFace ID
 
 Optional:
+  -s SPECULATOR_MODEL            Speculator model path or HuggingFace ID
+                                 (omit for built-in MTP heads)
   --num-spec-tokens TOKENS       Number of speculative tokens (default: 3)
   --method METHOD                Speculative decoding method (default: eagle3)
   --tensor-parallel-size SIZE    Number of GPUs (default: 1)
-  --max-model-len LENGTH      Max model length (default: 24000)
+  --max-model-len LENGTH         Max model length (default: 24000)
   --gpu-memory-utilization UTIL  GPU memory fraction (default: 0.85)
   --port PORT                    Server port (default: 8000)
   --health-check-timeout SECS    Health check timeout (default: 300)
-  --log-file FILE               Log file path (default: vllm_server.log)
-  --pid-file FILE               PID file path (default: vllm_server.pid)
-  -h, --help                    Show this help message
+  --log-file FILE                Log file path (default: vllm_server.log)
+  --pid-file FILE                PID file path (default: vllm_server.pid)
+  --tokenizer-mode MODE          Tokenizer mode passed to vllm (e.g. auto)
+  --no-enable-chunked-prefill    Pass --no-enable-chunked-prefill to vllm
+  -h, --help                     Show this help message
 
-Example:
+Examples:
+  # Eagle3 (separate speculator)
   $0 -b "RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic" \\
      -s "RedHatAI/Llama-3.3-70B-Instruct-speculator.eagle3" \\
-     --num-spec-tokens 3 \\
-     --method eagle3
+     --num-spec-tokens 3 --method eagle3
+
+  # MTP (built-in head)
+  $0 -b "Qwen/Qwen3-Next-80B-A3B-Instruct" \\
+     --num-spec-tokens 2 --method mtp \\
+     --tokenizer-mode auto --no-enable-chunked-prefill
 EOF
 }
 
@@ -99,6 +109,14 @@ while [[ $# -gt 0 ]]; do
             PID_FILE="$2"
             shift 2
             ;;
+        --tokenizer-mode)
+            TOKENIZER_MODE="$2"
+            shift 2
+            ;;
+        --no-enable-chunked-prefill)
+            NO_CHUNKED_PREFILL="true"
+            shift
+            ;;
         -h|--help)
             show_usage
             exit 0
@@ -136,11 +154,7 @@ if [[ -z "${BASE_MODEL}" ]]; then
     exit 1
 fi
 
-if [[ -z "${SPECULATOR_MODEL}" ]]; then
-    echo "[ERROR] Missing required argument: -s SPECULATOR_MODEL" >&2
-    show_usage
-    exit 1
-fi
+# SPECULATOR_MODEL is optional: omit for built-in MTP heads
 
 # ==============================================================================
 # Start Server
@@ -148,7 +162,7 @@ fi
 
 echo "[INFO] Starting vLLM server with speculative decoding"
 echo "[INFO]   Base model: ${BASE_MODEL}"
-echo "[INFO]   Speculator model: ${SPECULATOR_MODEL}"
+echo "[INFO]   Speculator model: ${SPECULATOR_MODEL:-(built-in MTP head)}"
 echo "[INFO]   Num speculative tokens: ${NUM_SPEC_TOKENS}"
 echo "[INFO]   Method: ${METHOD}"
 echo "[INFO]   Tensor parallel size: ${TENSOR_PARALLEL_SIZE}"
@@ -156,6 +170,22 @@ echo "[INFO]   Max model length: ${MAX_MODEL_LEN}"
 echo "[INFO]   GPU memory utilization: ${GPU_MEMORY_UTILIZATION}"
 echo "[INFO]   Port: ${PORT}"
 echo "[INFO]   Log file: ${SERVER_LOG}"
+[[ -n "${TOKENIZER_MODE}" ]] && echo "[INFO]   Tokenizer mode: ${TOKENIZER_MODE}"
+[[ "${NO_CHUNKED_PREFILL}" == "true" ]] && echo "[INFO]   Chunked prefill: disabled"
+
+# Build speculative-config JSON:
+#   With external speculator (Eagle): include model + max_model_len fields
+#   Without speculator (MTP built-in): method + num_speculative_tokens only
+if [[ -n "${SPECULATOR_MODEL}" ]]; then
+    SPEC_CONFIG="{\"model\": \"${SPECULATOR_MODEL}\", \"num_speculative_tokens\": ${NUM_SPEC_TOKENS}, \"method\": \"${METHOD}\", \"max_model_len\": ${MAX_MODEL_LEN}}"
+else
+    SPEC_CONFIG="{\"method\": \"${METHOD}\", \"num_speculative_tokens\": ${NUM_SPEC_TOKENS}}"
+fi
+
+# Build optional extra flags
+EXTRA_FLAGS=()
+[[ -n "${TOKENIZER_MODE}" ]] && EXTRA_FLAGS+=(--tokenizer-mode "${TOKENIZER_MODE}")
+[[ "${NO_CHUNKED_PREFILL}" == "true" ]] && EXTRA_FLAGS+=(--no-enable-chunked-prefill)
 
 vllm serve "${BASE_MODEL}" \
     --seed 42 \
@@ -163,7 +193,8 @@ vllm serve "${BASE_MODEL}" \
     --max-model-len "${MAX_MODEL_LEN}" \
     --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
     --port "${PORT}" \
-    --speculative-config "{\"model\": \"${SPECULATOR_MODEL}\", \"num_speculative_tokens\": ${NUM_SPEC_TOKENS}, \"method\": \"${METHOD}\", \"max_model_len\": ${MAX_MODEL_LEN}}" \
+    --speculative-config "${SPEC_CONFIG}" \
+    "${EXTRA_FLAGS[@]}" \
     > "${SERVER_LOG}" 2>&1 &
 
 VLLM_PID=$!

--- a/examples/evaluate/eval-guidellm/scripts/vllm_serve.sh
+++ b/examples/evaluate/eval-guidellm/scripts/vllm_serve.sh
@@ -187,6 +187,12 @@ EXTRA_FLAGS=()
 [[ -n "${TOKENIZER_MODE}" ]] && EXTRA_FLAGS+=(--tokenizer-mode "${TOKENIZER_MODE}")
 [[ "${NO_CHUNKED_PREFILL}" == "true" ]] && EXTRA_FLAGS+=(--no-enable-chunked-prefill)
 
+# Fail fast if the port is already in use rather than burying the error in vLLM logs
+if ss -tlnp 2>/dev/null | grep -q ":${PORT} " || nc -z 127.0.0.1 "${PORT}" 2>/dev/null; then
+    echo "[ERROR] Port ${PORT} is already in use. Stop the existing process or set PORT to a different value." >&2
+    exit 1
+fi
+
 vllm serve "${BASE_MODEL}" \
     --seed 42 \
     --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}" \


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Add support for models with built-in MTP (Multi-Token Prediction) speculative heads to the
eval-guidellm benchmark framework, so they can be evaluated without a separate speculator
checkpoint.

## Description

- `SPECULATOR_MODEL` is now optional; omit it for built-in MTP heads (e.g. Qwen3-Next-80B)
- Added `TOKENIZER_MODE` and `NO_CHUNKED_PREFILL` config variables for MTP compatibility
- `vllm_serve.sh` builds the speculative-config JSON conditionally — with or without an
  external speculator model — so both EAGLE3 and MTP paths use the same script
- Added `METHOD`/`SPECULATOR_MODEL` consistency guard: `METHOD=eagle3` without
  `SPECULATOR_MODEL` now fails with a clear error instead of a cryptic vLLM startup failure
- Added port-in-use check before launching vLLM
- Added `configs/qwen3-next-80b-mtp.env` for the GSM8K-finetuned Qwen3-Next-80B checkpoint
- Updated `README.md` with MTP architecture explanation and config table entries

## Related Issue

N/A

## Tests

```bash
cd examples/evaluate/eval-guidellm
CUDA_VISIBLE_DEVICES=0,1,2,3 ./run_evaluation.sh -c configs/qwen3-next-80b-mtp.env
```

<details>
<summary>Benchmark results (math_reasoning, 80 requests, num_speculative_tokens=3)</summary>

| Checkpoint      | Pos0  | Pos1  | Pos2  | MeanAccepted |
| --------------- | ----- | ----- | ----- | ------------ |
| Base MTP head   | 0.873 | 0.778 | 0.675 | 2.01         |
| GSM8K finetuned | 0.934 | 0.891 | 0.838 | 2.46         |

| Metric                       | Value                 |
| ---------------------------- | --------------------- |
| Position acceptance rates    | [0.892, 0.811, 0.708] |
| Conditional acceptance rates | [0.892, 0.909, 0.873] |
| Generation throughput        | 1532.6 tok/s          |
| Mean TTFT                    | 1088 ms               |
| Inter-token latency          | 6.2 ms                |

</details>

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
