### PR TITLE
Graceful shutdown on interrupt

### DIFF
--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import shutil
 from abc import abstractmethod
 from pathlib import Path
@@ -17,6 +18,8 @@ from torch.distributed.checkpoint.state_dict import (
 from transformers.modeling_utils import PreTrainedModel
 
 from speculators.utils.util import get_current_device
+
+logger = logging.getLogger("speculators")
 
 
 class BaseCheckpointer:
@@ -69,7 +72,7 @@ class BaseCheckpointer:
         scheduler.load_state_dict(full_state_dict)
 
     def save_scheduler_state_dict(
-        self, scheduler: torch.optim.lr_scheduler.LRScheduler, epoch: int
+        self, scheduler: torch.optim.lr_scheduler.LRScheduler, epoch: int | str
     ):
         scheduler_path = self.scheduler_path(epoch)
         torch.save(scheduler.state_dict(), scheduler_path)
@@ -79,7 +82,7 @@ class BaseCheckpointer:
         self,
         model: PreTrainedModel,
         optimizer: torch.optim.Optimizer,
-        epoch: int,
+        epoch: int | str,
         float_dtype: torch.dtype = torch.bfloat16,
     ):
         raise NotImplementedError
@@ -90,21 +93,28 @@ class BaseCheckpointer:
         last_checkpoint_num = -1
         for d in self.path.iterdir():
             if d.is_dir():
+                if d.name == "interrupted":
+                    logger.warning(
+                        f"Found interrupted checkpoint at {d}. "
+                        "To resume from it, rename it to an epoch number "
+                        "(e.g., 'mv interrupted 5' to resume as epoch 5)."
+                    )
+                    continue
                 try:
                     last_checkpoint_num = max(last_checkpoint_num, int(d.name))
                 except ValueError:
                     continue
         return last_checkpoint_num
 
-    def model_path(self, epoch: int):
+    def model_path(self, epoch: int | str):
         model_fname = "model.safetensors"
         return self.path / str(epoch) / model_fname
 
-    def optimizer_path(self, epoch: int):
+    def optimizer_path(self, epoch: int | str):
         optimizer_fname = "optimizer_state_dict.pt"
         return self.path / str(epoch) / optimizer_fname
 
-    def scheduler_path(self, epoch: int):
+    def scheduler_path(self, epoch: int | str):
         scheduler_fname = "scheduler_state_dict.pt"
         return self.path / str(epoch) / scheduler_fname
 
@@ -252,7 +262,7 @@ class SingleGPUCheckpointer(BaseCheckpointer):
         self,
         model: PreTrainedModel,
         optimizer: torch.optim.Optimizer,
-        epoch: int,
+        epoch: int | str,
         float_dtype: torch.dtype = torch.bfloat16,
     ):
         model_state_dict = convert_float_dtype(model.state_dict(), float_dtype)
@@ -316,7 +326,7 @@ class DistributedCheckpointer(BaseCheckpointer):
         self,
         model: PreTrainedModel,
         optimizer: torch.optim.Optimizer,
