### PR TITLE
Feat/fp8 connector

### DIFF
--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -48,7 +48,7 @@ def parse_args():
         help=(
             "Quantize hidden states to float8_e4m3fn with per-token scaling "
             "before saving. Uses a custom KV connector that stores FP8 data "
-            "with scaling factors, reducing disk usage by ~50%%."
+            "with scaling factors."
         ),
     )
     parser.add_argument(

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -98,9 +98,7 @@ def main():
     extra_config: dict[str, str] = {"shared_storage_path": args.hidden_states_path}
     if args.fp8_quantize:
         connector_name = "FP8HiddenStatesConnector"
-        module_path = (
-            "speculators.data_generation.fp8_hidden_states_connector"
-        )
+        module_path = "speculators.data_generation.fp8_hidden_states_connector"
     else:
         connector_name = "ExampleHiddenStatesConnector"
         module_path = None

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -3,6 +3,7 @@ import json
 import os
 import sys
 import warnings
+from typing import Any
 
 
 def parse_args():
@@ -39,6 +40,15 @@ def parse_args():
         help=(
             "Append the last layer (num_hidden_layers) to "
             "target_layer_ids for verifier hidden states extraction. Default: True"
+        ),
+    )
+    parser.add_argument(
+        "--fp8-quantize",
+        action="store_true",
+        help=(
+            "Quantize hidden states to float8_e4m3fn with per-token scaling "
+            "before saving. Uses a custom KV connector that stores FP8 data "
+            "with scaling factors, reducing disk usage by ~50%%."
         ),
     )
     parser.add_argument(
@@ -85,11 +95,23 @@ def main():
             "hf_config": {"eagle_aux_hidden_state_layer_ids": target_layer_ids}
         },
     }
