### PR TITLE
Sliding window attention for DFlash

### DIFF
--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -157,6 +157,11 @@ def main():
                 "preprocessing. To existing overwrite files use --overwrite."
             )
             sys.exit(0)
+        if args.overwrite:
+            import shutil
+
+            shutil.rmtree(output)
+            output.mkdir(parents=True)
     else:
         output.mkdir(parents=True)
 

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -25,6 +25,7 @@ Usage:
 import argparse
 import glob
 import logging
+import shutil
 import sys
 from pathlib import Path
 
@@ -158,8 +159,6 @@ def main():
             )
             sys.exit(0)
         if args.overwrite:
-            import shutil
-
             shutil.rmtree(output)
             output.mkdir(parents=True)
     else:

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -107,6 +107,7 @@ def create_transformer_layer_config(
     draft_arch: str = "llama",
     hidden_act: str | None = None,
     sliding_window: int | None = None,
+    full_attention_interval: int | None = None,
 ) -> PretrainedConfig:
     if draft_arch not in DRAFT_ARCH_CONFIGS:
         raise ValueError(
@@ -157,7 +158,14 @@ def create_transformer_layer_config(
 
     if sliding_window is not None:
         kwargs["sliding_window"] = sliding_window
-        kwargs["layer_types"] = ["sliding_attention"] * num_layers
+        if full_attention_interval is not None:
+            kwargs["layer_types"] = [
+                "full_attention" if (i + 1) % full_attention_interval == 0
+                else "sliding_attention"
+                for i in range(num_layers)
+            ]
+        else:
+            kwargs["layer_types"] = ["sliding_attention"] * num_layers
 
     return config_class(**kwargs)
 
@@ -256,12 +264,14 @@ def main(args: argparse.Namespace):
 
     # Setup speculator config
     sliding_window = getattr(args, "sliding_window", None) or None
+    full_attention_interval = getattr(args, "full_attention_interval", None)
     transformer_layer_config = create_transformer_layer_config(
         args.verifier_name_or_path,
         args.num_layers,
         draft_arch=args.draft_arch,
         hidden_act=args.draft_hidden_act,
         sliding_window=sliding_window,
+        full_attention_interval=full_attention_interval,
     )
 
     args.mask_token_id = resolve_mask_token_id(
@@ -652,9 +662,17 @@ def parse_args():
     parser.add_argument(
         "--sliding-window",
         type=int,
-        default=2048,
-        help="Sliding window size for DFlash attention (default: 2048). "
-        "Set to 0 to disable and use full attention.",
+        default=0,
+        help="Sliding window size for DFlash attention (default: 0 = full attention). "
+        "Set to a positive value (e.g. 2048) to enable sliding window attention.",
+    )
+    parser.add_argument(
+        "--full-attention-interval",
+        type=int,
+        default=None,
+        help="Every Nth layer uses full attention instead of sliding window. "
+        "Requires --sliding-window > 0. E.g., --full-attention-interval 3 "
+        "with 5 layers gives [slide, slide, full, slide, slide].",
     )
     # Dataloader parameters
     parser.add_argument(

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -275,7 +275,7 @@ def main(args: argparse.Namespace):
         num_layers=args.num_layers,
         draft_arch=args.draft_arch,
         hidden_act=args.draft_hidden_act,
-        sliding_window_size=args.sliding_window_size,
+        sliding_window=args.sliding_window,
         sliding_window_indices=args.sliding_window_indices,
     )
 
@@ -665,7 +665,7 @@ def parse_args():
         help="Minimum retention ratio for COD sampling in P-EAGLE (default: 0.2)",
     )
     parser.add_argument(
-        "--sliding-window-size",
+        "--sliding-window",
         type=int,
         default=2048,
         help="Sliding window size for sliding window attention layers."

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -278,7 +278,7 @@ def main(args: argparse.Namespace):
 
     d2t, t2d, draft_vocab_size = parse_vocab_mappings(args)
 
-    if len(args.sliding_window_indices) and args.speculator_type != "dflash":
+    if args.sliding_window_indices and args.speculator_type != "dflash":
         raise ValueError(
             "Currently sliding window attention is only supported by dflash "
             "draft models. Please open an issue/pr if you would like to use "
@@ -708,7 +708,7 @@ def parse_args():
         "--sliding-window-indices",
         type=int,
         nargs="+",
-        default=None,
+        default=[],
         help="(Optional) A (space separated) list of draft layer indices of sliding "
         " window layers. All other draft layers are assumed to be full attention "
         "layers. (e.g. 0 2 4 will make the first, third, and fifth layers use "

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -106,6 +106,7 @@ def create_transformer_layer_config(
     num_layers: int,
     draft_arch: str = "llama",
     hidden_act: str | None = None,
+    sliding_window: int | None = None,
 ) -> PretrainedConfig:
     if draft_arch not in DRAFT_ARCH_CONFIGS:
         raise ValueError(
@@ -139,7 +140,7 @@ def create_transformer_layer_config(
             "nor 'hidden_activation'"
         )
 
-    return config_class(
+    kwargs = dict(
         vocab_size=verifier_config.vocab_size,
         hidden_size=verifier_config.hidden_size,
         intermediate_size=verifier_config.intermediate_size,
@@ -153,6 +154,12 @@ def create_transformer_layer_config(
         head_dim=getattr(verifier_config, "head_dim", None),
         tie_word_embeddings=False,
     )
+
+    if sliding_window is not None:
+        kwargs["sliding_window"] = sliding_window
+        kwargs["layer_types"] = ["sliding_attention"] * num_layers
+
+    return config_class(**kwargs)
 
 
 def _load_mappings(d2t_path, t2d_path, expected_draft_vocab_size: int | None):
@@ -248,11 +255,13 @@ def main(args: argparse.Namespace):
     d2t, t2d, draft_vocab_size = parse_vocab_mappings(args)
 
     # Setup speculator config
+    sliding_window = getattr(args, "sliding_window", None) or None
     transformer_layer_config = create_transformer_layer_config(
         args.verifier_name_or_path,
         args.num_layers,
         draft_arch=args.draft_arch,
         hidden_act=args.draft_hidden_act,
+        sliding_window=sliding_window,
     )
 
     args.mask_token_id = resolve_mask_token_id(
@@ -639,6 +648,13 @@ def parse_args():
         type=float,
         default=0.2,
         help="Minimum retention ratio for COD sampling in P-EAGLE (default: 0.2)",
+    )
+    parser.add_argument(
+        "--sliding-window",
+        type=int,
+        default=2048,
+        help="Sliding window size for DFlash attention (default: 2048). "
+        "Set to 0 to disable and use full attention.",
     )
     # Dataloader parameters
     parser.add_argument(

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -674,6 +674,14 @@ def parse_args():
         "Requires --sliding-window > 0. E.g., --full-attention-interval 3 "
         "with 5 layers gives [slide, slide, full, slide, slide].",
     )
+    parser.add_argument(
+        "--swa-causal",
+        action="store_true",
+        default=False,
+        help="Use causal (left-to-right) masking within draft blocks for sliding "
+        "window attention layers. Full attention layers are always bidirectional. "
+        "Matches vLLM inference behavior when SWA layers use causal attention.",
+    )
     # Dataloader parameters
     parser.add_argument(
         "--num-workers", type=int, default=12, help="Number of dataloader workers"

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -144,7 +144,7 @@ def create_transformer_layer_config(
             f"{type(verifier_config).__name__} has neither 'hidden_act' "
             "nor 'hidden_activation'"
         )
-    
+
     if sliding_window_indices and (
         min(sliding_window_indices) < 0 or max(sliding_window_indices) >= num_layers
     ):
@@ -156,7 +156,7 @@ def create_transformer_layer_config(
         "sliding_attention" if i in sliding_window_indices else "full_attention"
         for i in range(num_layers)
     ]
-    
+
     config = config_class(
         vocab_size=verifier_config.vocab_size,
         hidden_size=verifier_config.hidden_size,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -104,10 +104,10 @@ def setup_dataloader(
 def create_transformer_layer_config(
     verifier_name_or_path: str,
     num_layers: int,
-    draft_arch: str = "llama",
-    hidden_act: str | None = None,
-    sliding_window: int | None = None,
-    full_attention_interval: int | None = None,
+    draft_arch: str,
+    hidden_act: str | None,
+    sliding_window: int,
+    sliding_window_indices: list[int],
 ) -> PretrainedConfig:
     if draft_arch not in DRAFT_ARCH_CONFIGS:
         raise ValueError(
@@ -141,7 +141,19 @@ def create_transformer_layer_config(
             "nor 'hidden_activation'"
         )
 
-    kwargs = dict(
+    if sliding_window_indices and (
+        min(sliding_window_indices) < 0 or max(sliding_window_indices) >= num_layers
+    ):
+        raise ValueError(
+            "Sliding window indices must be validate draft layer ids "
+            "in range [0, num_layers)."
+        )
+    layer_types = [
+        "sliding_attention" if i in sliding_window_indices else "full_attention"
+        for i in range(num_layers)
+    ]
+
+    return config_class(
         vocab_size=verifier_config.vocab_size,
         hidden_size=verifier_config.hidden_size,
         intermediate_size=verifier_config.intermediate_size,
@@ -154,20 +166,9 @@ def create_transformer_layer_config(
         rms_norm_eps=verifier_config.rms_norm_eps,
         head_dim=getattr(verifier_config, "head_dim", None),
         tie_word_embeddings=False,
+        sliding_window=sliding_window,
+        layer_types=layer_types,
     )
-
-    if sliding_window is not None:
-        kwargs["sliding_window"] = sliding_window
-        if full_attention_interval is not None:
-            kwargs["layer_types"] = [
-                "full_attention" if (i + 1) % full_attention_interval == 0
-                else "sliding_attention"
-                for i in range(num_layers)
-            ]
-        else:
-            kwargs["layer_types"] = ["sliding_attention"] * num_layers
-
-    return config_class(**kwargs)
 
 
 def _load_mappings(d2t_path, t2d_path, expected_draft_vocab_size: int | None):
@@ -262,16 +263,20 @@ def main(args: argparse.Namespace):
 
     d2t, t2d, draft_vocab_size = parse_vocab_mappings(args)
 
+    if len(args.sliding_window_indices) and args.speculator_type != "dflash":
+        raise ValueError(
+            "Currently sliding window attention is only supported by dflash "
+            "draft models. Please open an issue/pr if you would like to use "
+            "sliding window attention with a different speculator type"
+        )
     # Setup speculator config
-    sliding_window = getattr(args, "sliding_window", None) or None
-    full_attention_interval = getattr(args, "full_attention_interval", None)
     transformer_layer_config = create_transformer_layer_config(
-        args.verifier_name_or_path,
-        args.num_layers,
+        verifier_name_or_path=args.verifier_name_or_path,
+        num_layers=args.num_layers,
         draft_arch=args.draft_arch,
         hidden_act=args.draft_hidden_act,
-        sliding_window=sliding_window,
-        full_attention_interval=full_attention_interval,
+        sliding_window_size=args.sliding_window_size,
+        sliding_window_indices=args.sliding_window_indices,
     )
 
     args.mask_token_id = resolve_mask_token_id(
@@ -660,27 +665,30 @@ def parse_args():
         help="Minimum retention ratio for COD sampling in P-EAGLE (default: 0.2)",
     )
     parser.add_argument(
-        "--sliding-window",
+        "--sliding-window-size",
         type=int,
-        default=0,
-        help="Sliding window size for DFlash attention (default: 0 = full attention). "
-        "Set to a positive value (e.g. 2048) to enable sliding window attention.",
+        default=2048,
+        help="Sliding window size for sliding window attention layers."
+        "Must also set --sliding-window-indices.",
     )
     parser.add_argument(
-        "--full-attention-interval",
+        "--sliding-window-indices",
         type=int,
+        nargs="+",
         default=None,
-        help="Every Nth layer uses full attention instead of sliding window. "
-        "Requires --sliding-window > 0. E.g., --full-attention-interval 3 "
-        "with 5 layers gives [slide, slide, full, slide, slide].",
+        help="(Optional) A (space separated) list of draft layer indices of sliding "
+        " window layers. All other draft layers are assumed to be full attention "
+        "layers. (e.g. 0 2 4 will make the first, third, and fifth layers use "
+        "sliding window attention and the second and fourth will be full attention)."
+        "Defaults to all layers using full attention.",
     )
     parser.add_argument(
-        "--swa-causal",
+        "--sliding-window-non-causal",
         action="store_true",
         default=False,
-        help="Use causal (left-to-right) masking within draft blocks for sliding "
-        "window attention layers. Full attention layers are always bidirectional. "
-        "Matches vLLM inference behavior when SWA layers use causal attention.",
+        help="Use non-causal (bidirectional) masking within draft blocks for sliding "
+        "window attention layers. Full attention layers are always bidirectional, for"
+        "DFlash. Note: vLLM currently doesn't support these models",
     )
     # Dataloader parameters
     parser.add_argument(

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -93,9 +93,10 @@ def _normalize_conversation(
         # Build normalized turn with role and content
         normalized_turn = {"role": role, "content": content}
 
-        # Preserve 'thinking' field if it exists
-        if "thinking" in turn and turn["thinking"]:
-            normalized_turn["thinking"] = turn["thinking"]
+        thinking = turn.get("thinking") or turn.get("reasoning_content")
+        if thinking:
+            normalized_turn["thinking"] = thinking
+            normalized_turn["reasoning_content"] = thinking
 
         normalized.append(normalized_turn)
 

--- a/src/speculators/models/dflash/attention.py
+++ b/src/speculators/models/dflash/attention.py
@@ -9,6 +9,7 @@ def create_anchor_block_mask_mod(
     total_seq_len: int,
     anchor_positions: torch.Tensor,
     block_size: int,
+    sliding_window: int | None = None,
 ):
     """
     Build a flex-attention mask mod where each query block corresponds to one anchor.
@@ -94,7 +95,13 @@ def create_anchor_block_mask_mod(
         same_doc = (q_doc == kv_doc) & (q_doc != -1)
         before_anchor = kv_base_pos < q_anchor
 
-        return kv_is_base & same_doc & before_anchor
+        in_window = (
+            (kv_base_pos >= q_anchor - sliding_window)
+            if sliding_window is not None
+            else True
+        )
+
+        return kv_is_base & same_doc & before_anchor & in_window
 
     def same_block_mod(_b, _h, q_idx, kv_idx):
         """

--- a/src/speculators/models/dflash/attention.py
+++ b/src/speculators/models/dflash/attention.py
@@ -10,6 +10,7 @@ def create_anchor_block_mask_mod(
     anchor_positions: torch.Tensor,
     block_size: int,
     sliding_window: int | None = None,
+    causal: bool = False,
 ):
     """
     Build a flex-attention mask mod where each query block corresponds to one anchor.
@@ -105,12 +106,16 @@ def create_anchor_block_mask_mod(
 
     def same_block_mod(_b, _h, q_idx, kv_idx):
         """
-        Queries may attend bidirectionally to all tokens in their own synthetic block.
+        Queries may attend to tokens in their own synthetic block.
+        Bidirectional unless causal=True, in which case only prior positions.
         """
         q_block = q_idx // block_size
         kv_is_block = kv_idx >= total_seq_len
         kv_block = (kv_idx - total_seq_len) // block_size
 
-        return kv_is_block & (q_block == kv_block)
+        same = kv_is_block & (q_block == kv_block)
+        if causal:
+            same = same & (kv_idx <= q_idx + total_seq_len)
+        return same
 
     return or_masks(base_prefix_mod, same_block_mod), q_len, kv_len

--- a/src/speculators/models/dflash/attention.py
+++ b/src/speculators/models/dflash/attention.py
@@ -10,7 +10,7 @@ def create_anchor_block_mask_mod(
     anchor_positions: torch.Tensor,
     block_size: int,
     sliding_window: int | None = None,
-    causal: bool = False,
+    sliding_window_non_causal: bool = False,
 ):
     """
     Build a flex-attention mask mod where each query block corresponds to one anchor.
@@ -33,10 +33,15 @@ def create_anchor_block_mask_mod(
         total_seq_len: padded packed sequence width
         anchor_positions: [n_anchors] absolute positions into the packed base sequence
         block_size: number of query tokens per anchor block
+        sliding_window: integer size of sliding window or None for full attn
+        sliding_window_non_causal: Use non causal mask for sliding window attn
 
     Returns:
         mask_mod, q_len, kv_len
     """
+    # Always use non_causal for full attn
+    non_causal = sliding_window is None or sliding_window_non_causal
+
     device = lengths.device
     anchor_positions = anchor_positions.to(device=device, dtype=torch.long).contiguous()
 
@@ -107,14 +112,15 @@ def create_anchor_block_mask_mod(
     def same_block_mod(_b, _h, q_idx, kv_idx):
         """
         Queries may attend to tokens in their own synthetic block.
-        Bidirectional unless causal=True, in which case only prior positions.
+        Non-causal unless non_causal=False,
+        in which case only prior positions are attended.
         """
         q_block = q_idx // block_size
         kv_is_block = kv_idx >= total_seq_len
         kv_block = (kv_idx - total_seq_len) // block_size
 
         same = kv_is_block & (q_block == kv_block)
-        if causal:
+        if not non_causal:
             same = same & (kv_idx <= q_idx + total_seq_len)
         return same
 

--- a/src/speculators/models/dflash/config.py
+++ b/src/speculators/models/dflash/config.py
@@ -71,10 +71,11 @@ class DFlashSpeculatorConfig(SpeculatorModelConfig):
         description="Token ID used for masking",
     )
 
-    swa_causal: bool = Field(
+    sliding_window_non_causal: bool = Field(
         default=False,
-        description="Use causal (left-to-right) masking within draft blocks for "
-        "sliding window attention layers. Full attention layers are always bidirectional.",
+        description="Use non-causal (bidirectional) masking within draft blocks for "
+        "sliding window attention layers. Full attention layers are always "
+        "bidirectional.",
     )
 
     @field_serializer("transformer_layer_config")

--- a/src/speculators/models/dflash/config.py
+++ b/src/speculators/models/dflash/config.py
@@ -71,6 +71,12 @@ class DFlashSpeculatorConfig(SpeculatorModelConfig):
         description="Token ID used for masking",
     )
 
+    swa_causal: bool = Field(
+        default=False,
+        description="Use causal (left-to-right) masking within draft blocks for "
+        "sliding window attention layers. Full attention layers are always bidirectional.",
+    )
+
     @field_serializer("transformer_layer_config")
     def serialize_transformer_config(self, value: PretrainedConfig) -> dict:
         """Serialize transformer config to dict."""

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -61,6 +61,15 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
                 for layer_idx in range(num_draft_layers)
             ]
         )
+        self.sliding_window = tl_config.sliding_window
+        self.sliding_window_indices = [
+            i
+            for i in range(num_draft_layers)
+            if tl_config.layer_types == "sliding_attention"
+        ]
+        self.uses_sliding_window_attn = bool(self.sliding_window_indices)
+        self.uses_full_attn = bool(num_draft_layers - len(self.sliding_window_indices))
+        self.sliding_window_non_causal = config.sliding_window_non_causal
 
         if config.aux_hidden_state_layer_ids is None:
             raise ValueError(
@@ -141,7 +150,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             max_anchors=kwargs.get("max_anchors", 3072),
             aux_hidden_state_layer_ids=target_layer_ids,
             mask_token_id=kwargs.get("mask_token_id"),
-            swa_causal=kwargs.get("swa_causal", False),
+            sliding_window_non_causal=kwargs.get("sliding_window_non_causal", False),
             speculators_config=SpeculatorsConfig(
                 algorithm="dflash",
                 proposal_methods=[
@@ -213,47 +222,32 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         )
         # shape: [num_anchors], [num_anchors]
 
-        tl_config = self.config.transformer_layer_config
-        sliding_window = getattr(tl_config, "sliding_window", None)
-        layer_types = getattr(tl_config, "layer_types", None)
-
-        needs_swa = (
-            sliding_window is not None
-            and layer_types is not None
-            and "sliding_attention" in layer_types
-        )
-        needs_full = (
-            layer_types is None
-            or "full_attention" in layer_types
-            or not needs_swa
-        )
-
-        mask_kwargs = dict(
-            lengths=lengths.to(device),
-            total_seq_len=total_seq_len,
-            anchor_positions=anchor_positions,
-            block_size=self.block_size,
-        )
-
-        swa_causal = getattr(self.config, "swa_causal", False)
-
-        def _build_mask(sw, causal=False):
-            mod, q, kv = create_anchor_block_mask_mod(**mask_kwargs, sliding_window=sw, causal=causal)
-            return create_block_mask(mod, B=None, H=None, Q_LEN=q, KV_LEN=kv, device=device), q, kv
-
-        if needs_swa:
-            swa_mask, q_len, kv_len = _build_mask(sliding_window, causal=swa_causal)
-        if needs_full:
-            full_mask, q_len, kv_len = _build_mask(None)
-
-        layer_masks = []
-        for i in range(len(self.layers)):
-            is_swa = (
-                layer_types is not None
-                and sliding_window is not None
-                and layer_types[i] == "sliding_attention"
+        full_attn_mask = None
+        if self.uses_full_attn:
+            mask_mod, q_len, kv_len = create_anchor_block_mask_mod(
+                lengths=lengths.to(device),
+                total_seq_len=total_seq_len,
+                anchor_positions=anchor_positions,
+                block_size=self.block_size,
+                sliding_window=None,
             )
-            layer_masks.append(swa_mask if is_swa else full_mask)
+            full_attn_mask = create_block_mask(
+                mask_mod, B=None, H=None, Q_LEN=q_len, KV_LEN=kv_len, device=device
+            )
+
+        sliding_window_attn_mask = None
+        if self.uses_sliding_window_attn:
+            mask_mod, q_len, kv_len = create_anchor_block_mask_mod(
+                lengths=lengths.to(device),
+                total_seq_len=total_seq_len,
+                anchor_positions=anchor_positions,
+                block_size=self.block_size,
+                sliding_window=self.sliding_window,
+                sliding_window_non_causal=self.sliding_window_non_causal,
+            )
+            sliding_window_attn_mask = create_block_mask(
+                mask_mod, B=None, H=None, Q_LEN=q_len, KV_LEN=kv_len, device=device
+            )
 
         mask_tokens_size = num_anchors * self.block_size
 
@@ -294,11 +288,13 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             targets = verifier_logits[:, anchored_block_indices]
             # shape: [1, num_anchors*block_size, draft_vocab_size]
 
-        for layer, mask in zip(self.layers, layer_masks):
+        for layer_idx, layer in enumerate(self.layers):
             noise_embedding = layer(
                 hidden_states=noise_embedding,
                 target_hidden=fc_output,
-                attention_mask=mask,
+                attention_mask=sliding_window_attn_mask
+                if layer_idx in self.sliding_window_indices
+                else full_attn_mask,
                 position_ids=position_ids,
                 use_cache=False,
                 position_embeddings=position_embeddings,

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -141,6 +141,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             max_anchors=kwargs.get("max_anchors", 3072),
             aux_hidden_state_layer_ids=target_layer_ids,
             mask_token_id=kwargs.get("mask_token_id"),
+            swa_causal=kwargs.get("swa_causal", False),
             speculators_config=SpeculatorsConfig(
                 algorithm="dflash",
                 proposal_methods=[
@@ -234,12 +235,14 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             block_size=self.block_size,
         )
 
-        def _build_mask(sw):
-            mod, q, kv = create_anchor_block_mask_mod(**mask_kwargs, sliding_window=sw)
+        swa_causal = getattr(self.config, "swa_causal", False)
+
+        def _build_mask(sw, causal=False):
+            mod, q, kv = create_anchor_block_mask_mod(**mask_kwargs, sliding_window=sw, causal=causal)
             return create_block_mask(mod, B=None, H=None, Q_LEN=q, KV_LEN=kv, device=device), q, kv
 
         if needs_swa:
-            swa_mask, q_len, kv_len = _build_mask(sliding_window)
+            swa_mask, q_len, kv_len = _build_mask(sliding_window, causal=swa_causal)
         if needs_full:
             full_mask, q_len, kv_len = _build_mask(None)
 

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -65,8 +65,8 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         self.sliding_window = tl_config.sliding_window
         self.sliding_window_indices = [
             i
-            for i in range(num_draft_layers)
-            if tl_config.layer_types == "sliding_attention"
+            for i, layer_type in enumerate(tl_config.layer_types)
+            if layer_type == "sliding_attention"
         ]
         self.uses_sliding_window_attn = bool(self.sliding_window_indices)
         self.uses_full_attn = bool(num_draft_layers - len(self.sliding_window_indices))

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -198,7 +198,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
     @torch.compiler.disable
     def _build_attention_mask(self, loss_mask, lengths, device):
         total_seq_len = loss_mask.shape[1]
-        
+
         anchor_positions, anchor_valid = select_anchors(
             loss_mask, self.config.max_anchors, self.block_size
         )
@@ -229,7 +229,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             sliding_window_attn_mask = create_block_mask(
                 mask_mod, B=None, H=None, Q_LEN=q_len, KV_LEN=kv_len, device=device
             )
-      
+
         return full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid
 
     @torch.compile
@@ -255,8 +255,8 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
                 total_seq_len, dtype=torch.long, device=device
             ).unsqueeze(0)
 
-        full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid = self._build_attention_mask(
-            loss_mask, lengths, device
+        full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid = (
+            self._build_attention_mask(loss_mask, lengths, device)
         )
 
         mask_tokens_size = num_anchors * self.block_size

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -212,11 +212,15 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         )
         # shape: [num_anchors], [num_anchors]
 
+        sliding_window = getattr(
+            self.config.transformer_layer_config, "sliding_window", None
+        )
         mask_mod, q_len, kv_len = create_anchor_block_mask_mod(
             lengths=lengths.to(device),
             total_seq_len=total_seq_len,
             anchor_positions=anchor_positions,
             block_size=self.block_size,
+            sliding_window=sliding_window,
         )
 
         attention_mask = create_block_mask(

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -212,25 +212,45 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         )
         # shape: [num_anchors], [num_anchors]
 
-        sliding_window = getattr(
-            self.config.transformer_layer_config, "sliding_window", None
+        tl_config = self.config.transformer_layer_config
+        sliding_window = getattr(tl_config, "sliding_window", None)
+        layer_types = getattr(tl_config, "layer_types", None)
+
+        needs_swa = (
+            sliding_window is not None
+            and layer_types is not None
+            and "sliding_attention" in layer_types
         )
-        mask_mod, q_len, kv_len = create_anchor_block_mask_mod(
+        needs_full = (
+            layer_types is None
+            or "full_attention" in layer_types
+            or not needs_swa
+        )
+
+        mask_kwargs = dict(
             lengths=lengths.to(device),
             total_seq_len=total_seq_len,
             anchor_positions=anchor_positions,
             block_size=self.block_size,
-            sliding_window=sliding_window,
         )
 
-        attention_mask = create_block_mask(
-            mask_mod,
-            B=None,
-            H=None,
-            Q_LEN=q_len,
-            KV_LEN=kv_len,
-            device=device,
-        )
+        def _build_mask(sw):
+            mod, q, kv = create_anchor_block_mask_mod(**mask_kwargs, sliding_window=sw)
+            return create_block_mask(mod, B=None, H=None, Q_LEN=q, KV_LEN=kv, device=device), q, kv
+
+        if needs_swa:
+            swa_mask, q_len, kv_len = _build_mask(sliding_window)
+        if needs_full:
+            full_mask, q_len, kv_len = _build_mask(None)
+
+        layer_masks = []
+        for i in range(len(self.layers)):
+            is_swa = (
+                layer_types is not None
+                and sliding_window is not None
+                and layer_types[i] == "sliding_attention"
+            )
+            layer_masks.append(swa_mask if is_swa else full_mask)
 
         mask_tokens_size = num_anchors * self.block_size
 
@@ -271,11 +291,11 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             targets = verifier_logits[:, anchored_block_indices]
             # shape: [1, num_anchors*block_size, draft_vocab_size]
 
-        for layer in self.layers:
+        for layer, mask in zip(self.layers, layer_masks):
             noise_embedding = layer(
                 hidden_states=noise_embedding,
                 target_hidden=fc_output,
-                attention_mask=attention_mask,
+                attention_mask=mask,
                 position_ids=position_ids,
                 use_cache=False,
                 position_embeddings=position_embeddings,

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -13,7 +13,6 @@ import openai
 import torch
 import torch.nn.functional as F  # noqa: N812
 from datasets import load_from_disk
-from safetensors import SafetensorError
 from safetensors.torch import load_file
 from torch.utils.data import Dataset
 
@@ -250,12 +249,7 @@ class ArrowDataset(BaseDataset):
         file_idx = self._map_to_file_idx(index)
         candidate_path = self.hidden_states_path / f"hs_{file_idx}.safetensors"
         if candidate_path.exists():
-            try:
-                return load_file(candidate_path)
-            except SafetensorError as e:
-                raise RuntimeError(
-                    f"Failed to load {candidate_path}: {e}"
-                ) from None
+            return load_file(candidate_path)
 
         return None
 
@@ -276,12 +270,7 @@ class ArrowDataset(BaseDataset):
             warnings.warn(str(e), stacklevel=1)
             return None
 
-        try:
-            loaded_hs = load_file(hs_filepath)
-        except SafetensorError as e:
-            raise RuntimeError(
-                f"Failed to load generated hidden states from {hs_filepath}: {e}"
-            ) from None
+        loaded_hs = load_file(hs_filepath)
 
         match self.on_generate:
             case "cache":

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -13,6 +13,7 @@ import openai
 import torch
 import torch.nn.functional as F  # noqa: N812
 from datasets import load_from_disk
+from safetensors import SafetensorError
 from safetensors.torch import load_file
 from torch.utils.data import Dataset
 
@@ -249,7 +250,12 @@ class ArrowDataset(BaseDataset):
         file_idx = self._map_to_file_idx(index)
         candidate_path = self.hidden_states_path / f"hs_{file_idx}.safetensors"
         if candidate_path.exists():
-            return load_file(candidate_path)
+            try:
+                return load_file(candidate_path)
+            except SafetensorError as e:
+                raise RuntimeError(
+                    f"Failed to load {candidate_path}: {e}"
+                ) from None
 
         return None
 
@@ -270,7 +276,12 @@ class ArrowDataset(BaseDataset):
             warnings.warn(str(e), stacklevel=1)
             return None
 
-        loaded_hs = load_file(hs_filepath)
+        try:
+            loaded_hs = load_file(hs_filepath)
+        except SafetensorError as e:
+            raise RuntimeError(
+                f"Failed to load generated hidden states from {hs_filepath}: {e}"
+            ) from None
 
         match self.on_generate:
             case "cache":


### PR DESCRIPTION
<!-- markdownlint-disable -->

This PR adds support for sliding window attention in DFlash speculators.  

## Purpose

Based on the paper: https://arxiv.org/pdf/2605.09992v1, we believe there may be some benefit to using sliding windows for speculation instead of full attention, especially for long-context sequences.  At the very least it will save us on kv cache allocation for longer sequences.  

## Description

The PR adds: 
1. Support for specifying the sliding window frequency upon starting training and putting the configuration in the config.  
2. Modifications to the attention function to mask in/out the appropriate window.  

## Related Issue

NA 

## Tests

with the extra flags:
--sliding-window 2048 --swa-causal

Results in acceptance rates of: 

Accepted throughput: 124.69 tokens/s, Drafted throughput: 480.85 tokens/s, Accepted: 1247 tokens, Drafted: 4809 tokens, Per-position acceptance rate: 0.757, 0.491, 0.303, 0.157, 0.074, 0.025, 0.009, Avg Draft acceptance rate: 25.9%
Accepted throughput: 53.00 tokens/s, Drafted throughput: 158.89 tokens/s, Accepted: 530 tokens, Drafted: 1589 tokens, Per-position acceptance rate: 0.824, 0.612, 0.427, 0.264, 0.137, 0.053, 0.018, Avg Draft acceptance rate: 33.4%
 
for the curl requests: 
Write merge sort in python
Prove that the sum of the eigenvalues of a matrix is its trace.

I will do a run with a full dataset when possible.  

Limited results using gemma 4:  

Available in:  inference-optimization/Gemma4_SWA_DFLASH

Note: Support for this requires the DFlash branch of vllm, with a few modifications to remove the +1 to the layer indices and the square root scaling on the embedding.  I will put up a branch shortly.  

Results from using gemma 4 training for full epochs:  

(APIServer pid=3517143) INFO 05-20 04:34:41 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 4.95, Accepted throughput: 14.70 tokens/s, Drafted throughput: 26.05 tokens/s, Accepted: 1201 tokens, Drafted: 2128 tokens, Per-position acceptance rate: 0.898, 0.757, 0.645, 0.546, 0.464, 0.362, 0.280, Avg Draft acceptance rate: 56.4%
(APIServer pid=3517143) INFO:     127.0.0.1:34968 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=3517143) INFO 05-20 04:34:51 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 11.2 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=3517143) INFO 05-20 04:34:51 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 5.09, Accepted throughput: 9.00 tokens/s, Drafted throughput: 15.40 tokens/s, Accepted: 90 tokens, Drafted: 154 tokens, Per-position acceptance rate: 0.955, 0.682, 0.591, 0.500, 0.455, 0.455, 0.455, Avg Draft acceptance rate: 58.4%



{"id":"chatcmpl-9612b5fbbf5601ef","object":"chat.completion","created":1779251672,"prompt_routed_experts":null,"model":"inference-optimization/Gemma4_SWA_DFLASH","choices":[{"index":0,"message":{"role":"assistant","content":"Here is a clean, efficient implementation of the **Merge Sort** algorithm in Python.\n\n### The Code\n\n```python\ndef merge_sort(arr):\n    # Base case: if the list has 1 or 0 elements, it is already sorted\n    if len(arr) <= 1:\n        return arr\n\n    # 1. Find the middle point and split the array into two halves\n    mid = len(arr) // 2\n    left_half = arr[:mid]\n    right_half = arr[mid:]\n\n    # 2. Recursively sort both halves\n    left_sorted = merge_sort(left_half)\n    right_sorted = merge_sort(right_half)\n\n    # 3. Merge the sorted halves back together\n    return merge(left_sorted, right_sorted)\n\ndef merge(left, right):\n    result = []\n    i = j = 0\n\n    # Compare elements from both lists and pick the smaller one\n    while i < len(left) and j < len(right):\n        if left[i] < right[j]:\n            result.append(left[i])\n            i += 1\n        else:\n            result.append(right[j])\n            j += 1\n\n    # If there are remaining elements in left or right, append them\n    result.extend(left[i:])\n    result.extend(right[j:])\n    \n    return result\n\n# --- Testing the code ---\nif __name__ == \"__main__\":\n    test_list = [38, 27, 43, 3, 9, 82, 10]\n    print(f\"Original list: {test_list}\")\n    \n    sorted_list = merge_sort(test_list)\n    print(f\"Sorted list:   {sorted_list}\")\n```\n\n---\n\n### How it Works (The Logic)\n\nMerge Sort is a **Divide and Conquer** algorithm. It breaks the problem down into smaller sub-problems until they are easy to solve, then combines the solutions.\n\n1.  **Divide:** The `merge_sort` function splits the array in half repeatedly. This continues until you have several lists that contain only one element each.\n2.  **Conquer:** A list with one element is considered \"sorted.\" \n3.  **Combine (Merge):** The `merge` function takes two sorted lists and zips them together. It looks at the first element of both lists, picks the smallest, and moves it into the result list. It repeats this until all elements are merged back into one large sorted array.\n\n### Complexity Analysis\n\n| Complexity | Notation | Explanation |\n| :--- | :--- | :--- |\n| **Time Complexity** | $O(n \\log n)$ | The array is split in half $\\log n$ times, and at each level of splitting, we perform $n$ operations to merge. |\n| **Space Complexity** | $O(n)$ | Merge sort requires extra space to create the temporary sub-lists during the merge process. |\n\n### Key Features\n*   **Stable:** It preserves the relative order of equal elements.\n*   **Predictable:** Unlike Quick Sort, Merge Sort always runs in $O(n \\log n)$ time, regardless of whether the input is already sorted or completely random.","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"stop","stop_reason":106,"token_ids":null,"routed_experts":null}],"service_tier":null,"system_fingerprint":"vllm-0.20.2rc1.dev208+g8cb2db160-tp2-a4d25172","usage":{"prompt_tokens":18,"total_tokens":750,"completion_tokens":732,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}{"id":"chatcmpl-bf9353bb8918ee7e","object":"chat.completion","created":1779251676,"prompt_routed_experts":null,"model":"inference-optimization/Gemma4_SWA_DFLASH","choices":[{"index":0,"message":{"role":"assistant","content":"To prove that the sum of the eigenvalues of a square matrix is equal to its trace, we utilize the properties of the **characteristic polynomial**.\n\n### 1. Definitions\nLet $A$ be an $n \\times n$ matrix.\n*   **The Trace:** $\\text{tr}(A) = \\sum_{i=1}^n a_{ii}$ (the sum of the diagonal elements).\n*   **The Eigenvalues:** The scalars $\\lambda_1, \\lambda_2, \\dots, \\lambda_n$ are the roots of the characteristic polynomial $p(\\lambda) = \\det(A - \\lambda I)$.\n\n---\n\n### 2. The Characteristic Polynomial (Two Perspectives)\n\n**Perspective A: Expansion by Determinant**\nThe characteristic polynomial is defined as:\n$$p(\\lambda) = \\det(A - \\lambda I) = \\det \\begin{pmatrix} a_{11} - \\lambda & a_{12} & \\dots \\\\ a_{21} & a_{22} - \\lambda & \\dots \\\\ \\vdots & \\vdots & \\ddots \\end{pmatrix}$$\nWhen we multiply out this determinant, the term with the highest power of $\\lambda$ comes from the product of the diagonal elements:\n$$(a_{11} - \\lambda)(a_{22} - \\lambda) \\dots (a_{nn} - \\lambda)$$\nIf we expand this product, the $\\lambda^n$ term is $(-1)^n \\lambda^n$. The term containing $\\lambda^{n-1}$ is formed by picking $\\lambda$ from $(n-1)$ factors and a diagonal element $a_{ii}$ from the remaining factor. Thus:\n$$p(\\lambda) = (-1)^n \\lambda^n + (-1)^{n-1}(a_{11} + a_{22} + \\dots + a_{nn})\\lambda^{n-1} + \\dots + \\det(A)$$\nUsing the definition of the trace, we can write this as:\n$$p(\\lambda) = (-1)^n \\lambda^n + (-1)^{n-1}\\text{tr}(A)\\lambda^{n-1} + \\dots + \\det(A) \\quad \\text{--- (Eq. 1)}$$\n\n**Perspective B: Factored Form (Roots)**\nBy the Fundamental Theorem of Algebra, a polynomial can be written in terms of its roots (the eigenvalues $\\lambda_i$):\n$$p(\\lambda) = (\\lambda_1 - \\lambda)(\\lambda_2 - \\lambda) \\dots (\\lambda_n - \\lambda)$$\nExpanding this product:\n$$p(\\lambda) = (-1)^n (\\lambda - \\lambda_1)(\\lambda - \\lambda_2) \\dots (\\lambda - \\lambda_n)$$\nExpanding the brackets:\n$$p(\\lambda) = (-1)^n \\left[ \\lambda^n - (\\lambda_1 + \\lambda_2 + \\dots + \\lambda_n)\\lambda^{n-1} + \\dots + (-1)^n \\prod \\lambda_i \\right]$$\nDistributing the $(-1)^n$:\n$$p(\\lambda) = (-1)^n \\lambda^n + (-1)^{n-1}(\\sum_{i=1}^n \\lambda_i)\\lambda^{n-1} + \\dots + \\prod \\lambda_i \\quad \\text{--- (Eq. 2)}$$\n\n---\n\n### 3. Comparison and Conclusion\nSince (Eq. 1) and (Eq. 2) describe the same polynomial $p(\\lambda)$, the coefficients of corresponding powers of $\\lambda$ must be equal. \n\nComparing the coefficients of $\\lambda^{n-1}$:\n$$(-1)^{n-1}\\text{tr}(A) = (-1)^{n-1} \\sum_{i=1}^n \\lambda_i$$\n\nDividing both sides by $(-1)^{n-1}$, we get:\n$$\\text{tr}(A) = \\sum_{i=1}^n \\lambda_i$$\n\n**$\\text{Q.E.D.}$**","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":null},"logprobs":null,"finish_reason":"stop","stop_reason":106,"token_ids":null,"routed_experts":null}],"service_tier":null,"system_fingerprint":"vllm-0.20.2rc1.dev208+g8cb2db160-tp2-a4d25172","usage":{"prompt_tokens":27,"total_tokens":914,"completion_tokens":887,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}





Notes: 

The current vllm integration assumes causal attention for sliding window layers and bidirectional for full attention layers.  

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