-        epoch: int,
+        epoch: int | str,
         float_dtype: torch.dtype = torch.bfloat16,
     ):
         model_state_dict = get_model_state_dict(
@@ -356,7 +366,7 @@ class DistributedCheckpointer(BaseCheckpointer):
         dist.barrier()
 
     def save_scheduler_state_dict(
-        self, scheduler: torch.optim.lr_scheduler.LRScheduler, epoch: int
+        self, scheduler: torch.optim.lr_scheduler.LRScheduler, epoch: int | str
     ):
         if dist.get_rank() == 0:
             super().save_scheduler_state_dict(scheduler, epoch)

--- a/src/speculators/train/graceful_shutdown.py
+++ b/src/speculators/train/graceful_shutdown.py
@@ -5,7 +5,7 @@ When Ctrl+C is pressed during training:
 - In single-GPU mode, the process receives SIGINT directly
 
 This module handles both cases by registering handlers for SIGINT and SIGTERM.
-The first signal raises a TrainingInterrupted exception that unwinds the call
+The first signal raises a TrainingInterruptedError exception that unwinds the call
 stack -- this works even when a process is stuck in a NCCL collective, data
 loading, or a GPU kernel. The exception is caught at the run_training level
 to attempt a checkpoint save.
@@ -24,6 +24,8 @@ import logging
 import os
 import signal
 import threading
+from functools import wraps
+from typing import Any
 
 logger = logging.getLogger("speculators")
 
@@ -31,16 +33,14 @@ logger = logging.getLogger("speculators")
 DEFAULT_SHUTDOWN_TIMEOUT = 120
 
 
-class TrainingInterrupted(Exception):
+class TrainingInterruptedError(Exception):
     """Raised by the signal handler to interrupt training for checkpoint save."""
-
-    pass
 
 
 class GracefulShutdownHandler:
     """Manages graceful shutdown with checkpoint saving on interrupt.
 
-    First interrupt: raises TrainingInterrupted to break out of stuck code.
+    First interrupt: raises TrainingInterruptedError to break out of stuck code.
     Subsequent rapid signals (from torchrun re-sends): silently ignored.
     After restore(): default handlers are active, so another Ctrl+C kills.
     """
@@ -48,8 +48,8 @@ class GracefulShutdownHandler:
     def __init__(self, timeout: int = DEFAULT_SHUTDOWN_TIMEOUT):
         self._interrupted = False
         self._lock = threading.Lock()
-        self._original_sigint = None
-        self._original_sigterm = None
+        self._original_sigint: Any = None
+        self._original_sigterm: Any = None
         self._timeout = timeout
         self._owner_pid: int | None = None
 
@@ -72,10 +72,10 @@ class GracefulShutdownHandler:
         if self._original_sigterm is not None:
             signal.signal(signal.SIGTERM, self._original_sigterm)
 
-    def _handler(self, signum, frame):
+    def _handler(self, signum, frame):  # noqa: ARG002
         # Only handle in the process that installed the handler.
         # Forked dataloader workers inherit signal handlers but should
-        # not raise TrainingInterrupted (it would crash the worker).
+        # not raise TrainingInterruptedError (it would crash the worker).
         if os.getpid() != self._owner_pid:
             return
 
@@ -91,8 +91,61 @@ class GracefulShutdownHandler:
                 f"Received {sig_name} — interrupting training to save checkpoint. "
                 "Send again to force immediate exit."
             )
-            raise TrainingInterrupted(sig_name)
+            raise TrainingInterruptedError(sig_name)
 
     @property
     def timeout(self) -> int:
         return self._timeout
+
+
+def with_graceful_shutdown(
+    save_label: str = "interrupted",
+    timeout: int = DEFAULT_SHUTDOWN_TIMEOUT,
+):
+    """Decorator that wraps a Trainer method with graceful shutdown handling.
+
+    The decorated method's `self` must have `maybe_save_checkpoint(label)` and
+    `checkpointer.path`.
+    """
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(self, *args, **kwargs):
+            handler = GracefulShutdownHandler(timeout=timeout)
+            handler.install()
+
+            try:
+                return fn(self, *args, **kwargs)
+            except TrainingInterruptedError:
+                handler.restore()
+
+                logger.warning(
+                    "Training interrupted — attempting to save checkpoint "
+                    f"(timeout={handler.timeout}s, send Ctrl+C again to force exit)..."
+                )
+
+                def _watchdog():
+                    logger.error(
+                        f"Interrupt checkpoint save timed out after {handler.timeout}s "
+                        "— forcing exit"
+                    )
+                    os._exit(1)
+
+                timer = threading.Timer(handler.timeout, _watchdog)
+                timer.daemon = True
+                timer.start()
+
+                try:
+                    self.maybe_save_checkpoint(save_label)
+                    logger.info(
+                        "Interrupt checkpoint saved to "
+                        f"'{self.checkpointer.path / save_label}'"
+                    )
+                except Exception:
+                    logger.exception("Failed to save interrupt checkpoint")
+                finally:
+                    timer.cancel()
+
+        return wrapper
+
+    return decorator

