### PR TITLE
Support transformers v5.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "setuptools",
     "torch>=2.9.0,<=2.11.0",
     "tqdm>=4.66.3,<=4.67.3",
-    "transformers>=4.56.1,<5.4.0",
+    "transformers>=4.56.1,<5.7.0",
     "typer>=0.12.0",
 ]
 

--- a/src/speculators/config.py
+++ b/src/speculators/config.py
@@ -228,7 +228,10 @@ class SpeculatorModelConfig(PydanticClassRegistryMixin, PretrainedConfig):
     is_composition: ClassVar[bool] = False  # type: ignore[misc]
     attribute_map: ClassVar[dict[str, str]] = {}  # type: ignore[misc]
     base_model_tp_plan: ClassVar[dict[str, Any] | None] = None  # type: ignore[misc]
-    base_model_pp_plan: ClassVar[dict[str, tuple[list[str]]] | None] = None  # type: ignore[misc]
+    base_model_pp_plan: ClassVar[dict[str, Any] | None] = None  # type: ignore[misc]
+    base_model_ep_plan: ClassVar[dict[str, Any] | None] = None  # type: ignore[misc]
+    has_no_defaults_at_init: ClassVar[bool] = False  # type: ignore[misc]
+    keys_to_ignore_at_inference: ClassVar[list[str]] = []  # type: ignore[misc]
     _auto_class: ClassVar[str | None] = ""  # type: ignore[misc]
 
     # Speculator model instance attributes
@@ -255,6 +258,12 @@ class SpeculatorModelConfig(PydanticClassRegistryMixin, PretrainedConfig):
         # reset kwargs handled by Pydantic so PretrainedConfig doesn't override
         for field in self.__class__.model_fields:
             kwargs[field] = getattr(self, field)
+
+        # strip ClassVars so PretrainedConfig.__post_init__ doesn't try to
+        # setattr them (pydantic blocks setattr on ClassVar names)
+        class_vars = self.__class__.__class_vars__
+        for cv in class_vars:
+            kwargs.pop(cv, None)
 
         # initialize the Hugging Face PretrainedConfig arguments for the model
         PretrainedConfig.__init__(self, **kwargs)
@@ -284,6 +293,9 @@ class SpeculatorModelConfig(PydanticClassRegistryMixin, PretrainedConfig):
             "attribute_map",
             "base_model_tp_plan",
             "base_model_pp_plan",
+            "base_model_ep_plan",
+            "has_no_defaults_at_init",
+            "keys_to_ignore_at_inference",
             "_auto_class",
         ):
             config_dict.pop(key, None)

