### PR TITLE
Standardize default directory names in training pipeline

### DIFF
--- a/docs/algorithms/add_new_algorithms.md
+++ b/docs/algorithms/add_new_algorithms.md
@@ -111,8 +111,8 @@ torchrun --nnodes=1 --nproc_per_node=8 scripts/train.py \
     --verifier-name-or-path meta-llama/Llama-3.1-8B \
     --num-layers 1 \
     --block-size 8 \
-    --data-path ./data \
-    --save-path ./checkpoints \
+    --data-path ./output \
+    --save-path ./output/checkpoints \
     --epochs 20
 ```
 

--- a/scripts/build_vocab_mapping.py
+++ b/scripts/build_vocab_mapping.py
@@ -40,8 +40,8 @@ def parse_args():
     parser.add_argument(
         "--token-freq-path",
         type=str,
-        required=True,
-        help="Path to token frequency distribution file (.pt)",
+        default="./output/token_freq.pt",
+        help="Path to token frequency distribution file (.pt) (default: ./output/token_freq.pt)",
     )
     parser.add_argument(
         "--draft-vocab-size",
@@ -64,8 +64,8 @@ def parse_args():
     parser.add_argument(
         "--output-path",
         type=str,
-        required=True,
-        help="Path to save the vocabulary mapping files",
+        default="./output",
+        help="Path to save the vocabulary mapping files (default: ./output)",
     )
 
     return parser.parse_args()

--- a/scripts/build_vocab_mapping.py
+++ b/scripts/build_vocab_mapping.py
@@ -41,7 +41,8 @@ def parse_args():
         "--token-freq-path",
         type=str,
         default="./output/token_freq.pt",
-        help="Path to token frequency distribution file (.pt) (default: ./output/token_freq.pt)",
+        help="Path to token frequency distribution file (.pt)"
+        " (default: ./output/token_freq.pt)",
     )
     parser.add_argument(
         "--draft-vocab-size",

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -85,8 +85,8 @@ def parse_args():
     parser.add_argument(
         "--preprocessed-data",
         type=str,
-        required=True,
-        help="Path to preprocessed dataset (dataset produced by prepare_data.py)",
+        default="./output",
+        help="Path to preprocessed dataset (dataset produced by prepare_data.py) (default: ./output)",
     )
     parser.add_argument(
         "--max-samples",

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -86,7 +86,8 @@ def parse_args():
         "--preprocessed-data",
         type=str,
         default="./output",
-        help="Path to preprocessed dataset (dataset produced by prepare_data.py) (default: ./output)",
+        help="Path to preprocessed dataset (dataset produced by prepare_data.py)"
+        " (default: ./output)",
     )
     parser.add_argument(
         "--max-samples",

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -99,7 +99,10 @@ def parse_args():
 
     # Output arguments
     parser.add_argument(
-        "--output", type=str, required=True, help="Directory to save output dataset"
+        "--output",
+        type=str,
+        default="./output",
+        help="Directory to save output dataset (default: ./output)",
     )
     parser.add_argument(
         "--overwrite",

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -387,7 +387,16 @@ def parse_args():
         default="",
         help="The pretrained draft model to finetune",
     )
-    parser.add_argument("--data-path", type=str, default="./data")
+    parser.add_argument(
+        "--data-path",
+        type=str,
+        default="./output",
+        help=(
+            "Root data directory containing the preprocessed dataset, "
+            "vocab mappings (d2t.npy, t2d.npy), token frequencies "
+            "(token_freq.pt), and hidden states (default: ./output)"
+        ),
+    )
     parser.add_argument(
         "--hidden-states-path",
         type=str,
@@ -462,7 +471,7 @@ def parse_args():
             "removed soon."
         ),
     )
-    parser.add_argument("--save-path", type=str, default="./checkpoints")
+    parser.add_argument("--save-path", type=str, default="./output/checkpoints")
     parser.add_argument("--epochs", type=int, default=20)
     parser.add_argument("--lr", type=float, default=1e-4)
     parser.add_argument("--no-resume-from-checkpoint", action="store_true")


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
Standardize default directory names in our training pipeline. 
<!--- Why your changes are needed -->

## Description
Standardized the input/output main directory of all our training-related scripts to be `./output` and added `--help` comment for some.
<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests
Tested locally.

<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
