### PR TITLE
Fix speculator config for models with explicit head_dim

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -139,18 +139,34 @@ def create_transformer_layer_config(
             "nor 'hidden_activation'"
         )
 
+    head_dim = getattr(verifier_config, "head_dim", None)
+    num_attention_heads = verifier_config.num_attention_heads
+    num_key_value_heads = verifier_config.num_key_value_heads
+
+    # Models like Qwen3.6-27B use an explicit head_dim where
+    # hidden_size != num_attention_heads * head_dim (e.g. 5120 != 24 * 256).
+    # LlamaConfig validates hidden_size % num_attention_heads == 0, so
+    # recompute heads to match hidden_size // head_dim for the speculator.
+    if (
+        head_dim
+        and verifier_config.hidden_size % num_attention_heads != 0
+        and verifier_config.hidden_size % head_dim == 0
+    ):
+        num_attention_heads = verifier_config.hidden_size // head_dim
+        num_key_value_heads = min(num_key_value_heads, num_attention_heads)
+
     return config_class(
         vocab_size=verifier_config.vocab_size,
         hidden_size=verifier_config.hidden_size,
         intermediate_size=verifier_config.intermediate_size,
         num_hidden_layers=num_layers,
-        num_attention_heads=verifier_config.num_attention_heads,
-        num_key_value_heads=verifier_config.num_key_value_heads,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=num_key_value_heads,
         hidden_act=hidden_act,
         max_position_embeddings=verifier_config.max_position_embeddings,
         initializer_range=verifier_config.initializer_range,
         rms_norm_eps=verifier_config.rms_norm_eps,
-        head_dim=getattr(verifier_config, "head_dim", None),
+        head_dim=head_dim,
         tie_word_embeddings=False,
     )
 


### PR DESCRIPTION

<!-- markdownlint-disable -->

## Purpose

Models like Laguna XS and Qwen3.6-27B have hidden_size (5120) not divisible by num_attention_heads (24) because they use an explicit head_dim (256). LlamaConfig's validate_architecture rejects this, so recompute num_attention_heads as hidden_size // head_dim for the speculator.

## Description

This PR changes the way we calculate the attention heads so that the initialization doesn't fail when we use we use a hidden state dim that isn't divisible by the number of attention heads in the model, due to a limitation in the llama config. 

## Related Issue

NA

## Tests

Using this PR makes Qwen 3.6 27B run whereas it previously failed

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
