### PR TITLE
Dflash verifier targets

### DIFF
--- a/src/speculators/model.py
+++ b/src/speculators/model.py
@@ -129,6 +129,8 @@ class DraftVocabMixin(nn.Module):
         is True. Subclasses can override to load additional weights (e.g. norms,
         tokenizer) by calling super().load_verifier_weights() first.
         """
+        import warnings  # noqa: PLC0415
+
         from speculators.utils.loading import load_model_layers  # noqa: PLC0415
 
         speculators_config = getattr(
@@ -140,8 +142,13 @@ class DraftVocabMixin(nn.Module):
         if verifier_config.name_or_path is None:
             return
 
+        # Determine which weights to load based on model attributes
+        weights_to_load = ["embed_tokens.weight", "lm_head.weight"]
+        if hasattr(self, "verifier_norm"):
+            weights_to_load.append("model.norm.weight")
+
         verifier_weights = load_model_layers(
-            ["embed_tokens.weight", "lm_head.weight"],
+            weights_to_load,
             verifier_config.name_or_path,
         )
 
@@ -169,6 +176,19 @@ class DraftVocabMixin(nn.Module):
         self.verifier_lm_head.load_state_dict(
             {"weight": lm_head_weight.detach().clone()}, strict=False
         )
+
+        # Load verifier norm weights if the model has verifier_norm
+        if hasattr(self, "verifier_norm"):
+            if "model.norm.weight" not in verifier_weights:
+                warnings.warn(
+                    f"Could not find final norm weights in {verifier_config.name_or_path}. "
+                    "Using default initialization (weight=1.0).",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            else:
+                verifier_norm_sd = {"weight": verifier_weights["model.norm.weight"]}
+                self.verifier_norm.load_state_dict(verifier_norm_sd)
 
 
 class SpeculatorModel(ClassRegistryMixin, PreTrainedModel):  # type: ignore[misc]

--- a/src/speculators/model.py
+++ b/src/speculators/model.py
@@ -7,7 +7,7 @@ in the Speculators library.
 
 import os
 from abc import abstractmethod
-from typing import ClassVar
+from typing import ClassVar, cast
 
 import torch
 from torch import nn
@@ -33,6 +33,7 @@ class DraftVocabMixin(nn.Module):
     embed_tokens: nn.Embedding
     lm_head: nn.Linear
     verifier_lm_head: nn.Linear
+    verifier_norm: nn.Module
 
     def _init_vocab(self, config):
         """Initialize vocab mappings, token embeddings, and LM heads.
@@ -181,7 +182,8 @@ class DraftVocabMixin(nn.Module):
         if hasattr(self, "verifier_norm"):
             if "model.norm.weight" not in verifier_weights:
                 warnings.warn(
-                    f"Could not find final norm weights in {verifier_config.name_or_path}. "
+                    f"Could not find final norm weights in "
+                    f"{verifier_config.name_or_path}. "
                     "Using default initialization (weight=1.0).",
                     UserWarning,
                     stacklevel=2,

--- a/src/speculators/model.py
+++ b/src/speculators/model.py
@@ -189,7 +189,7 @@ class DraftVocabMixin(nn.Module):
                 )
             else:
                 verifier_norm_sd = {"weight": verifier_weights["model.norm.weight"]}
-                self.verifier_norm.load_state_dict(verifier_norm_sd)
+                self.verifier_norm.load_state_dict(verifier_norm_sd)  # type: ignore[union-attr]
 
 
 class SpeculatorModel(ClassRegistryMixin, PreTrainedModel):  # type: ignore[misc]

--- a/src/speculators/model.py
+++ b/src/speculators/model.py
@@ -7,7 +7,7 @@ in the Speculators library.
 
 import os
 from abc import abstractmethod
-from typing import ClassVar, cast
+from typing import ClassVar
 
 import torch
 from torch import nn

--- a/src/speculators/model.py
+++ b/src/speculators/model.py
@@ -33,7 +33,6 @@ class DraftVocabMixin(nn.Module):
     embed_tokens: nn.Embedding
     lm_head: nn.Linear
     verifier_lm_head: nn.Linear
