### PR TITLE
Add multi-gpu marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,5 +267,6 @@ markers = [
     "sanity: detailed tests to ensure major functions work correctly",
     "regression: tests to ensure that new changes do not break existing functionality",
     "e2e: end-to-end integration tests",
-    "slow: tests that take a long time to run"
+    "slow: tests that take a long time to run",
+    "multi_gpu: tests that require 2+ GPUs"
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,11 @@ def seed():
 requires_cuda = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="CUDA required"
 )
+
+
 def requires_multi_gpu(fn):
     fn = pytest.mark.multi_gpu(fn)
-    fn = pytest.mark.skipif(
+    return pytest.mark.skipif(
         not torch.cuda.is_available() or torch.cuda.device_count() < 2,
         reason="2+ GPUs required",
     )(fn)
-    return fn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,10 @@ def seed():
 requires_cuda = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="CUDA required"
 )
-requires_multi_gpu = pytest.mark.skipif(
-    not torch.cuda.is_available() or torch.cuda.device_count() < 2,
-    reason="2+ GPUs required",
-)
+def requires_multi_gpu(fn):
+    fn = pytest.mark.multi_gpu(fn)
+    fn = pytest.mark.skipif(
+        not torch.cuda.is_available() or torch.cuda.device_count() < 2,
+        reason="2+ GPUs required",
+    )(fn)
+    return fn


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
We have several tests that require multiple gpus to run. Now they're skipped in nightly. Adding a tag so we can create a separate workflow for them.

<!--- Why your changes are needed -->

## Description
Add `multi-gpu` marker.

<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests

<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
