### PR TITLE
Improve data_generation_offline2.py shutdown and print vllm logs

### DIFF
--- a/scripts/data_generation_offline2.py
+++ b/scripts/data_generation_offline2.py
@@ -15,6 +15,7 @@ Usage:
 import argparse
 import asyncio
 import logging
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -315,8 +316,9 @@ async def worker(
                     )
         except Exception as e:
             if fail_on_error:
-                cancel_event.set()
-                raise
+                logger.error("Fatal: sample %d failed with --fail-on-error: %s", idx, e)
+                logging.shutdown()
+                os._exit(1)
             logger.warning("Skipping sample %d due to error: %s", idx, e)
             skipped_indices.append(idx)
             if failure_tracker is not None and failure_tracker.record_failure():
@@ -460,6 +462,9 @@ def main():
         asyncio.run(generate_and_save_hidden_states(args, dataset))
     except KeyboardInterrupt:
         sys.exit(130)
+    except Exception:
+        logger.exception("Data generation failed")
+        sys.exit(1)
 
     logger.info("Data generation complete!")
 

--- a/scripts/data_generation_offline2.py
+++ b/scripts/data_generation_offline2.py
@@ -316,7 +316,9 @@ async def worker(
                     )
         except Exception as e:
             if fail_on_error:
-                logger.error("Fatal: sample %d failed with --fail-on-error: %s", idx, e)
+                logger.exception(
+                    "Fatal: sample %d failed with --fail-on-error: %s", idx, e
+                )
                 logging.shutdown()
                 os._exit(1)
             logger.warning("Skipping sample %d due to error: %s", idx, e)

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -102,7 +102,11 @@ def launch_vllm_server(
         logger.info("vLLM server ready on port {}", port)
     except Exception:
         process.terminate()
-        process.wait(timeout=30)
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
         raise
 
     return process

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -91,21 +91,16 @@ def launch_vllm_server(
         str(max_model_len),
         "--gpu-memory-utilization",
         str(gpu_memory_utilization),
+        "--disable-uvicorn-access-log",
     ]
     logger.info("Starting vLLM server: {}", " ".join(cmd))
 
-    process = subprocess.Popen(  # noqa: S603
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-    )
+    process = subprocess.Popen(cmd)  # noqa: S603
 
     try:
         wait_for_server(port, process=process)
         logger.info("vLLM server ready on port {}", port)
     except Exception:
-        # Dump captured output to help debug startup failures
-        output = process.stdout.read().decode() if process.stdout else ""
-        if output:
-            logger.error("vLLM server output:\n{}", indent(output, "    "))
         process.terminate()
         process.wait(timeout=30)
         raise
@@ -123,13 +118,7 @@ def stop_vllm_server(process: subprocess.Popen):
             process.kill()
             process.wait(timeout=10)
     if process.returncode not in (0, -15):  # -15 = SIGTERM (expected)
-        output = process.stdout.read().decode() if process.stdout else ""
-        if output:
-            logger.error(
-                "vLLM server exited with code {}. Output:\n{}",
-                process.returncode,
-                indent(output, "    "),
-            )
+        logger.error("vLLM server exited with code {}", process.returncode)
     logger.info("vLLM server stopped (exit code {})", process.returncode)
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

<!--- Why your changes are needed -->

Currently, we're timing out because `data_generation_offline2.py` failing doesn't seem to always exit correctly. This pr makes it exit more forcefully if there are any issues.

We also update vllm the print logs (with uvicorn logs disabled) during generation. This means we won't print all 5000 status ok logs for all the requests, but will display any errors that may occur. 

This also might be fixing the time out issue we were having which seems like it might've been an issue with the logs being captured by the testing process. 


## Description

<!--- High-level concise summary of changes -->


## Related Issue

<!--- Link related issue if applicable -->

## Tests

<!--- Please describe in detail how you tested your changes. -->

E2E test run. Note this still failed but no longer gets stuck and hangs. It's failing on dflash related tests, unrelated to data gen. 
https://github.com/neuralmagic/llm-compressor-testing/actions/runs/24676474803/job/72161733494

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