-    verifier_norm: nn.Module
 
     def _init_vocab(self, config):
         """Initialize vocab mappings, token embeddings, and LM heads.

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -92,21 +92,6 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         self.block_size = config.block_size
         self.post_init()
 
-    def load_verifier_weights(self):
-        super().load_verifier_weights()
-
-        from speculators.utils.loading import load_model_layers  # noqa: PLC0415
-
-        verifier_config = self.config.speculators_config.verifier
-        verifier_weights = load_model_layers(
-            ["model.norm.weight"],
-            verifier_config.name_or_path,
-        )
-
-        if "model.norm.weight" in verifier_weights:
-            verifier_norm_sd = {"weight": verifier_weights["model.norm.weight"]}
-            self.verifier_norm.load_state_dict(verifier_norm_sd)
-
     @classmethod
     def from_training_args(
         cls,

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -27,6 +27,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
     _no_split_modules = ["Qwen3DFlashDecoderLayer"]
     _keys_to_ignore_on_load_missing: ClassVar[list[str]] = [  # type: ignore[misc]
         "embed_tokens.weight",
+        "verifier_norm.weight",
         "t2d",
         "d2t",
     ]
@@ -83,8 +84,28 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             config.transformer_layer_config.hidden_size,
             eps=config.transformer_layer_config.rms_norm_eps,  # type: ignore[arg-type]
         )
+        self.verifier_norm = Qwen3RMSNorm(
+            config.transformer_layer_config.hidden_size,
+            eps=config.transformer_layer_config.rms_norm_eps,  # type: ignore[arg-type]
+        )
+        self.verifier_norm.weight.requires_grad = False
         self.block_size = config.block_size
         self.post_init()
+
+    def load_verifier_weights(self):
+        super().load_verifier_weights()
+
+        from speculators.utils.loading import load_model_layers  # noqa: PLC0415
+
+        verifier_config = self.config.speculators_config.verifier
+        verifier_weights = load_model_layers(
+            ["model.norm.weight"],
+            verifier_config.name_or_path,
+        )
+
+        if "model.norm.weight" in verifier_weights:
+            verifier_norm_sd = {"weight": verifier_weights["model.norm.weight"]}
+            self.verifier_norm.load_state_dict(verifier_norm_sd)
 
     @classmethod
     def from_training_args(
@@ -195,7 +216,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         hidden_states: torch.Tensor,  # shape: [1,total_seq_len,num_hidden*hidden_size]
         input_ids: torch.Tensor,  # shape: [1, total_seq_len]
         loss_mask: torch.Tensor,  # shape: [1, total_seq_len]
-        verifier_last_hidden_states: torch.Tensor,  # shape: [1, total_seq_len, hidden_size] # noqa: ARG002, E501
+        verifier_last_hidden_states: torch.Tensor,  # shape: [1, total_seq_len, hidden_size] # noqa: E501
         lengths: torch.Tensor | None = None,  # shape: [batch_size]
         position_ids: torch.Tensor | None = None,  # shape: [1, total_seq_len]
         **kwargs,
@@ -262,7 +283,11 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             anchor_positions, self.block_size, input_ids.numel()
         )  # shape: [num_anchors*block_size]
 
-        targets = input_ids.clone()[:, anchored_block_indices]
+        with torch.no_grad():
+            verifier_logits = self.verifier_lm_head(
+                self.verifier_norm(verifier_last_hidden_states)
+            )
+        targets = torch.argmax(verifier_logits, dim=-1)[:, anchored_block_indices]
         # shape: [1, num_anchors*block_size] # noqa: ERA001
 
         for layer in self.layers:
@@ -279,17 +304,6 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         logits = self.lm_head(self.norm(noise_embedding))
         # shape: [1, num_anchors*block_size, vocab_size] # noqa: ERA001
 
-        # Convert targets from verifier vocab to draft vocab
-        # t2d is a boolean mask [verifier_vocab_size] - True where
-        # verifier token exists in draft
-        # cumsum gives us the draft index for each verifier token
-        draft_indices = torch.cumsum(self.t2d.long(), dim=0) - 1  # type: ignore[union-attr,operator]
-        targets_draft = torch.where(
-            self.t2d[targets],  # type: ignore[index]
-            draft_indices[targets],  # type: ignore[index]
-            torch.tensor(-100, dtype=torch.long, device=device),
-        )
-
         aligned_loss_mask = loss_mask.clone()[:, anchored_block_indices]
         # shape: [1, num_anchors*block_size] # noqa: ERA001
 
@@ -302,7 +316,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
 
         aligned_loss_mask[:, :: self.block_size] = 0
         loss, metrics = compute_metrics(
-            logits, targets_draft, aligned_loss_mask, self.block_size
+            logits, targets, aligned_loss_mask, self.block_size
         )
         draft_tokens = torch.argmax(logits, dim=-1)
 

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -290,7 +290,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         verifier_preds = torch.argmax(verifier_logits, dim=-1)
         # Shift right by 1 so verifier_preds[i] predicts token at position i
         verifier_preds = torch.cat(
-            [input_ids[:, :1], verifier_preds[:, :-1]], dim=1
+            [verifier_preds.new_zeros(1, 1), verifier_preds[:, :-1]], dim=1
         )
         targets = verifier_preds[:, anchored_block_indices]
         # shape: [1, num_anchors*block_size] # noqa: ERA001

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -287,7 +287,12 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             verifier_logits = self.verifier_lm_head(
                 self.verifier_norm(verifier_last_hidden_states)
             )
-        targets = torch.argmax(verifier_logits, dim=-1)[:, anchored_block_indices]
+        verifier_preds = torch.argmax(verifier_logits, dim=-1)
+        # Shift right by 1 so verifier_preds[i] predicts token at position i
+        verifier_preds = torch.cat(
+            [input_ids[:, :1], verifier_preds[:, :-1]], dim=1
+        )
+        targets = verifier_preds[:, anchored_block_indices]
         # shape: [1, num_anchors*block_size] # noqa: ERA001
 
         for layer in self.layers:

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -1,6 +1,5 @@
 # ruff: noqa: ERA001
 import copy
-import warnings
 from typing import ClassVar
 
 import torch
@@ -17,7 +16,6 @@ from speculators.models.eagle3.attention import (
 from speculators.models.eagle3.model_definitions import model_classes
 from speculators.models.utils import resolve_target_layer_ids
 from speculators.proposals.greedy import GreedyTokenProposalConfig
-from speculators.utils.loading import load_model_layers
 
 
 def align_for_step(
@@ -244,23 +242,6 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
                 f"Verifier hidden size {verifier_model_config.hidden_size} does not"
                 f" match draft hidden size {self.hidden_size}."
             )
-
-        # Load verifier norm weights
-        verifier_weights = load_model_layers(
-            ["model.norm.weight"],
-            verifier_config.name_or_path,  # type: ignore[arg-type]
-        )
-
-        if "model.norm.weight" not in verifier_weights:
-            warnings.warn(
-                f"Could not find final norm weights in {verifier_config.name_or_path}. "
-                "Using default initialization (weight=1.0).",
-                UserWarning,
-                stacklevel=2,
-            )
-        else:
-            verifier_norm_sd = {"weight": verifier_weights["model.norm.weight"]}
-            self.verifier_norm.load_state_dict(verifier_norm_sd)
 
     @conditional_torch_compile
     def forward(  # noqa: C901


### PR DESCRIPTION
<!-- markdownlint-disable -->


## Purpose

Currently the DFlash code gets the targets from input_ids.  This saves memory during training but means that the code only works optimally when responses have been regenerated using the target model.  

## Description

This PR changes the DFlash code to get the targets by recomputing from the last verifier hidden state.  It still uses one-hot CE loss, experiments using KL-Div instead will be left to a later PR.  

## Related Issue

NA

## Tests

I ran a Qwen 3 8B model on 50k samples for 2 epochs and got:  

vllm bench serve   --backend openai-chat   --endpoint /v1/chat/completions   --dataset-name hf   --dataset-path philschmid/mt-bench   --num-prompts 80   --max-concurrency 1   --model 2 --tokenizer Qwen/Qwen3-8B   --base-url http://localhost:8000   --temperature 0.0   --hf-output-len 
2048

tip: install termplotlib and gnuplot to plot the metrics
============ Serving Benchmark Result ============
Successful requests:                     80        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  538.29    
Total input tokens:                      6078      
Total generated tokens:                  114010    
Request throughput (req/s):              0.15      
Output token throughput (tok/s):         211.80    
Peak output token throughput (tok/s):    80.00     
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          223.09    
---------------Time to First Token----------------
Mean TTFT (ms):                          43.95     
Median TTFT (ms):                        29.72     
P99 TTFT (ms):                           263.66    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          4.97      
Median TPOT (ms):                        4.90      
P99 TPOT (ms):                           7.28      
---------------Inter-token Latency----------------
Mean ITL (ms):                           13.19     
Median ITL (ms):                         13.15     
P99 ITL (ms):                            14.56     
---------------Speculative Decoding---------------
Acceptance rate (%):                     25.95     
Acceptance length:                       2.82      
Drafts:                                  40475     
Draft tokens:                            283325    
Accepted tokens:                         73509     
Per-position acceptance (%):
  Position 0:                            70.49     
  Position 1:                            44.72     
  Position 2:                            27.79     
  Position 3:                            17.41     
  Position 4:                            10.78     
  Position 5:                            6.62      
  Position 6:                            3.81      

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
