### PR TITLE
Add simple timer metrics for trainer profiling

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -328,6 +328,7 @@ def main(args: argparse.Namespace):
         checkpoint_freq=args.checkpoint_freq,
         save_best=args.save_best,
         hidden_states_dtype=hidden_states_dtype,
+        log_interval=args.log_interval,
     )
     trainer = Trainer(draft_model, trainer_config, train_loader, val_loader)
 
@@ -528,6 +529,12 @@ def parse_args():
         action="store_true",
         default=False,
         help="Pointing to checkpoint with lowest validation loss.",
+    )
+    parser.add_argument(
+        "--log-interval",
+        type=int,
+        default=10,
+        help="Log per-phase profile metrics every N steps.",
     )
 
     # lr scheduler

--- a/src/speculators/train/profiling.py
+++ b/src/speculators/train/profiling.py
@@ -1,0 +1,112 @@
+"""Lightweight step-level profiling for the training loop."""
+
+import threading
+import time
+from collections import defaultdict
+
+import torch
+
+PHASES = ("fetch", "h2d", "fwd", "bwd", "opt")
+
+
+class StepTimer:
+    def __init__(self, warmup_steps: int = 10):
+        self.warmup_steps = warmup_steps
+        self.steps_seen = 0
+        self._sustained_time = 0.0
+        self._sustained_fetch = 0.0
+        self._sustained_tokens = 0
+        self._sustained_steps = 0
+        self._reset_window()
+
+    def _reset_window(self):
+        self._win_sum: dict[str, float] = defaultdict(float)
+        self._win_steps = 0
+        self._win_tokens = 0
+
+    def record(self, phases: dict[str, float], tokens: int) -> None:
+        self.steps_seen += 1
+        for k in PHASES:
+            self._win_sum[k] += phases.get(k, 0.0)
+        self._win_steps += 1
+        self._win_tokens += tokens
+
+        if self.steps_seen > self.warmup_steps:
+            step_time = sum(phases.get(k, 0.0) for k in PHASES)
+            self._sustained_time += step_time
+            self._sustained_fetch += phases.get("fetch", 0.0)
+            self._sustained_tokens += tokens
+            self._sustained_steps += 1
+
+    def window_snapshot(self) -> dict[str, float]:
+        if self._win_steps == 0:
+            return {}
+        means_s = {k: self._win_sum[k] / self._win_steps for k in PHASES}
+        step_s = sum(means_s.values())
+        snap: dict[str, float] = {f"{k}_ms": means_s[k] * 1000 for k in PHASES}
+        snap["step_ms"] = step_s * 1000
+        win_wall = sum(self._win_sum.values())
+        snap["tokens_per_s"] = self._win_tokens / win_wall if win_wall > 0 else 0.0
+        snap["fetch_frac"] = self._win_sum["fetch"] / win_wall if win_wall > 0 else 0.0
+        self._reset_window()
+        return snap
+
+    def sustained_snapshot(self) -> dict[str, float]:
+        if self._sustained_steps == 0:
+            return {}
+        return {
+            "sustained_tokens_per_s": self._sustained_tokens / self._sustained_time,
+            "sustained_fetch_frac": self._sustained_fetch / self._sustained_time,
+            "sustained_step_ms": (self._sustained_time / self._sustained_steps) * 1000,
+            "sustained_steps": float(self._sustained_steps),
+        }
+
+
+class GpuUtilSampler:
+    def __init__(self, device: int, interval_s: float = 0.25):
+        self.device = device
+        self.interval = interval_s
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._sum = 0.0
+        self._count = 0
+        self._enabled = False
+
+    def start(self) -> None:
+        try:
+            torch.cuda.utilization(self.device)
+        except Exception:
+            return
+        self._enabled = True
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._thread is None:
+            return
+        self._stop.set()
+        self._thread.join(timeout=1.0)
+        self._thread = None
+
+    def _run(self) -> None:
+        while not self._stop.wait(self.interval):
+            try:
+                u = float(torch.cuda.utilization(self.device))
+            except Exception:
+                continue
+            with self._lock:
+                self._sum += u
+                self._count += 1
+
+    def pop_mean(self) -> float | None:
+        if not self._enabled:
+            return None
+        with self._lock:
+            if self._count == 0:
+                return None
+            mean = self._sum / self._count
+            self._sum = 0.0
+            self._count = 0
+            return mean

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import warnings
 from typing import Literal, NamedTuple
 
