### PR TITLE
Incorporating min valid token to address issue 385

### DIFF
--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -174,6 +174,15 @@ def parse_args():
         default=8,
         help="Number of CPU processes for dataset preprocessing (default: 8)",
     )
+    parser.add_argument(
+        "--minimum-valid-tokens",
+        type=int,
+        default=None,
+        help=(
+            "Drop samples whose loss mask contains fewer than this many "
+            "trainable tokens."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -349,6 +358,7 @@ def main():
         token_freq_path=args.token_freq_path,
         assistant_pattern=args.assistant_pattern,
         turn_dropout=args.turn_dropout,
+        minimum_valid_tokens=args.minimum_valid_tokens,
     )
     num_saved = generate_and_save_hidden_states(args, dataset)
 

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -122,6 +122,15 @@ def parse_args():
         default=8,
         help="Number of CPU processes for dataset preprocessing (default: 8)",
     )
+    parser.add_argument(
+        "--minimum-valid-tokens",
+        type=int,
+        default=None,
+        help=(
+            "Drop samples whose loss mask contains fewer than this many "
+            "trainable tokens."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -164,6 +173,7 @@ def main():
         token_freq_path=token_freq_path,
         assistant_pattern=args.assistant_pattern,
         turn_dropout=args.turn_dropout,
+        minimum_valid_tokens=args.minimum_valid_tokens,
     )
 
     log.info("Done preparing data")

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -261,6 +261,7 @@ def _preprocess_batch(
     max_length: int,
     assistant_pattern: str | Pattern[str] | None,
     turn_dropout: bool = False,
+    minimum_valid_tokens: int | None = None,
 ) -> dict[str, list]:
     """Process a batch of conversations into tokenized format with loss masks."""
 
@@ -337,6 +338,12 @@ def _preprocess_batch(
                 f"loss_mask={len(loss_mask)}"
             )
 
+            # Filtering samples out with too few valid tokens
+            if minimum_valid_tokens is not None:
+                num_valid_tokens = int(loss_mask.sum().item())
+                if num_valid_tokens < minimum_valid_tokens:
+                    continue
+
             # Append to results
             results["input_ids"].append(torch.tensor(input_ids, dtype=torch.long))
             results["loss_mask"].append(loss_mask)
@@ -359,6 +366,7 @@ def build_eagle3_dataset(
     num_proc: int = 8,
     assistant_pattern: str | Pattern[str] | None = None,
     turn_dropout: bool = False,
+    minimum_valid_tokens: int | None = None,
 ) -> HFDataset:
     """Build EAGLE3 dataset by tokenizing conversations and creating loss masks.
 
@@ -374,6 +382,7 @@ def build_eagle3_dataset(
                           chat template.
         turn_dropout: If True, randomly keeps first N consecutive turns per
                      conversation
+        minimum_valid_tokens: Number of tokens to consider for a valid sample
     """
     # Detect and use provided assistant message pattern
     if assistant_pattern is not None:
@@ -389,7 +398,12 @@ def build_eagle3_dataset(
 
     dataset = dataset.map(
         lambda examples: _preprocess_batch(
-            examples, tokenizer, max_length, assistant_pattern, turn_dropout
+            examples,
+            tokenizer,
+            max_length,
+            assistant_pattern,
+            turn_dropout,
+            minimum_valid_tokens,
         ),
         batched=True,
         num_proc=num_proc,
@@ -432,6 +446,7 @@ def load_and_preprocess_dataset(
     token_freq_path: Path | str = "./token_freq.pt",  # noqa: S107
     assistant_pattern: str | None = None,
     turn_dropout: bool = False,
+    minimum_valid_tokens: int | None = None,
 ) -> tuple[HFDataset, PreTrainedTokenizerBase]:
     """Load, tokenize, and preprocess a dataset for EAGLE3 training.
 
@@ -452,11 +467,18 @@ def load_and_preprocess_dataset(
                           chat template.
         turn_dropout: If True, randomly keeps first N consecutive turns per
                      conversation
+        minimum_valid_tokens: Number of tokens to consider for a valid sample
 
     Returns:
         Tuple of (preprocessed_dataset, tokenizer)
     """
+    if minimum_valid_tokens is not None and minimum_valid_tokens < 0:
+        raise ValueError("minimum_valid_tokens must be >= 0")
     log.section("Starting dataset preprocessing")
+    if minimum_valid_tokens is not None:
+        log.info(
+            f"Filtering samples with fewer than {minimum_valid_tokens} valid tokens"
+        )
 
     log.subsection("Loading tokenizer")
     tokenizer = AutoTokenizer.from_pretrained(target_model_path, trust_remote_code=True)
@@ -493,12 +515,15 @@ def load_and_preprocess_dataset(
             num_proc=build_dataset_num_proc,
             assistant_pattern=assistant_pattern,
             turn_dropout=turn_dropout,
+            minimum_valid_tokens=minimum_valid_tokens,
         )
+        if minimum_valid_tokens is not None:
+            log.info(f"Kept {len(preprocessed_dataset)} samples after filtering")
         processed_datasets.append(preprocessed_dataset)
 
     combined_dataset = concatenate_datasets(processed_datasets)
     combined_dataset.shuffle(seed=seed)
-    if max_samples is not None and len(raw_dataset) > max_samples:
+    if max_samples is not None and len(combined_dataset) > max_samples:
         combined_dataset = combined_dataset.select(range(max_samples))
 
     log.subsection("Computing token frequency distribution")

--- a/tests/datagen/test_preprocessing.py
+++ b/tests/datagen/test_preprocessing.py
@@ -472,6 +472,104 @@ def test_preprocess_batch_falls_back_to_regex():
     assert torch.any(results["loss_mask"][0] == 1)
 
 
+@pytest.mark.sanity
+def test_preprocess_batch_minimum_valid_tokens_filters_regex_path():
+    """Test that minimum_valid_tokens drops short samples on regex path."""
+    tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_REPO, trust_remote_code=True)
+
+    if not hasattr(tokenizer, "apply_chat_template") or tokenizer.chat_template is None:
+        pytest.skip("Tokenizer does not support chat templates")
+
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    examples = {
+        "conversations": [
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "OK"},
+            ]
+        ]
+    }
+
+    assistant_pattern = _detect_assistant_pattern(tokenizer)
+
+    baseline = _preprocess_batch(
+        examples,
+        tokenizer,
+        max_length=128,
+        assistant_pattern=assistant_pattern,
+    )
+
+    assert len(baseline["loss_mask"]) == 1
+    valid_count = int(baseline["loss_mask"][0].sum().item())
+    assert valid_count > 0
+
+    filtered = _preprocess_batch(
+        examples,
+        tokenizer,
+        max_length=128,
+        assistant_pattern=assistant_pattern,
+        minimum_valid_tokens=valid_count + 1,
+    )
+
+    assert filtered["input_ids"] == []
+    assert filtered["loss_mask"] == []
+    assert filtered["seq_len"] == []
+
+
+@pytest.mark.sanity
+def test_preprocess_batch_minimum_valid_tokens_keeps_boundary_case():
+    """Test that a sample is kept when valid tokens equal the threshold."""
+    tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_REPO, trust_remote_code=True)
+
+    if not hasattr(tokenizer, "apply_chat_template") or tokenizer.chat_template is None:
+        pytest.skip("Tokenizer does not support chat templates")
+
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    examples = {
+        "conversations": [
+            [
+                {"role": "user", "content": "Explain speculative decoding."},
+                {
+                    "role": "assistant",
+                    "content": (
+                        "Speculative decoding uses a draft model to propose tokens "
+                        "that a verifier model then checks."
+                    ),
+                },
+            ]
+        ]
+    }
+
+    assistant_pattern = _detect_assistant_pattern(tokenizer)
+
+    baseline = _preprocess_batch(
+        examples,
+        tokenizer,
+        max_length=256,
+        assistant_pattern=assistant_pattern,
+    )
+
+    assert len(baseline["loss_mask"]) == 1
+    valid_count = int(baseline["loss_mask"][0].sum().item())
+    assert valid_count > 0
+
+    kept = _preprocess_batch(
+        examples,
+        tokenizer,
+        max_length=256,
+        assistant_pattern=assistant_pattern,
+        minimum_valid_tokens=valid_count,
+    )
+
+    assert len(kept["input_ids"]) == 1
+    assert len(kept["loss_mask"]) == 1
+    assert int(kept["loss_mask"][0].sum().item()) == valid_count
+
+
 # Tests for build_eagle3_dataset
 
 
