### PR TITLE
Change dependabot prod deps strategy to auto

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    versioning-strategy: "widen"
+    versioning-strategy: "auto"
     allow:
       - dependency-type: "production"
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Apparently the "widen" strategy isn't support for "pip", so going to use "auto" (which seems to be widening already anyways). 

See https://github.com/vllm-project/speculators/network/updates "Dependabot" tab.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--


<!--- Why your changes are needed -->

## Description

Change strategy to "auto" for production dependencies only

<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests

N/A

<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