--- a/src/speculators/train/graceful_shutdown.py
+++ b/src/speculators/train/graceful_shutdown.py
@@ -1,0 +1,98 @@
+"""Graceful shutdown handler for saving checkpoints on interrupt.
+
+When Ctrl+C is pressed during training:
+- torchrun intercepts SIGINT and sends SIGINT/SIGTERM to all worker processes
+- In single-GPU mode, the process receives SIGINT directly
+
+This module handles both cases by registering handlers for SIGINT and SIGTERM.
+The first signal raises a TrainingInterrupted exception that unwinds the call
+stack -- this works even when a process is stuck in a NCCL collective, data
+loading, or a GPU kernel. The exception is caught at the run_training level
+to attempt a checkpoint save.
+
+Key design decisions:
+- The handler only raises in the process that called install() (tracked via
+  PID). Forked dataloader workers inherit the handler but ignore the signal,
+  preventing worker crashes.
+- After the first signal, subsequent rapid re-sends (torchrun sends SIGINT
+  to the process group AND then again directly to each child) are silently
+  ignored. Default handlers are restored explicitly before the save attempt,
+  so a deliberate second Ctrl+C during the save will force immediate exit.
+"""
+
+import logging
+import os
+import signal
+import threading
+
+logger = logging.getLogger("speculators")
+
+# Default timeout for coordinated shutdown save (seconds)
+DEFAULT_SHUTDOWN_TIMEOUT = 120
+
+
+class TrainingInterrupted(Exception):
+    """Raised by the signal handler to interrupt training for checkpoint save."""
+
+    pass
+
+
+class GracefulShutdownHandler:
+    """Manages graceful shutdown with checkpoint saving on interrupt.
+
+    First interrupt: raises TrainingInterrupted to break out of stuck code.
+    Subsequent rapid signals (from torchrun re-sends): silently ignored.
+    After restore(): default handlers are active, so another Ctrl+C kills.
+    """
+
+    def __init__(self, timeout: int = DEFAULT_SHUTDOWN_TIMEOUT):
+        self._interrupted = False
+        self._lock = threading.Lock()
+        self._original_sigint = None
+        self._original_sigterm = None
+        self._timeout = timeout
+        self._owner_pid: int | None = None
+
+    def install(self):
+        """Register signal handlers for SIGINT and SIGTERM."""
+        self._owner_pid = os.getpid()
+        self._original_sigint = signal.getsignal(signal.SIGINT)
+        self._original_sigterm = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGINT, self._handler)
+        signal.signal(signal.SIGTERM, self._handler)
+
+    def restore(self):
+        """Restore original signal handlers.
+
+        Called before the checkpoint save attempt so that a deliberate
+        second Ctrl+C during the save causes immediate exit.
+        """
+        if self._original_sigint is not None:
+            signal.signal(signal.SIGINT, self._original_sigint)
+        if self._original_sigterm is not None:
+            signal.signal(signal.SIGTERM, self._original_sigterm)
+
+    def _handler(self, signum, frame):
+        # Only handle in the process that installed the handler.
+        # Forked dataloader workers inherit signal handlers but should
+        # not raise TrainingInterrupted (it would crash the worker).
+        if os.getpid() != self._owner_pid:
+            return
+
+        sig_name = signal.Signals(signum).name
+        with self._lock:
+            if self._interrupted:
+                # Already interrupted. Ignore rapid re-sends from torchrun.
+                # Default handlers will be restored via restore() before the
+                # save attempt, so a deliberate second Ctrl+C will force exit.
+                return
+            self._interrupted = True
+            logger.warning(
+                f"Received {sig_name} — interrupting training to save checkpoint. "
+                "Send again to force immediate exit."
+            )
+            raise TrainingInterrupted(sig_name)
+
+    @property
+    def timeout(self) -> int:
+        return self._timeout

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -1,6 +1,5 @@
 import logging
 import warnings
-from datetime import timedelta
 from typing import Literal, NamedTuple
 
 import torch
