### PR TITLE
Expand E2E testing

### DIFF
--- a/tests/e2e/regression/test_eagle3_offline_acceptance.py
+++ b/tests/e2e/regression/test_eagle3_offline_acceptance.py
@@ -1,0 +1,27 @@
+"""E2E test for the offline training workflow.
+
+Exercises the full offline pipeline:
+  1. Prepare data (scripts/prepare_data.py)
+  2. Launch a vLLM server for hidden-state extraction (scripts/launch_vllm.py)
+  3. Generate hidden states offline (scripts/data_generation_offline2.py)
+  4. Stop the vLLM server
+  5. Train a draft model using pre-generated hidden states (scripts/train.py)
+  6. Validate the trained checkpoint via vLLM inference (run_vllm_engine)
+"""
+
+from pathlib import Path
+
+from tests.e2e.smoke.test_offline_training import run_offline_e2e
+
+
+def test_offline_regression(tmp_path: Path, prompts):
+    run_offline_e2e(
+        tmp_path,
+        "Qwen/Qwen3-8B",
+        max_samples=5000,
+        seq_length=8192,
+        vllm_gpu_util=0.9,
+        epochs=3,
+        prompts=prompts,
+        acceptance_thresholds=[0.4, 0.1, 0.01],
+    )

--- a/tests/e2e/regression/test_eagle3_online_acceptance.py
+++ b/tests/e2e/regression/test_eagle3_online_acceptance.py
@@ -1,0 +1,25 @@
+"""E2E test for the online training workflow.
+
+Exercises the full pipeline documented in examples/ONLINE_TRAINING.md:
+  1. Prepare data (scripts/prepare_data.py)
+  2. Launch a vLLM server for hidden-state extraction (scripts/launch_vllm.py)
+  3. Train a draft model against the live server (scripts/train.py)
+  4. Validate the trained checkpoint via vLLM inference (run_vllm_engine)
+"""
+
+from pathlib import Path
+
+from tests.e2e.smoke.test_online_training import run_online_e2e
+
+
+def test_online_regression(tmp_path: Path, prompts):
+    run_online_e2e(
+        tmp_path,
+        "Qwen/Qwen3-8B",
+        max_samples=5000,
+        seq_length=8192,
+        vllm_gpu_util=0.75,
+        epochs=3,
+        prompts=prompts,
+        acceptance_thresholds=[0.4, 0.1, 0.01],
+    )

