### PR TITLE
Add FP8 quantization for hidden state data generation

### DIFF
--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -38,6 +38,10 @@ envs.VLLM_WORKER_MULTIPROC_METHOD = "spawn"
 from speculators.data_generation.config_generator import (  # noqa: E402
     DataGenerationConfig,
 )
+from speculators.data_generation.fp8_utils import (  # noqa: E402
+    FP8_FORMAT_KEY,
+    SCALES_KEY,
+)
 from speculators.data_generation.logging_utils import PipelineLogger  # noqa: E402
 from speculators.data_generation.preprocessing import (  # noqa: E402
     load_and_preprocess_dataset,
@@ -183,6 +187,25 @@ def parse_args():
             "trainable tokens."
         ),
     )
+    parser.add_argument(
+        "--fp8-quantize",
+        action="store_true",
+        default=False,
+        help=(
+            "Quantize hidden states to float8_e4m3fn with scaling "
+            "before saving."
+        ),
+    )
+    parser.add_argument(
+        "--fp8-granularity",
+        type=str,
+        choices=["per_tensor", "per_token"],
+        default="per_token",
+        help=(
+            "FP8 quantization granularity. per_token (default) uses one scale "
+            "per token position; per_tensor uses one scale for the whole tensor."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -268,6 +291,8 @@ def generate_and_save_hidden_states(args, dataset):
         max_model_len=args.seq_length,
         gpu_memory_utilization=args.gpu_memory_utilization,
         tensor_parallel_size=args.tensor_parallel_size,
+        fp8_quantize=args.fp8_quantize,
+        fp8_granularity=args.fp8_granularity,
     )
 
     log.info(f"Processing {num_samples - start_sample_idx}/{num_samples} samples")
@@ -309,6 +334,10 @@ def generate_and_save_hidden_states(args, dataset):
                     "hidden_states": [h.contiguous() for h in result["hidden_states"]],
                     "loss_mask": loss_mask,
                 }
