### PR TITLE
Pin pygments version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ dev = [
     "mkdocstrings-python~=1.16.12",
     "mkdocs-gen-files~=0.5.0",
     "mkdocs-nav-weight~=0.2.0",
+    "pygments<2.20.0",
 
     # general and configurations
     "sphinx~=7.1.2",


### PR DESCRIPTION


<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
pygments==2.20.0 attempts to call `.replace` on a None object during docs build. This pr temporarily pins the version until the issue is resolved upstream.

## Related Issue

https://github.com/pygments/pygments/issues/3076

## Tests

CI.

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