--- a/tests/e2e/smoke/test_offline_training.py
+++ b/tests/e2e/smoke/test_offline_training.py
@@ -9,109 +9,85 @@ Exercises the full offline pipeline:
   6. Validate the trained checkpoint via vLLM inference (run_vllm_engine)
 """
 
-import subprocess
-import sys
 from pathlib import Path
 
 import pytest
-from loguru import logger
 
 from tests.e2e.utils import (
-    SCRIPTS_DIR,
-    launch_vllm_server,
-    prepare_data,
+    launch_vllm_server_context,
+    run_data_generation_offline2,
+    run_prepare_data,
+    run_training,
     run_vllm_engine,
-    stop_vllm_server,
 )
 
 MODEL = "Qwen/Qwen3-0.6B"
-VLLM_PORT = 8322
-
-
-@pytest.fixture
-def vllm_server(tmp_path):
-    """Launch a vLLM server configured for hidden-state extraction."""
-    hidden_states_path = str(tmp_path / "hidden_states")
-    process = launch_vllm_server(MODEL, VLLM_PORT, hidden_states_path)
-
-    yield {
-        "port": VLLM_PORT,
-        "hidden_states_path": hidden_states_path,
-        "process": process,
-    }
-
-    stop_vllm_server(process)
 
 
 @pytest.mark.e2e
 @pytest.mark.slow
-def test_offline_training(
-    tmp_path: Path, prompts: list[list[dict[str, str]]], vllm_server
+def test_offline_smoke(tmp_path: Path, prompts: list[list[dict[str, str]]]):
+    run_offline_e2e(tmp_path, MODEL, prompts=prompts, vllm_gpu_util=0.9)
+
+
+def run_offline_e2e(
+    tmp_path: Path,
+    model: str,
+    max_samples: int = 50,
+    seq_length: int = 512,
+    vllm_gpu_util: float = 0.5,
+    port: int = 8321,
+    draft_vocab_size: int = 8192,
+    epochs: int = 1,
+    lr: float = 3e-4,
+    prompts: list[list[dict[str, str]]] | None = None,
+    disable_compile_cache: bool = False,
+    max_tokens: int = 50,
+    ignore_eos: bool = True,
+    acceptance_thresholds: list[float] | None = None,
 ):
     data_path = tmp_path / "data"
-    hidden_states_path = tmp_path / "offline_hidden_states"
+    offline_hidden_states = tmp_path / "offline_hidden_states"
     save_path = tmp_path / "checkpoints"
-    port = vllm_server["port"]
 
     # Step 1: Prepare data
-    prepare_data(MODEL, data_path)
+    run_prepare_data(model, data_path, max_samples, seq_length)
 
-    # Step 2: Generate hidden states offline
-    datagen_cmd = [
-        sys.executable,
-        str(SCRIPTS_DIR / "data_generation_offline2.py"),
-        "--preprocessed-data",
-        str(data_path),
-        "--endpoint",
-        f"http://localhost:{port}/v1",
-        "--output",
-        str(hidden_states_path),
-        "--max-samples",
-        "50",
-        "--concurrency",
-        "4",
-        "--validate-outputs",
-    ]
-    logger.info("Generating hidden states offline: {}", " ".join(datagen_cmd))
-    result = subprocess.run(  # noqa: S603
-        datagen_cmd, stderr=subprocess.PIPE, text=True, check=False
+    with launch_vllm_server_context(
+        model,
+        port,
+        tmp_path / "vllm_hidden_states",
+        max_model_len=seq_length + 1,
+        gpu_memory_utilization=vllm_gpu_util,
+    ):
+        # Step 2: Generate hidden states offline
+        run_data_generation_offline2(
+            data_path, offline_hidden_states, port, max_samples
+        )
+
+    # Step 3: Train using pre-generated hidden states (no live server needed)
+    run_training(
+        model,
+        data_path,
+        save_path,
+        seq_length,
+        port,
+        draft_vocab_size,
+        epochs,
+        lr,
+        online=False,
+        hidden_states_path=offline_hidden_states,
     )
-    assert result.returncode == 0, (
-        f"data_generation_offline2.py failed:\n{result.stderr}"
-    )
 
-    # Step 3: Stop the vLLM server to free GPU memory before training
-    stop_vllm_server(vllm_server["process"])
-
-    # Step 4: Train using pre-generated hidden states (no live server needed)
-    train_cmd = [
-        sys.executable,
-        str(SCRIPTS_DIR / "train.py"),
-        "--verifier-name-or-path",
-        MODEL,
-        "--data-path",
-        str(data_path),
-        "--hidden-states-path",
-        str(hidden_states_path),
-        "--save-path",
-        str(save_path),
-        "--draft-vocab-size",
-        "8192",
-        "--epochs",
-        "1",
-        "--lr",
-        "3e-4",
-        "--total-seq-len",
-        "512",
-        "--on-missing",
-        "raise",
-    ]
-    logger.info("Running training: {}", " ".join(train_cmd))
-    result = subprocess.run(  # noqa: S603
-        train_cmd, stderr=subprocess.PIPE, text=True, check=False
-    )
-    assert result.returncode == 0, f"train.py failed:\n{result.stderr}"
-
-    # Step 5: Validate trained checkpoint with vLLM inference
-    checkpoint_path = str(save_path / "0")
-    run_vllm_engine(model_path=checkpoint_path, tmp_path=tmp_path, prompts=prompts)
+    # Step 4: Validate trained checkpoint with vLLM inference
+    if prompts is not None:
+        checkpoint_path = str(save_path / "checkpoint_best")
+        run_vllm_engine(
+            model_path=checkpoint_path,
+            tmp_path=tmp_path,
+            prompts=prompts,
+            disable_compile_cache=disable_compile_cache,
+            max_tokens=max_tokens,
+            ignore_eos=ignore_eos,
+            acceptance_thresholds=acceptance_thresholds,
+        )

--- a/tests/e2e/smoke/test_offline_training.py
+++ b/tests/e2e/smoke/test_offline_training.py
@@ -62,7 +62,11 @@ def run_offline_e2e(
     ):
         # Step 2: Generate hidden states offline
         run_data_generation_offline2(
-            data_path, offline_hidden_states, port, max_samples
+            data_path,
+            offline_hidden_states,
+            port,
+            max_samples,
+            timeout=25 * 60,  # 25 mins
         )
 
     # Step 3: Train using pre-generated hidden states (no live server needed)

--- a/tests/e2e/smoke/test_online_training.py
+++ b/tests/e2e/smoke/test_online_training.py
@@ -64,7 +64,15 @@ def run_online_e2e(
     ):
         # Step 2: Train against live vLLM server
         run_training(
-            model, data_path, save_path, seq_length, port, draft_vocab_size, epochs, lr
+            model,
+            data_path,
+            save_path,
+            seq_length,
+            port,
+            draft_vocab_size,
+            epochs,
+            lr,
+            timeout=30 * 60,  # 30 mins
         )
 
     # Step 3: Validate trained checkpoint with vLLM inference

--- a/tests/e2e/smoke/test_online_training.py
+++ b/tests/e2e/smoke/test_online_training.py
@@ -7,86 +7,75 @@ Exercises the full pipeline documented in examples/ONLINE_TRAINING.md:
   4. Validate the trained checkpoint via vLLM inference (run_vllm_engine)
 """
 