@@ -567,6 +665,75 @@ def test_build_eagle3_dataset_removes_original_columns():
     if len(result) > 0:
         assert "conversations" not in result.column_names
         assert "extra_column" not in result.column_names
+
+
+@pytest.mark.sanity
+def test_build_eagle3_dataset_minimum_valid_tokens_filters_short_samples():
+    """Test that build_eagle3_dataset removes samples below the token threshold."""
+    tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_REPO, trust_remote_code=True)
+
+    if not hasattr(tokenizer, "apply_chat_template") or tokenizer.chat_template is None:
+        pytest.skip("Tokenizer does not support chat templates")
+
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    short_conv = [
+        {"role": "user", "content": "Hi"},
+        {"role": "assistant", "content": "OK"},
+    ]
+    long_conv = [
+        {"role": "user", "content": "Explain speculative decoding."},
+        {
+            "role": "assistant",
+            "content": (
+                "Speculative decoding uses a draft model to propose multiple "
+                "candidate tokens that a stronger verifier then checks."
+            ),
+        },
+    ]
+
+    assistant_pattern = _detect_assistant_pattern(tokenizer)
+
+    short_baseline = _preprocess_batch(
+        {"conversations": [short_conv]},
+        tokenizer,
+        max_length=256,
+        assistant_pattern=assistant_pattern,
+    )
+    long_baseline = _preprocess_batch(
+        {"conversations": [long_conv]},
+        tokenizer,
+        max_length=256,
+        assistant_pattern=assistant_pattern,
+    )
+
+    assert len(short_baseline["loss_mask"]) == 1
+    assert len(long_baseline["loss_mask"]) == 1
+
+    short_count = int(short_baseline["loss_mask"][0].sum().item())
+    long_count = int(long_baseline["loss_mask"][0].sum().item())
+
+    assert short_count > 0
+    assert long_count > short_count
+
+    threshold = short_count + 1
+
+    dataset = HFDataset.from_dict({"conversations": [short_conv, long_conv]})
+    result = build_eagle3_dataset(
+        dataset,
+        tokenizer,
+        max_length=256,
+        num_proc=1,
+        assistant_pattern=assistant_pattern,
+        minimum_valid_tokens=threshold,
+    )
+
+    assert isinstance(result, HFDataset)
+    assert len(result) == 1
+
+    remaining_valid_count = int(result[0]["loss_mask"].sum().item())
+    assert remaining_valid_count >= threshold
 
 
 # Tests for turn dropout feature


