### PR TITLE
Add Dependabot configuration for pip and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable Dependabot version update PRs
- Configures weekly checks for both `pip` (Python dependencies in `pyproject.toml`) and `github-actions` (workflow action versions)
- PRs will be opened automatically but **not** auto-merged

## Test plan
- [ ] Verify `.github/dependabot.yml` is valid YAML and accepted by GitHub
- [ ] Confirm Dependabot PRs appear after the next scheduled weekly run
- [ ] Confirm no auto-merge behavior is triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)