### PR TITLE
Remove redundant padding-position check in anchor mask creation

### DIFF
--- a/src/speculators/models/dflash/attention.py
+++ b/src/speculators/models/dflash/attention.py
@@ -74,13 +74,6 @@ def create_anchor_block_mask_mod(
             f"anchor_positions out of range: {anchor_positions[oob].tolist()}"
         )
 
-    anchor_docs = document_ids[anchor_positions]
-    if (pad_mask := anchor_docs == -1).any():
-        raise ValueError(
-            f"anchor_positions include padding locations:"
-            f" {anchor_positions[pad_mask].tolist()}"
-        )
-
     # For each query position, which anchor does it belong to?
     # query q in [j*block_size, (j+1)*block_size) belongs to anchor_positions[j]
     query_anchor_positions = torch.repeat_interleave(anchor_positions, block_size)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The hard error when anchor_positions land on padding locations is redundant: base_prefix_mod already guards against this with the q_doc != -1 check, and invalid anchors have their loss zeroed out via anchor_valid. The error breaks valid edge cases like empty batches where select_anchors returns all-zero positions.

## Description
 
Keeping track of this for later.  

## Related Issue



## Tests



I have filled in:

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [ ] I (a human) have written or reviewed the code in this pr to the best of my ability.