-    kv_transfer_config = {
-        "kv_connector": "ExampleHiddenStatesConnector",
+    extra_config: dict[str, str] = {"shared_storage_path": args.hidden_states_path}
+    if args.fp8_quantize:
+        connector_name = "FP8HiddenStatesConnector"
+        module_path = (
+            "speculators.data_generation.fp8_hidden_states_connector"
+        )
+    else:
+        connector_name = "ExampleHiddenStatesConnector"
+        module_path = None
+
+    kv_transfer_config: dict[str, Any] = {
+        "kv_connector": connector_name,
         "kv_role": "kv_producer",
-        "kv_connector_extra_config": {"shared_storage_path": args.hidden_states_path},
+        "kv_connector_extra_config": extra_config,
     }
+    if module_path is not None:
+        kv_transfer_config["kv_connector_module_path"] = module_path
 
     cmd = [
         sys.executable,

--- a/src/speculators/data_generation/fp8_hidden_states_connector.py
+++ b/src/speculators/data_generation/fp8_hidden_states_connector.py
@@ -29,12 +29,8 @@ from speculators.data_generation.fp8_utils import (
 if TYPE_CHECKING:
     from vllm.v1.attention.backend import AttentionMetadata
 
-ExampleHiddenStatesConnector = _eh_mod.ExampleHiddenStatesConnector
-ExampleHiddenStatesConnectorMetadata = _eh_mod.ExampleHiddenStatesConnectorMetadata
-extract_from_kv_cache = _eh_mod.extract_from_kv_cache
 
-
-class FP8HiddenStatesConnector(ExampleHiddenStatesConnector):
+class FP8HiddenStatesConnector(_eh_mod.ExampleHiddenStatesConnector):
     """Quantizes hidden states to float8_e4m3fn with per-token scaling
     before saving to safetensors.
 
@@ -58,11 +54,13 @@ class FP8HiddenStatesConnector(ExampleHiddenStatesConnector):
         assert isinstance(attn_metadata, CacheOnlyAttentionMetadata)
 
         connector_metadata = self._get_connector_metadata()
-        assert isinstance(connector_metadata, ExampleHiddenStatesConnectorMetadata)
+        assert isinstance(
+            connector_metadata, _eh_mod.ExampleHiddenStatesConnectorMetadata
+        )
 
         os.makedirs(self._storage_path, exist_ok=True)
         for request in connector_metadata.requests:
-            hidden_states = extract_from_kv_cache(
+            hidden_states = _eh_mod.extract_from_kv_cache(
                 kv_layer, request.slot_mapping, request.token_ids.shape[0]
             )
             cpu_hs = hidden_states.detach().cpu()

--- a/src/speculators/data_generation/fp8_hidden_states_connector.py
+++ b/src/speculators/data_generation/fp8_hidden_states_connector.py
@@ -12,7 +12,6 @@ Launch example::
 from __future__ import annotations
 
 import os
-from concurrent.futures import Future, ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Optional
 
 import safetensors.torch
@@ -48,16 +47,6 @@ class FP8HiddenStatesConnector(ExampleHiddenStatesConnector):
         hidden_states_scales – fp32 [seq_len, 1]
         token_ids            – int64 [seq_len]
     """
-
-    def __init__(
-        self,
-        vllm_config: "VllmConfig",
-        role: KVConnectorRole,
-        kv_cache_config: Optional["KVCacheConfig"] = None,
-    ):
-        super().__init__(vllm_config, role, kv_cache_config)
-        self._executor = ThreadPoolExecutor(max_workers=4)
-        self._pending: list[Future] = []
 
     def save_kv_layer(
         self,
@@ -97,13 +86,4 @@ class FP8HiddenStatesConnector(ExampleHiddenStatesConnector):
                 SCALES_KEY: scales,
                 "token_ids": request.token_ids.detach().cpu(),
             }
-            self._pending.append(
-                self._executor.submit(
-                    safetensors.torch.save_file, tensors, request.filename
-                )
-            )
-
-    def wait_for_save(self):
-        for f in self._pending:
-            f.result()
-        self._pending.clear()
+            safetensors.torch.save_file(tensors, request.filename)

--- a/src/speculators/data_generation/fp8_hidden_states_connector.py
+++ b/src/speculators/data_generation/fp8_hidden_states_connector.py
@@ -1,7 +1,7 @@
 """KV connector that quantizes hidden states to FP8 before writing to disk.
 
 Drop-in replacement for vLLM's ExampleHiddenStatesConnector. Loaded via
-the ``kv_connector_module_path`` factory mechanism — no vLLM modifications
+the ``kv_connector_module_path`` factory mechanism - no vLLM modifications
 required.
 
 Launch example::
@@ -36,9 +36,9 @@ class FP8HiddenStatesConnector(_eh_mod.ExampleHiddenStatesConnector):
 
     The output file contains three tensors::
 
-        hidden_states        – fp8 [seq_len, num_layers, hidden_size]
-        hidden_states_scales – fp32 [seq_len, 1]
-        token_ids            – int64 [seq_len]
+        hidden_states        - fp8 [seq_len, num_layers, hidden_size]
+        hidden_states_scales - fp32 [seq_len, 1]
+        token_ids            - int64 [seq_len]
     """
 
     def save_kv_layer(

--- a/src/speculators/data_generation/fp8_hidden_states_connector.py
+++ b/src/speculators/data_generation/fp8_hidden_states_connector.py
@@ -1,0 +1,89 @@
+"""KV connector that quantizes hidden states to FP8 before writing to disk.
+
+Drop-in replacement for vLLM's ExampleHiddenStatesConnector. Loaded via
+the ``kv_connector_module_path`` factory mechanism — no vLLM modifications
+required.
+
+Launch example::
+
+    python scripts/launch_vllm.py MODEL --fp8-quantize -- ...
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any, Optional
+
+import safetensors.torch
+import torch
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorRole,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.example_hidden_states_connector import (
+    ExampleHiddenStatesConnector,
+    ExampleHiddenStatesConnectorMetadata,
+    extract_from_kv_cache,
+)
+
+from speculators.data_generation.fp8_utils import (
+    SCALES_KEY,
+    quantize_tensor_to_fp8,
+)
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.v1.attention.backend import AttentionMetadata
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+
+
+class FP8HiddenStatesConnector(ExampleHiddenStatesConnector):
+    """Quantizes hidden states to float8_e4m3fn with per-token scaling
+    before saving to safetensors.
+
+    The output file contains three tensors::
+
+        hidden_states        – fp8 [seq_len, num_layers, hidden_size]
+        hidden_states_scales – fp32 [seq_len, 1]
+        token_ids            – int64 [seq_len]
+    """
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: "AttentionMetadata",
+        **kwargs: Any,
+    ) -> None:
+        if layer_name not in self.cache_layers:
+            return
+
+        from vllm.model_executor.models.extract_hidden_states import (
+            CacheOnlyAttentionMetadata,
+        )
+
+        assert isinstance(attn_metadata, CacheOnlyAttentionMetadata)
+
+        connector_metadata = self._get_connector_metadata()
+        assert isinstance(connector_metadata, ExampleHiddenStatesConnectorMetadata)
+
+        os.makedirs(self._storage_path, exist_ok=True)
+        for request in connector_metadata.requests:
+            hidden_states = extract_from_kv_cache(
+                kv_layer, request.slot_mapping, request.token_ids.shape[0]
+            )
+            cpu_hs = hidden_states.detach().cpu()
+
+            # Flatten to [seq_len, num_layers * hidden_size] for quantization,
+            # then reshape back so the file layout stays consistent.
+            original_shape = cpu_hs.shape  # [seq_len, num_layers, hidden_size]
+            flat = cpu_hs.reshape(cpu_hs.shape[0], -1)
+            fp8_flat, scales = quantize_tensor_to_fp8(flat)
+            fp8_hs = fp8_flat.reshape(original_shape)
+
+            tensors: dict[str, torch.Tensor] = {
+                "hidden_states": fp8_hs,
+                SCALES_KEY: scales,
+                "token_ids": request.token_ids.detach().cpu(),
+            }
+            safetensors.torch.save_file(tensors, request.filename)

--- a/src/speculators/data_generation/fp8_hidden_states_connector.py
+++ b/src/speculators/data_generation/fp8_hidden_states_connector.py
@@ -12,6 +12,7 @@ Launch example::
 from __future__ import annotations
 
 import os
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Optional
 
 import safetensors.torch
@@ -47,6 +48,16 @@ class FP8HiddenStatesConnector(ExampleHiddenStatesConnector):
         hidden_states_scales – fp32 [seq_len, 1]
         token_ids            – int64 [seq_len]
     """
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        role: KVConnectorRole,
+        kv_cache_config: Optional["KVCacheConfig"] = None,
+    ):
+        super().__init__(vllm_config, role, kv_cache_config)
+        self._executor = ThreadPoolExecutor(max_workers=4)
+        self._pending: list[Future] = []
 
     def save_kv_layer(
         self,
@@ -86,4 +97,13 @@ class FP8HiddenStatesConnector(ExampleHiddenStatesConnector):
                 SCALES_KEY: scales,
                 "token_ids": request.token_ids.detach().cpu(),
             }
-            safetensors.torch.save_file(tensors, request.filename)
+            self._pending.append(
+                self._executor.submit(
+                    safetensors.torch.save_file, tensors, request.filename
+                )
+            )
+
+    def wait_for_save(self):
+        for f in self._pending:
+            f.result()
+        self._pending.clear()

--- a/src/speculators/data_generation/fp8_hidden_states_connector.py
+++ b/src/speculators/data_generation/fp8_hidden_states_connector.py
@@ -12,18 +12,12 @@ Launch example::
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import safetensors.torch
 import torch
-
-from vllm.distributed.kv_transfer.kv_connector.v1.base import (
-    KVConnectorRole,
-)
-from vllm.distributed.kv_transfer.kv_connector.v1.example_hidden_states_connector import (
-    ExampleHiddenStatesConnector,
-    ExampleHiddenStatesConnectorMetadata,
-    extract_from_kv_cache,
+from vllm.distributed.kv_transfer.kv_connector.v1 import (
+    example_hidden_states_connector as _eh_mod,
 )
 from vllm.model_executor.models.extract_hidden_states import CacheOnlyAttentionMetadata
 
@@ -34,6 +28,10 @@ from speculators.data_generation.fp8_utils import (
 
 if TYPE_CHECKING:
     from vllm.v1.attention.backend import AttentionMetadata
+
+ExampleHiddenStatesConnector = _eh_mod.ExampleHiddenStatesConnector
+ExampleHiddenStatesConnectorMetadata = _eh_mod.ExampleHiddenStatesConnectorMetadata
+extract_from_kv_cache = _eh_mod.extract_from_kv_cache
 
 
 class FP8HiddenStatesConnector(ExampleHiddenStatesConnector):

--- a/src/speculators/data_generation/fp8_hidden_states_connector.py
+++ b/src/speculators/data_generation/fp8_hidden_states_connector.py
@@ -25,6 +25,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.example_hidden_states_connecto
     ExampleHiddenStatesConnectorMetadata,
     extract_from_kv_cache,
 )
+from vllm.model_executor.models.extract_hidden_states import CacheOnlyAttentionMetadata
 
 from speculators.data_generation.fp8_utils import (
     SCALES_KEY,
@@ -32,9 +33,7 @@ from speculators.data_generation.fp8_utils import (
 )
 
 if TYPE_CHECKING:
-    from vllm.config import VllmConfig
     from vllm.v1.attention.backend import AttentionMetadata
-    from vllm.v1.kv_cache_interface import KVCacheConfig
 
 
 class FP8HiddenStatesConnector(ExampleHiddenStatesConnector):
@@ -52,15 +51,11 @@ class FP8HiddenStatesConnector(ExampleHiddenStatesConnector):
         self,
         layer_name: str,
         kv_layer: torch.Tensor,
-        attn_metadata: "AttentionMetadata",
-        **kwargs: Any,
+        attn_metadata: AttentionMetadata,
+        **_kwargs: Any,
     ) -> None:
         if layer_name not in self.cache_layers:
             return
-
-        from vllm.model_executor.models.extract_hidden_states import (
-            CacheOnlyAttentionMetadata,
-        )
 
         assert isinstance(attn_metadata, CacheOnlyAttentionMetadata)
 

--- a/src/speculators/data_generation/fp8_utils.py
+++ b/src/speculators/data_generation/fp8_utils.py
@@ -12,8 +12,6 @@ import torch
 
 FP8_DTYPE = torch.float8_e4m3fn
 FP8_MAX = torch.finfo(FP8_DTYPE).max  # 448.0
-FP8_FORMAT_KEY = "fp8_format"
-FP8_FORMAT_VALUE = "per_token_scaled"
 SCALES_KEY = "hidden_states_scales"
 
 
@@ -42,60 +40,3 @@ def dequantize_fp8_tensor(
 ) -> torch.Tensor:
     """Dequantize an FP8 tensor back to the target dtype."""
     return fp8_tensor.to(dtype) * scale.to(dtype)
-
-
-def quantize_hidden_states(
-    hidden_states: list[torch.Tensor],
-) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
-    """Quantize a list of hidden state tensors (one per layer) to FP8.
-
-    Args:
-        hidden_states: List of tensors, each [seq_len, hidden_size].
-
-    Returns:
-        Tuple of (fp8_tensors, scales) where each list has one entry per layer.
-    """
-    fp8_tensors = []
-    scales = []
-    for h in hidden_states:
-        fp8_h, s = quantize_tensor_to_fp8(h)
-        fp8_tensors.append(fp8_h)
-        scales.append(s)
-    return fp8_tensors, scales
-
-
-def dequantize_hidden_states(
-    fp8_hidden_states: list[torch.Tensor],
-    scales: list[torch.Tensor],
-    dtype: torch.dtype = torch.bfloat16,
-) -> list[torch.Tensor]:
-    """Dequantize a list of FP8 hidden state tensors back to the target dtype."""
-    return [
-        dequantize_fp8_tensor(h, s, dtype)
-        for h, s in zip(fp8_hidden_states, scales)
-    ]
-
-
-def pack_fp8_sample(
-    input_ids: torch.Tensor,
-    hidden_states: list[torch.Tensor],
-    loss_mask: torch.Tensor,
-) -> dict:
-    """Quantize hidden states and pack into the FP8 data format.
-
-    Args:
-        input_ids: Token IDs tensor.
-        hidden_states: List of bf16/fp32 hidden state tensors.
-        loss_mask: Loss mask tensor.
-
-    Returns:
-        Dict with fp8 hidden states, scales, and format marker.
-    """
-    fp8_hidden, scales = quantize_hidden_states(hidden_states)
-    return {
-        "input_ids": input_ids,
-        "hidden_states": fp8_hidden,
-        SCALES_KEY: scales,
-        "loss_mask": loss_mask,
-        FP8_FORMAT_KEY: FP8_FORMAT_VALUE,
-    }

--- a/src/speculators/data_generation/fp8_utils.py
+++ b/src/speculators/data_generation/fp8_utils.py
@@ -1,0 +1,101 @@
+"""Utilities for FP8 scaled quantization of hidden states.
+
+Uses per-token scaling: one float32 scale per row/token (shape [seq_len, 1]).
+
+Quantize: scale = amax / FP8_MAX; fp8 = (tensor / scale).to(fp8_dtype)
+Dequantize: restored = fp8.to(target_dtype) * scale
+"""
+
+from __future__ import annotations
+
+import torch
+
+FP8_DTYPE = torch.float8_e4m3fn
+FP8_MAX = torch.finfo(FP8_DTYPE).max  # 448.0
+FP8_FORMAT_KEY = "fp8_format"
+FP8_FORMAT_VALUE = "per_token_scaled"
+SCALES_KEY = "hidden_states_scales"
+
+
+def quantize_tensor_to_fp8(
+    tensor: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a single tensor to FP8 with per-token scaling.
+
+    Args:
+        tensor: Input tensor of shape [seq_len, hidden_size] in any float dtype.
+
+    Returns:
+        Tuple of (fp8_tensor, scale) where scale shape is [seq_len, 1].
+    """
+    fp32 = tensor.float()
+    amax = fp32.abs().amax(dim=-1, keepdim=True)  # [seq_len, 1]
+    scale = (amax / FP8_MAX).clamp(min=1e-12)
+    fp8_tensor = (fp32 / scale).to(FP8_DTYPE)
+    return fp8_tensor, scale
+
+
+def dequantize_fp8_tensor(
+    fp8_tensor: torch.Tensor,
+    scale: torch.Tensor,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize an FP8 tensor back to the target dtype."""
+    return fp8_tensor.to(dtype) * scale.to(dtype)
+
+
+def quantize_hidden_states(
+    hidden_states: list[torch.Tensor],
+) -> tuple[list[torch.Tensor], list[torch.Tensor]]:
+    """Quantize a list of hidden state tensors (one per layer) to FP8.
+
+    Args:
+        hidden_states: List of tensors, each [seq_len, hidden_size].
+
+    Returns:
+        Tuple of (fp8_tensors, scales) where each list has one entry per layer.
+    """
+    fp8_tensors = []
+    scales = []
+    for h in hidden_states:
+        fp8_h, s = quantize_tensor_to_fp8(h)
+        fp8_tensors.append(fp8_h)
+        scales.append(s)
+    return fp8_tensors, scales
+
+
+def dequantize_hidden_states(
+    fp8_hidden_states: list[torch.Tensor],
+    scales: list[torch.Tensor],
+    dtype: torch.dtype = torch.bfloat16,
+) -> list[torch.Tensor]:
+    """Dequantize a list of FP8 hidden state tensors back to the target dtype."""
+    return [
+        dequantize_fp8_tensor(h, s, dtype)
+        for h, s in zip(fp8_hidden_states, scales)
+    ]
+
+
+def pack_fp8_sample(
+    input_ids: torch.Tensor,
+    hidden_states: list[torch.Tensor],
+    loss_mask: torch.Tensor,
+) -> dict:
+    """Quantize hidden states and pack into the FP8 data format.
+
+    Args:
+        input_ids: Token IDs tensor.
+        hidden_states: List of bf16/fp32 hidden state tensors.
+        loss_mask: Loss mask tensor.
+
+    Returns:
+        Dict with fp8 hidden states, scales, and format marker.
+    """
+    fp8_hidden, scales = quantize_hidden_states(hidden_states)
+    return {
+        "input_ids": input_ids,
+        "hidden_states": fp8_hidden,
+        SCALES_KEY: scales,
+        "loss_mask": loss_mask,
+        FP8_FORMAT_KEY: FP8_FORMAT_VALUE,
+    }

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -17,6 +17,7 @@ from datasets import load_from_disk
 from safetensors.torch import load_file
 from torch.utils.data import Dataset
 
+from speculators.data_generation.fp8_utils import dequantize_fp8_tensor
 from speculators.data_generation.vllm_client import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_REQUEST_TIMEOUT,
@@ -323,8 +324,6 @@ class ArrowDataset(BaseDataset):
         hs = loaded_hs["hidden_states"]
 
         if "hidden_states_scales" in loaded_hs:
-            from speculators.data_generation.fp8_utils import dequantize_fp8_tensor
-
             flat = hs.reshape(hs.shape[0], -1)
             hs = dequantize_fp8_tensor(
                 flat, loaded_hs["hidden_states_scales"], torch.bfloat16

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -106,6 +106,32 @@ def standardize_data_v1(data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def standardize_data_v2_fp8(data: dict[str, Any]) -> dict[str, Any]:
+    """Standardize FP8 scaled data (v2 format) by dequantizing hidden states."""
+    from speculators.data_generation.fp8_utils import dequantize_fp8_tensor
+
+    hidden_states = [
+        dequantize_fp8_tensor(h, s, torch.bfloat16)
+        for h, s in zip(data["hidden_states"], data["hidden_states_scales"])
+    ]
+    return {
+        "hidden_states": torch.cat(hidden_states[:-1], dim=-1),
+        "input_ids": data["input_ids"],
+        "verifier_last_hidden_states": hidden_states[-1],
+        "loss_mask": data["loss_mask"],
+    }
+
+
+def standardize_data_auto(data: dict[str, Any]) -> dict[str, Any]:
+    """Auto-detect data format and standardize accordingly.
+
+    Handles both v1 (bf16) and v2 (fp8 scaled) formats transparently.
+    """
+    if "fp8_format" in data:
+        return standardize_data_v2_fp8(data)
+    return standardize_data_v1(data)
+
+
 class BaseDataset(Dataset):
     def __init__(
         self,
@@ -306,10 +332,11 @@ class ArrowDataset(BaseDataset):
         if loaded_hs is None:
             return loaded_hs
 
-        # loaded_hs structure: {
-        #   "hidden_states": [seq_len, 4, hidden_size]
-        #   "token_ids": [seq_len]
-        # }
+        # loaded_hs structure (bf16):
+        #   {"hidden_states": [seq_len, 4, hidden_size], "token_ids": [seq_len]}
+        # loaded_hs structure (fp8):
+        #   {"hidden_states": fp8 [seq_len, 4, hidden_size],
+        #    "hidden_states_scales": [seq_len, 1] or [1], "token_ids": [seq_len]}
 
         if not torch.equal(loaded_hs["token_ids"], self.data[index]["input_ids"]):
             warnings.warn(
@@ -319,14 +346,20 @@ class ArrowDataset(BaseDataset):
             )
             return None
 
+        hs = loaded_hs["hidden_states"]
+
+        if "hidden_states_scales" in loaded_hs:
+            from speculators.data_generation.fp8_utils import dequantize_fp8_tensor
+
+            flat = hs.reshape(hs.shape[0], -1)
+            hs = dequantize_fp8_tensor(
+                flat, loaded_hs["hidden_states_scales"], torch.bfloat16
+            ).reshape(hs.shape)
+
         return {
-            "hidden_states": loaded_hs["hidden_states"][:, :-1].flatten(
-                1
-            ),  # [seq_len, 3 * hidden_size]
+            "hidden_states": hs[:, :-1].flatten(1),  # [seq_len, 3 * hidden_size]
             "input_ids": loaded_hs["token_ids"],  # [seq_len]
-            "verifier_last_hidden_states": loaded_hs["hidden_states"][
-                :, -1
-            ],  # [seq_len, hidden_size]
+            "verifier_last_hidden_states": hs[:, -1],  # [seq_len, hidden_size]
             "loss_mask": self.data[index]["loss_mask"],  # [seq_len]
         }
 
@@ -421,7 +454,7 @@ class SampleFileDataset(BaseDataset):
         ]
 
     def _get_raw_data(self, index):
-        return standardize_data_v1(
+        return standardize_data_auto(
             torch.load(
                 self.data[index], mmap=True, weights_only=True, map_location="cpu"
             )

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -106,32 +106,6 @@ def standardize_data_v1(data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def standardize_data_v2_fp8(data: dict[str, Any]) -> dict[str, Any]:
-    """Standardize FP8 scaled data (v2 format) by dequantizing hidden states."""
-    from speculators.data_generation.fp8_utils import dequantize_fp8_tensor
-
-    hidden_states = [
-        dequantize_fp8_tensor(h, s, torch.bfloat16)
-        for h, s in zip(data["hidden_states"], data["hidden_states_scales"])
-    ]
-    return {
-        "hidden_states": torch.cat(hidden_states[:-1], dim=-1),
-        "input_ids": data["input_ids"],
-        "verifier_last_hidden_states": hidden_states[-1],
-        "loss_mask": data["loss_mask"],
-    }
-
-
-def standardize_data_auto(data: dict[str, Any]) -> dict[str, Any]:
-    """Auto-detect data format and standardize accordingly.
-
-    Handles both v1 (bf16) and v2 (fp8 scaled) formats transparently.
-    """
-    if "fp8_format" in data:
-        return standardize_data_v2_fp8(data)
-    return standardize_data_v1(data)
-
-
 class BaseDataset(Dataset):
     def __init__(
         self,
@@ -454,7 +428,7 @@ class SampleFileDataset(BaseDataset):
         ]
 
     def _get_raw_data(self, index):
-        return standardize_data_auto(
+        return standardize_data_v1(
             torch.load(
                 self.data[index], mmap=True, weights_only=True, map_location="cpu"
             )

--- a/tests/unit/convert/test_eagle3_converter.py
+++ b/tests/unit/convert/test_eagle3_converter.py
@@ -260,14 +260,15 @@ class TestEagle3ConverterFixes:
         checkpoint_path = "nm-testing/testing-llama3.1.8b-2layer-eagle3"
         base_model = "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic"
 
+        ckpt_leaf = checkpoint_path.rsplit("/", maxsplit=1)[-1]
         converter.convert(
             checkpoint_path,
-            tmp_path / checkpoint_path.split("/")[-1],
+            tmp_path / ckpt_leaf,
             base_model,
             norm_before_residual=False,
         )
 
-        config = load_checkpoint_config(tmp_path / checkpoint_path.split("/")[-1])
+        config = load_checkpoint_config(tmp_path / ckpt_leaf)
 
         # Verify that num_hidden_layers is correctly set to 2
         assert config["transformer_layer_config"]["num_hidden_layers"] == 2


### PR DESCRIPTION
## Summary
Optional FP8 (`float8_e4m3fn`) quantization of hidden states during vLLM extraction via a custom **KV connector**  Enabled with **`launch_vllm.py --fp8-quantize`** (`FP8HiddenStatesConnector`)

## Files
- **`fp8_utils.py`** — quant / dequant (per-token scaling)
- **`fp8_hidden_states_connector.py`** — connector: FP8 + scales → safetensors
- **`launch_vllm.py`** — `--fp8-quantize` wires `kv_connector_module_path`
- **`train/data.py`** — `ArrowDataset`: dequantize when `hidden_states_scales` present in safetensors

## Tested
Qwen3-8B, vLLM 0.18.0, temp=`default`

### FP8 (ckpt 2)
| Dataset | k=1 | k=2 | k=3 | k=4 | k=5 |
|---------|-----|-----|-----|-----|-----|
| HumanEval | 1.78 | 2.34 | 2.74 | 3.05 | 3.21 |
| math_reasoning | 1.81 | 2.42 | 2.87 | 3.19 | 3.39 |
| qa | 1.69 | 2.11 | 2.39 | 2.57 | 2.64 |
| question | 1.72 | 2.19 | 2.50 | 2.70 | 2.81 |
| rag | 1.69 | 2.15 | 2.41 | 2.61 | 2.67 |
| summarization | 1.62 | 1.95 | 2.13 | 2.23 | 2.28 |
| translation | 1.65 | 2.04 | 2.26 | 2.39 | 2.46 |

### BF16 (ckpt 2)
| Dataset | k=1 | k=2 | k=3 | k=4 | k=5 |
|---------|-----|-----|-----|-----|-----|
| HumanEval | 1.78 | 2.36 | 2.75 | 3.02 | 3.19 |
| math_reasoning | 1.81 | 2.42 | 2.87 | 3.18 | 3.41 |
| qa | 1.68 | 2.13 | 2.41 | 2.60 | 2.69 |
| question | 1.72 | 2.19 | 2.50 | 2.68 | 2.83 |
| rag | 1.70 | 2.14 | 2.42 | 2.60 | 2.66 |
| summarization | 1.62 | 1.95 | 2.14 | 2.23 | 2.28 |
| translation | 1.65 | 2.04 | 2.26 | 2.38 | 2.46 |