+                if SCALES_KEY in result:
+                    result_cleaned[SCALES_KEY] = result[SCALES_KEY]
+                if FP8_FORMAT_KEY in result:
+                    result_cleaned[FP8_FORMAT_KEY] = result[FP8_FORMAT_KEY]
                 output_path = Path(args.output_dir) / f"data_{file_idx}.pt"
                 future = thread_executor.submit(
                     save_sample_to_disk, result_cleaned, output_path

--- a/src/speculators/data_generation/fp8_utils.py
+++ b/src/speculators/data_generation/fp8_utils.py
@@ -1,0 +1,136 @@
+"""Utilities for FP8 scaled quantization of hidden states.
+
+Supports two granularities:
+  - per_tensor_scaled: one float32 scale per [seq_len, hidden_size] tensor (shape [1])
+  - per_token_scaled:  one float32 scale per row/token (shape [seq_len, 1])
+
+Quantize: scale = amax / FP8_MAX; fp8 = (tensor / scale).to(fp8_dtype)
+Dequantize: restored = fp8.to(target_dtype) * scale
+
+Both granularities use the same dequantize path — broadcasting handles the
+shape difference transparently.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+
+FP8_DTYPE = torch.float8_e4m3fn
+FP8_MAX = torch.finfo(FP8_DTYPE).max  # 448.0
+FP8_FORMAT_KEY = "fp8_format"
+FP8_FORMAT_PER_TENSOR = "per_tensor_scaled"
+FP8_FORMAT_PER_TOKEN = "per_token_scaled"
+SCALES_KEY = "hidden_states_scales"
+
+Granularity = Literal["per_tensor", "per_token"]
+
+
+def quantize_tensor_to_fp8(
+    tensor: torch.Tensor,
+    granularity: Granularity = "per_token",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a single tensor to FP8 with scaling.
+
+    Args:
+        tensor: Input tensor of shape [seq_len, hidden_size] in any float dtype.
+        granularity: "per_tensor" for one global scale, "per_token" for one
+                     scale per row (token position).
+
+    Returns:
+        Tuple of (fp8_tensor, scale).
+        - per_tensor: scale shape [1]
+        - per_token:  scale shape [seq_len, 1]
+    """
+    fp32 = tensor.float()
+    if granularity == "per_token":
+        amax = fp32.abs().amax(dim=-1, keepdim=True)  # [seq_len, 1]
+    else:
+        amax = fp32.abs().amax().reshape(1)  # [1]
+    scale = (amax / FP8_MAX).clamp(min=1e-12)
+    fp8_tensor = (fp32 / scale).to(FP8_DTYPE)
+    return fp8_tensor, scale
+
+
+def dequantize_fp8_tensor(
+    fp8_tensor: torch.Tensor,
+    scale: torch.Tensor,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize an FP8 tensor back to the target dtype.
+
+    Works for both per-tensor (scale shape [1]) and per-token (scale shape
+    [seq_len, 1]) — broadcasting handles both cases.
+    """
+    return fp8_tensor.to(dtype) * scale.to(dtype)
+
+
+def quantize_hidden_states(
+    hidden_states: list[torch.Tensor],
+    granularity: Granularity = "per_token",
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    """Quantize a list of hidden state tensors (one per layer) to FP8.
+
+    Args:
+        hidden_states: List of tensors, each [seq_len, hidden_size].
+        granularity: Quantization granularity.
+
+    Returns:
+        Tuple of (fp8_tensors, scales) where each list has one entry per layer.
+    """
+    fp8_tensors = []
+    scales = []
+    for h in hidden_states:
+        fp8_h, s = quantize_tensor_to_fp8(h, granularity)
+        fp8_tensors.append(fp8_h)
+        scales.append(s)
+    return fp8_tensors, scales
+
+
+def dequantize_hidden_states(
+    fp8_hidden_states: list[torch.Tensor],
+    scales: list[torch.Tensor],
+    dtype: torch.dtype = torch.bfloat16,
+) -> list[torch.Tensor]:
+    """Dequantize a list of FP8 hidden state tensors back to the target dtype.
+
+    Works for both per-tensor and per-token scales (broadcasting handles both).
+    """
+    return [
+        dequantize_fp8_tensor(h, s, dtype)
+        for h, s in zip(fp8_hidden_states, scales)
+    ]
+
+
+def _format_value(granularity: Granularity) -> str:
+    if granularity == "per_token":
+        return FP8_FORMAT_PER_TOKEN
+    return FP8_FORMAT_PER_TENSOR
+
+
+def pack_fp8_sample(
+    input_ids: torch.Tensor,
+    hidden_states: list[torch.Tensor],
+    loss_mask: torch.Tensor,
+    granularity: Granularity = "per_token",
+) -> dict:
+    """Quantize hidden states and pack into the v2 FP8 data format.
+
+    Args:
+        input_ids: Token IDs tensor.
+        hidden_states: List of bf16/fp32 hidden state tensors.
+        loss_mask: Loss mask tensor.
+        granularity: Quantization granularity.
+
+    Returns:
+        Dict in v2 format with fp8 hidden states, scales, and format marker.
+    """
+    fp8_hidden, scales = quantize_hidden_states(hidden_states, granularity)
+    return {
+        "input_ids": input_ids,
+        "hidden_states": fp8_hidden,
+        SCALES_KEY: scales,
+        "loss_mask": loss_mask,
+        FP8_FORMAT_KEY: _format_value(granularity),
+    }

--- a/src/speculators/data_generation/vllm_hidden_states_generator.py
+++ b/src/speculators/data_generation/vllm_hidden_states_generator.py
@@ -30,6 +30,7 @@ from vllm.v1.structured_output import StructuredOutputManager
 
 from speculators.utils.util import empty_cache, is_npu_available, mem_get_info
 
+from .fp8_utils import FP8_FORMAT_KEY, SCALES_KEY, Granularity, _format_value, quantize_tensor_to_fp8
 from .logging_utils import PipelineLogger
 
 __all__ = ["VllmHiddenStatesGenerator"]
@@ -84,6 +85,8 @@ class VllmHiddenStatesGenerator:
         gpu_memory_utilization: float = 0.8,
         tensor_parallel_size: int = 1,
         max_num_batched_tokens: int | None = None,
+        fp8_quantize: bool = False,
+        fp8_granularity: Granularity = "per_token",
     ):
         warnings.warn(
             "VllmHiddenStatesGenerator and the associated data_generation_offline.py"
@@ -93,6 +96,8 @@ class VllmHiddenStatesGenerator:
         )
         self.model_path = model_path
         self.tensor_parallel_size = tensor_parallel_size
+        self.fp8_quantize = fp8_quantize
+        self.fp8_granularity: Granularity = fp8_granularity
         self._request_counter = 0
 
         log.info(f"Initializing hidden states generator for {model_path}")
@@ -279,7 +284,6 @@ class VllmHiddenStatesGenerator:
                     max_tokens=MAX_DECODE_TOKENS, temperature=SAMPLING_TEMPERATURE
                 ),
                 pooling_params=None,
-                eos_token_id=self.tokenizer.eos_token_id,
                 arrival_time=INITIAL_ARRIVAL_TIME,
                 block_hasher=self.block_hasher,
             )
@@ -323,7 +327,7 @@ class VllmHiddenStatesGenerator:
                 )
 
             model_output = self.executor.execute_model(scheduler_output)
-            self.executor.sample_tokens(model_output)
+            self.executor.sample_tokens(None)
 
         # Abort all requests (prefill complete, don't need decode)
         self.scheduler.finish_requests(
@@ -352,16 +356,29 @@ class VllmHiddenStatesGenerator:
                     f"Available: {list(request_states_dict.keys())}"
                 )
 
-            layer_states = [h.clone().cpu() for h in request_states_dict[req_id]]
+            layer_states = []
+            layer_scales = []
+            for h in request_states_dict[req_id]:
+                cpu_h = h.clone().cpu()
+                if self.fp8_quantize:
+                    fp8_h, scale = quantize_tensor_to_fp8(cpu_h, self.fp8_granularity)
+                    layer_states.append(fp8_h)
+                    layer_scales.append(scale)
+                else:
+                    layer_states.append(cpu_h)
+
             input_ids_tensor = torch.as_tensor(input_ids_list[i], dtype=torch.long)
 
-            results.append(
-                {
-                    "input_ids": input_ids_tensor,
-                    "hidden_states": layer_states,
-                    "loss_mask": None,
-                }
-            )
+            result = {
+                "input_ids": input_ids_tensor,
+                "hidden_states": layer_states,
+                "loss_mask": None,
+            }
+            if self.fp8_quantize:
+                result[SCALES_KEY] = layer_scales
+                result[FP8_FORMAT_KEY] = _format_value(self.fp8_granularity)
+
+            results.append(result)
 
         empty_cache()
         return results

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -106,6 +106,32 @@ def standardize_data_v1(data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def standardize_data_v2_fp8(data: dict[str, Any]) -> dict[str, Any]:
+    """Standardize FP8 scaled data (v2 format) by dequantizing hidden states."""
+    from speculators.data_generation.fp8_utils import dequantize_fp8_tensor
+
+    hidden_states = [
+        dequantize_fp8_tensor(h, s, torch.bfloat16)
+        for h, s in zip(data["hidden_states"], data["hidden_states_scales"])
+    ]
+    return {
+        "hidden_states": torch.cat(hidden_states[:-1], dim=-1),
+        "input_ids": data["input_ids"],
+        "verifier_last_hidden_states": hidden_states[-1],
+        "loss_mask": data["loss_mask"],
+    }
+
+
+def standardize_data_auto(data: dict[str, Any]) -> dict[str, Any]:
+    """Auto-detect data format and standardize accordingly.
+
+    Handles both v1 (bf16) and v2 (fp8 scaled) formats transparently.
+    """
+    if "fp8_format" in data:
+        return standardize_data_v2_fp8(data)
+    return standardize_data_v1(data)
+
+
 class BaseDataset(Dataset):
     def __init__(
         self,
@@ -421,7 +447,7 @@ class SampleFileDataset(BaseDataset):
         ]
 
     def _get_raw_data(self, index):
-        return standardize_data_v1(
+        return standardize_data_auto(
             torch.load(
                 self.data[index], mmap=True, weights_only=True, map_location="cpu"
             )


### PR DESCRIPTION
Add optional FP8 quantization of hidden states during data generation, reducing disk usage by ~50% with minimal precision loss. Training transparently dequantizes FP8 data back to bf16.

New files:
- `fp8_utils.py`: core quant/dequant with per-tensor and per-token scaling

Modified files:
- `data_generation_offline.py`: `--fp8-quantize` and `--fp8-granularity` flags
- `vllm_hidden_states_generator.py`: optional FP8 path in `generate()`
- `train/data.py`: auto-detect FP8 format and dequantize at load time

Design
- FP8 only activates when `--fp8-quantize` is passed during datagen, or when saved data contains the `fp8_format` key
- Existing bf16 data loads identically through `standardize_data_auto`

Tested with Qwen3-8B (`inference-optimization/Speculators-DEMO-Qwen3_8b`), `vLLM 0.18.0`, `temperature=0`. 

**FP8 hidden states:**
| Benchmark | k=1 | k=2 | k=3 | k=4 | k=5 |
|---|---|---|---|---|---|
| HumanEval | 1.80 | 2.43 | 2.91 | 3.17 | 3.39 |
| math_reasoning | 1.82 | 2.45 | 2.90 | 3.26 | 3.46 |
| qa | 1.74 | 2.25 | 2.67 | 2.94 | 3.09 |
| question | 1.75 | 2.27 | 2.60 | 2.85 | 2.96 |
| rag | 1.73 | 2.19 | 2.53 | 2.76 | 2.85 |
| summarization | 1.62 | 1.96 | 2.16 | 2.23 | 2.29 |
| translation | 1.65 | 2.03 | 2.26 | 2.38 | 2.44 |

**BF16 hidden states (baseline):**
| Benchmark | k=1 | k=2 | k=3 | k=4 | k=5 |
|---|---|---|---|---|---|
| HumanEval | 1.81 | 2.44 | 2.87 | 3.21 | 3.44 |
| math_reasoning | 1.82 | 2.44 | 2.91 | 3.23 | 3.51 |
| qa | 1.74 | 2.25 | 2.61 | 2.90 | 3.03 |
| question | 1.77 | 2.26 | 2.62 | 2.84 | 2.92 |
| rag | 1.73 | 2.22 | 2.57 | 2.77 | 2.82 |
| summarization | 1.62 | 1.96 | 2.14 | 2.24 | 2.31 |
| translation | 1.65 | 2.04 | 2.25 | 2.37 | 2.46 |