@@ -22,6 +23,7 @@ from speculators.train.checkpointer import (
     DistributedCheckpointer,
     SingleGPUCheckpointer,
 )
+from speculators.train.profiling import GpuUtilSampler, StepTimer
 from speculators.train.utils import apply_fully_sharded
 
 root_logger = logging.getLogger("speculators")
@@ -46,6 +48,8 @@ class TrainerConfig(NamedTuple):
     checkpoint_freq: int = 1
     save_best: bool = False
     hidden_states_dtype: torch.dtype = torch.bfloat16
+    log_interval: int = 10
+    profile_warmup_steps: int = 10
 
 
 class Trainer:
@@ -71,6 +75,9 @@ class Trainer:
         self.setup_trainer()
         self.setup_model()
         self.setup_optimizer()
+
+        self.step_timer = StepTimer(warmup_steps=config.profile_warmup_steps)
+        self.gpu_sampler = GpuUtilSampler(device=self.local_rank)
 
     def setup_trainer(self):
         if self.checkpointer.previous_epoch != -1:
@@ -234,35 +241,74 @@ class Trainer:
         if self.local_rank == 0:
             train_loader = tqdm(train_loader, desc=f"Epoch {epoch}")  # type: ignore[assignment]
 
+        world_size = dist.get_world_size() if self.is_distributed else 1
+
+        torch.cuda.synchronize(self.local_rank)
+        t_prev = time.perf_counter()
+
         for batch in train_loader:
+            t_fetch = time.perf_counter()
+
             gpu_batch = {
                 k: v.to(self.local_rank, non_blocking=True)
                 if isinstance(v, torch.Tensor)
                 else v
                 for k, v in batch.items()
             }
+            torch.cuda.synchronize(self.local_rank)
+            t_h2d = time.perf_counter()
 
             _draft_tokens, loss, metrics = self.model(
                 **gpu_batch, **self.config.train_call_kwargs
             )
+            torch.cuda.synchronize(self.local_rank)
+            t_fwd = time.perf_counter()
 
             self.opt.zero_grad()
             loss.backward()
+            torch.cuda.synchronize(self.local_rank)
+            t_bwd = time.perf_counter()
+
             torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
             self.opt.step()
 
             current_lr = self.opt.param_groups[0]["lr"]
             if self.scheduler is not None:
                 self.scheduler.step()
+            torch.cuda.synchronize(self.local_rank)
+            t_opt = time.perf_counter()
+
+            tokens = int(batch["input_ids"].numel()) * world_size
+            self.step_timer.record(
+                {
+                    "fetch": t_fetch - t_prev,
+                    "h2d": t_h2d - t_fetch,
+                    "fwd": t_fwd - t_h2d,
+                    "bwd": t_bwd - t_fwd,
+                    "opt": t_opt - t_bwd,
+                },
+                tokens=tokens,
+            )
+            t_prev = t_opt
 
             if self.is_distributed:
                 for v in metrics.values():
                     dist.reduce(v, dst=0, op=dist.ReduceOp.AVG)
 
             metrics = {k: v.item() for k, v in metrics.items()}
+            log_payload: dict = {
+                "train": metrics,
+                "epoch": epoch,
+                "lr": current_lr,
+            }
+            if (self.global_step + 1) % self.config.log_interval == 0:
+                profile_snap = self.step_timer.window_snapshot()
+                gpu_util = self.gpu_sampler.pop_mean()
+                if gpu_util is not None:
+                    profile_snap["gpu_util_pct"] = gpu_util
+                log_payload["profile"] = profile_snap
             metric_logger.info(
-                {"train": metrics, "epoch": epoch, "lr": current_lr},
-                extra={"step": self.global_step},
+                log_payload, extra={"step": self.global_step}
             )
             self.global_step += 1
 
@@ -355,27 +401,39 @@ class Trainer:
 
     def run_training(self):
         n_epochs = self.config.num_epochs
