### PR TITLE
Add support for async hidden states connector

### DIFF
--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -290,7 +290,7 @@ async def worker(  # noqa: C901
                     max_retries=max_retries,
                 )
             lock_path = hidden_states_path + ".lock"
-            if Path(lock_path).exists():
+            if Path(lock_path).exists():  # noqa: ASYNC240
                 await wait_for_lock_async(lock_path)
 
             async with write_semaphore:  # Limit number of active disk writes

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -171,21 +171,21 @@ def parse_args():
 def get_existing_hidden_state_indices(output_path: Path) -> list[int]:
     """Find existing `hs_i.safetensors` files (where i is the file index)"""
 
-    existing_file_indices = []
+    existing_file_indices_set: set[int] = set()
 
     if not output_path.exists():
-        return existing_file_indices
+        return []
 
     for file_path in output_path.iterdir():
         if file_path.name.startswith("hs_") and file_path.name.endswith(".safetensors"):
             index_str = file_path.stem[3:]  # Remove "hs_" prefix
             try:
                 file_index = int(index_str)
-                existing_file_indices.append(file_index)
+                existing_file_indices_set.add(file_index)
             except ValueError:
                 continue
 
-    return sorted(existing_file_indices)
+    return sorted(existing_file_indices_set)
 
 
 def get_indices_to_process(
@@ -248,7 +248,7 @@ def check_safetensors_file(path: Path, tokens: list[int]):
             )
 
 
-async def worker(
+async def worker(  # noqa: C901
     client,
     model: str,
     queue: "asyncio.Queue[dict[str, Any]]",

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -30,6 +30,7 @@ from speculators.data_generation.vllm_client import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_REQUEST_TIMEOUT,
     generate_hidden_states_async,
+    wait_for_lock_async,
 )
 from speculators.train.data import build_client_item
 from speculators.train.logger import setup_root_logger
@@ -288,6 +289,10 @@ async def worker(
                     timeout=request_timeout,
                     max_retries=max_retries,
                 )
+            lock_path = hidden_states_path + ".lock"
+            if Path(lock_path).exists():
+                await wait_for_lock_async(lock_path)
+
             async with write_semaphore:  # Limit number of active disk writes
                 await asyncio.to_thread(
                     shutil.move, hidden_states_path, target_hidden_states_path

--- a/src/speculators/data_generation/vllm_client.py
+++ b/src/speculators/data_generation/vllm_client.py
@@ -1,6 +1,8 @@
 import asyncio
+import fcntl
 import functools
 import logging
+import os
 import time
 from typing import TYPE_CHECKING, Any, TypedDict
 
@@ -120,6 +122,43 @@ class ClientItem(TypedDict):
     messages: NotRequired[list[ChatCompletionMessageParam]]
     """If provided, pass `messages` to Chat Completions API
     instead of passing `token_ids` to Completions API."""
+
+
+async def _poll_lock_async(fd, poll_interval):
+    while True:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return
+        except BlockingIOError:
+            await asyncio.sleep(poll_interval)
+
+
+async def wait_for_lock_async(lock_path, timeout=10.0, poll_interval=0.1):
+    fd = os.open(lock_path, os.O_RDONLY)
+    try:
+        await asyncio.wait_for(_poll_lock_async(fd, poll_interval), timeout=timeout)
+    finally:
+        os.close(fd)
+        os.remove(lock_path)
+
+
+def wait_for_lock(lock_path, timeout=10.0, poll_interval=0.1):
+    fd = os.open(lock_path, os.O_RDONLY)
+    try:
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Timed out waiting for lock: {lock_path}"
+                    ) from None
+                time.sleep(poll_interval)
+    finally:
+        os.close(fd)
+        os.remove(lock_path)
 
 
 @with_retries

--- a/src/speculators/data_generation/vllm_client.py
+++ b/src/speculators/data_generation/vllm_client.py
@@ -137,9 +137,11 @@ async def wait_for_lock_async(lock_path, timeout=10.0, poll_interval=0.1):
     fd = os.open(lock_path, os.O_RDONLY)
     try:
         await asyncio.wait_for(_poll_lock_async(fd, poll_interval), timeout=timeout)
-    finally:
+    except BaseException:
         os.close(fd)
-        os.remove(lock_path)
+        raise
+    os.close(fd)
+    os.remove(lock_path)
 
 
 def wait_for_lock(lock_path, timeout=10.0, poll_interval=0.1):
@@ -149,16 +151,18 @@ def wait_for_lock(lock_path, timeout=10.0, poll_interval=0.1):
         while True:
             try:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                return
+                break
             except BlockingIOError:
                 if time.monotonic() >= deadline:
                     raise TimeoutError(
                         f"Timed out waiting for lock: {lock_path}"
                     ) from None
                 time.sleep(poll_interval)
-    finally:
+    except BaseException:
         os.close(fd)
-        os.remove(lock_path)
+        raise
+    os.close(fd)
+    os.remove(lock_path)
 
 
 @with_retries

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -285,19 +285,22 @@ class ArrowDataset(BaseDataset):
                 timeout=self.request_timeout,
                 max_retries=self.max_retries,
             )
