### PR TITLE
docs: add FastMTP documentation, benchmarks, and integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ ______________________________________________________________________
 
 ______________________________________________________________________
 
+## Supported Algorithms
+
+| Algorithm | Registry Key | Status | Description |
+| --- | --- | --- | --- |
+| [EAGLE-3](https://github.com/vllm-project/speculators/tree/main/src/speculators/models/eagle3) | `eagle3` | ✅ Supported | Feature-level draft model with vocabulary mapping between draft and target tokenizers |
+| [FastMTP](https://arxiv.org/abs/2509.18362) | `mtp` | 🚧 In Progress | Multi-token prediction using a single recursive MTP layer (Cai et al., 2025) |
+
+✅ = Supported, 🚧 = In Progress
+
 ## Key Features
 
 - **Offline Training Data Generation using vLLM:** Enable the generation of hidden states using vLLM. Data samples are saved to disk and can be used for draft model training.

--- a/docs/algorithms/fast_mtp.md
+++ b/docs/algorithms/fast_mtp.md
@@ -1,0 +1,188 @@
+---
+weight: -3
+---
+
+# FastMTP (Multi-Token Prediction)
+
+FastMTP is a speculative decoding algorithm introduced by TencentBAC that accelerates LLM inference by predicting multiple future tokens per forward pass using a single MTP (Multi-Token Prediction) layer applied recursively.
+
+!!! note "Status" FastMTP support is under active development. The model definition and converter are being integrated on feature branches. This documentation reflects the target design and will be updated as components land on `main`.
+
+**Paper:** Cai et al., [FastMTP: Accelerating LLM Inference with Enhanced Multi-Token Prediction](https://arxiv.org/abs/2509.18362), arXiv:2509.18362, 2025.
+
+## Architecture Overview
+
+FastMTP uses a single MTP layer that is applied recursively across prediction steps. At each step $k$, the layer receives:
+
+1. **Token embedding** for `input_ids[t+k+1]` (the ground-truth next token)
+2. **Hidden state** from step $k-1$ (or the verifier's hidden state for step 0)
+
+Each step predicts token $t+k+2$.
+
+```mermaid
+flowchart LR
+    VH["Verifier hidden[t]"] --> HN["hidden_layernorm"]
+    TE1["Token embed[t+1]"] --> TN1["token_layernorm"]
+    HN --> IP1["input_proj"]
+    TN1 --> IP1
+    IP1 --> AM1["attn + MLP"]
+    AM1 --> MH0["MTP hidden[step=0]"]
+
+    MH0 --> HN2["hidden_layernorm"]
+    TE2["Token embed[t+2]"] --> TN2["token_layernorm"]
+    HN2 --> IP2["input_proj"]
+    TN2 --> IP2
+    IP2 --> AM2["attn + MLP"]
+    AM2 --> MH1["MTP hidden[step=1]"]
+
+    MH0 --> LH0["lm_head"] --> L0["logits[step=0]"]
+    MH1 --> LH1["lm_head"] --> L1["logits[step=1]"]
+```
+
+### Key Components
+
+| Component          | Description                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| `hidden_layernorm` | RMSNorm applied to incoming hidden states                                                   |
+| `token_layernorm`  | RMSNorm applied to token embeddings                                                         |
+| `input_proj`       | Linear projection that fuses hidden states and embeddings (`2 * hidden_size → hidden_size`) |
+| `attn + MLP`       | Standard transformer decoder layer (reuses verifier architecture)                           |
+| `final_layernorm`  | RMSNorm on MTP layer output                                                                 |
+| `embed_tokens`     | Shared with verifier (frozen during training)                                               |
+| `lm_head`          | Shared with verifier (frozen during training)                                               |
+
+### Supported Checkpoints
+
+| Model                                                                 | `model_type`     | Architecture      |
+| --------------------------------------------------------------------- | ---------------- | ----------------- |
+| [Qwen3-Next](https://huggingface.co/Qwen/Qwen3-Next-80B-A3B-Instruct) | `qwen3_next`     | Sparse MoE        |
+| MiMo (TencentBAC/FastMTP)                                             | `mimo` / `qwen2` | Qwen2-based dense |
+
+## Training Guide
+
+### Training Objective
+
+FastMTP uses a weighted multi-step cross-entropy loss:
+
+$$\\mathcal{L}_{\\text{mtp}} = \\sum_{k=0}^{K-1} \\alpha_k \\cdot \\text{CE}(\\text{logits}_k,\\ \\text{tokens}_{t+k+2})$$
+
+Default step weights use exponential decay ($\\beta = 0.6$, normalized): $\\alpha = [0.51, 0.31, 0.18]$ for $K = 3$ steps. Loss is computed only on response tokens via a `loss_mask`.
+
+### Data Generation
+
+FastMTP training requires hidden states from the verifier model. Use the standard Speculators offline data generation pipeline:
+
+```bash
+python scripts/data_generation_offline.py \
+    --model-name Qwen/Qwen3-Next-80B-A3B-Instruct \
+    --dataset HuggingFaceH4/ultrachat_200k \
+    --output-dir ./data/fast_mtp \
+    --tensor-parallel-size 4
+```
+
+### Training
+
+Once data is generated, train the FastMTP head:
+
+```bash
+torchrun --nnodes=1 --nproc_per_node=8 scripts/train.py \
+    --speculator-type mtp \
+    --verifier-name-or-path Qwen/Qwen3-Next-80B-A3B-Instruct \
+    --data-path ./data/fast_mtp \
+    --save-path ./checkpoints/fast_mtp \
+    --epochs 20 \
+    --num-layers 1
+```
+
+### Configuration Reference
+
+Key configuration fields in `FastMTPConfig`:
+
+| Parameter                  | Type               | Default       | Description                                                 |
+| -------------------------- | ------------------ | ------------- | ----------------------------------------------------------- |
+| `speculators_model_type`   | `str`              | `"mtp"`       | Algorithm identifier for registry lookup                    |
+| `transformer_layer_config` | `PretrainedConfig` | `Qwen2Config` | Underlying transformer architecture config                  |
+| `num_nextn_predict_layers` | `int`              | `1`           | Number of MTP prediction heads (currently only 1 supported) |
+
+Derived properties (not stored, computed at runtime):
+
+| Property                | Source                                                      | Description                |
+| ----------------------- | ----------------------------------------------------------- | -------------------------- |
+| `hidden_size`           | `transformer_layer_config.hidden_size`                      | Hidden dimension           |
+| `vocab_size`            | `transformer_layer_config.vocab_size`                       | Vocabulary size            |
+| `num_speculative_steps` | `speculators_config.proposal_methods[0].speculative_tokens` | Number of prediction steps |
+
+## Inference Guide
+
+### vLLM Deployment
+
+Models trained through Speculators can be served directly with vLLM:
+
+```bash
+vllm serve <path-to-fast-mtp-checkpoint>
+```
+
+vLLM reads the `speculators_config` from the model's `config.json` and automatically sets up both the speculator and verifier for speculative decoding.
+
+### Programmatic Usage
+
+```python
+from speculators import SpeculatorModelConfig
+
+# Load a FastMTP config
+config = SpeculatorModelConfig.from_pretrained("path/to/fast_mtp_checkpoint")
+print(config.speculators_model_type)  # "mtp"
+print(config.vocab_size)              # derived from transformer_layer_config
+print(config.hidden_size)             # derived from transformer_layer_config
+```
+
+## Benchmarking
+
+### Using GuideLLM
+
+After deploying a FastMTP model with vLLM, benchmark it using [GuideLLM](https://github.com/vllm-project/guidellm):
+
+```bash
+# Start vLLM server with the speculator
+vllm serve <path-to-fast-mtp-checkpoint> --port 8000
+
+# Run GuideLLM benchmark
+guidellm benchmark \
+    --target http://localhost:8000 \
+    --model <path-to-fast-mtp-checkpoint> \
+    --dataset openai/humaneval
+```
+
+See the [GuideLLM evaluation example](../examples/eval-guidellm.md) for detailed instructions.
+
+### Key Metrics
+
+When evaluating FastMTP performance, focus on:
+
+| Metric                    | Description                                         | How to Measure               |
+| ------------------------- | --------------------------------------------------- | ---------------------------- |
+| **Acceptance rate**       | Fraction of drafted tokens accepted by the verifier | vLLM logs or GuideLLM output |
+| **Latency (TTFT)**        | Time to first token                                 | GuideLLM benchmark           |
+| **Throughput (tokens/s)** | End-to-end generation throughput                    | GuideLLM benchmark           |
+| **Memory overhead**       | Additional GPU memory used by the speculator        | `nvidia-smi` during serving  |
+
+### Expected Performance
+
+Based on the [FastMTP paper](https://arxiv.org/abs/2509.18362) (Section 4):
+
+- **2–3× speedup** over standard autoregressive decoding on supported models
+- Minimal memory overhead due to single-layer recursive design
+- Higher acceptance rates on structured/predictable content
+
+## References
+
+```bibtex
+@article{cai2025fastmtp,
+  title={FastMTP: Accelerating LLM Inference with Enhanced Multi-Token Prediction},
+  author={Cai, Yuxuan and Liang, Xiaozhuan and Wang, Xinghua and Ma, Jin
+          and Liang, Haijin and Luo, Jinwen and Zuo, Xinyu and Duan, Lisheng
+          and Yin, Yuyang and Chen, Xi},
+  journal={arXiv preprint arXiv:2509.18362},
+  year={2025}
+}
+```

--- a/docs/algorithms/index.md
+++ b/docs/algorithms/index.md
@@ -1,0 +1,39 @@
+---
+weight: -99
+---
+
+# Algorithms
+
+Speculators supports multiple speculative decoding algorithms. Each algorithm has its own model architecture, training procedure, and configuration format, but all share the same registry system and deployment pipeline.
+
+## Supported Algorithms
+
+| Algorithm                                                                                      | Registry Key | Status         | Description                                                                                                      |
+| ---------------------------------------------------------------------------------------------- | ------------ | -------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [EAGLE-3](https://github.com/vllm-project/speculators/tree/main/src/speculators/models/eagle3) | `eagle3`     | ✅ Supported   | Feature-level draft model with vocabulary mapping between draft and target tokenizers                            |
+| [FastMTP](fast_mtp.md)                                                                         | `mtp`        | 🚧 In Progress | Multi-token prediction using a single recursive MTP layer ([arXiv:2509.18362](https://arxiv.org/abs/2509.18362)) |
+
+✅ = Supported, 🚧 = In Progress
+
+## Adding New Algorithms
+
+See the [Adding New Algorithms](add_new_algorithms.md) guide for step-by-step instructions on implementing a new speculative decoding algorithm in Speculators.
+
+## How the Registry Works
+
+Speculators uses a class registry pattern to dynamically discover and instantiate algorithm implementations. When you register a config or model class:
+
+```python
+@SpeculatorModelConfig.register("my_algo")
+class MyAlgoConfig(SpeculatorModelConfig):
+    speculators_model_type: Literal["my_algo"] = "my_algo"
+```
+
+The training script can then look up your algorithm by name:
+
+```python
+model_class = SpeculatorModel.get_class("my_algo")
+model = model_class.from_training_args(verifier_config, **args)
+```
+
+This keeps algorithm implementations self-contained and avoids modifying shared training infrastructure when adding new algorithms.

--- a/tests/integration/framework/__init__.py
+++ b/tests/integration/framework/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for the speculators framework."""

--- a/tests/integration/framework/test_algorithm_registry.py
+++ b/tests/integration/framework/test_algorithm_registry.py
@@ -1,0 +1,231 @@
+"""Integration tests for the algorithm registry system in the Speculators library.
+
+Tests the full register -> resolve -> instantiate pipeline to verify that
+the registry infrastructure works end-to-end for algorithm discovery.
+"""
+
+from typing import Literal
+
+import pytest
+
+from speculators import (
+    SpeculatorModelConfig,
+    SpeculatorsConfig,
+    TokenProposalConfig,
+    VerifierConfig,
+    reload_schemas,
+)
+from speculators.proposals.greedy import GreedyTokenProposalConfig
+from speculators.utils.registry import ClassRegistryMixin
+
+# ===== Test-Specific Registry Subclasses =====
+
+
+@TokenProposalConfig.register("integ_test_proposal")
+class IntegTestProposalConfig(TokenProposalConfig):
+    proposal_type: Literal["integ_test_proposal"] = "integ_test_proposal"
+    test_beam_width: int = 4
+
+
+@SpeculatorModelConfig.register("integ_test_algo")
+class IntegTestAlgoConfig(SpeculatorModelConfig):
+    speculators_model_type: Literal["integ_test_algo"] = "integ_test_algo"
+    custom_block_size: int = 8
+    custom_num_heads: int = 4
+
+
+reload_schemas()
+
+
+# ===== Fixtures =====
+
+
+@pytest.fixture
+def verifier_config():
+    return VerifierConfig(
+        name_or_path="test/verifier-model",
+        architectures=["TestForCausalLM"],
+    )
+
+
+@pytest.fixture
+def greedy_proposal():
+    return GreedyTokenProposalConfig(speculative_tokens=5)
+
+
+@pytest.fixture
+def speculators_config(greedy_proposal, verifier_config):
+    return SpeculatorsConfig(
+        algorithm="integ_test_algo",
+        proposal_methods=[greedy_proposal],
+        default_proposal_method="greedy",
+        verifier=verifier_config,
+    )
+
+
+@pytest.fixture
+def full_config(speculators_config):
+    return IntegTestAlgoConfig(
+        speculators_model_type="integ_test_algo",
+        speculators_config=speculators_config,
+        custom_block_size=16,
+        custom_num_heads=8,
+    )
+
+
+# ===== Registration Tests =====
+
+
+@pytest.mark.smoke
+def test_registry_contains_builtin_algorithms():
+    """Built-in algorithms (eagle3) should be discoverable via the registry."""
+    assert SpeculatorModelConfig.registry is not None
+    assert "eagle3" in SpeculatorModelConfig.registry
+
+
+@pytest.mark.smoke
+def test_registry_contains_test_algorithm():
+    """Test-registered algorithm should be discoverable."""
+    assert SpeculatorModelConfig.registry is not None
+    assert "integ_test_algo" in SpeculatorModelConfig.registry
+    assert SpeculatorModelConfig.registry["integ_test_algo"] is IntegTestAlgoConfig
+
+
+@pytest.mark.sanity
+def test_registered_classes_returns_all():
+    """registered_classes() includes both built-in and test-registered types."""
+    classes = SpeculatorModelConfig.registered_classes()
+    class_names = [cls.__name__ for cls in classes]
+    assert "Eagle3SpeculatorConfig" in class_names
+    assert "IntegTestAlgoConfig" in class_names
+
+
+@pytest.mark.sanity
+def test_proposal_registry_contains_builtin_and_test():
+    """TokenProposalConfig registry includes greedy and test proposal."""
+    classes = TokenProposalConfig.registered_classes()
+    class_names = [cls.__name__ for cls in classes]
+    assert "GreedyTokenProposalConfig" in class_names
+    assert "IntegTestProposalConfig" in class_names
+
+
+@pytest.mark.regression
+def test_duplicate_registration_raises():
+    """Attempting to register the same name twice should raise ValueError."""
+
+    class FreshRegistry(ClassRegistryMixin):
+        pass
+
+    @FreshRegistry.register("unique_algo")
+    class FirstAlgo:
+        pass
+
+    with pytest.raises(ValueError, match="already registered"):
+
+        @FreshRegistry.register("unique_algo")
+        class SecondAlgo:
+            pass
+
+
+# ===== Resolve Tests =====
+
+
+@pytest.mark.smoke
+def test_resolve_config_via_model_validate(full_config):
+    """model_validate dispatches to the correct subclass via discriminator."""
+    config_dict = full_config.model_dump()
+    resolved = SpeculatorModelConfig.model_validate(config_dict)
+
+    assert isinstance(resolved, IntegTestAlgoConfig)
+    assert resolved.speculators_model_type == "integ_test_algo"
+    assert resolved.custom_block_size == 16
+    assert resolved.custom_num_heads == 8
+
+
+@pytest.mark.smoke
+def test_resolve_config_via_from_dict(full_config):
+    """from_dict should dispatch to the correct subclass."""
+    config_dict = full_config.to_dict()
+    resolved = SpeculatorModelConfig.from_dict(config_dict)
+
+    assert isinstance(resolved, IntegTestAlgoConfig)
+    assert resolved.speculators_model_type == "integ_test_algo"
+
+
+@pytest.mark.sanity
+def test_resolve_greedy_proposal_via_model_validate():
+    """TokenProposalConfig should resolve greedy proposal from dict."""
+    proposal = GreedyTokenProposalConfig(speculative_tokens=3)
+    config_dict = proposal.model_dump()
+    resolved = TokenProposalConfig.model_validate(config_dict)
+
+    assert isinstance(resolved, GreedyTokenProposalConfig)
+    assert resolved.speculative_tokens == 3
+
+
+# ===== Instantiate Tests =====
+
+
+@pytest.mark.sanity
+def test_instantiate_full_config_from_parts(verifier_config):
+    """Build a complete SpeculatorModelConfig from individual components."""
+    proposal = GreedyTokenProposalConfig(speculative_tokens=7)
+    spec_config = SpeculatorsConfig(
+        algorithm="integ_test_algo",
+        proposal_methods=[proposal],
+        default_proposal_method="greedy",
+        verifier=verifier_config,
+    )
+    model_config = IntegTestAlgoConfig(
+        speculators_model_type="integ_test_algo",
+        speculators_config=spec_config,
+        custom_block_size=32,
+    )
+
+    assert model_config.speculators_model_type == "integ_test_algo"
+    assert model_config.speculators_config.algorithm == "integ_test_algo"
+    assert (
+        model_config.speculators_config.verifier.name_or_path == "test/verifier-model"
+    )
+    assert model_config.speculators_config.proposal_methods[0].speculative_tokens == 7
+    assert model_config.custom_block_size == 32
+
+
+@pytest.mark.regression
+def test_end_to_end_register_resolve_instantiate():
+    """Full pipeline: register a new type, build, serialize, deserialize."""
+
+    @SpeculatorModelConfig.register("e2e_test_model")
+    class E2ETestModelConfig(SpeculatorModelConfig):
+        speculators_model_type: Literal["e2e_test_model"] = "e2e_test_model"
+        hidden_dim: int = 512
+
+    reload_schemas()
+
+    # Build using built-in GreedyTokenProposalConfig for round-trip stability
+    proposal = GreedyTokenProposalConfig(speculative_tokens=10)
+    verifier = VerifierConfig(
+        name_or_path="test/e2e-verifier", architectures=["E2EModel"]
+    )
+    spec_config = SpeculatorsConfig(
+        algorithm="e2e_test_model",
+        proposal_methods=[proposal],
+        default_proposal_method="greedy",
+        verifier=verifier,
+    )
+    config = E2ETestModelConfig(
+        speculators_config=spec_config,
+        hidden_dim=1024,
+    )
+
+    # Serialize
+    config_dict = config.model_dump()
+
+    # Deserialize (should dispatch correctly)
+    restored = SpeculatorModelConfig.model_validate(config_dict)
+
+    assert isinstance(restored, E2ETestModelConfig)
+    assert restored.hidden_dim == 1024
+    assert restored.speculators_config.algorithm == "e2e_test_model"
+    assert restored.speculators_config.proposal_methods[0].speculative_tokens == 10
+    assert restored.speculators_config.verifier.name_or_path == "test/e2e-verifier"

--- a/tests/integration/framework/test_config_serialization.py
+++ b/tests/integration/framework/test_config_serialization.py
@@ -1,0 +1,230 @@
+"""Integration tests for config serialization round-trips in the Speculators library.
+
+Tests that speculator configurations can survive full save -> load -> verify
+cycles through multiple serialization formats (Pydantic, HF-style dicts,
+and local filesystem persistence).
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from speculators import (
+    SpeculatorModelConfig,
+    SpeculatorsConfig,
+    VerifierConfig,
+    reload_schemas,
+)
+from speculators.proposals.greedy import GreedyTokenProposalConfig
+
+# ===== Test-Specific Config Subclass =====
+
+
+@SpeculatorModelConfig.register("serial_test_algo")
+class SerialTestAlgoConfig(SpeculatorModelConfig):
+    speculators_model_type: Literal["serial_test_algo"] = "serial_test_algo"
+    num_draft_layers: int = 2
+    draft_hidden_size: int = 256
+    use_shared_weights: bool = True
+
+
+reload_schemas()
+
+
+# ===== Fixtures =====
+
+
+@pytest.fixture
+def full_config():
+    proposal = GreedyTokenProposalConfig(speculative_tokens=7)
+    verifier = VerifierConfig(
+        name_or_path="test/serial-verifier",
+        architectures=["SerialTestModel"],
+    )
+    spec_config = SpeculatorsConfig(
+        algorithm="serial_test_algo",
+        proposal_methods=[proposal],
+        default_proposal_method="greedy",
+        verifier=verifier,
+    )
+    return SerialTestAlgoConfig(
+        speculators_config=spec_config,
+        num_draft_layers=4,
+        draft_hidden_size=512,
+        use_shared_weights=False,
+    )
+
+
+# ===== Pydantic Round-Trip Tests =====
+
+
+@pytest.mark.smoke
+def test_pydantic_model_dump_round_trip(full_config):
+    """model_dump -> model_validate should preserve all fields."""
+    dumped = full_config.model_dump()
+    restored = SpeculatorModelConfig.model_validate(dumped)
+
+    assert isinstance(restored, SerialTestAlgoConfig)
+    assert restored.speculators_model_type == "serial_test_algo"
+    assert restored.num_draft_layers == 4
+    assert restored.draft_hidden_size == 512
+    assert restored.use_shared_weights is False
+    assert restored.speculators_config.algorithm == "serial_test_algo"
+    assert restored.speculators_config.verifier.name_or_path == "test/serial-verifier"
+    assert restored.speculators_config.proposal_methods[0].speculative_tokens == 7
+
+
+@pytest.mark.sanity
+def test_pydantic_round_trip_preserves_defaults():
+    """Default field values should survive serialization round-trip."""
+    proposal = GreedyTokenProposalConfig()
+    verifier = VerifierConfig(
+        name_or_path="test/default-verifier",
+        architectures=["DefaultModel"],
+    )
+    spec_config = SpeculatorsConfig(
+        algorithm="serial_test_algo",
+        proposal_methods=[proposal],
+        default_proposal_method="greedy",
+        verifier=verifier,
+    )
+    config = SerialTestAlgoConfig(speculators_config=spec_config)
+
+    dumped = config.model_dump()
+    restored = SpeculatorModelConfig.model_validate(dumped)
+
+    assert isinstance(restored, SerialTestAlgoConfig)
+    assert restored.num_draft_layers == 2
+    assert restored.draft_hidden_size == 256
+    assert restored.use_shared_weights is True
+
+
+# ===== HF-Style Dict Round-Trip Tests =====
+
+
+@pytest.mark.smoke
+def test_to_dict_from_dict_round_trip(full_config):
+    """to_dict -> from_dict should preserve all fields."""
+    config_dict = full_config.to_dict()
+    restored = SpeculatorModelConfig.from_dict(config_dict)
+
+    assert isinstance(restored, SerialTestAlgoConfig)
+    assert restored.speculators_model_type == "serial_test_algo"
+    assert restored.num_draft_layers == 4
+    assert restored.draft_hidden_size == 512
+
+
+@pytest.mark.sanity
+def test_to_diff_dict_from_dict_round_trip(full_config):
+    """to_diff_dict -> from_dict should preserve non-default fields."""
+    diff_dict = full_config.to_diff_dict()
+    restored = SpeculatorModelConfig.from_dict(diff_dict)
+
+    assert isinstance(restored, SerialTestAlgoConfig)
+    assert restored.speculators_model_type == "serial_test_algo"
+    assert restored.num_draft_layers == 4
+
+
+# ===== Filesystem Persistence Tests =====
+
+
+@pytest.mark.smoke
+def test_save_load_pretrained_local(full_config):
+    """save_pretrained -> from_pretrained with local directory."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        save_path = Path(tmp_dir) / "config.json"
+        full_config.save_pretrained(save_path)
+        assert save_path.exists()
+
+        restored = SpeculatorModelConfig.from_pretrained(save_path)
+
+        assert isinstance(restored, SerialTestAlgoConfig)
+        assert restored.speculators_model_type == "serial_test_algo"
+        assert restored.num_draft_layers == 4
+        assert restored.draft_hidden_size == 512
+        assert restored.use_shared_weights is False
+        assert (
+            restored.speculators_config.verifier.name_or_path == "test/serial-verifier"
+        )
+
+
+@pytest.mark.sanity
+def test_saved_json_is_valid(full_config):
+    """Saved config should be valid JSON with expected structure."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        save_path = Path(tmp_dir) / "config.json"
+        full_config.save_pretrained(save_path)
+
+        # save_pretrained may create a directory; find the actual JSON file
+        if save_path.is_dir():
+            json_file = save_path / "config.json"
+        else:
+            json_file = save_path
+
+        with json_file.open() as f:
+            data = json.load(f)
+
+        assert isinstance(data, dict)
+        assert data["speculators_model_type"] == "serial_test_algo"
+        assert "speculators_config" in data
+        assert data["speculators_config"]["algorithm"] == "serial_test_algo"
+        assert (
+            data["speculators_config"]["verifier"]["name_or_path"]
+            == "test/serial-verifier"
+        )
+
+
+@pytest.mark.regression
+def test_save_load_preserves_nested_proposal_config(full_config):
+    """Nested proposal config should survive filesystem round-trip."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        save_path = Path(tmp_dir) / "config.json"
+        full_config.save_pretrained(save_path)
+        restored = SpeculatorModelConfig.from_pretrained(save_path)
+
+        original_proposal = full_config.speculators_config.proposal_methods[0]
+        restored_proposal = restored.speculators_config.proposal_methods[0]
+
+        assert isinstance(restored_proposal, GreedyTokenProposalConfig)
+        assert (
+            restored_proposal.speculative_tokens == original_proposal.speculative_tokens
+        )
+
+
+# ===== Cross-Format Consistency Tests =====
+
+
+@pytest.mark.regression
+def test_pydantic_and_hf_dict_produce_same_result(full_config):
+    """Pydantic dump and HF to_dict reload identically."""
+    pydantic_dict = full_config.model_dump()
+    hf_dict = full_config.to_dict()
+
+    restored_pydantic = SpeculatorModelConfig.model_validate(pydantic_dict)
+    restored_hf = SpeculatorModelConfig.from_dict(hf_dict)
+
+    assert (
+        restored_pydantic.speculators_model_type == restored_hf.speculators_model_type
+    )
+    assert restored_pydantic.num_draft_layers == restored_hf.num_draft_layers
+    assert restored_pydantic.draft_hidden_size == restored_hf.draft_hidden_size
+    assert restored_pydantic.use_shared_weights == restored_hf.use_shared_weights
+    assert (
+        restored_pydantic.speculators_config.algorithm
+        == restored_hf.speculators_config.algorithm
+    )
+
+
+@pytest.mark.regression
+def test_json_string_round_trip(full_config):
+    """to_json_string -> json.loads -> model_validate should work."""
+    json_str = full_config.to_json_string()
+    data = json.loads(json_str)
+    restored = SpeculatorModelConfig.model_validate(data)
+
+    assert isinstance(restored, SerialTestAlgoConfig)
+    assert restored.num_draft_layers == 4
+    assert restored.draft_hidden_size == 512


### PR DESCRIPTION
## What's broken?

FastMTP (Multi-Token Prediction) lacks user-facing documentation, algorithm-specific guides, and integration test coverage. Users looking to understand, train, or deploy FastMTP speculators must read source code or the paper directly. Additionally, the `docs/algorithms/` section has no algorithm-specific guides (not even for the fully-supported EAGLE-3), making it harder for new users to get started.

## Who is affected?

Anyone looking to understand, train, or deploy FastMTP speculators, as well as users exploring the Speculators library who want an overview of supported algorithms.

## What this PR adds

### Documentation
- **`docs/algorithms/fast_mtp.md`** — Comprehensive FastMTP guide covering:
  - Architecture overview (MTPBlock structure, shared-weight design, recursive forward pass)
  - Training guide (data generation, finetuning workflow, loss function with step weights)
  - Inference/deployment guide (vLLM integration)
  - Configuration reference (all fields and derived properties)
  - Benchmarking instructions (GuideLLM setup, key metrics, expected performance)
  - Based on [arXiv:2509.18362](https://arxiv.org/abs/2509.18362) and feature branch implementation
- **`docs/algorithms/index.md`** — Algorithms overview page listing EAGLE-3 (supported) and FastMTP (in progress), with an explanation of the registry system
- **`README.md`** — Added "Supported Algorithms" table

### Integration Tests
- **`tests/integration/framework/test_algorithm_registry.py`** (10 tests) — End-to-end tests for the algorithm registry system:
  - Registration: built-in + dynamic algorithm discovery
  - Resolution: `model_validate` and `from_dict` dispatch to correct subclass
  - Instantiation: building complete configs from individual components
  - Full pipeline: register → build → serialize → deserialize
- **`tests/integration/framework/test_config_serialization.py`** (9 tests) — Config round-trip tests:
  - Pydantic `model_dump` → `model_validate`
  - HF-style `to_dict` → `from_dict` and `to_diff_dict`
  - Filesystem persistence: `save_pretrained` → `from_pretrained`
  - Cross-format consistency
  - JSON string round-trips

## How do we know it works?

- All 19 new integration tests pass
- All 221 existing unit tests pass (7 skipped, pre-existing)
- `ruff check` and `ruff format` pass on all new files
- Markdown formatted with `mdformat`

## Relation to PR #326

PR #326 has been open for 40+ days with no human review. This contribution is independently written and includes integration tests (not covered by #326).

Fixes #276