-        for epoch in range(self.current_epoch, n_epochs):
-            root_logger.info(f"Training epoch {epoch + 1}/{n_epochs} started")
-            self.train_epoch(epoch)
-            root_logger.info(f"Training epoch {epoch + 1}/{n_epochs} completed")
+        self.gpu_sampler.start()
+        try:
+            for epoch in range(self.current_epoch, n_epochs):
+                root_logger.info(f"Training epoch {epoch + 1}/{n_epochs} started")
+                self.train_epoch(epoch)
+                root_logger.info(f"Training epoch {epoch + 1}/{n_epochs} completed")
 
-            if self.is_distributed:
-                dist.barrier()
+                if self.is_distributed:
+                    dist.barrier()
 
-            val_metrics = None
+                val_metrics = None
 
-            if self.val_loader is None:
-                root_logger.warning("No val loader, skipping validation epoch")
-            else:
-                root_logger.info(f"Validation epoch {epoch + 1}/{n_epochs} started")
-                val_metrics = self.val_epoch(epoch)
-                root_logger.info(f"Validation epoch {epoch + 1}/{n_epochs} completed")
+                if self.val_loader is None:
+                    root_logger.warning("No val loader, skipping validation epoch")
+                else:
+                    root_logger.info(f"Validation epoch {epoch + 1}/{n_epochs} started")
+                    val_metrics = self.val_epoch(epoch)
+                    root_logger.info(
+                        f"Validation epoch {epoch + 1}/{n_epochs} completed"
+                    )
 
-            if self.is_distributed:
-                dist.barrier()
+                if self.is_distributed:
+                    dist.barrier()
 
-            self.maybe_save_checkpoint(epoch, val_metrics)
+                self.maybe_save_checkpoint(epoch, val_metrics)
 
-            if self.is_distributed:
-                dist.barrier()
+                if self.is_distributed:
+                    dist.barrier()
+        finally:
+            self.gpu_sampler.stop()
+            sustained = self.step_timer.sustained_snapshot()
+            if sustained:
+                root_logger.info(f"Sustained throughput: {sustained}")
+                metric_logger.info(
+                    {"profile": sustained}, extra={"step": self.global_step}
+                )


### PR DESCRIPTION
Commands:
```
python prepare_data.py --model Qwen/Qwen3-8B --data sharegpt --max-samples 2000 --seq-length 4096

# vLLM on GPU 2
CUDA_VISIBLE_DEVICES=2 python scripts/launch_vllm.py Qwen/Qwen3-8B \
    --hidden-states-path ./profile_run/hidden_states \
    -- --port 8000 --max-model-len 5120 --gpu-memory-utilization 0.85

# Trainer on GPU 3
CUDA_VISIBLE_DEVICES=3 python scripts/train.py \
    --verifier-name-or-path Qwen/Qwen3-8B \
    --data-path ./profile_run/data \
    --hidden-states-path ./profile_run/hidden_states \
    --vllm-endpoint http://localhost:8000/v1 \
    --save-path ./profile_run/checkpoint \
    --draft-vocab-size 32000 \
    --epochs 1 \
    --total-seq-len 4096 \
    --logger tensorboard \
    --log-dir ./profile_run/tb \
    --run-name qwen3_8b_profile \
    --log-interval 10 \
    --no-resume-from-checkpoint
```


