### PR TITLE
Sweep concurrencies regeneration

### DIFF
--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -281,7 +281,10 @@ async def main():
         dataset = dataset.shuffle(
             seed=args.shuffle_seed, buffer_size=args.shuffle_buffer_size
         )
-        print(f"Shuffling with seed={args.shuffle_seed}, buffer={args.shuffle_buffer_size}")
+        print(
+            f"Shuffling with seed={args.shuffle_seed},"
+            f" buffer={args.shuffle_buffer_size}"
+        )
 
     queue: asyncio.Queue = asyncio.Queue(maxsize=args.concurrency * 4)
     semaphore = asyncio.Semaphore(args.concurrency)

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -93,6 +93,23 @@ def parse_args():
         default=None,
         help="Only process rows where language==this (e.g., EN)",
     )
+    parser.add_argument(
+        "--shuffle",
+        action="store_true",
+        help="Shuffle the dataset before processing",
+    )
+    parser.add_argument(
+        "--shuffle-seed",
+        type=int,
+        default=42,
+        help="Random seed for shuffling (default: 42)",
+    )
+    parser.add_argument(
+        "--shuffle-buffer-size",
+        type=int,
+        default=10000,
+        help="Buffer size for streaming shuffle (default: 10000)",
+    )
     return parser.parse_args()
 
 
@@ -259,6 +276,12 @@ async def main():
 
     seen_ids = load_seen(args.outfile) if args.resume else set()
     dataset = load_dataset(dataset_id, name=subset, split=split, streaming=True)
+
+    if args.shuffle:
+        dataset = dataset.shuffle(
+            seed=args.shuffle_seed, buffer_size=args.shuffle_buffer_size
+        )
+        print(f"Shuffling with seed={args.shuffle_seed}, buffer={args.shuffle_buffer_size}")
 
     queue: asyncio.Queue = asyncio.Queue(maxsize=args.concurrency * 4)
     semaphore = asyncio.Semaphore(args.concurrency)

--- a/scripts/response_regeneration/sweep_concurrency.sh
+++ b/scripts/response_regeneration/sweep_concurrency.sh
@@ -22,7 +22,7 @@ MAX_MODEL_LEN=""
 REASONING_PARSER=""
 GPUS=""
 DURATION=60
-CONCURRENCIES=(64 128 256 512)
+CONCURRENCIES=(64 128 256 512 1024)
 
 # Collect args for script.py (dataset, shuffle, etc.)
 PYTHON_ARGS=()
@@ -152,6 +152,26 @@ while [ $RETRY -lt $MAX_RETRIES ]; do
 done
 echo ""
 
+# Warmup run (15s) to prime prefix cache and trigger kernel compilation
+WARMUP_OUTFILE="sweep_warmup.jsonl"
+rm -f "$WARMUP_OUTFILE"
+echo "Warmup: running 15s burst to prime caches and compile kernels..."
+timeout 15 python "$SCRIPT_DIR/script.py" \
+    "${PYTHON_ARGS[@]}" \
+    --endpoint "http://127.0.0.1:$PORT/v1/chat/completions" \
+    --concurrency 64 \
+    --outfile "$WARMUP_OUTFILE" \
+    --shuffle \
+    2>&1 || true
+rm -f "$WARMUP_OUTFILE"
+echo "Warmup complete."
+echo ""
+
+# Randomize sweep order to avoid ordering bias
+SHUFFLED_CONCURRENCIES=($(printf '%s\n' "${CONCURRENCIES[@]}" | shuf))
+echo "Sweep order (randomized): ${SHUFFLED_CONCURRENCIES[*]}"
+echo ""
+
 # Run sweep
 declare -a RESULTS_CONC
 declare -a RESULTS_COUNT
@@ -160,7 +180,7 @@ declare -a RESULTS_RATE
 BEST_CONC=0
 BEST_RATE=0
 
-for CONC in "${CONCURRENCIES[@]}"; do
+for CONC in "${SHUFFLED_CONCURRENCIES[@]}"; do
     OUTFILE="sweep_concurrency_${CONC}.jsonl"
     rm -f "$OUTFILE"
 