--- a/src/speculators/convert/eagle/eagle3_converter.py
+++ b/src/speculators/convert/eagle/eagle3_converter.py
@@ -11,6 +11,8 @@ from transformers import LlamaConfig, PretrainedConfig
 from speculators.config import SpeculatorsConfig, VerifierConfig
 from speculators.convert.eagle.eagle3_legacy_model import Eagle3Speculator
 from speculators.convert.eagle.utils import (
+    build_llama_config_dtype_kwarg,
+    build_llama_config_rope_kwargs,
     ensure_checkpoint_is_local,
     find_vocab_size,
     load_checkpoint_config,
@@ -158,11 +160,13 @@ class Eagle3Converter:
             rms_norm_eps=eagle_config.get("rms_norm_eps", 1e-6),
             use_cache=True,
             attention_bias=eagle_config.get("attention_bias", False),
-            rope_theta=eagle_config.get("rope_theta", 10000.0),
             mlp_bias=eagle_config.get("mlp_bias", False),
             tie_word_embeddings=False,
-            torch_dtype=eagle_config.get("torch_dtype"),
             head_dim=eagle_config.get("head_dim"),
+            **build_llama_config_rope_kwargs(
+                rope_theta=eagle_config.get("rope_theta", 10000.0),
+            ),
+            **build_llama_config_dtype_kwarg(eagle_config.get("torch_dtype")),
         )
 
     def _save_converted_checkpoint(

--- a/src/speculators/convert/eagle/eagle_converter.py
+++ b/src/speculators/convert/eagle/eagle_converter.py
@@ -14,6 +14,7 @@ from speculators.convert.eagle.eagle_legacy_model import (
     EagleSpeculatorConfig,
 )
 from speculators.convert.eagle.utils import (
+    build_llama_config_rope_kwargs,
     detect_fusion_bias_and_layernorms,
     ensure_checkpoint_is_local,
     load_checkpoint_config,
@@ -156,11 +157,13 @@ class EagleConverter:
             bos_token_id=eagle_config.get("bos_token_id", 1),
             eos_token_id=eagle_config.get("eos_token_id", 2),
             tie_word_embeddings=False,  # Eagle uses separate embed_tokens from verifier
-            rope_theta=eagle_config.get("rope_theta", 10000.0),
-            rope_scaling=eagle_config.get("rope_scaling"),
             attention_bias=eagle_config.get("attention_bias", False),
             attention_dropout=eagle_config.get("attention_dropout", 0.0),
             mlp_bias=eagle_config.get("mlp_bias", False),
+            **build_llama_config_rope_kwargs(
+                rope_theta=eagle_config.get("rope_theta", 10000.0),
+                rope_scaling=eagle_config.get("rope_scaling"),
+            ),
         )
 
     def _build_eagle_speculator_config(

--- a/src/speculators/convert/eagle/utils.py
+++ b/src/speculators/convert/eagle/utils.py
@@ -2,13 +2,53 @@
 Utility functions for checkpoint conversion operations.
 """
 
+from __future__ import annotations
+
+import inspect
 import json
 from pathlib import Path
+from typing import Any
 
 import torch
 from huggingface_hub import snapshot_download
 from loguru import logger
 from safetensors import safe_open
+from transformers import LlamaConfig
+
+_LLAMA_CONFIG_PARAMS = set(inspect.signature(LlamaConfig.__init__).parameters)
+_LLAMA_CONFIG_HAS_ROPE_THETA = "rope_theta" in _LLAMA_CONFIG_PARAMS
+_LLAMA_CONFIG_HAS_TORCH_DTYPE = "torch_dtype" in _LLAMA_CONFIG_PARAMS
+
+
+def build_llama_config_dtype_kwarg(torch_dtype: str | None) -> dict[str, Any]:
+    if torch_dtype is None:
+        return {}
+    if _LLAMA_CONFIG_HAS_TORCH_DTYPE:
+        return {"torch_dtype": torch_dtype}
+    return {"dtype": torch_dtype}
+
+
+def build_llama_config_rope_kwargs(
+    rope_theta: float = 10000.0,
+    rope_scaling: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if _LLAMA_CONFIG_HAS_ROPE_THETA:
+        kwargs: dict[str, Any] = {"rope_theta": rope_theta}
+        if rope_scaling is not None:
+            kwargs["rope_scaling"] = rope_scaling
+        return kwargs
+
+    rope_params: dict[str, Any] = {"rope_theta": rope_theta}
+    if rope_scaling is not None:
+        rope_params["rope_type"] = rope_scaling.get(
+            "rope_type", rope_scaling.get("type", "default")
+        )
+        for k, v in rope_scaling.items():
+            if k not in ("rope_type", "type"):
+                rope_params[k] = v
+    else:
+        rope_params["rope_type"] = "default"
+    return {"rope_parameters": rope_params}
 
 
 def find_vocab_size(config_dict: dict) -> int | None:

--- a/src/speculators/models/eagle3/model_definitions.py
+++ b/src/speculators/models/eagle3/model_definitions.py
@@ -111,7 +111,7 @@ class Eagle3FirstLayerMixin:
         return hidden_states  # noqa: RET504
 
 
-class LlamaDecoderEagle3FirstLayer(Eagle3FirstLayerMixin, LlamaDecoderLayer):
+class LlamaDecoderEagle3FirstLayer(Eagle3FirstLayerMixin, LlamaDecoderLayer):  # type:ignore[misc]
     def __init__(
         self,
         config: LlamaConfig,
@@ -122,7 +122,7 @@ class LlamaDecoderEagle3FirstLayer(Eagle3FirstLayerMixin, LlamaDecoderLayer):
         self._patch_eagle3_projections(config, LlamaRMSNorm, norm_before_residual)
 
 
-class Qwen3DecoderEagle3FirstLayer(Eagle3FirstLayerMixin, Qwen3DecoderLayer):
+class Qwen3DecoderEagle3FirstLayer(Eagle3FirstLayerMixin, Qwen3DecoderLayer):  # type:ignore[misc]
     def __init__(
         self,
         config: Qwen3Config,

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -5,7 +5,7 @@ Unit tests for the config module in the Speculators library.
 import tempfile
 
 import pytest
-from transformers import PretrainedConfig
+from transformers import AutoConfig
 
 from speculators import (
     VerifierConfig,
@@ -17,7 +17,7 @@ from speculators import (
 @pytest.mark.smoke
 def test_verifier_config_from_verifier_config():
     with tempfile.TemporaryDirectory() as tmp_dir:
-        pretrained_config = PretrainedConfig.from_pretrained(
+        pretrained_config = AutoConfig.from_pretrained(
             pretrained_model_name_or_path="RedHatAI/Llama-3.1-8B-Instruct",
             cache_dir=tmp_dir,
         )

--- a/tests/unit/models/test_eagle_model.py
+++ b/tests/unit/models/test_eagle_model.py
@@ -113,16 +113,7 @@ def sample_llama_config():
         num_key_value_heads=8,
         pretraining_tp=1,
         rms_norm_eps=1e-5,  # type: ignore[arg-type] # (bad transformer's type hint, int instead of float)
-        rope_scaling={
-            "factor": 8.0,
-            "high_freq_factor": 4.0,
-            "low_freq_factor": 1.0,
-            "original_max_position_embeddings": 8192,
-            "rope_type": "llama3",
-        },
-        rope_theta=500000.0,
         tie_word_embeddings=False,
-        torch_dtype="float32",
         transformers_version="4.46.0",
         use_cache=True,
         vocab_size=128256,

--- a/tests/unit/train/test_setup_model.py
+++ b/tests/unit/train/test_setup_model.py
@@ -52,7 +52,7 @@ TINY_LLAMA_CONFIG = LlamaConfig(
     max_position_embeddings=32,
     rms_norm_eps=1e-6,  # type: ignore[arg-type] # (bad transformer's type hint, int instead of float)
     tie_word_embeddings=False,
-    _attn_implementation="eager",
+    _attn_implementation="eager",  # type: ignore[call-arg]
 )
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

<!--- Why your changes are needed -->
Support newer models available in transformers v5.4, v5.5, and v5.6 while maintaining backwards compat.

## Description

<!--- High-level concise summary of changes -->

There were a couple changes in newer transformers versions that required extra:
1. Rather than directly using `rope_theta` and `rope_scaling` in `LlamaConfig`, these were moved into a `rope_parameters` dict.
2. `torch_dtype` was replaced by `dtype` in the configs

To support these use cases (only used in legacy conversion code paths) we add some `build_llama_config_*` helper utils which use the right parameters for the install transformers version. 

## Related Issue

<!--- Link related issue if applicable -->

## Tests

Locally ran unit + integration + quality tests on both transformers v5.6 and v5.3.
Will also observe CI and run an e2e:

E2E (3.12, transformers, vllm@nightly): https://github.com/neuralmagic/llm-compressor-testing/actions/runs/24798432365/job/72574317390

E2E (3.12, transformers<5.0.0, vllm@nightly): https://github.com/neuralmagic/llm-compressor-testing/actions/runs/24809029898/job/72609644599

<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
