### PR TITLE
Improve E2E test logging (via `--log-freq` arg) and update timeouts. 

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -372,6 +372,7 @@ def main(args: argparse.Namespace):
         checkpoint_freq=args.checkpoint_freq,
         save_best=args.save_best,
         hidden_states_dtype=hidden_states_dtype,
+        log_freq=args.log_freq,
     )
     trainer = Trainer(draft_model, trainer_config, train_loader, val_loader)
 
@@ -499,6 +500,12 @@ def parse_args():
         help="One of 'trackio', 'wandb', 'tensorboard' or comma separated list of them",
     )
     parser.add_argument("--total-seq-len", type=int, default=8192)
+    parser.add_argument(
+        "--log-freq",
+        type=int,
+        default=1,
+        help="Log training metrics every N steps (default: 1)",
+    )
     parser.add_argument("--log-dir", type=str, default="./logs")
     parser.add_argument("--run-name", type=str, default=None)
     parser.add_argument("--num-layers", type=int, default=1)

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -46,6 +46,7 @@ class TrainerConfig(NamedTuple):
     checkpoint_freq: int = 1
     save_best: bool = False
     hidden_states_dtype: torch.dtype = torch.bfloat16
+    log_freq: int = 1
 
 
 class Trainer:
@@ -210,15 +211,21 @@ class Trainer:
             if self.scheduler is not None:
                 self.scheduler.step()
 
-            if self.is_distributed:
-                for v in metrics.values():
-                    dist.reduce(v, dst=0, op=dist.ReduceOp.AVG)
+            if self.global_step % self.config.log_freq == 0:
+                if self.is_distributed:
+                    for v in metrics.values():
+                        dist.reduce(v, dst=0, op=dist.ReduceOp.AVG)
 
-            metrics = {k: v.item() for k, v in metrics.items()}
-            metric_logger.info(
-                {"train": metrics, "epoch": epoch, "lr": current_lr},
-                extra={"step": self.global_step},
-            )
+                metrics = {k: v.item() for k, v in metrics.items()}
+                metric_logger.info(
+                    {
+                        "train": metrics,
+                        "epoch": epoch,
+                        "lr": current_lr,
+                        "global_step": self.global_step,
+                    },
+                    extra={"step": self.global_step},
+                )
             self.global_step += 1
 
     @torch.no_grad()

--- a/tests/e2e/regression/test_eagle3_offline_acceptance.py
+++ b/tests/e2e/regression/test_eagle3_offline_acceptance.py
@@ -26,4 +26,5 @@ def test_offline_regression(tmp_path: Path, prompts):
         epochs=3,
         prompts=prompts,
         acceptance_thresholds=[0.4, 0.07, 0.007],
+        log_freq=50,
     )

--- a/tests/e2e/regression/test_eagle3_online_acceptance.py
+++ b/tests/e2e/regression/test_eagle3_online_acceptance.py
@@ -24,4 +24,6 @@ def test_online_regression(tmp_path: Path, prompts):
         epochs=3,
         prompts=prompts,
         acceptance_thresholds=[0.4, 0.1, 0.01],
+        log_freq=50,
+        train_timeout=45 * 60,  # 45 mins
     )

--- a/tests/e2e/regression/test_training_only_acceptance.py
+++ b/tests/e2e/regression/test_training_only_acceptance.py
@@ -43,6 +43,8 @@ def test_eagle3_qwen3_8b_sharegpt(tmp_path: Path, prompts: list[list[dict[str, s
         lr=3e-4,
         draft_vocab_size=8192,
         online=False,
+        log_freq=50,
+        timeout=30 * 60,  # 30 mins
     )
     final_checkpoint = str(save_path / str(epochs - 1))
     run_vllm_engine(
@@ -72,6 +74,8 @@ def test_dflash_qwen3_8b_sharegpt(tmp_path: Path, prompts: list[list[dict[str, s
         draft_vocab_size=8192,
         num_layers=3,
         online=False,
+        log_freq=50,
+        timeout=30 * 60,  # 30 mins
     )
     final_checkpoint = str(save_path / str(epochs - 1))
     run_vllm_engine(

--- a/tests/e2e/smoke/test_offline_training.py
+++ b/tests/e2e/smoke/test_offline_training.py
@@ -73,6 +73,9 @@ def run_offline_e2e(
     speculator_type: str = "eagle3",
     extra_train_args: list[str] | None = None,
     target_layer_ids: list[int] | None = None,
+    log_freq: int = 1,
+    train_timeout: int = 30 * 60,  # 30 mins
+    datagen_timeout: int = 25 * 60,  # 25 mins
 ):
     data_path = tmp_path / "data"
     offline_hidden_states = tmp_path / "offline_hidden_states"
@@ -95,7 +98,7 @@ def run_offline_e2e(
             offline_hidden_states,
             port,
             max_samples,
-            timeout=25 * 60,
+            timeout=datagen_timeout,
         )
 
     # Step 3: Train using pre-generated hidden states (no live server needed)
@@ -113,6 +116,8 @@ def run_offline_e2e(
         speculator_type=speculator_type,
         extra_train_args=extra_train_args,
         target_layer_ids=target_layer_ids,
+        log_freq=log_freq,
+        timeout=train_timeout,
     )
 
     # Step 4: Validate trained checkpoint with vLLM inference

--- a/tests/e2e/smoke/test_online_training.py
+++ b/tests/e2e/smoke/test_online_training.py
@@ -42,6 +42,8 @@ def run_online_e2e(
     max_tokens: int = 50,
     ignore_eos: bool = True,
     acceptance_thresholds: list[float] | None = None,
+    log_freq: int = 1,
+    train_timeout: int = 30 * 60,  # 30 mins
 ):
     """
     Run online training e2e testing pipeline.
@@ -72,7 +74,8 @@ def run_online_e2e(
             draft_vocab_size,
             epochs,
             lr,
-            timeout=30 * 60,  # 30 mins
+            log_freq=log_freq,
+            timeout=train_timeout,
         )
 
     # Step 3: Validate trained checkpoint with vLLM inference

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -219,6 +219,7 @@ def run_training(
     extra_train_args: list[str] | None = None,
     target_layer_ids: list[int] | None = None,
     num_layers: int | None = None,
+    log_freq: int = 1,
 ):
     train_cmd = [
         sys.executable,
@@ -241,6 +242,8 @@ def run_training(
         str(seq_length),
         "--speculator-type",
         speculator_type,
+        "--log-freq",
+        str(log_freq),
     ]
     if online:
         train_cmd += [


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

Currently it's difficult to parse E2E logs because we are logging metrics on every step which is very verbose. This pr adds the ability to log every `N` steps instead. 

I also updated the timeouts / added timeout arg options to some of the regression tests. 

<!--- Why your changes are needed -->

## Description

<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests

<!--- Please describe in detail how you tested your changes. -->

Will run E2E on pr:

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