@@ -23,10 +22,7 @@ from speculators.train.checkpointer import (
     DistributedCheckpointer,
     SingleGPUCheckpointer,
 )
-from speculators.train.graceful_shutdown import (
-    GracefulShutdownHandler,
-    TrainingInterrupted,
-)
+from speculators.train.graceful_shutdown import with_graceful_shutdown
 from speculators.train.utils import apply_fully_sharded
 
 root_logger = logging.getLogger("speculators")
@@ -271,10 +267,15 @@ class Trainer:
         )
         return val_metrics
 
-    def maybe_save_checkpoint(self, epoch: int):
-        if self.config.save_best:
-            return
-        if not (epoch == 0 or (epoch + 1) % self.config.checkpoint_freq == 0):
+    def maybe_save_checkpoint(self, epoch: int | str):
+        if epoch != "interrupted" and (
+            self.config.save_best
+            or (
+                isinstance(epoch, int)
+                and epoch != 0
+                and (epoch + 1) % self.config.checkpoint_freq != 0
+            )
+        ):
             return
 
         root_logger.info(f"Saving checkpoint to {self.checkpointer.path / str(epoch)}")
@@ -305,50 +306,8 @@ class Trainer:
         if self.config.save_best:
             self.checkpointer.cleanup_keep_only_best(best_epoch=epoch)
 
-    def _save_interrupt_checkpoint(self, timeout: int):
-        """Save a checkpoint to the 'interrupted' directory.
-
-        In distributed mode, uses monitored_barrier (host-side, Store-based)
-        to synchronize ranks with a timeout. This works even if NCCL is in a
-        bad state from the interrupted operation.
-        """
-        interrupt_dir = "interrupted"
-
-        if self.is_distributed:
-            dist.monitored_barrier(timeout=timedelta(seconds=timeout))
-
-        self.checkpointer.save_checkpoint(self.model, self.opt, interrupt_dir)
-        if self.scheduler is not None:
-            self.checkpointer.save_scheduler_state_dict(
-                self.scheduler, interrupt_dir
-            )
-
+    @with_graceful_shutdown()
     def run_training(self):
-        shutdown_handler = GracefulShutdownHandler()
-        shutdown_handler.install()
-
-        try:
-            self._run_training_loop()
-        except TrainingInterrupted:
-            # Restore default handlers so a second Ctrl+C during save
-            # causes immediate exit
-            shutdown_handler.restore()
-
-            root_logger.warning(
-                "Training interrupted — attempting to save checkpoint "
-                f"(timeout={shutdown_handler.timeout}s, send Ctrl+C again "
-                "to force exit)..."
-            )
-            try:
-                self._save_interrupt_checkpoint(shutdown_handler.timeout)
-                root_logger.info(
-                    "Interrupt checkpoint saved to "
-                    f"'{self.checkpointer.path / 'interrupted'}'"
-                )
-            except Exception:
-                root_logger.exception("Failed to save interrupt checkpoint")
-
-    def _run_training_loop(self):
         n_epochs = self.config.num_epochs
         for epoch in range(self.current_epoch, n_epochs):
             root_logger.info(f"Training epoch {epoch + 1}/{n_epochs} started")

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from datetime import timedelta
 from typing import Literal, NamedTuple
 
 import torch
@@ -21,6 +22,10 @@ from speculators.train.checkpointer import (
     BaseCheckpointer,
     DistributedCheckpointer,
     SingleGPUCheckpointer,
+)
+from speculators.train.graceful_shutdown import (
+    GracefulShutdownHandler,
+    TrainingInterrupted,
 )
 from speculators.train.utils import apply_fully_sharded
 
@@ -300,7 +305,50 @@ class Trainer:
         if self.config.save_best:
             self.checkpointer.cleanup_keep_only_best(best_epoch=epoch)
 