+
+            loaded_hs = load_file(hs_filepath)
+
+            match self.on_generate:
+                case "cache":
+                    file_idx = self._map_to_file_idx(index)
+                    target_path = self.hidden_states_path / f"hs_{file_idx}.safetensors"
+                    shutil.move(hs_filepath, target_path)
+                case "delete":
+                    Path(hs_filepath).unlink()
         except Exception as e:  # noqa: BLE001
-            warnings.warn(str(e), stacklevel=1)
+            warnings.warn(
+                f"Failed to load/cache hidden states for sample {index}: {e}",
+                stacklevel=1,
+            )
             return None
-
-        loaded_hs = load_file(hs_filepath)
-
-        match self.on_generate:
-            case "cache":
-                file_idx = self._map_to_file_idx(index)
-                target_path = self.hidden_states_path / f"hs_{file_idx}.safetensors"
-                shutil.move(hs_filepath, target_path)
-            case "delete":
-                Path(hs_filepath).unlink()
 
         return loaded_hs
 

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -21,6 +21,7 @@ from speculators.data_generation.vllm_client import (
     DEFAULT_REQUEST_TIMEOUT,
     ClientItem,
     generate_hidden_states,
+    wait_for_lock,
 )
 from speculators.train.noise_transforms import TransformTensors
 
@@ -259,6 +260,11 @@ class ArrowDataset(BaseDataset):
     def _maybe_load_hs_file(self, index: int) -> dict[str, torch.Tensor] | None:
         file_idx = self._map_to_file_idx(index)
         candidate_path = self.hidden_states_path / f"hs_{file_idx}.safetensors"
+
+        lock_path = str(candidate_path) + ".lock"
+        if Path(lock_path).exists():
+            wait_for_lock(lock_path)
+
         if candidate_path.exists():
             return load_file(candidate_path)
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

https://github.com/vllm-project/vllm/pull/37374 updates the ExampleHiddenStatesConnector to write the hidden states to disk in an async manner (and also in `.pt` files instead of `.saftensors`). This pr adds support for this while maintaining support for the previous implementation.

<!--- Why your changes are needed -->

## Description

The new system creates lock files for each hidden state file before starting to write the hidden states. On the client side, we block on obtaining the lock and once it's ready the hidden states are fully written to disk and can be read.

We only employ this behavior if the lock file exists, otherwise we assume the hidden states are fully written. This supports the existing system, and also works for offline or cached data gen results.

We clean up (delete) lock files after obtaining them.

<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests

Will run smoke / regression tests on this pr to ensure compatibility with existing system. I have also tested this locally with the upstream pr. 
<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
