### PR TITLE
Fix off-by-one in dflash config

### DIFF
--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -151,7 +151,8 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
                 algorithm="dflash",
                 proposal_methods=[
                     GreedyTokenProposalConfig(
-                        speculative_tokens=kwargs.get("block_size", 8),
+                        # DFlash first position is anchor position, not used during gen
+                        speculative_tokens=kwargs.get("block_size", 8) - 1,
                     )
                 ],
                 default_proposal_method="greedy",

--- a/tests/e2e/regression/test_training_only_acceptance.py
+++ b/tests/e2e/regression/test_training_only_acceptance.py
@@ -80,5 +80,5 @@ def test_dflash_qwen3_8b_sharegpt(tmp_path: Path, prompts: list[list[dict[str, s
         max_tokens=512,
         ignore_eos=True,
         prompts=prompts,
-        acceptance_thresholds=[0.30, 0.05, 0.001, 0, 0, 0, 0, 0],
+        acceptance_thresholds=[0.30, 0.05, 0.001, 0, 0, 0, 0],
     )


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

There's an off by 1 error in the way we save our DFlash configs. During training we use a block size of 8, but that results in only 7 speculated tokens since the 0-th token re-predicts the anchor token value. 

<!--- Why your changes are needed -->

## Description

Fix off by one in the configs we save for dflash.

<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests

N/A

<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
