### PR TITLE
Fix local_rank usage in distributed batch sampler for multi-node training

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -55,7 +55,7 @@ def set_seed(seed: int, deterministic: bool = False):
 def setup_dataloader(
     dataset: BaseEagle3Dataset,
     world_size: int,
-    local_rank: int,
+    rank: int,
     hidden_size: int,
     num_workers: int = 12,
     prefetch_factor: int = 4,
@@ -64,7 +64,7 @@ def setup_dataloader(
     Args:
         file_list: List of file paths to load data from.
         world_size: Number of processes in the distributed training.
-        local_rank: Rank of the current process.
+        rank: Global rank of the current process.
         add_noise: Whether to add noise to the data.
         noise_std: Standard deviation for noise augmentation.
         num_workers: Number of dataloader workers.
@@ -76,7 +76,7 @@ def setup_dataloader(
         batch_max_length=args.total_seq_len,
         lengths=dataset.approx_lengths,
         num_replicas=world_size,
-        rank=local_rank,
+        rank=rank,
     )
     return DataLoader(
         dataset,
@@ -213,6 +213,9 @@ def main(args: argparse.Namespace):
 
     # Setup distributed training
     local_rank, world_size, rank, is_distributed = maybe_setup_distributed()
+    logger.info(
+        f"Using RANK: {rank}, LOCAL_RANK: {local_rank}, WORLD_SIZE: {world_size}"
+    )
     if not hasattr(torch, args.hidden_states_dtype):
         raise ValueError(
             "--hidden-states-dtype must be a dtype attribute of torch. e.g. `bfloat16`"
@@ -295,7 +298,7 @@ def main(args: argparse.Namespace):
     train_loader = setup_dataloader(
         train_dataset,
         world_size,
-        local_rank,
+        rank,
         transformer_layer_config.hidden_size,
         num_workers=args.num_workers,
         prefetch_factor=args.prefetch_factor,
@@ -303,7 +306,7 @@ def main(args: argparse.Namespace):
     val_loader = setup_dataloader(
         val_dataset,
         world_size,
-        local_rank,
+        rank,
         transformer_layer_config.hidden_size,
         num_workers=args.num_workers,
         prefetch_factor=args.prefetch_factor,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -213,9 +213,6 @@ def main(args: argparse.Namespace):
 
     # Setup distributed training
     local_rank, world_size, rank, is_distributed = maybe_setup_distributed()
-    logger.info(
-        f"Using RANK: {rank}, LOCAL_RANK: {local_rank}, WORLD_SIZE: {world_size}"
-    )
     if not hasattr(torch, args.hidden_states_dtype):
         raise ValueError(
             "--hidden-states-dtype must be a dtype attribute of torch. e.g. `bfloat16`"
@@ -321,6 +318,7 @@ def main(args: argparse.Namespace):
         lr=args.lr,
         resume_from_checkpoint=not args.no_resume_from_checkpoint,
         is_distributed=is_distributed,
+        rank=rank,
         local_rank=local_rank,
         train_call_kwargs=train_call_kwargs,
         val_call_kwargs=val_call_kwargs,

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import warnings
 from typing import Literal, NamedTuple
 
@@ -58,6 +59,7 @@ class Trainer:
     ):
         self.model = model
         self.config = config
+        self.rank = int(os.environ.get("RANK", "0"))
         self.local_rank = config.local_rank
         self.train_loader = train_loader
         self.val_loader = val_loader
@@ -231,7 +233,7 @@ class Trainer:
             self.train_loader.batch_sampler.set_epoch(epoch)  # type: ignore[union-attr]
 
         train_loader = self.train_loader
-        if self.local_rank == 0:
+        if self.rank == 0:
             train_loader = tqdm(train_loader, desc=f"Epoch {epoch}")  # type: ignore[assignment]
 
         for batch in train_loader:
@@ -274,7 +276,7 @@ class Trainer:
         if hasattr(self.val_loader.batch_sampler, "set_epoch"):
             self.val_loader.batch_sampler.set_epoch(epoch)  # type: ignore[union-attr]
         val_loader = self.val_loader
-        if self.local_rank == 0:
+        if self.rank == 0:
             val_loader = tqdm(val_loader, desc=f"Epoch {epoch}")  # type: ignore[assignment]
 
         val_metrics: dict[str, float] = {}

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import warnings
 from typing import Literal, NamedTuple
 
@@ -37,6 +36,7 @@ class TrainerConfig(NamedTuple):
     save_path: str
     resume_from_checkpoint: bool = False
     is_distributed: bool = False
+    rank: int = 0
     local_rank: int = 0
     train_call_kwargs: dict = {}
     val_call_kwargs: dict = {}
@@ -59,7 +59,7 @@ class Trainer:
     ):
         self.model = model
         self.config = config
-        self.rank = int(os.environ.get("RANK", "0"))
+        self.rank = config.rank
         self.local_rank = config.local_rank
         self.train_loader = train_loader
         self.val_loader = val_loader

--- a/src/speculators/train/utils.py
+++ b/src/speculators/train/utils.py
@@ -35,7 +35,8 @@ def maybe_setup_distributed() -> tuple[int, int, int, bool]:
     rank = dist.get_rank()
 
     logger.info(
-        f"Started distributed with local_rank={local_rank}, world_size={world_size}",
+        f"Started distributed with local_rank={local_rank},"
+        f" world_size={world_size}, rank={rank}",
         extra={"override_rank0_filter": True},
     )
     return local_rank, world_size, rank, True

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -18,6 +18,7 @@ def _make_minimal_trainer(tmp_path: Path, checkpoint_freq: int, save_best: bool)
         save_path=str(tmp_path),
         resume_from_checkpoint=False,
         is_distributed=False,
+        rank=0,
         local_rank=0,
         checkpoint_freq=checkpoint_freq,
         save_best=save_best,
@@ -26,6 +27,7 @@ def _make_minimal_trainer(tmp_path: Path, checkpoint_freq: int, save_best: bool)
     trainer.current_epoch = 0
     trainer.global_step = 0
     trainer.is_distributed = False
+    trainer.rank = 0
     trainer.local_rank = 0
     trainer.resume_from_checkpoint = False
     trainer.train_loader = cast("DataLoader[Any]", [])

--- a/tests/unit/train/test_setup_model.py
+++ b/tests/unit/train/test_setup_model.py
@@ -131,6 +131,7 @@ def _make_trainer_no_init(
     *,
     is_distributed=False,
     resume_from_checkpoint=False,
+    rank=0,
     local_rank=0,
     save_path="/tmp/test_ckpt",
     hidden_states_dtype=torch.bfloat16,
@@ -142,18 +143,41 @@ def _make_trainer_no_init(
         save_path=save_path,
         resume_from_checkpoint=resume_from_checkpoint,
         is_distributed=is_distributed,
+        rank=rank,
         local_rank=local_rank,
         hidden_states_dtype=hidden_states_dtype,
     )
     trainer = Trainer.__new__(Trainer)
     trainer.model = model
     trainer.config = config
+    trainer.rank = config.rank
     trainer.local_rank = config.local_rank
     trainer.is_distributed = config.is_distributed
     trainer.resume_from_checkpoint = config.resume_from_checkpoint
     trainer.train_loader = MagicMock(__len__=MagicMock(return_value=1))
     trainer.val_loader = None
     return trainer
+
+
+def test_trainer_uses_rank_from_config(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    monkeypatch.setattr(Trainer, "setup_trainer", lambda self: None)
+    monkeypatch.setattr(Trainer, "setup_model", lambda self: None)
+    monkeypatch.setattr(Trainer, "setup_optimizer", lambda self: None)
+
+    trainer = Trainer(
+        MagicMock(),
+        TrainerConfig(
+            lr=1e-4,
+            num_epochs=1,
+            save_path=str(tmp_path),
+            rank=3,
+            local_rank=1,
+        ),
+        MagicMock(),
+    )
+
+    assert trainer.rank == 3
+    assert trainer.local_rank == 1
 
 
 def _param_checksums(state_dict: dict[str, torch.Tensor]) -> dict[str, float]:
@@ -474,7 +498,9 @@ def _worker_distributed_fresh_init(rank, world_size, results_dir):
         # Capture rank 0's pre-FSDP state dict for comparison
         pre_fsdp_checksums = _param_checksums(model.state_dict()) if rank == 0 else {}
 
-        trainer = _make_trainer_no_init(model, is_distributed=True, local_rank=rank)
+        trainer = _make_trainer_no_init(
+            model, is_distributed=True, rank=rank, local_rank=rank
+        )
         trainer.checkpointer = MagicMock()
         trainer.checkpointer.previous_epoch = -1
 
@@ -560,6 +586,7 @@ def _worker_distributed_resume(rank, world_size, ckpt_dir, results_dir):
             model,
             is_distributed=True,
             resume_from_checkpoint=True,
+            rank=rank,
             local_rank=rank,
             save_path=ckpt_dir,
         )
@@ -628,7 +655,9 @@ def _worker_distributed_from_pretrained(rank, world_size, model_dir, results_dir
             model = Eagle3DraftModel.from_pretrained(model_dir)
         _fill_nan_weights(model)  # fill verifier weights post-load
 
-        trainer = _make_trainer_no_init(model, is_distributed=True, local_rank=rank)
+        trainer = _make_trainer_no_init(
+            model, is_distributed=True, rank=rank, local_rank=rank
+        )
         trainer.checkpointer = MagicMock()
         trainer.checkpointer.previous_epoch = -1
 


### PR DESCRIPTION
## Summary

Fix data duplication bug in multi-node distributed training caused by passing `local_rank` instead of global `rank` to `MultipackDistributedBatchSamplerV2`.

In multi-node setups, `local_rank` is per-node (e.g., 0–3 on each node), so processes on different nodes with the same `local_rank` receive identical data shards — every GPU trains on duplicated data.

## What's broken?

When training with `nnodes > 1`, data sharding is incorrect. For example, in a 2-node × 4-GPU setup:
- Node 0, GPU 0: `local_rank=0, rank=0` → gets shard 0
- Node 1, GPU 0: `local_rank=0, rank=4` → **also gets shard 0** (should get shard 4)

Additionally, tqdm progress bars appear on every node's GPU 0 instead of just the global rank 0 process.

Single-node training is unaffected because `local_rank == rank` when `nnodes=1`.

## Changes

- **`scripts/train.py`**: `setup_dataloader()` now accepts and passes global `rank` (instead of `local_rank`) to `MultipackDistributedBatchSamplerV2` for correct data sharding. Added rank logging after distributed setup.
- **`src/speculators/train/trainer.py`**: Added `self.rank` (from `RANK` env var) and use it for tqdm progress bar guards instead of `self.local_rank`.
- **`src/speculators/train/utils.py`**: Include global rank in distributed setup log message.

## Context

Rebased version of #299 by @Liccol, which has been stale with merge conflicts. All review feedback from @fynnsu on that PR has been incorporated.

Part of #356.

## Testing

- Single-node: no behavioral change (`local_rank == rank` when `nnodes=1`)
- Multi-node: each rank now correctly receives unique data shards via `MultipackDistributedBatchSamplerV2`
- Lint: `ruff check` and `ruff format` pass on all changed files

cc @fynnsu
