### PR TITLE
Fix optimizer resume bug

### DIFF
--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -111,20 +111,24 @@ class BaseCheckpointer:
     def best_path(self) -> Path:
         return self.path / "checkpoint_best"
 
-    def best_val_loss_path(self) -> Path:
-        return self.path / "checkpoint_best" / "metrics.json"
+    def val_metrics_path(self, epoch: int) -> Path:
+        return self.path / str(epoch) / "val_metrics.json"
 
-    def save_best_val_loss(self, val_loss: float):
-        self.path.mkdir(parents=True, exist_ok=True)
-        self.best_val_loss_path().write_text(json.dumps({"best_val_loss": val_loss}))
+    def save_val_metrics(self, epoch: int, val_metrics: dict[str, float]):
+        path = self.val_metrics_path(epoch)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(val_metrics))
 
     def load_best_val_loss(self) -> float | None:
-        p = self.best_val_loss_path()
+        best_epoch = self.read_best_epoch()
+        if best_epoch is None:
+            return None
+        p = self.val_metrics_path(best_epoch)
         if not p.exists():
             return None
         try:
             data = json.loads(p.read_text())
-            return float(data["best_val_loss"])
+            return float(data["loss_epoch"])
         except (json.JSONDecodeError, KeyError, ValueError, TypeError):
             return None
 
@@ -176,8 +180,6 @@ class BaseCheckpointer:
         if not keep_dir.exists() or not keep_dir.is_dir():
             raise FileNotFoundError(f"Best epoch dir does not exist: {keep_dir}")
 
-        val_loss_file = self.best_val_loss_path()
-
         for child in self.path.iterdir():
             # Keep the symlink itself
             if child == best_link:
@@ -185,10 +187,6 @@ class BaseCheckpointer:
 
             # Keep the best epoch directory
             if child == keep_dir:
-                continue
-
-            # Keep the best_val_loss file
-            if child == val_loss_file:
                 continue
 
             # Delete numbered epoch directories and any other stray dirs/files
@@ -352,9 +350,9 @@ class DistributedCheckpointer(BaseCheckpointer):
 
         dist.barrier()
 
-    def save_best_val_loss(self, val_loss: float):
+    def save_val_metrics(self, epoch: int, val_metrics: dict[str, float]):
         if dist.get_rank() == 0:
-            super().save_best_val_loss(val_loss)
+            super().save_val_metrics(epoch, val_metrics)
         dist.barrier()
 
     def save_scheduler_state_dict(

--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 from abc import abstractmethod
 from pathlib import Path
@@ -110,6 +111,23 @@ class BaseCheckpointer:
     def best_path(self) -> Path:
         return self.path / "checkpoint_best"
 
+    def best_val_loss_path(self) -> Path:
+        return self.path / "best_val_loss.json"
+
+    def save_best_val_loss(self, val_loss: float):
+        self.path.mkdir(parents=True, exist_ok=True)
+        self.best_val_loss_path().write_text(json.dumps({"best_val_loss": val_loss}))
+
+    def load_best_val_loss(self) -> float | None:
+        p = self.best_val_loss_path()
+        if not p.exists():
+            return None
+        try:
+            data = json.loads(p.read_text())
+            return float(data["best_val_loss"])
+        except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+            return None
+
     def read_best_epoch(self) -> int | None:
         """Return the epoch that `checkpoint_best` points to."""
         best_path = self.best_path()
@@ -158,6 +176,8 @@ class BaseCheckpointer:
         if not keep_dir.exists() or not keep_dir.is_dir():
             raise FileNotFoundError(f"Best epoch dir does not exist: {keep_dir}")
 
+        val_loss_file = self.best_val_loss_path()
+
         for child in self.path.iterdir():
             # Keep the symlink itself
             if child == best_link:
@@ -165,6 +185,10 @@ class BaseCheckpointer:
 
             # Keep the best epoch directory
             if child == keep_dir:
+                continue
+
+            # Keep the best_val_loss file
+            if child == val_loss_file:
                 continue
 
             # Delete numbered epoch directories and any other stray dirs/files
@@ -282,6 +306,12 @@ class DistributedCheckpointer(BaseCheckpointer):
             full_state_dict,
             options=StateDictOptions(full_state_dict=True, broadcast_from_rank0=True),
         )
