### PR TITLE
Remove `failed`  from error messages

### DIFF
--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -317,7 +317,7 @@ async def worker(
         except Exception as e:
             if fail_on_error:
                 logger.exception(
-                    "Fatal: sample %d failed with --fail-on-error: %s", idx, e
+                    "Fatal: sample %d aborted with --fail-on-error: %s", idx, e
                 )
                 logging.shutdown()
                 os._exit(1)
@@ -327,7 +327,7 @@ async def worker(
                 cancel_event.set()
                 raise RuntimeError(
                     f"Aborting: {failure_tracker.threshold} consecutive samples "
-                    "failed. The vLLM server may be unreachable."
+                    "errored out. The vLLM server may be unreachable."
                 ) from e
         else:
             if failure_tracker is not None:

--- a/src/speculators/data_generation/vllm_client.py
+++ b/src/speculators/data_generation/vllm_client.py
@@ -29,14 +29,14 @@ def _handle_retry_error(
     if attempt < total_attempts:
         backoff = RETRY_BACKOFF_BASE**attempt
         logger.warning(
-            "Request failed (attempt %d/%d): %s. Retrying in %ds...",
+            "Request aborted (attempt %d/%d): %s. Retrying in %ds...",
             attempt,
             total_attempts,
             error,
             backoff,
         )
         return backoff
-    logger.error("Request failed after %d attempts: %s", total_attempts, error)
+    logger.error("Request timed out after %d attempts: %s", total_attempts, error)
     return None
 
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
To avoid crowding the search result of `failed` in our test pipeline, remove the wording `failed` from our time out error messages.
<!--- Why your changes are needed -->

## Description
Reword error messages.

<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests

<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
