### PR TITLE
Add timeouts/retries to all vllm requests

### DIFF
--- a/scripts/data_generation_offline2.py
+++ b/scripts/data_generation_offline2.py
@@ -402,7 +402,9 @@ async def generate_and_save_hidden_states(args, dataset):
         max_consec = args.concurrency
     failure_tracker = _FailureTracker(max_consec) if not args.fail_on_error else None
 
-    async with openai.AsyncOpenAI(base_url=args.endpoint, api_key="EMPTY") as client:
+    async with openai.AsyncOpenAI(
+        base_url=args.endpoint, api_key="EMPTY", max_retries=0
+    ) as client:
         list_models = await client.models.list()
         model_id = list_models.data[0].id
         if args.model and args.model != model_id:

--- a/scripts/data_generation_offline2.py
+++ b/scripts/data_generation_offline2.py
@@ -333,6 +333,45 @@ async def worker(
             queue.task_done()
 
 
+async def _feed_queue(to_process, dataset, queue, cancel_event):
+    """Feed dataset items into the worker queue, respecting cancellation."""
+    for i in to_process:
+        if cancel_event.is_set():
+            break
+        item = dataset[i]
+        # Check cancel_event while waiting for queue space to avoid
+        # deadlocking when all workers have died.
+        while not cancel_event.is_set():
+            try:
+                queue.put_nowait({"idx": i, "input_ids": item["input_ids"]})
+                break
+            except asyncio.QueueFull:
+                await asyncio.sleep(0.1)
+
+
+async def _shutdown_workers(workers, queue, cancel_event):
+    """Shut down workers and propagate the first real exception."""
+    logger.info("Waiting for remaining file saves to complete...")
+    if cancel_event.is_set():
+        # Workers may be dead or draining — cancel any that are
+        # still alive so we don't deadlock on sentinel puts.
+        for w in workers:
+            if not w.done():
+                w.cancel()
+    else:
+        # Normal shutdown: send sentinel values so workers exit
+        for _ in range(len(workers)):
+            await queue.put(None)
+    results = await asyncio.gather(*workers, return_exceptions=True)
+
+    # Propagate the first real worker exception (skip CancelledError)
+    for result in results:
+        if isinstance(result, Exception) and not isinstance(
+            result, asyncio.CancelledError
+        ):
+            raise result
+
+
 async def generate_and_save_hidden_states(args, dataset):
     if args.output is None:
         hidden_states_dir = Path(args.preprocessed_data) / "hidden_states"
@@ -396,38 +435,8 @@ async def generate_and_save_hidden_states(args, dataset):
                 for _ in range(args.concurrency * 2)
             ]
 
-            for i in to_process:
-                if cancel_event.is_set():
-                    break
-                item = dataset[i]
-                # Check cancel_event while waiting for queue space to avoid
-                # deadlocking when all workers have died.
-                while not cancel_event.is_set():
-                    try:
-                        queue.put_nowait({"idx": i, "input_ids": item["input_ids"]})
-                        break
-                    except asyncio.QueueFull:
-                        await asyncio.sleep(0.1)
-
-            logger.info("Waiting for remaining file saves to complete...")
-            if cancel_event.is_set():
-                # Workers may be dead or draining — cancel any that are
-                # still alive so we don't deadlock on sentinel puts.
-                for w in workers:
-                    if not w.done():
-                        w.cancel()
-            else:
-                # Normal shutdown: send sentinel values so workers exit
-                for _ in range(len(workers)):
-                    await queue.put(None)
-            results = await asyncio.gather(*workers, return_exceptions=True)
-
-    # Propagate the first real worker exception (skip CancelledError)
-    for result in results:
-        if isinstance(result, Exception) and not isinstance(
-            result, asyncio.CancelledError
-        ):
-            raise result
+            await _feed_queue(to_process, dataset, queue, cancel_event)
+            await _shutdown_workers(workers, queue, cancel_event)
 
     num_saved = len(to_process) - len(skipped_indices)
     logger.info(f"Saved {num_saved} new data points to {args.output}")

--- a/scripts/data_generation_offline2.py
+++ b/scripts/data_generation_offline2.py
@@ -25,10 +25,35 @@ from datasets import load_from_disk
 from safetensors import safe_open
 from tqdm import tqdm
 