+
+        # Cast step counters back to float32
+        for state in optimizer.state.values():
+            if "step" in state and isinstance(state["step"], torch.Tensor):
+                state["step"] = state["step"].float()
+
         dist.barrier()
 
     def save_checkpoint(
@@ -320,6 +350,11 @@ class DistributedCheckpointer(BaseCheckpointer):
         if dist.get_rank() == 0:
             super().cleanup_keep_only_best(best_epoch)
 
+        dist.barrier()
+
+    def save_best_val_loss(self, val_loss: float):
+        if dist.get_rank() == 0:
+            super().save_best_val_loss(val_loss)
         dist.barrier()
 
     def save_scheduler_state_dict(

--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -112,7 +112,7 @@ class BaseCheckpointer:
         return self.path / "checkpoint_best"
 
     def best_val_loss_path(self) -> Path:
-        return self.path / "best_val_loss.json"
+        return self.path / "checkpoint_best" / "metrics.json"
 
     def save_best_val_loss(self, val_loss: float):
         self.path.mkdir(parents=True, exist_ok=True)

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -274,8 +274,8 @@ class Trainer:
                 self.checkpointer.save_checkpoint(self.model, self.opt, epoch)
                 if self.scheduler is not None:
                     self.checkpointer.save_scheduler_state_dict(self.scheduler, epoch)
+                self.checkpointer.save_val_metrics(epoch, val_metrics)
                 self.checkpointer.update_best_symlink(epoch)
-                self.checkpointer.save_best_val_loss(self.best_val_loss)
                 root_logger.info(
                     f"Updated checkpoint_best -> {epoch} "
                     f"(loss_epoch={self.best_val_loss:.6f})"
@@ -290,6 +290,8 @@ class Trainer:
             self.checkpointer.save_checkpoint(self.model, self.opt, epoch)
             if self.scheduler is not None:
                 self.checkpointer.save_scheduler_state_dict(self.scheduler, epoch)
+            if val_metrics is not None:
+                self.checkpointer.save_val_metrics(epoch, val_metrics)
             root_logger.info(
                 f"Checkpoint saved to {self.checkpointer.path / str(epoch)}"
             )
@@ -304,7 +306,6 @@ class Trainer:
                     f"(loss_epoch={self.best_val_loss:.6f})"
                 )
                 self.checkpointer.update_best_symlink(epoch)
-                self.checkpointer.save_best_val_loss(self.best_val_loss)
                 root_logger.info(
                     f"Updated checkpoint_best -> {epoch} "
                     f"(loss_epoch={self.best_val_loss:.6f})"

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -91,6 +91,14 @@ class Trainer:
         self.global_step = 0
         self.best_val_loss = float("inf")
 
+        if self.resume_from_checkpoint and self.checkpointer.previous_epoch != -1:
+            saved = self.checkpointer.load_best_val_loss()
+            if saved is not None:
+                self.best_val_loss = saved
+                root_logger.info(
+                    f"Restored best_val_loss={self.best_val_loss:.6f} from checkpoint"
+                )
+
     def setup_model(self):
         # Verify model is compatible with training infrastructure
         SpeculatorModel.verify_training_compatible(self.model)
@@ -104,9 +112,7 @@ class Trainer:
             # Single device case
             self.model.to(self.local_rank)  # type: ignore[arg-type]
             if load_checkpoint:
-                restored_from_best = self.init_best_val_loss_from_checkpoint_best()
-                if not restored_from_best:
-                    self.checkpointer.load_model_state_dict(self.model)
+                self.checkpointer.load_model_state_dict(self.model)
             return
 
         # Distributed case
@@ -118,9 +124,7 @@ class Trainer:
         apply_fully_sharded(self.model)
 
         if load_checkpoint:
-            restored_from_best = self.init_best_val_loss_from_checkpoint_best()
-            if not restored_from_best:
-                self.checkpointer.load_model_state_dict(self.model)
+            self.checkpointer.load_model_state_dict(self.model)
         else:
             # Broadcast full state dict from rank 0 to all ranks
             set_model_state_dict(
@@ -134,55 +138,6 @@ class Trainer:
             )
             del full_state_dict
             dist.barrier()
-
-    def init_best_val_loss_from_checkpoint_best(self) -> bool:
-        """
-        If resuming and checkpoint_best exists, initialize self.best_val_loss.
-        If checkpoint_best is missing or broken, keep best_val_loss as inf).
-        """
-        best_epoch = self.checkpointer.read_best_epoch()
-
-        if best_epoch is None:
-            return False
-
-        if self.val_loader is None:
-            root_logger.warning(
-                f"Found checkpoint_best -> {best_epoch} but no val_loader; "
-                f"leaving best_val_loss=inf."
-            )
-            return False
-
-        last_epoch = self.checkpointer.previous_epoch  # Epoch to resume from
-
-        root_logger.info(
-            f"Initializing best_val_loss from checkpoint_best -> {best_epoch} "
-            f"(will resume from epoch {last_epoch})"
-        )
-
-        self.checkpointer.load_model_state_dict_for_epoch(self.model, best_epoch)
-        val_metrics = self.val_epoch(best_epoch)
-
-        val_loss = None
-        if val_metrics is not None and "loss_epoch" in val_metrics:
-            val_loss = float(val_metrics["loss_epoch"])
-
-        if val_loss is None:
-            root_logger.warning(
-                f"Could not compute loss_epoch for checkpoint_best -> {best_epoch}; "
-                "leaving best_val_loss=inf."
-            )
-        else:
-            self.best_val_loss = val_loss
-            root_logger.info(
-                f"Restored best_val_loss={self.best_val_loss:.6f} "
-                f"from checkpoint_best -> {best_epoch}"
-            )
-
-        # Restore LAST weights so training resumes normally
-        if last_epoch != best_epoch:
-            self.checkpointer.load_model_state_dict_for_epoch(self.model, last_epoch)
-
-        return True
 
     def setup_optimizer(self):
         # Setup optimizer
@@ -320,6 +275,7 @@ class Trainer:
                 if self.scheduler is not None:
                     self.checkpointer.save_scheduler_state_dict(self.scheduler, epoch)
                 self.checkpointer.update_best_symlink(epoch)
+                self.checkpointer.save_best_val_loss(self.best_val_loss)
                 root_logger.info(
                     f"Updated checkpoint_best -> {epoch} "
                     f"(loss_epoch={self.best_val_loss:.6f})"
@@ -348,6 +304,7 @@ class Trainer:
                     f"(loss_epoch={self.best_val_loss:.6f})"
                 )
                 self.checkpointer.update_best_symlink(epoch)
+                self.checkpointer.save_best_val_loss(self.best_val_loss)
                 root_logger.info(
                     f"Updated checkpoint_best -> {epoch} "
                     f"(loss_epoch={self.best_val_loss:.6f})"

--- a/tests/e2e/smoke/test_resume_optimizer.py
+++ b/tests/e2e/smoke/test_resume_optimizer.py
@@ -1,0 +1,107 @@
+"""E2E regression test: resume from checkpoint with checkpoint_best symlink.
+
+Verifies that distributed training can resume from a checkpoint when
+checkpoint_best exists.
+
+Steps:
+  1. Prepare data
+  2. Generate hidden states offline (via vLLM server)
+  3. Train for 1 epoch with --save-best (creates checkpoint_best symlink)
+  4. Resume training for epoch 2
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from loguru import logger
+
+from tests.e2e.utils import (
+    SCRIPTS_DIR,
+    launch_vllm_server_context,
+    run_data_generation_offline2,
+    run_prepare_data,
+)
+
+MODEL = "Qwen/Qwen3-0.6B"
+VLLM_PORT = 8323
+
+
+def _run_distributed_training(
+    data_path: Path,
+    hidden_states_path: Path,
+    save_path: Path,
+    *,
+    epochs: int,
+    nproc: int = 2,
+) -> subprocess.CompletedProcess:
+    """Run distributed training via torchrun with --save-best."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--nproc_per_node",
+        str(nproc),
+        str(SCRIPTS_DIR / "train.py"),
+        "--verifier-name-or-path",
+        MODEL,
+        "--speculator-type",
+        "eagle3",
+        "--data-path",
+        str(data_path),
+        "--hidden-states-path",
+        str(hidden_states_path),
+        "--save-path",
+        str(save_path),
+        "--draft-vocab-size",
+        "8192",
+        "--lr",
+        "3e-4",
+        "--total-seq-len",
+        "512",
+        "--on-missing",
+        "raise",
+        "--save-best",
+        "--epochs",
+        str(epochs),
+    ]
+    logger.info("Running distributed training: {}", " ".join(cmd))
+    return subprocess.run(  # noqa: S603
+        cmd, stderr=subprocess.PIPE, text=True, check=False
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+def test_resume_after_checkpoint_best(tmp_path: Path):
+    data_path = tmp_path / "data"
+    hidden_states_path = tmp_path / "offline_hidden_states"
+    save_path = tmp_path / "checkpoints"
+
+    # Step 1: Prepare data
+    run_prepare_data(MODEL, data_path)
+
+    # Step 2: Generate hidden states offline
+    with launch_vllm_server_context(
+        MODEL, VLLM_PORT, str(tmp_path / "hidden_states")
+    ):
+        run_data_generation_offline2(data_path, hidden_states_path, port=VLLM_PORT)
+
+    # Step 3: Train 1 epoch with --save-best
+    result = _run_distributed_training(
+        data_path, hidden_states_path, save_path, epochs=1
+    )
+    assert result.returncode == 0, f"Training epoch 0 failed:\n{result.stderr}"
+
+    checkpoint_best = save_path / "checkpoint_best"
+    assert checkpoint_best.is_symlink(), "checkpoint_best symlink was not created"
+    logger.info("checkpoint_best -> {}", checkpoint_best.resolve())
+
+    # Step 4: Resume training for epoch 2
+    result = _run_distributed_training(
+        data_path, hidden_states_path, save_path, epochs=2
+    )
+    assert result.returncode == 0, (
+        f"Resume from checkpoint failed (optimizer loading bug?):\n{result.stderr}"
+    )

--- a/tests/e2e/smoke/test_resume_optimizer.py
+++ b/tests/e2e/smoke/test_resume_optimizer.py
@@ -83,9 +83,7 @@ def test_resume_after_checkpoint_best(tmp_path: Path):
     run_prepare_data(MODEL, data_path)
 
     # Step 2: Generate hidden states offline
-    with launch_vllm_server_context(
-        MODEL, VLLM_PORT, str(tmp_path / "hidden_states")
-    ):
+    with launch_vllm_server_context(MODEL, VLLM_PORT, str(tmp_path / "hidden_states")):
         run_data_generation_offline2(data_path, hidden_states_path, port=VLLM_PORT)
 
     # Step 3: Train 1 epoch with --save-best

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -209,18 +209,22 @@ def test_checkpoint_freq_flag_controls_saves(
     assert best_path.resolve() == (tmp_path / "5").resolve()
 
 
-def test_save_and_load_best_val_loss(tmp_path: Path):
+def test_save_and_load_val_metrics(tmp_path: Path):
     cp = SingleGPUCheckpointer(str(tmp_path))
 
     # No file yet
     assert cp.load_best_val_loss() is None
 
-    # Save and reload
-    cp.save_best_val_loss(0.123456)
+    # Save val_metrics for epoch 0 and point checkpoint_best at it
+    (tmp_path / "0").mkdir()
+    cp.save_val_metrics(0, {"loss_epoch": 0.123456, "full_acc_0_epoch": 0.5})
+    cp.update_best_symlink(0)
     assert cp.load_best_val_loss() == pytest.approx(0.123456)
 
-    # Overwrite
-    cp.save_best_val_loss(0.05)
+    # Save better metrics for epoch 1 and update best
+    (tmp_path / "1").mkdir()
+    cp.save_val_metrics(1, {"loss_epoch": 0.05, "full_acc_0_epoch": 0.7})
+    cp.update_best_symlink(1)
     assert cp.load_best_val_loss() == pytest.approx(0.05)
 
 
@@ -228,7 +232,8 @@ def test_best_val_loss_restored_on_resume(tmp_path: Path):
     (tmp_path / "4").mkdir()
 
     cp = SingleGPUCheckpointer(str(tmp_path))
-    cp.save_best_val_loss(0.42)
+    cp.save_val_metrics(4, {"loss_epoch": 0.42, "full_acc_0_epoch": 0.6})
+    cp.update_best_symlink(4)
 
     trainer = Trainer.__new__(Trainer)
     trainer.resume_from_checkpoint = True

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -209,58 +209,40 @@ def test_checkpoint_freq_flag_controls_saves(
     assert best_path.resolve() == (tmp_path / "5").resolve()
 
 
-def test_init_best_val_loss_on_resume_with_and_without_checkpoint_best(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
-    (tmp_path / "0").mkdir()
+def test_save_and_load_best_val_loss(tmp_path: Path):
+    cp = SingleGPUCheckpointer(str(tmp_path))
+
+    # No file yet
+    assert cp.load_best_val_loss() is None
+
+    # Save and reload
+    cp.save_best_val_loss(0.123456)
+    assert cp.load_best_val_loss() == pytest.approx(0.123456)
+
+    # Overwrite
+    cp.save_best_val_loss(0.05)
+    assert cp.load_best_val_loss() == pytest.approx(0.05)
+
+
+def test_best_val_loss_restored_on_resume(tmp_path: Path):
     (tmp_path / "4").mkdir()
-    (tmp_path / "checkpoint_best").symlink_to("0", target_is_directory=True)
+
+    cp = SingleGPUCheckpointer(str(tmp_path))
+    cp.save_best_val_loss(0.42)
 
     trainer = Trainer.__new__(Trainer)
+    trainer.resume_from_checkpoint = True
     trainer.is_distributed = False
     trainer.local_rank = 0
-    trainer.val_loader = cast("DataLoader[Any]", [])
+    trainer.checkpointer = cp
+
+    trainer.current_epoch = cp.previous_epoch + 1
+    trainer.global_step = 0
     trainer.best_val_loss = float("inf")
-    trainer.model = cast("SpeculatorModel", object())
-    trainer.checkpointer = SingleGPUCheckpointer(str(tmp_path))
 
-    calls: list[int] = []
+    # Simulate the load that setup_trainer does
+    saved = trainer.checkpointer.load_best_val_loss()
+    if saved is not None:
+        trainer.best_val_loss = saved
 
-    def fake_load_for_epoch(_model, epoch: int, float_dtype=None):
-        calls.append(epoch)
-
-    monkeypatch.setattr(
-        trainer.checkpointer, "load_model_state_dict_for_epoch", fake_load_for_epoch
-    )
-    monkeypatch.setattr(trainer, "val_epoch", lambda epoch: {"loss_epoch": 0.123})
-
-    trainer.init_best_val_loss_from_checkpoint_best()
-
-    assert trainer.best_val_loss == 0.123
-    assert calls == [0, 4]
-
-    tmp2 = tmp_path / "no_best"
-    tmp2.mkdir()
-    (tmp2 / "4").mkdir()
-
-    trainer2 = Trainer.__new__(Trainer)
-    trainer2.is_distributed = False
-    trainer2.local_rank = 0
-    trainer2.val_loader = cast("DataLoader[Any]", [])
-    trainer2.best_val_loss = float("inf")
-    trainer2.model = cast("SpeculatorModel", object())
-    trainer2.checkpointer = SingleGPUCheckpointer(str(tmp2))
-
-    calls2: list[int] = []
-
-    monkeypatch.setattr(
-        trainer2.checkpointer,
-        "load_model_state_dict_for_epoch",
-        lambda *_args, **_kwargs: calls2.append(1),
-    )
-    monkeypatch.setattr(trainer2, "val_epoch", lambda epoch: {"loss_epoch": 0.001})
-
-    trainer2.init_best_val_loss_from_checkpoint_best()
-
-    assert trainer2.best_val_loss == float("inf")
-    assert calls2 == []
+    assert trainer.best_val_loss == pytest.approx(0.42)


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
Fix optimizer resume dtype error.    
<!--- Why your changes are needed -->

## Description

When we resume distributed training from the previous `best_checkpoint`, there is a type mismatch bug.
```
RuntimeError: aten._foreach_mul_.Scalar: got mixed torch.Tensor and DTensor, need to convert all torch.Tensor to DTensor before calling distributed operators!
```
This is because `init_best_val_loss_from_checkpoint_best()` was called inside `setup_model()`,  we ran a forward pass in validation to calculate the `best_val_loss`. This forward pass converts model parameters into DTensors with some other bookkeeping params and `set_optimizer_state_dict` then crashes because it was expecting clean tensors. 

There's another issue with `step` data type now because `convert_float_dtype` casts all floating-point tensors to bfloat16 when saving/loading, including Adam's step counters. PyTorch's `_group_tensors_by_device_and_dtype` only exempts CPU step tensors that are float32 or float64, so bfloat16 step tensors cause a  device/dtype grouping error at optimizer.step().   

Now we're saving `best_val_loss` in a json along with best checkpoint and loading it directly instead of running a full validation forward pass to avoid this type mismatch and casting step dtype back to float32.

<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests

Added `/home/shanjiaz/speculators/tests/e2e/smoke/test_resume_optimizer.py` and ran locally to make sure it captures this bug properly. Had to update `tests/unit/train/test_checkpoint.py` as well because the flow is now different. 

<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
