### PR TITLE
Add tqdm progress bar for response regeneration

### DIFF
--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -233,7 +233,7 @@ async def worker(
             queue.task_done()
 
 
-async def main():
+async def main():  # noqa: PLR0915
     """Main async function to process dataset through vLLM endpoints."""
     args = parse_args()
 

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import aiohttp
 from datasets import load_dataset
+from tqdm import tqdm
 
 DATASET_CONFIGS = {
     "magpie": {
@@ -154,6 +155,8 @@ async def worker(
     args,
     out_fh,
     endpoint: str,
+    progress,
+    stats: dict[str, int],
 ):
     """Worker that pulls items from queue and sends them to the vLLM endpoint."""
     while True:
@@ -206,6 +209,7 @@ async def worker(
             }
             out_fh.write(json.dumps(output, ensure_ascii=False) + "\n")
             out_fh.flush()
+            stats["ok"] += 1
         except Exception as e:  # noqa: BLE001
             error_output = {
                 "id": item.get("uuid") or f"sample_{idx}",
@@ -218,7 +222,14 @@ async def worker(
             }
             out_fh.write(json.dumps(error_output, ensure_ascii=False) + "\n")
             out_fh.flush()
+            stats["errors"] += 1
         finally:
+            progress.update(1)
+            progress.set_postfix(
+                ok=stats["ok"],
+                errors=stats["errors"],
+                refresh=False,
+            )
             queue.task_done()
 
 
@@ -276,43 +287,72 @@ async def main():
         timeout=timeout, connector=connector, headers=headers
     ) as session:
         with open(args.outfile, "a", encoding="utf-8") as output_file:  # noqa: ASYNC230
-            workers = [
-                asyncio.create_task(
-                    worker(semaphore, session, queue, args, output_file, endpoint)
-                )
-                for _ in range(args.concurrency)
-            ]
+            stats = {"ok": 0, "errors": 0}
+            progress_total = args.limit if args.limit is not None else None
+            progress = tqdm(
+                total=progress_total,
+                desc="Generating responses",
+                unit="sample",
+                dynamic_ncols=True,
+            )
+            workers = []
 
-            processed_count = 0
-            for index, row in enumerate(dataset):
-                if args.limit is not None and processed_count >= args.limit:
-                    break
+            try:
+                workers = [
+                    asyncio.create_task(
+                        worker(
+                            semaphore,
+                            session,
+                            queue,
+                            args,
+                            output_file,
+                            endpoint,
+                            progress,
+                            stats,
+                        )
+                    )
+                    for _ in range(args.concurrency)
+                ]
 
-                if args.language_filter and row.get("language") != args.language_filter:
-                    continue
+                processed_count = 0
+                for index, row in enumerate(dataset):
+                    if args.limit is not None and processed_count >= args.limit:
+                        break
 
-                prompt = row.get(prompt_field)
-                if not prompt:
-                    continue
+                    if (
+                        args.language_filter
+                        and row.get("language") != args.language_filter
+                    ):
+                        continue
 
-                uuid = row.get("uuid")
-                key = str(uuid or index)
-                if key in seen_ids:
-                    continue
+                    prompt = row.get(prompt_field)
+                    if not prompt:
+                        continue
 
-                await queue.put(
-                    {
-                        "idx": index,
-                        "uuid": uuid,
-                        "prompt": prompt,
-                    }
-                )
-                processed_count += 1
+                    uuid = row.get("uuid")
+                    key = str(uuid or index)
+                    if key in seen_ids:
+                        continue
 
-            # Signal workers to stop
-            for _ in range(len(workers)):
-                await queue.put(None)
-            await asyncio.gather(*workers)
+                    await queue.put(
+                        {
+                            "idx": index,
+                            "uuid": uuid,
+                            "prompt": prompt,
+                        }
+                    )
+                    processed_count += 1
+
+                if progress.total is None or processed_count < progress.total:
+                    progress.total = processed_count
+                    progress.refresh()
+
+                # Signal workers to stop
+                for _ in range(len(workers)):
+                    await queue.put(None)
+                await asyncio.gather(*workers)
+            finally:
+                progress.close()
 
 
 if __name__ == "__main__":

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -224,16 +224,16 @@ async def worker(
             out_fh.flush()
             stats["errors"] += 1
         finally:
-            progress.update(1)
             progress.set_postfix(
                 ok=stats["ok"],
                 errors=stats["errors"],
                 refresh=False,
             )
+            progress.update(1)
             queue.task_done()
 
 
-async def main():  # noqa: PLR0915
+async def main():
     """Main async function to process dataset through vLLM endpoints."""
     args = parse_args()
 
@@ -286,73 +286,62 @@ async def main():  # noqa: PLR0915
     async with aiohttp.ClientSession(
         timeout=timeout, connector=connector, headers=headers
     ) as session:
-        with open(args.outfile, "a", encoding="utf-8") as output_file:  # noqa: ASYNC230
-            stats = {"ok": 0, "errors": 0}
-            progress_total = args.limit if args.limit is not None else None
-            progress = tqdm(
-                total=progress_total,
+        with (
+            open(args.outfile, "a", encoding="utf-8") as output_file,  # noqa: ASYNC230
+            tqdm(
+                total=args.limit,
                 desc="Generating responses",
                 unit="sample",
                 dynamic_ncols=True,
-            )
-            workers = []
-
-            try:
-                workers = [
-                    asyncio.create_task(
-                        worker(
-                            semaphore,
-                            session,
-                            queue,
-                            args,
-                            output_file,
-                            endpoint,
-                            progress,
-                            stats,
-                        )
+            ) as progress,
+        ):
+            stats = {"ok": 0, "errors": 0}
+            workers = [
+                asyncio.create_task(
+                    worker(
+                        semaphore,
+                        session,
+                        queue,
+                        args,
+                        output_file,
+                        endpoint,
+                        progress,
+                        stats,
                     )
-                    for _ in range(args.concurrency)
-                ]
+                )
+                for _ in range(args.concurrency)
+            ]
 
-                processed_count = 0
-                for index, row in enumerate(dataset):
-                    if args.limit is not None and processed_count >= args.limit:
-                        break
+            processed_count = 0
+            for index, row in enumerate(dataset):
+                if args.limit is not None and processed_count >= args.limit:
+                    break
 
-                    if (
-                        args.language_filter
-                        and row.get("language") != args.language_filter
-                    ):
-                        continue
+                if args.language_filter and row.get("language") != args.language_filter:
+                    continue
 
-                    prompt = row.get(prompt_field)
-                    if not prompt:
-                        continue
+                prompt = row.get(prompt_field)
+                if not prompt:
+                    continue
 
-                    uuid = row.get("uuid")
-                    key = str(uuid or index)
-                    if key in seen_ids:
-                        continue
+                uuid = row.get("uuid")
+                key = str(uuid or index)
+                if key in seen_ids:
+                    continue
 
-                    await queue.put(
-                        {
-                            "idx": index,
-                            "uuid": uuid,
-                            "prompt": prompt,
-                        }
-                    )
-                    processed_count += 1
+                await queue.put(
+                    {
+                        "idx": index,
+                        "uuid": uuid,
+                        "prompt": prompt,
+                    }
+                )
+                processed_count += 1
 
-                if progress.total is None or processed_count < progress.total:
-                    progress.total = processed_count
-                    progress.refresh()
-
-                # Signal workers to stop
-                for _ in range(len(workers)):
-                    await queue.put(None)
-                await asyncio.gather(*workers)
-            finally:
-                progress.close()
+            # Signal workers to stop
+            for _ in range(len(workers)):
+                await queue.put(None)
+            await asyncio.gather(*workers)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Right now it is not very clear (without manually checking logs) at which stage of the regeneration pipeline the script is as there are no progress bars. This PR adds a simple tqdm progress bar which gives us ETA and the current state. It looks like this:
```bash
=========================================
Response Regeneration Pipeline
=========================================

Step 1: Starting vLLM server on port 8005
  Model: /home/eldarkurtic/hf_models/Qwen/Qwen3-8B
  GPUs: 4,5,6,7
  Data parallel size: 4
  Tensor parallel size: 1
  Command: vllm serve /home/eldarkurtic/hf_models/Qwen/Qwen3-8B --host 127.0.0.1 --port 8005 --data-parallel-size 4 --tensor-parallel-size 1

Step 2: Waiting for server to be ready...
  (Large models may take several minutes to load)
  Still waiting... (5 retries)
  Still waiting... (10 retries)
  Still waiting... (15 retries)
  Still waiting... (20 retries)
  Server ready (after 23 retries)

Step 3: Running response regeneration...
Arguments: --model /home/eldarkurtic/hf_models/Qwen/Qwen3-8B --dataset magpie --limit 5000 --endpoint http://127.0.0.1:8005/v1/chat/completions

Using endpoint: http://127.0.0.1:8005/v1/chat/completions
Using model: /home/eldarkurtic/hf_models/Qwen/Qwen3-8B
Using dataset: Magpie-Align/Magpie-Llama-3.1-Pro-300K-Filtered
Split: train
Prompt field: instruction
Output file: magpie_Qwen3-8B.jsonl

Generating responses: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5000/5000 [49:29<00:00,  1.68sample/s, errors=0, ok=5000]

```