Per-window profile output:
```
[win 0, warmup]  profile/fetch_ms=508.218 profile/h2d_ms=2.558  profile/fwd_ms=754.997 profile/bwd_ms=24.885 profile/opt_ms=26.411
profile/step_ms=1.32e+03 profile/tokens_per_s=3.11e+03 profile/fetch_frac=0.386 profile/gpu_util_pct=5.176
[win 1]          profile/fetch_ms=1.837   profile/h2d_ms=2.485  profile/fwd_ms=34.157  profile/bwd_ms=19.875 profile/opt_ms=5.641
profile/step_ms=63.996   profile/tokens_per_s=6.40e+04 profile/fetch_frac=0.029 profile/gpu_util_pct=90.000
[win 2]          profile/fetch_ms=1.912   profile/h2d_ms=3.463  profile/fwd_ms=13.503  profile/bwd_ms=20.270 profile/opt_ms=5.666
profile/step_ms=44.813   profile/tokens_per_s=9.14e+04 profile/fetch_frac=0.043 profile/gpu_util_pct=91.000
[win 3]          profile/fetch_ms=3.176   profile/h2d_ms=4.275  profile/fwd_ms=15.440  profile/bwd_ms=20.543 profile/opt_ms=5.927
profile/step_ms=49.361   profile/tokens_per_s=8.30e+04 profile/fetch_frac=0.064 profile/gpu_util_pct=80.500
[win 4]          profile/fetch_ms=2.408   profile/h2d_ms=2.492  profile/fwd_ms=12.996  profile/bwd_ms=19.709 profile/opt_ms=6.430
profile/step_ms=44.035   profile/tokens_per_s=9.30e+04 profile/fetch_frac=0.055 profile/gpu_util_pct=81.500
[win 5]          profile/fetch_ms=18.445  profile/h2d_ms=3.857  profile/fwd_ms=14.518  profile/bwd_ms=19.791 profile/opt_ms=6.570
profile/step_ms=63.180   profile/tokens_per_s=6.48e+04 profile/fetch_frac=0.292 profile/gpu_util_pct=75.500
[win 6]          profile/fetch_ms=53.687  profile/h2d_ms=2.460  profile/fwd_ms=12.457  profile/bwd_ms=19.482 profile/opt_ms=5.628
profile/step_ms=93.714   profile/tokens_per_s=4.37e+04 profile/fetch_frac=0.573 profile/gpu_util_pct=45.500
[win 7]          profile/fetch_ms=149.371 profile/h2d_ms=3.350  profile/fwd_ms=12.768  profile/bwd_ms=21.318 profile/opt_ms=5.646
profile/step_ms=192.453  profile/tokens_per_s=2.13e+04 profile/fetch_frac=0.776 profile/gpu_util_pct=23.875
[win 8]          profile/fetch_ms=143.065 profile/h2d_ms=2.433  profile/fwd_ms=14.576  profile/bwd_ms=22.914 profile/opt_ms=5.915
profile/step_ms=188.903  profile/tokens_per_s=2.17e+04 profile/fetch_frac=0.757 profile/gpu_util_pct=22.286
[win 9]          profile/fetch_ms=143.723 profile/h2d_ms=2.480  profile/fwd_ms=12.542  profile/bwd_ms=19.724 profile/opt_ms=5.636
profile/step_ms=184.105  profile/tokens_per_s=2.22e+04 profile/fetch_frac=0.781 profile/gpu_util_pct=26.000
[win 10]         profile/fetch_ms=2.424   profile/h2d_ms=2.452  profile/fwd_ms=13.355  profile/bwd_ms=19.999 profile/opt_ms=6.401
profile/step_ms=44.630   profile/tokens_per_s=9.18e+04 profile/fetch_frac=0.054 profile/gpu_util_pct=84.000
[win 11]         profile/fetch_ms=65.846  profile/h2d_ms=2.463  profile/fwd_ms=13.213  profile/bwd_ms=20.802 profile/opt_ms=6.507
profile/step_ms=108.831  profile/tokens_per_s=3.76e+04 profile/fetch_frac=0.605 profile/gpu_util_pct=46.000
[win 12]         profile/fetch_ms=87.614  profile/h2d_ms=3.186  profile/fwd_ms=16.729  profile/bwd_ms=21.317 profile/opt_ms=6.307
profile/step_ms=135.153  profile/tokens_per_s=3.03e+04 profile/fetch_frac=0.648 profile/gpu_util_pct=17.600
[win 13]         profile/fetch_ms=96.599  profile/h2d_ms=2.488  profile/fwd_ms=14.576  profile/bwd_ms=21.311 profile/opt_ms=5.698
profile/step_ms=140.671  profile/tokens_per_s=2.91e+04 profile/fetch_frac=0.687 profile/gpu_util_pct=29.333
```

```
Sustained throughput:
{'sustained_tokens_per_s': 40816.877346239264,
'sustained_fetch_frac':   0.5533778186932062,
'sustained_step_ms':      100.35064576975515,
'sustained_steps':        139.0}
```