### PR TITLE
saparate saving/metrics logic and save before validate

### DIFF
--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -266,57 +266,39 @@ class Trainer:
         )
         return val_metrics
 
-    def maybe_save_checkpoint(self, epoch: int, val_metrics: dict | None):
-        if (
-            self.config.save_best
-            and val_metrics is not None
-            and "loss_epoch" in val_metrics
-        ):
-            if val_metrics["loss_epoch"] < self.best_val_loss:
-                self.best_val_loss = val_metrics["loss_epoch"]
-                root_logger.info(
-                    f"Saving new best checkpoint at epoch {epoch} "
-                    f"(loss_epoch={self.best_val_loss:.6f})"
-                )
-                self.checkpointer.save_checkpoint(self.model, self.opt, epoch)
-                if self.scheduler is not None:
-                    self.checkpointer.save_scheduler_state_dict(self.scheduler, epoch)
-                self.checkpointer.save_val_metrics(epoch, val_metrics)
-                self.checkpointer.update_best_symlink(epoch)
-                root_logger.info(
-                    f"Updated checkpoint_best -> {epoch} "
-                    f"(loss_epoch={self.best_val_loss:.6f})"
-                )
-                # Keep ONLY the best checkpoint folder + best_checkpoint symlink
-                self.checkpointer.cleanup_keep_only_best(best_epoch=epoch)
+    def maybe_save_checkpoint(self, epoch: int):
+        if self.config.save_best:
+            return
+        if not (epoch == 0 or (epoch + 1) % self.config.checkpoint_freq == 0):
+            return
 
-        elif epoch == 0 or (epoch + 1) % self.config.checkpoint_freq == 0:
-            root_logger.info(
-                f"Saving checkpoint to {self.checkpointer.path / str(epoch)}"
-            )
+        root_logger.info(f"Saving checkpoint to {self.checkpointer.path / str(epoch)}")
+        self.checkpointer.save_checkpoint(self.model, self.opt, epoch)
+        if self.scheduler is not None:
+            self.checkpointer.save_scheduler_state_dict(self.scheduler, epoch)
+        root_logger.info(f"Checkpoint saved to {self.checkpointer.path / str(epoch)}")
+
+    def maybe_update_best(self, epoch: int, val_metrics: dict | None):
+        if val_metrics is None or "loss_epoch" not in val_metrics:
+            return
+        if val_metrics["loss_epoch"] >= self.best_val_loss:
+            return
+
+        if self.config.save_best:
             self.checkpointer.save_checkpoint(self.model, self.opt, epoch)
             if self.scheduler is not None:
                 self.checkpointer.save_scheduler_state_dict(self.scheduler, epoch)
-            if val_metrics is not None:
-                self.checkpointer.save_val_metrics(epoch, val_metrics)
-            root_logger.info(
-                f"Checkpoint saved to {self.checkpointer.path / str(epoch)}"
-            )
-            if (
-                val_metrics is not None
-                and "loss_epoch" in val_metrics
-                and val_metrics["loss_epoch"] < self.best_val_loss
-            ):
-                self.best_val_loss = val_metrics["loss_epoch"]
-                root_logger.info(
-                    f"Updating new best checkpoint symlink at epoch {epoch} "
-                    f"(loss_epoch={self.best_val_loss:.6f})"
-                )
-                self.checkpointer.update_best_symlink(epoch)
-                root_logger.info(
-                    f"Updated checkpoint_best -> {epoch} "
-                    f"(loss_epoch={self.best_val_loss:.6f})"
-                )
+        elif not (self.checkpointer.path / str(epoch)).exists():
+            return
+
+        self.best_val_loss = val_metrics["loss_epoch"]
+        self.checkpointer.save_val_metrics(epoch, val_metrics)
+        self.checkpointer.update_best_symlink(epoch)
+        root_logger.info(
+            f"Updated checkpoint_best -> {epoch} (loss_epoch={self.best_val_loss:.6f})"
+        )
+        if self.config.save_best:
+            self.checkpointer.cleanup_keep_only_best(best_epoch=epoch)
 
     def run_training(self):
         n_epochs = self.config.num_epochs
@@ -324,6 +306,11 @@ class Trainer:
             root_logger.info(f"Training epoch {epoch + 1}/{n_epochs} started")
             self.train_epoch(epoch)
             root_logger.info(f"Training epoch {epoch + 1}/{n_epochs} completed")
+
+            if self.is_distributed:
+                dist.barrier()
+
+            self.maybe_save_checkpoint(epoch)
 
             if self.is_distributed:
                 dist.barrier()
@@ -340,7 +327,7 @@ class Trainer:
             if self.is_distributed:
                 dist.barrier()
 
-            self.maybe_save_checkpoint(epoch, val_metrics)
+            self.maybe_update_best(epoch, val_metrics)
 
             if self.is_distributed:
                 dist.barrier()

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -288,7 +288,7 @@ class Trainer:
             self.checkpointer.save_checkpoint(self.model, self.opt, epoch)
             if self.scheduler is not None:
                 self.checkpointer.save_scheduler_state_dict(self.scheduler, epoch)
-        elif not (self.checkpointer.path / str(epoch)).exists():
+        elif not (epoch == 0 or (epoch + 1) % self.config.checkpoint_freq == 0):
             return
 
         self.best_val_loss = val_metrics["loss_epoch"]


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Purpose
It's more common for our research team to run extremely long training jobs. Saving checkpoints before validation would help saving progress before process crash. 
<!--- Why your changes are needed -->

## Description
Moved saving logic before validation
<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests
Tested locally, expected logs:
``` bash
Epoch 0 100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 41/41  [ 0:00:29 < 0:00:00 , 31 it/s ]
           INFO     Training epoch 1/1 completed                                                                                                                                                                                             trainer.py:315
           INFO     Saving checkpoint to /tmp/pytest-of-shanjiaz/pytest-14/test_offline_smoke_eagle3_extr0/checkpoints/0                                                                                                                     trainer.py:275
           INFO     Checkpoint saved to /tmp/pytest-of-shanjiaz/pytest-14/test_offline_smoke_eagle3_extr0/checkpoints/0                                                                                                                      trainer.py:281
           INFO     Validation epoch 1/1 started                                                                                                                                                                                             trainer.py:330
Epoch 0 100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 5/5  [ 0:00:09 < 0:00:00 , 189 it/s ]
[18:23:59] INFO     val/loss_0_epoch=5.304, val/full_acc_0_epoch=0.045, val/cond_acc_0_epoch=0.045, val/loss_1_epoch=5.327, val/full_acc_1_epoch=0.001, val/cond_acc_1_epoch=0.016, val/loss_2_epoch=5.336, val/full_acc_2_epoch=0.00e+00,   trainer.py:264
                    val/cond_acc_2_epoch=0.00e+00, val/loss_epoch=15.967, epoch=0                                                                                                                                                                          
           INFO     Validation epoch 1/1 completed                      
```
<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