-import subprocess
-import sys
 from pathlib import Path
 
 import pytest
-from loguru import logger
 
 from tests.e2e.utils import (
-    SCRIPTS_DIR,
-    launch_vllm_server,
-    prepare_data,
+    launch_vllm_server_context,
+    run_prepare_data,
+    run_training,
     run_vllm_engine,
-    stop_vllm_server,
 )
 
 MODEL = "Qwen/Qwen3-0.6B"
-VLLM_PORT = 8321
-
-
-@pytest.fixture
-def vllm_server(tmp_path):
-    """Launch a vLLM server configured for hidden-state extraction."""
-    hidden_states_path = str(tmp_path / "hidden_states")
-    process = launch_vllm_server(MODEL, VLLM_PORT, hidden_states_path)
-
-    yield {
-        "port": VLLM_PORT,
-        "hidden_states_path": hidden_states_path,
-        "process": process,
-    }
-
-    stop_vllm_server(process)
 
 
 @pytest.mark.e2e
 @pytest.mark.slow
-def test_online_training(
-    tmp_path: Path, prompts: list[list[dict[str, str]]], vllm_server
+def test_online_smoke(tmp_path: Path, prompts: list[list[dict[str, str]]]):
+    run_online_e2e(tmp_path, MODEL, prompts=prompts)
+
+
+def run_online_e2e(
+    tmp_path: Path,
+    model: str,
+    max_samples: int = 50,
+    seq_length: int = 512,
+    vllm_gpu_util: float = 0.5,
+    port: int = 8321,
+    draft_vocab_size: int = 8192,
+    epochs: int = 1,
+    lr: float = 3e-4,
+    prompts: list[list[dict[str, str]]] | None = None,
+    disable_compile_cache: bool = False,
+    max_tokens: int = 50,
+    ignore_eos: bool = True,
+    acceptance_thresholds: list[float] | None = None,
 ):
+    """
+    Run online training e2e testing pipeline.
+
+    If prompts is None, skip testing the final model in vllm
+    """
     data_path = tmp_path / "data"
     save_path = tmp_path / "checkpoints"
-    port = vllm_server["port"]
 
     # Step 1: Prepare data
-    prepare_data(MODEL, data_path)
+    run_prepare_data(model, data_path, max_samples, seq_length)
 
-    # Step 2: Train against live vLLM server
-    train_cmd = [
-        sys.executable,
-        str(SCRIPTS_DIR / "train.py"),
-        "--verifier-name-or-path",
-        MODEL,
-        "--data-path",
-        str(data_path),
-        "--vllm-endpoint",
-        f"http://localhost:{port}/v1",
-        "--save-path",
-        str(save_path),
-        "--draft-vocab-size",
-        "8192",
-        "--epochs",
-        "1",
-        "--lr",
-        "3e-4",
-        "--total-seq-len",
-        "512",
-        "--on-missing",
-        "generate",
-        "--on-generate",
-        "delete",
-    ]
-    logger.info("Running training: {}", " ".join(train_cmd))
-    result = subprocess.run(  # noqa: S603
-        train_cmd, stderr=subprocess.PIPE, text=True, check=False
-    )
-    assert result.returncode == 0, f"train.py failed:\n{result.stderr}"
-
-    # Stop the vLLM server to free GPU memory before running inference
-    stop_vllm_server(vllm_server["process"])
+    hidden_states_path = str(tmp_path / "hidden_states")
+    with launch_vllm_server_context(
+        model,
+        port,
+        hidden_states_path,
+        max_model_len=seq_length + 1,
+        gpu_memory_utilization=vllm_gpu_util,
+    ):
+        # Step 2: Train against live vLLM server
+        run_training(
+            model, data_path, save_path, seq_length, port, draft_vocab_size, epochs, lr
+        )
 
     # Step 3: Validate trained checkpoint with vLLM inference
-    checkpoint_path = str(save_path / "0")
-    run_vllm_engine(model_path=checkpoint_path, tmp_path=tmp_path, prompts=prompts)
+    if prompts is not None:
+        checkpoint_path = str(save_path / "checkpoint_best")
+        run_vllm_engine(
+            model_path=checkpoint_path,
+            tmp_path=tmp_path,
+            prompts=prompts,
+            disable_compile_cache=disable_compile_cache,
+            max_tokens=max_tokens,
+            ignore_eos=ignore_eos,
+            acceptance_thresholds=acceptance_thresholds,
+        )

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -6,6 +6,7 @@ import time
 import urllib.error
 import urllib.request
 from collections.abc import Iterable
+from contextlib import contextmanager
 from pathlib import Path
 from textwrap import indent
 
@@ -15,7 +16,10 @@ __all__ = [
     "SCRIPTS_DIR",
     "VLLM_PYTHON",
     "launch_vllm_server",
-    "prepare_data",
+    "launch_vllm_server_context",
+    "run_data_generation_offline2",
+    "run_prepare_data",
+    "run_training",
     "run_vllm_engine",
     "stop_vllm_server",
     "wait_for_server",
@@ -74,7 +78,7 @@ def launch_vllm_server(
         str(SCRIPTS_DIR / "launch_vllm.py"),
         model,
         "--hidden-states-path",
-        hidden_states_path,
+        str(hidden_states_path),
         "--",
         "--port",
         str(port),
@@ -110,7 +114,16 @@ def stop_vllm_server(process: subprocess.Popen):
     logger.info("vLLM server stopped")
 
 
-def prepare_data(
+@contextmanager
+def launch_vllm_server_context(*args, **kwargs):
+    process = launch_vllm_server(*args, **kwargs)
+    try:
+        yield
+    finally:
+        stop_vllm_server(process)
+
+
+def run_prepare_data(
     model: str, data_path: Path, max_samples: int = 50, seq_length: int = 512
 ):
     """Tokenize ShareGPT data using prepare_data.py."""
@@ -133,6 +146,95 @@ def prepare_data(
         cmd, stderr=subprocess.PIPE, text=True, check=False
     )
     assert result.returncode == 0, f"prepare_data.py failed:\n{result.stderr}"
+
+
+def run_data_generation_offline2(
+    data_path: Path,
+    hidden_states_path: Path | None = None,
+    port: int = 8321,
+    max_samples: int = 50,
+    concurrency: int = 4,
+    validate_outputs: bool = True,
+):
+    datagen_cmd = [
+        sys.executable,
+        str(SCRIPTS_DIR / "data_generation_offline2.py"),
+        "--preprocessed-data",
+        str(data_path),
+        "--endpoint",
+        f"http://localhost:{port}/v1",
+        "--max-samples",
+        str(max_samples),
+        "--concurrency",
+        str(concurrency),
+    ]
+    if validate_outputs:
+        datagen_cmd.append("--validate-outputs")
+
+    if hidden_states_path is not None:
+        datagen_cmd += ["--output", str(hidden_states_path)]
+
+    logger.info("Generating hidden states offline: {}", " ".join(datagen_cmd))
+    result = subprocess.run(  # noqa: S603
+        datagen_cmd, stderr=subprocess.PIPE, text=True, check=False
+    )
+    assert result.returncode == 0, (
+        f"data_generation_offline2.py failed:\n{result.stderr}"
+    )
+
+
+def run_training(
+    model: str,
+    data_path: Path,
+    save_path: Path,
+    seq_length: int = 512,
+    port: int = 8321,
+    draft_vocab_size: int = 8192,
+    epochs: int = 1,
+    lr: float = 3e-4,
+    online: bool = True,
+    hidden_states_path: Path | None = None,
+):
+    train_cmd = [
+        sys.executable,
+        str(SCRIPTS_DIR / "train.py"),
+        "--verifier-name-or-path",
+        model,
+        "--data-path",
+        str(data_path),
+        "--vllm-endpoint",
+        f"http://localhost:{port}/v1",
+        "--save-path",
+        str(save_path),
+        "--draft-vocab-size",
+        str(draft_vocab_size),
+        "--epochs",
+        str(epochs),
+        "--lr",
+        str(lr),
+        "--total-seq-len",
+        str(seq_length),
+    ]
+    if online:
+        train_cmd += [
+            "--on-missing",
+            "generate",
+            "--on-generate",
+            "delete",
+        ]
+    else:
+        train_cmd += [
+            "--on-missing",
+            "raise",
+        ]
+    if hidden_states_path is not None:
+        train_cmd += ["--hidden-states-path", str(hidden_states_path)]
+
+    logger.info("Running training: {}", " ".join(train_cmd))
+    result = subprocess.run(  # noqa: S603
+        train_cmd, stderr=subprocess.PIPE, text=True, check=False
+    )
+    assert result.returncode == 0, f"train.py failed:\n{result.stderr}"
 
 
 def run_vllm_engine(

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -89,12 +89,18 @@ def launch_vllm_server(
     ]
     logger.info("Starting vLLM server: {}", " ".join(cmd))
 
-    process = subprocess.Popen(cmd)  # noqa: S603
+    process = subprocess.Popen(  # noqa: S603
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
 
     try:
         wait_for_server(port, process=process)
         logger.info("vLLM server ready on port {}", port)
     except Exception:
+        # Dump captured output to help debug startup failures
+        output = process.stdout.read().decode() if process.stdout else ""
+        if output:
+            logger.error("vLLM server output:\n{}", indent(output, "    "))
         process.terminate()
         process.wait(timeout=30)
         raise
@@ -111,7 +117,15 @@ def stop_vllm_server(process: subprocess.Popen):
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait(timeout=10)
-    logger.info("vLLM server stopped")
+    if process.returncode not in (0, -15):  # -15 = SIGTERM (expected)
+        output = process.stdout.read().decode() if process.stdout else ""
+        if output:
+            logger.error(
+                "vLLM server exited with code {}. Output:\n{}",
+                process.returncode,
+                indent(output, "    "),
+            )
+    logger.info("vLLM server stopped (exit code {})", process.returncode)
 
 
 @contextmanager
@@ -124,7 +138,11 @@ def launch_vllm_server_context(*args, **kwargs):
 
 
 def run_prepare_data(
-    model: str, data_path: Path, max_samples: int = 50, seq_length: int = 512
+    model: str,
+    data_path: Path,
+    max_samples: int = 50,
+    seq_length: int = 512,
+    timeout: float | None = None,
 ):
     """Tokenize ShareGPT data using prepare_data.py."""
     cmd = [
@@ -143,7 +161,7 @@ def run_prepare_data(
     ]
     logger.info("Preparing data: {}", " ".join(cmd))
     result = subprocess.run(  # noqa: S603
-        cmd, stderr=subprocess.PIPE, text=True, check=False
+        cmd, check=False, timeout=timeout
     )
     assert result.returncode == 0, f"prepare_data.py failed:\n{result.stderr}"
 
@@ -155,6 +173,7 @@ def run_data_generation_offline2(
     max_samples: int = 50,
     concurrency: int = 4,
     validate_outputs: bool = True,
+    timeout: float | None = None,
 ):
     datagen_cmd = [
         sys.executable,
@@ -176,7 +195,7 @@ def run_data_generation_offline2(
 
     logger.info("Generating hidden states offline: {}", " ".join(datagen_cmd))
     result = subprocess.run(  # noqa: S603
-        datagen_cmd, stderr=subprocess.PIPE, text=True, check=False
+        datagen_cmd, stderr=subprocess.PIPE, text=True, check=False, timeout=timeout
     )
     assert result.returncode == 0, (
         f"data_generation_offline2.py failed:\n{result.stderr}"
@@ -194,6 +213,7 @@ def run_training(
     lr: float = 3e-4,
     online: bool = True,
     hidden_states_path: Path | None = None,
+    timeout: float | None = None,
 ):
     train_cmd = [
         sys.executable,
@@ -232,7 +252,7 @@ def run_training(
 
     logger.info("Running training: {}", " ".join(train_cmd))
     result = subprocess.run(  # noqa: S603
-        train_cmd, stderr=subprocess.PIPE, text=True, check=False
+        train_cmd, stderr=subprocess.PIPE, text=True, check=False, timeout=timeout
     )
     assert result.returncode == 0, f"train.py failed:\n{result.stderr}"
 
@@ -245,6 +265,7 @@ def run_vllm_engine(
     max_tokens: int = 50,
     ignore_eos: bool = True,
     acceptance_thresholds: Iterable[float] | None = None,
+    timeout: float | None = None,
 ):
     VLLM_PYTHON = os.environ.get("VLLM_PYTHON", sys.executable)
     logger.info("vLLM Python executable: {}", VLLM_PYTHON)
@@ -292,6 +313,7 @@ def run_vllm_engine(
         text=True,
         check=False,
         env=env,
+        timeout=timeout,
     )
     logger.info("run_vllm.py output:\n{}", indent(result.stdout, "    "))
 
@@ -306,6 +328,7 @@ def run_vllm_engine(
     outputs_token_ids = results_dict["outputs"]
     metrics_dict = results_dict["metrics"]
     logger.info("outputs_token_ids: {}", outputs_token_ids)
+    logger.info("metrics_dict: {}", metrics_dict)
 
     for output_token_ids in outputs_token_ids:
         # If max_tokens is 100 or less, make sure the output length is max_tokens

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -163,7 +163,7 @@ def run_prepare_data(
     result = subprocess.run(  # noqa: S603
         cmd, check=False, timeout=timeout
     )
-    assert result.returncode == 0, f"prepare_data.py failed:\n{result.stderr}"
+    assert result.returncode == 0, "prepare_data.py failed"
 
 
 def run_data_generation_offline2(


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Refactors E2E testing into reusable components, so that it is easier to add new tests. Also adds regression tests for the new online/offline datagen + training + evaluation system.

<!--- Why your changes are needed -->

## Description

Factors out some of the e2e logic into:
- `run_data_generation_offline2`
- `run_training`
- `run_prepare_data`
- `launch_vllm_server`

Which can then we reused to create the different e2e workflows. Added a bunch of optional arguments to those e2e workflows allowing both smoke and regression tests to use the same workflow functions.

Adds new 5k sample regression tests for the online/offline e2e flows. 

<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests

Will manually trigger e2e test. 

<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