+    def _save_interrupt_checkpoint(self, timeout: int):
+        """Save a checkpoint to the 'interrupted' directory.
+
+        In distributed mode, uses monitored_barrier (host-side, Store-based)
+        to synchronize ranks with a timeout. This works even if NCCL is in a
+        bad state from the interrupted operation.
+        """
+        interrupt_dir = "interrupted"
+
+        if self.is_distributed:
+            dist.monitored_barrier(timeout=timedelta(seconds=timeout))
+
+        self.checkpointer.save_checkpoint(self.model, self.opt, interrupt_dir)
+        if self.scheduler is not None:
+            self.checkpointer.save_scheduler_state_dict(
+                self.scheduler, interrupt_dir
+            )
+
     def run_training(self):
+        shutdown_handler = GracefulShutdownHandler()
+        shutdown_handler.install()
+
+        try:
+            self._run_training_loop()
+        except TrainingInterrupted:
+            # Restore default handlers so a second Ctrl+C during save
+            # causes immediate exit
+            shutdown_handler.restore()
+
+            root_logger.warning(
+                "Training interrupted — attempting to save checkpoint "
+                f"(timeout={shutdown_handler.timeout}s, send Ctrl+C again "
+                "to force exit)..."
+            )
+            try:
+                self._save_interrupt_checkpoint(shutdown_handler.timeout)
+                root_logger.info(
+                    "Interrupt checkpoint saved to "
+                    f"'{self.checkpointer.path / 'interrupted'}'"
+                )
+            except Exception:
+                root_logger.exception("Failed to save interrupt checkpoint")
+
+    def _run_training_loop(self):
         n_epochs = self.config.num_epochs
         for epoch in range(self.current_epoch, n_epochs):
             root_logger.info(f"Training epoch {epoch + 1}/{n_epochs} started")

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -1,3 +1,5 @@
+import os
+import signal
 from pathlib import Path
 from typing import Any, cast
 
@@ -251,3 +253,38 @@ def test_best_val_loss_restored_on_resume(tmp_path: Path):
         trainer.best_val_loss = saved
 
     assert trainer.best_val_loss == pytest.approx(0.42)
+
+
+def test_graceful_shutdown_saves_interrupted_checkpoint(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    trainer = _make_minimal_trainer(tmp_path, checkpoint_freq=99, save_best=False)
+    trainer.config = trainer.config._replace(num_epochs=4)
+
+    saved_labels: list[int | str] = []
+
+    def fake_train_epoch(epoch: int):
+        if epoch == 2:
+            os.kill(os.getpid(), signal.SIGINT)
+
+    def fake_val_epoch(epoch: int):
+        return {"loss_epoch": 0.5}
+
+    def fake_cp_save_checkpoint(_model, _opt, epoch: int | str):
+        saved_labels.append(epoch)
+        (tmp_path / str(epoch)).mkdir(exist_ok=True)
+
+    trainer.train_epoch = fake_train_epoch
+    trainer.val_epoch = fake_val_epoch
+    monkeypatch.setattr(
+        trainer.checkpointer, "save_checkpoint", fake_cp_save_checkpoint
+    )
+    monkeypatch.setattr(
+        trainer.checkpointer,
+        "save_scheduler_state_dict",
+        lambda *_args, **_kwargs: None,
+    )
+
+    trainer.run_training()
+
+    assert "interrupted" in saved_labels


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

With this pr, when a training job is interrupted (e.g. using `Ctrl+C` or `kill <PID>` (sends `SIGTERM`) or `kill -INT <PID>` (sends `SIGINT`)), it will attempt to save a checkpoint of the current state to `CHECKPOINT_SAVE_PATH/interrupted`.

This can be useful to ensure failing jobs or long running jobs can be stopped without losing all progress. Note: this approach is not guaranteed to work in all scenarios, so the recommended approach is to wait for the checkpoints to be saved as normal. 

<!--- Why your changes are needed -->

## Description

Add signal handlers for the `SIGTERM` and `SIGINT` events which we wrap the main train/val/checkpointing loop in.

When one of these signals is received it raises a `TrainingInterruptedError` (note: all processes receive the signal) which gets caught by the wrapper and then executes a checkpoint save.
<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests

I have manually tested this works on a 1 gpu and 2 gpu setup.

<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