--- a/scripts/response_regeneration/sweep_concurrency.sh
+++ b/scripts/response_regeneration/sweep_concurrency.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+#
+# Sweep concurrency values to find optimal throughput for response regeneration.
+#
+# Starts a vLLM server once, then runs script.py at each concurrency level for
+# 60 seconds, counts completed samples, and reports the best throughput.
+#
+# Usage:
+#   ./sweep_concurrency.sh --model google/gemma-4-31B-it --tp-size 2 --dp-size 4 --dataset tulu3
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Defaults
+PORT=8000
+MODEL=""
+DP_SIZE=""
+TP_SIZE=""
+MAX_MODEL_LEN=""
+REASONING_PARSER=""
+GPUS=""
+DURATION=60
+CONCURRENCIES=(64 128 256 512)
+
+# Collect args for script.py (dataset, shuffle, etc.)
+PYTHON_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --port)
+            PORT="$2"
+            shift 2
+            ;;
+        --dp-size)
+            DP_SIZE="$2"
+            shift 2
+            ;;
+        --tp-size)
+            TP_SIZE="$2"
+            shift 2
+            ;;
+        --max-model-len)
+            MAX_MODEL_LEN="$2"
+            shift 2
+            ;;
+        --reasoning-parser)
+            REASONING_PARSER="$2"
+            shift 2
+            ;;
+        --model)
+            MODEL="$2"
+            PYTHON_ARGS+=("--model" "$2")
+            shift 2
+            ;;
+        --gpus)
+            GPUS="$2"
+            shift 2
+            ;;
+        --duration)
+            DURATION="$2"
+            shift 2
+            ;;
+        --concurrencies)
+            IFS=',' read -ra CONCURRENCIES <<< "$2"
+            shift 2
+            ;;
+        --concurrency)
+            echo "Ignoring --concurrency (this script sweeps concurrency values automatically)"
+            shift 2
+            ;;
+        --outfile)
+            echo "Ignoring --outfile (this script manages its own output files)"
+            shift 2
+            ;;
+        --resume)
+            shift
+            ;;
+        *)
+            PYTHON_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$MODEL" ]; then
+    echo "Error: --model is required."
+    echo "Usage: $0 --model MODEL [--tp-size N] [--dp-size N] [--dataset DATASET] [--duration SECS] [--concurrencies 64,128,256,512]"
+    exit 1
+fi
+
+# Build vllm serve command
+VLLM_CMD=(vllm serve "$MODEL" --host 127.0.0.1 --port "$PORT" --api-key "")
+[ -n "$DP_SIZE" ] && VLLM_CMD+=(--data-parallel-size "$DP_SIZE")
+[ -n "$TP_SIZE" ] && VLLM_CMD+=(--tensor-parallel-size "$TP_SIZE")
+[ -n "$MAX_MODEL_LEN" ] && VLLM_CMD+=(--max-model-len "$MAX_MODEL_LEN")
+[ -n "$REASONING_PARSER" ] && VLLM_CMD+=(--reasoning-parser "$REASONING_PARSER")
+
+cleanup() {
+    if [ -n "$VLLM_PID" ] && kill -0 "$VLLM_PID" 2>/dev/null; then
+        echo "Stopping vLLM server (PID $VLLM_PID)..."
+        kill "$VLLM_PID"
+        sleep 3
+        if kill -0 "$VLLM_PID" 2>/dev/null; then
+            kill -9 "$VLLM_PID"
+        fi
+    fi
+}
+trap cleanup EXIT
+
+echo "========================================="
+echo "Concurrency Sweep"
+echo "========================================="
+echo "  Model: $MODEL"
+echo "  Concurrencies: ${CONCURRENCIES[*]}"
+echo "  Duration per run: ${DURATION}s"
+[ -n "$DP_SIZE" ] && echo "  Data parallel size: $DP_SIZE"
+[ -n "$TP_SIZE" ] && echo "  Tensor parallel size: $TP_SIZE"
+echo ""
+
+# Start server
+echo "Starting vLLM server..."
+if [ -n "$GPUS" ]; then
+    CUDA_VISIBLE_DEVICES="$GPUS" "${VLLM_CMD[@]}" > "$SCRIPT_DIR/vllm_sweep.log" 2>&1 &
+else
+    "${VLLM_CMD[@]}" > "$SCRIPT_DIR/vllm_sweep.log" 2>&1 &
+fi
+VLLM_PID=$!
+
+# Wait for server
+ENDPOINT="http://127.0.0.1:$PORT/v1/models"
+MAX_RETRIES=300
+RETRY=0
+while [ $RETRY -lt $MAX_RETRIES ]; do
+    if ! kill -0 "$VLLM_PID" 2>/dev/null; then
+        echo "vLLM server died. Last 20 lines:"
+        tail -20 "$SCRIPT_DIR/vllm_sweep.log"
+        exit 1
+    fi
+    if curl -s --connect-timeout 5 --max-time 10 "$ENDPOINT" > /dev/null 2>&1; then
+        echo "Server ready."
+        break
+    fi
+    RETRY=$((RETRY + 1))
+    if [ $RETRY -eq $MAX_RETRIES ]; then
+        echo "Server failed to start."
+        tail -20 "$SCRIPT_DIR/vllm_sweep.log"
+        exit 1
+    fi
+    [ $((RETRY % 5)) -eq 0 ] && echo "  Waiting... ($RETRY retries)"
+    sleep 2
+done
+echo ""
+
+# Run sweep
+declare -a RESULTS_CONC
+declare -a RESULTS_COUNT
+declare -a RESULTS_RATE
+
+BEST_CONC=0
+BEST_RATE=0
+
+for CONC in "${CONCURRENCIES[@]}"; do
+    OUTFILE="sweep_concurrency_${CONC}.jsonl"
+    rm -f "$OUTFILE"
+
+    echo "-----------------------------------------"
+    echo "Testing concurrency=$CONC for ${DURATION}s..."
+
+    timeout "$DURATION" python "$SCRIPT_DIR/script.py" \
+        "${PYTHON_ARGS[@]}" \
+        --endpoint "http://127.0.0.1:$PORT/v1/chat/completions" \
+        --concurrency "$CONC" \
+        --outfile "$OUTFILE" \
+        --shuffle \
+        2>&1 || true
+
+    COUNT=0
+    [ -f "$OUTFILE" ] && COUNT=$(wc -l < "$OUTFILE" | tr -d ' ')
+    RATE=$(echo "scale=2; $COUNT / $DURATION" | bc)
+
+    echo "  Completed: $COUNT samples ($RATE samples/sec)"
+    echo ""
+
+    RESULTS_CONC+=("$CONC")
+    RESULTS_COUNT+=("$COUNT")
+    RESULTS_RATE+=("$RATE")
+
+    if (( $(echo "$RATE > $BEST_RATE" | bc -l) )); then
+        BEST_RATE=$RATE
+        BEST_CONC=$CONC
+    fi
+done
+
+# Print summary
+echo "========================================="
+echo "Results"
+echo "========================================="
+printf "%-15s %-15s %-15s\n" "Concurrency" "Samples" "Samples/sec"
+printf "%-15s %-15s %-15s\n" "-----------" "-------" "-----------"
+for i in "${!RESULTS_CONC[@]}"; do
+    MARKER=""
+    [ "${RESULTS_CONC[$i]}" = "$BEST_CONC" ] && MARKER=" <-- best"
+    printf "%-15s %-15s %-15s%s\n" "${RESULTS_CONC[$i]}" "${RESULTS_COUNT[$i]}" "${RESULTS_RATE[$i]}" "$MARKER"
+done
+echo ""
+echo "Best concurrency: $BEST_CONC ($BEST_RATE samples/sec)"
+echo "========================================="


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
We currently set the concurrency for the number of requests we're sending during response regeneration to 64, but it appears as though tuning that parameter can result in much better throughput

## Description

This PR adds a shell script to scripts that sweeps the concurrency value and reports the results.  It also adds shuffling to the dataset, since some datasets are ordered by topic.  

## Related Issue

NA

## Tests

Run with: 
./scripts/response_regeneration/sweep_concurrency.sh --model google/gemma-4-31B-it --tp-size 2 --dp-size 4 --dataset tulu3

Results: 

=========================================
Concurrency     Samples         Samples/sec
-----------     -------         -----------
256             525             8.75
512             677             11.28
64              186             3.10
1024            692             11.53           <-- best
128             336             5.60
2048            652             10.86          
4096            620             10.33
8192            535             8.91

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