-from speculators.data_generation.vllm_client import generate_hidden_states_async
+from speculators.data_generation.vllm_client import (
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_REQUEST_TIMEOUT,
+    generate_hidden_states_async,
+)
 from speculators.train.logger import setup_root_logger
 
 logger = logging.getLogger(__name__)
+
+
+class _FailureTracker:
+    """Tracks consecutive sample failures across async workers.
+
+    When the number of consecutive failures (with no successes in between)
+    reaches ``threshold``, the tracker signals that the run should abort.
+    Because asyncio is single-threaded, no locking is needed.
+    """
+
+    def __init__(self, threshold: int):
+        self.threshold = threshold
+        self._consecutive = 0
+
+    def record_success(self) -> None:
+        self._consecutive = 0
+
+    def record_failure(self) -> bool:
+        """Record a failure. Returns True when the threshold is reached."""
+        self._consecutive += 1
+        return self._consecutive >= self.threshold
 
 
 def parse_args():
@@ -106,6 +131,44 @@ def parse_args():
         help=(
             "Load generated safetensor files and check output token ids match prompt"
             " tokens and hidden states seq_len matches num tokens"
+        ),
+    )
+    parser.add_argument(
+        "--request-timeout",
+        type=float,
+        default=DEFAULT_REQUEST_TIMEOUT,
+        help=(
+            "Timeout in seconds for each individual vLLM request "
+            f"(default: {DEFAULT_REQUEST_TIMEOUT})"
+        ),
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=DEFAULT_MAX_RETRIES,
+        help=(
+            "Maximum number of retry attempts per request on failure "
+            f"(default: {DEFAULT_MAX_RETRIES})"
+        ),
+    )
+    parser.add_argument(
+        "--fail-on-error",
+        action="store_true",
+        help=(
+            "Abort when a request fails after all retries. "
+            "By default, failed samples are skipped."
+        ),
+    )
+    parser.add_argument(
+        "--max-consecutive-errors",
+        type=int,
+        default=None,
+        help=(
+            "Abort after this many consecutive sample failures (each sample "
+            "already retried --max-retries times). Prevents silently churning "
+            "through the entire dataset when the server is down. "
+            "Ignored when --fail-on-error is set. "
+            "(default: value of --concurrency)"
         ),
     )
 
@@ -208,6 +271,12 @@ async def worker(
     write_semaphore: asyncio.Semaphore,
     hidden_states_output_dir: Path,
     validate_outputs: bool,
+    request_timeout: float | None,
+    max_retries: int,
+    fail_on_error: bool,
+    skipped_indices: list[int],
+    cancel_event: asyncio.Event,
+    failure_tracker: _FailureTracker | None,
 ):
     """Worker that pulls items from queue and sends them to the vLLM endpoint."""
     while True:
@@ -217,6 +286,12 @@ async def worker(
             return
 
         idx = item["idx"]
+
+        # Drain remaining items quickly after cancellation
+        if cancel_event.is_set():
+            queue.task_done()
+            continue
+
         input_ids = item["input_ids"].tolist()
 
         target_hidden_states_path = hidden_states_output_dir / f"hs_{idx}.safetensors"
@@ -224,7 +299,11 @@ async def worker(
         try:
             async with vllm_semaphore:  # Limit number of active generate calls
                 hidden_states_path = await generate_hidden_states_async(
-                    client, model, input_ids
+                    client,
+                    model,
+                    input_ids,
+                    timeout=request_timeout,
+                    max_retries=max_retries,
                 )
             async with write_semaphore:  # Limit number of active disk writes
                 await asyncio.to_thread(
@@ -234,6 +313,21 @@ async def worker(
                     await asyncio.to_thread(
                         check_safetensors_file, target_hidden_states_path, input_ids
                     )
+        except Exception as e:
+            if fail_on_error:
+                cancel_event.set()
+                raise
+            logger.warning("Skipping sample %d due to error: %s", idx, e)
+            skipped_indices.append(idx)
+            if failure_tracker is not None and failure_tracker.record_failure():
+                cancel_event.set()
+                raise RuntimeError(
+                    f"Aborting: {failure_tracker.threshold} consecutive samples "
+                    "failed. The vLLM server may be unreachable."
+                ) from e
+        else:
+            if failure_tracker is not None:
+                failure_tracker.record_success()
         finally:
             pbar.update(1)
             queue.task_done()
@@ -261,6 +355,14 @@ async def generate_and_save_hidden_states(args, dataset):
     vllm_semaphore = asyncio.Semaphore(args.concurrency)
     write_semaphore = asyncio.Semaphore(args.concurrency)
 
+    skipped_indices: list[int] = []
+    cancel_event = asyncio.Event()
+
+    max_consec = args.max_consecutive_errors
+    if max_consec is None:
+        max_consec = args.concurrency
+    failure_tracker = _FailureTracker(max_consec) if not args.fail_on_error else None
+
     async with openai.AsyncOpenAI(base_url=args.endpoint, api_key="EMPTY") as client:
         list_models = await client.models.list()
         model_id = list_models.data[0].id
@@ -283,22 +385,56 @@ async def generate_and_save_hidden_states(args, dataset):
                         write_semaphore,
                         hidden_states_dir,
                         args.validate_outputs,
+                        args.request_timeout,
+                        args.max_retries,
+                        args.fail_on_error,
+                        skipped_indices,
+                        cancel_event,
+                        failure_tracker,
                     )
                 )
                 for _ in range(args.concurrency * 2)
             ]
 
             for i in to_process:
+                if cancel_event.is_set():
+                    break
                 item = dataset[i]
-                await queue.put({"idx": i, "input_ids": item["input_ids"]})
+                # Check cancel_event while waiting for queue space to avoid
+                # deadlocking when all workers have died.
+                while not cancel_event.is_set():
+                    try:
+                        queue.put_nowait({"idx": i, "input_ids": item["input_ids"]})
+                        break
+                    except asyncio.QueueFull:
+                        await asyncio.sleep(0.1)
 
             logger.info("Waiting for remaining file saves to complete...")
-            # Signale workers to stop
-            for _ in range(len(workers)):
-                await queue.put(None)
-            await asyncio.gather(*workers)
+            if cancel_event.is_set():
+                # Workers may be dead or draining — cancel any that are
+                # still alive so we don't deadlock on sentinel puts.
+                for w in workers:
+                    if not w.done():
+                        w.cancel()
+            else:
+                # Normal shutdown: send sentinel values so workers exit
+                for _ in range(len(workers)):
+                    await queue.put(None)
+            results = await asyncio.gather(*workers, return_exceptions=True)
 
-    logger.info(f"Saved {len(to_process)} new data points to {args.output}")
+    # Propagate the first real worker exception (skip CancelledError)
+    for result in results:
+        if isinstance(result, Exception) and not isinstance(
+            result, asyncio.CancelledError
+        ):
+            raise result
+
+    num_saved = len(to_process) - len(skipped_indices)
+    logger.info(f"Saved {num_saved} new data points to {args.output}")
+    if skipped_indices:
+        logger.warning(
+            f"Skipped {len(skipped_indices)} samples due to errors: {skipped_indices}"
+        )
 
 
 def main():

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -11,6 +11,10 @@ from transformers import LlamaConfig, PretrainedConfig
 from transformers.models.auto.configuration_auto import AutoConfig
 from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 
+from speculators.data_generation.vllm_client import (
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_REQUEST_TIMEOUT,
+)
 from speculators.model import SpeculatorModel
 from speculators.models.eagle3.data import shift_batch
 from speculators.train.data import (
@@ -296,6 +300,8 @@ def main(args: argparse.Namespace):
             split_ratio=0.9,
             model=args.verifier_name_or_path,
             hidden_states_dtype=hidden_states_dtype,
+            request_timeout=args.request_timeout,
+            max_retries=args.max_retries,
         )
         val_dataset = ArrowDataset(
             datapath=args.data_path,
@@ -307,6 +313,8 @@ def main(args: argparse.Namespace):
             split_ratio=-0.1,
             model=args.verifier_name_or_path,
             hidden_states_dtype=hidden_states_dtype,
+            request_timeout=args.request_timeout,
+            max_retries=args.max_retries,
         )
 
     train_loader = setup_dataloader(
@@ -423,6 +431,26 @@ def parse_args():
             "the hidden states in the args.hidden_states_path. This can be used to "
             "enable hybrid online/offline training, with hidden states generated on the"
             "first epoch, and reused on subsequent epochs."
+        ),
+    )
+    parser.add_argument(
+        "--request-timeout",
+        type=float,
+        default=DEFAULT_REQUEST_TIMEOUT,
+        help=(
+            "Timeout in seconds for each individual vLLM request "
+            f"(default: {DEFAULT_REQUEST_TIMEOUT}). "
+            "Only applies if --on-missing=generate."
+        ),
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=DEFAULT_MAX_RETRIES,
+        help=(
+            "Maximum number of retry attempts per vLLM request on failure "
+            f"(default: {DEFAULT_MAX_RETRIES}). "
+            "Only applies if --on-missing=generate."
         ),
     )
     parser.add_argument(

--- a/src/speculators/data_generation/vllm_client.py
+++ b/src/speculators/data_generation/vllm_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import logging
 import time
 
@@ -13,6 +14,72 @@ RETRY_BACKOFF_BASE = 2  # seconds
 
 class InvalidResponseError(Exception):
     pass
+
+
+def _handle_retry_error(
+    error: Exception, attempt: int, total_attempts: int
+) -> float | None:
+    """Handle a retry-eligible error.
+
+    Returns backoff seconds if the caller should retry, or ``None`` on the
+    final attempt.  Raises ``InvalidResponseError`` immediately.
+    """
+    if isinstance(error, InvalidResponseError):
+        raise error
+    if attempt < total_attempts:
+        backoff = RETRY_BACKOFF_BASE**attempt
+        logger.warning(
+            "Request failed (attempt %d/%d): %s. Retrying in %ds...",
+            attempt,
+            total_attempts,
+            error,
+            backoff,
+        )
+        return backoff
+    logger.error("Request failed after %d attempts: %s", total_attempts, error)
+    return None
+
+
+def with_retries(fn):
+    """Decorator that adds retry logic with exponential backoff.
+
+    The decorated function gains a ``max_retries`` keyword argument
+    (default ``DEFAULT_MAX_RETRIES``). ``InvalidResponseError`` is never
+    retried. Works for both sync and async functions.
+    """
+    if asyncio.iscoroutinefunction(fn):
+
+        @functools.wraps(fn)
+        async def async_wrapper(*args, max_retries=DEFAULT_MAX_RETRIES, **kwargs):
+            total_attempts = max_retries + 1
+            last_error: Exception | None = None
+            for attempt in range(1, total_attempts + 1):
+                try:
+                    return await fn(*args, **kwargs)
+                except Exception as e:
+                    last_error = e
+                    backoff = _handle_retry_error(e, attempt, total_attempts)
+                    if backoff is not None:
+                        await asyncio.sleep(backoff)
+            raise last_error  # type: ignore[misc]
+
+        return async_wrapper
+
+    @functools.wraps(fn)
+    def sync_wrapper(*args, max_retries=DEFAULT_MAX_RETRIES, **kwargs):
+        total_attempts = max_retries + 1
+        last_error: Exception | None = None
+        for attempt in range(1, total_attempts + 1):
+            try:
+                return fn(*args, **kwargs)
+            except Exception as e:
+                last_error = e
+                backoff = _handle_retry_error(e, attempt, total_attempts)
+                if backoff is not None:
+                    time.sleep(backoff)
+        raise last_error  # type: ignore[misc]
+
+    return sync_wrapper
 
 
 def extract_output(completion, token_ids) -> str:
@@ -32,12 +99,12 @@ def extract_output(completion, token_ids) -> str:
     return completion.kv_transfer_params.get("hidden_states_path")
 
 
+@with_retries
 async def generate_hidden_states_async(
     client: openai.AsyncClient,
     model: str,
     token_ids: list[int],
     timeout: float | None = DEFAULT_REQUEST_TIMEOUT,
-    max_retries: int = DEFAULT_MAX_RETRIES,
 ) -> str:
     """
     Runs decode w/ max_tokens 1 to generate hidden states and returns path to
@@ -48,87 +115,38 @@ async def generate_hidden_states_async(
         model: The model ID.
         token_ids: The input token IDs.
         timeout: Timeout in seconds for each request attempt. None for no timeout.
-        max_retries: Maximum number of retry attempts on failure.
     """
-    total_attempts = max_retries + 1
-    last_error: Exception | None = None
-    for attempt in range(1, total_attempts + 1):
-        try:
-            coro = client.completions.create(
-                model=model,
-                prompt=token_ids,
-                max_tokens=1,
-                extra_body={"return_token_ids": True},
-                timeout=timeout,
-            )
-            if timeout is not None:
-                completion = await asyncio.wait_for(coro, timeout=timeout)
-            else:
-                completion = await coro
+    coro = client.completions.create(
+        model=model,
+        prompt=token_ids,
+        max_tokens=1,
+        extra_body={"return_token_ids": True},
+        timeout=timeout,
+    )
+    if timeout is not None:
+        completion = await asyncio.wait_for(coro, timeout=timeout)
+    else:
+        completion = await coro
 
-            return extract_output(completion, token_ids)
-        except InvalidResponseError:
-            raise
-        except Exception as e:
-            last_error = e
-            if attempt < total_attempts:
-                backoff = RETRY_BACKOFF_BASE**attempt
-                logger.warning(
-                    "Request failed (attempt %d/%d): %s. Retrying in %ds...",
-                    attempt,
-                    total_attempts,
-                    e,
-                    backoff,
-                )
-                await asyncio.sleep(backoff)
-            else:
-                logger.error(
-                    "Request failed after %d attempts: %s",
-                    total_attempts,
-                    e,
-                )
-
-    raise last_error  # type: ignore[misc]
+    return extract_output(completion, token_ids)
 
 
+@with_retries
 def generate_hidden_states(
     client: openai.Client,
     model: str,
     token_ids: list[int],
     timeout: float | None = DEFAULT_REQUEST_TIMEOUT,
-    max_retries: int = DEFAULT_MAX_RETRIES,
 ) -> str:
-    total_attempts = max_retries + 1
-    last_error: Exception | None = None
-    for attempt in range(1, total_attempts + 1):
-        try:
-            completion = client.completions.create(
-                model=model,
-                prompt=token_ids,
-                max_tokens=1,
-                extra_body={"return_token_ids": True},
-                timeout=timeout,
-            )
-            return extract_output(completion, token_ids)
-        except InvalidResponseError:
-            raise
-        except Exception as e:
-            last_error = e
-            if attempt < total_attempts:
-                backoff = RETRY_BACKOFF_BASE**attempt
-                logger.warning(
-                    "Request failed (attempt %d/%d): %s. Retrying in %ds...",
-                    attempt,
-                    total_attempts,
-                    e,
-                    backoff,
-                )
-                time.sleep(backoff)
-            else:
-                logger.error(
-                    "Request failed after %d attempts: %s",
-                    total_attempts,
-                    e,
-                )
-
-    raise last_error  # type: ignore[misc]
+    """
+    Runs decode w/ max_tokens 1 to generate hidden states and returns path to
+    hidden states file.
+    """
+    completion = client.completions.create(
+        model=model,
+        prompt=token_ids,
+        max_tokens=1,
+        extra_body={"return_token_ids": True},
+        timeout=timeout,
+    )
+    return extract_output(completion, token_ids)

--- a/src/speculators/data_generation/vllm_client.py
+++ b/src/speculators/data_generation/vllm_client.py
@@ -50,8 +50,9 @@ async def generate_hidden_states_async(
         timeout: Timeout in seconds for each request attempt. None for no timeout.
         max_retries: Maximum number of retry attempts on failure.
     """
+    total_attempts = max_retries + 1
     last_error: Exception | None = None
-    for attempt in range(1, max_retries + 1):
+    for attempt in range(1, total_attempts + 1):
         try:
             coro = client.completions.create(
                 model=model,
@@ -70,12 +71,12 @@ async def generate_hidden_states_async(
             raise
         except Exception as e:
             last_error = e
-            if attempt < max_retries:
+            if attempt < total_attempts:
                 backoff = RETRY_BACKOFF_BASE**attempt
                 logger.warning(
                     "Request failed (attempt %d/%d): %s. Retrying in %ds...",
                     attempt,
-                    max_retries,
+                    total_attempts,
                     e,
                     backoff,
                 )
@@ -83,7 +84,7 @@ async def generate_hidden_states_async(
             else:
                 logger.error(
                     "Request failed after %d attempts: %s",
-                    max_retries,
+                    total_attempts,
                     e,
                 )
 
@@ -97,8 +98,9 @@ def generate_hidden_states(
     timeout: float | None = DEFAULT_REQUEST_TIMEOUT,
     max_retries: int = DEFAULT_MAX_RETRIES,
 ) -> str:
+    total_attempts = max_retries + 1
     last_error: Exception | None = None
-    for attempt in range(1, max_retries + 1):
+    for attempt in range(1, total_attempts + 1):
         try:
             completion = client.completions.create(
                 model=model,
@@ -112,12 +114,12 @@ def generate_hidden_states(
             raise
         except Exception as e:
             last_error = e
-            if attempt < max_retries:
+            if attempt < total_attempts:
                 backoff = RETRY_BACKOFF_BASE**attempt
                 logger.warning(
                     "Request failed (attempt %d/%d): %s. Retrying in %ds...",
                     attempt,
-                    max_retries,
+                    total_attempts,
                     e,
                     backoff,
                 )
@@ -125,7 +127,7 @@ def generate_hidden_states(
             else:
                 logger.error(
                     "Request failed after %d attempts: %s",
-                    max_retries,
+                    total_attempts,
                     e,
                 )
 

--- a/src/speculators/data_generation/vllm_client.py
+++ b/src/speculators/data_generation/vllm_client.py
@@ -1,4 +1,14 @@
+import asyncio
+import logging
+import time
+
 import openai
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REQUEST_TIMEOUT = 15  # seconds
+DEFAULT_MAX_RETRIES = 3
+RETRY_BACKOFF_BASE = 2  # seconds
 
 
 class InvalidResponseError(Exception):
@@ -23,30 +33,100 @@ def extract_output(completion, token_ids) -> str:
 
 
 async def generate_hidden_states_async(
-    client: openai.AsyncClient, model: str, token_ids: list[int]
+    client: openai.AsyncClient,
+    model: str,
+    token_ids: list[int],
+    timeout: float | None = DEFAULT_REQUEST_TIMEOUT,
+    max_retries: int = DEFAULT_MAX_RETRIES,
 ) -> str:
     """
     Runs decode w/ max_tokens 1 to generate hidden states and returns path to
     hidden states file.
+
+    Args:
+        client: The async OpenAI client.
+        model: The model ID.
+        token_ids: The input token IDs.
+        timeout: Timeout in seconds for each request attempt. None for no timeout.
+        max_retries: Maximum number of retry attempts on failure.
     """
+    last_error: Exception | None = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            coro = client.completions.create(
+                model=model,
+                prompt=token_ids,
+                max_tokens=1,
+                extra_body={"return_token_ids": True},
+                timeout=timeout,
+            )
+            if timeout is not None:
+                completion = await asyncio.wait_for(coro, timeout=timeout)
+            else:
+                completion = await coro
 
-    completion = await client.completions.create(
-        model=model,
-        prompt=token_ids,
-        max_tokens=1,
-        extra_body={"return_token_ids": True},
-    )
+            return extract_output(completion, token_ids)
+        except InvalidResponseError:
+            raise
+        except Exception as e:
+            last_error = e
+            if attempt < max_retries:
+                backoff = RETRY_BACKOFF_BASE**attempt
+                logger.warning(
+                    "Request failed (attempt %d/%d): %s. Retrying in %ds...",
+                    attempt,
+                    max_retries,
+                    e,
+                    backoff,
+                )
+                await asyncio.sleep(backoff)
+            else:
+                logger.error(
+                    "Request failed after %d attempts: %s",
+                    max_retries,
+                    e,
+                )
 
-    return extract_output(completion, token_ids)
+    raise last_error  # type: ignore[misc]
 
 
 def generate_hidden_states(
-    client: openai.Client, model: str, token_ids: list[int]
+    client: openai.Client,
+    model: str,
+    token_ids: list[int],
+    timeout: float | None = DEFAULT_REQUEST_TIMEOUT,
+    max_retries: int = DEFAULT_MAX_RETRIES,
 ) -> str:
-    completion = client.completions.create(
-        model=model,
-        prompt=token_ids,
-        max_tokens=1,
-        extra_body={"return_token_ids": True},
-    )
-    return extract_output(completion, token_ids)
+    last_error: Exception | None = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            completion = client.completions.create(
+                model=model,
+                prompt=token_ids,
+                max_tokens=1,
+                extra_body={"return_token_ids": True},
+                timeout=timeout,
+            )
+            return extract_output(completion, token_ids)
+        except InvalidResponseError:
+            raise
+        except Exception as e:
+            last_error = e
+            if attempt < max_retries:
+                backoff = RETRY_BACKOFF_BASE**attempt
+                logger.warning(
+                    "Request failed (attempt %d/%d): %s. Retrying in %ds...",
+                    attempt,
+                    max_retries,
+                    e,
+                    backoff,
+                )
+                time.sleep(backoff)
+            else:
+                logger.error(
+                    "Request failed after %d attempts: %s",
+                    max_retries,
+                    e,
+                )
+
+    raise last_error  # type: ignore[misc]

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -18,7 +18,8 @@ from safetensors.torch import load_file
 from torch.utils.data import Dataset
 
 from speculators.data_generation.vllm_client import (
-    InvalidResponseError,
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_REQUEST_TIMEOUT,
     generate_hidden_states,
 )
 from speculators.train.noise_transforms import TransformTensors
@@ -179,6 +180,8 @@ class ArrowDataset(BaseDataset):
         transform: TransformTensors | None = None,
         hidden_states_dtype=torch.float,
         model: str | None = None,
+        request_timeout: float | None = DEFAULT_REQUEST_TIMEOUT,
+        max_retries: int = DEFAULT_MAX_RETRIES,
     ):
         """Initialize the ArrowDataset.
         Args:
@@ -212,6 +215,8 @@ class ArrowDataset(BaseDataset):
         self.on_generate = on_generate
         self.client: openai.OpenAI | None = None
         self.model = model
+        self.request_timeout = request_timeout
+        self.max_retries = max_retries
 
         # Delay super init so that `_compute_approx_lengths` has required data
         super().__init__(max_len, transform, hidden_states_dtype)
@@ -253,8 +258,14 @@ class ArrowDataset(BaseDataset):
 
         input_ids = self.data[index]["input_ids"].tolist()
         try:
-            hs_filepath = generate_hidden_states(self.client, self.model, input_ids)  # type:ignore[arg-type]
-        except InvalidResponseError as e:
+            hs_filepath = generate_hidden_states(
+                self.client,  # type:ignore[arg-type]
+                self.model,  # type:ignore[arg-type]
+                input_ids,
+                timeout=self.request_timeout,
+                max_retries=self.max_retries,
+            )
+        except Exception as e:  # noqa: BLE001
             warnings.warn(str(e), stacklevel=1)
             return None
 

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -226,7 +226,9 @@ class ArrowDataset(BaseDataset):
 
     def _setup_client(self):
         # Delay client setup so it runs in dataloader thread if on_missing="generate"
-        self.client = openai.OpenAI(base_url=self.vllm_endpoint, api_key="EMPTY")
+        self.client = openai.OpenAI(
+            base_url=self.vllm_endpoint, api_key="EMPTY", max_retries=0
+        )
         list_models = self.client.models.list()
         model_id = list_models.data[0].id
         if self.model and self.model != model_id:

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -179,6 +179,7 @@ def run_data_generation_offline2(
     concurrency: int = 4,
     validate_outputs: bool = True,
     timeout: float | None = None,
+    fail_on_error: bool = True,
 ):
     datagen_cmd = [
         sys.executable,
@@ -194,6 +195,8 @@ def run_data_generation_offline2(
     ]
     if validate_outputs:
         datagen_cmd.append("--validate-outputs")
+    if fail_on_error:
+        datagen_cmd.append("--fail-on-error")
 
     if hidden_states_path is not None:
         datagen_cmd += ["--output", str(hidden_states_path)]


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Improve the robustness of our online/offline data generation with better handling for failed requests to vllm.

We had a nightly e2e CI run that just hung on data_generation_offline2.py. This pr ensures every vllm requests has appropriate timeouts with retry logic and handling when that fails.

<!--- Why your changes are needed -->

## Description

Requests to vLLM (in both online and offline training) will now have a timeout (default 15s) and max retries (default 3).

The data_generation_offline2.py script was also made more robust. It now has a `fail-on-error`  flag that will cause any issue with a sample that can't be handled by the timeout/retries to stop the process. 

Without the flag, the failing samples will be skipped. Except if `--max-consecutive-errors` fail in a row, the script will still crash. This is better handling for cases where the vllm server process goes down/becomes unreachable. The script will attempt a few samples, but if they're all failing it will terminate early. 

<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->
https://github.com/neuralmagic/llm-compressor-testing/actions/runs/24380242770/job/71202006249#step:10:32430


## Tests

<!--- Please describe in detail how you tested your changes. -->

Verified manually that the script crashes when vllm becomes unreachable. 

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