### PR DESCRIPTION
<!-- markdownlint-disable -->

This PR adds an optional `minimum_valid_tokens` filter to the preprocessing pipeline so that samples with too little trainable tokens can be dropped before downstream hidden-state generation and P-Eagle training.

## Purpose

Fix [RFC]: Drop bad samples during preprocessing #385

## Description

This PR introduces a new optional argument, `minimum_valid_tokens`, in the preprocessing pipeline.
When set, preprocessing computes the number of valid trainable tokens from the existing `loss_mask` in `src/speculators/data_generation/preprocessing.py` and drops samples whose valid-token count is below the threshold.

High-level changes:
- added `minimum_valid_tokens` to `_preprocess_batch(...)` function in `src/speculators/data_generation/preprocessing.py`
- filtered samples in `_preprocess_batch(...)` when `loss_mask.sum() < minimum_valid_tokens`
- passed the new argument through `build_eagle3_dataset(...)` in `src/speculators/data_generation/preprocessing.py`
- passes the new argument through `load_and_preprocess_dataset(...)`  in `src/speculators/data_generation/preprocessing.py`
- added CLI support via `--minimum-valid-tokens` in:
  - `scripts/prepare_data.py`
  - `scripts/data_generation_offline.py`
- Add verification in `load_and_preprocess_dataset(...)` to raise a flag in case negative values for `minimum_valid_tokens` is encountered.
- added test coverage for regex-path filtering, boundary behavior, and dataset-level filtering


## Related Issue

[RFC]: Drop bad samples during preprocessing #385

## Tests

I added test coverage in `tests/datagen/test_preprocessing.py` for the new filtering behavior.

Added tests:
- filtering of short samples in `_preprocess_batch(...)` on the regex fallback path
- boundary case where a sample is kept when `sum(loss_mask) == minimum_valid_tokens`
- dataset-level filtering in `build_eagle3_dataset(...)`, verifying that shorter samples are removed while longer samples remain

Specific tests can be ran with:
-pytest -q tests/datagen/test_preprocessing.py::test_preprocess_batch_minimum_valid_tokens_filters_regex_path
-pytest -q tests/datagen/test_preprocessing.py::test_preprocess_batch_minimum_valid_tokens_keeps_boundary_case
-pytest -q tests/datagen/test_preprocessing.py::test_build_eagle3_dataset_minimum_valid_tokens_filters_short_samples

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
