### PR TITLE
Add hc_mult support to DFlash for DeepSeek-V4-Flash

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -139,6 +139,8 @@ def create_transformer_layer_config(
             "nor 'hidden_activation'"
         )
 
+    hc_mult = getattr(verifier_config, "hc_mult", 1)
+
     return config_class(
         vocab_size=verifier_config.vocab_size,
         hidden_size=verifier_config.hidden_size,
@@ -152,6 +154,7 @@ def create_transformer_layer_config(
         rms_norm_eps=verifier_config.rms_norm_eps,
         head_dim=getattr(verifier_config, "head_dim", None),
         tie_word_embeddings=False,
+        hc_mult=hc_mult,
     )
 
 
@@ -334,11 +337,14 @@ def main(args: argparse.Namespace):
             max_retries=args.max_retries,
         )
 
+    hc_mult = getattr(transformer_layer_config, "hc_mult", 1)
+    effective_hidden_size = hc_mult * transformer_layer_config.hidden_size
+
     train_loader = setup_dataloader(
         train_dataset,
         world_size,
         local_rank,
-        transformer_layer_config.hidden_size,
+        effective_hidden_size,
         num_workers=args.num_workers,
         prefetch_factor=args.prefetch_factor,
         preprocess=preprocess,
@@ -347,7 +353,7 @@ def main(args: argparse.Namespace):
         val_dataset,
         world_size,
         local_rank,
-        transformer_layer_config.hidden_size,
+        effective_hidden_size,
         num_workers=args.num_workers,
         prefetch_factor=args.prefetch_factor,
         preprocess=preprocess,

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -16,6 +16,7 @@ from speculators.models.dflash.metrics import compute_metrics
 from speculators.models.dflash.model_definitions import Qwen3DFlashDecoderLayer
 from speculators.models.dflash.utils import (
     get_base_indices_for_anchored_blocks,
+    hc_head_project,
     select_anchors,
 )
 from speculators.models.utils import resolve_target_layer_ids
@@ -30,10 +31,16 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         "verifier_norm.weight",
         "t2d",
         "d2t",
+        "hc_head_fn",
+        "hc_head_base",
+        "hc_head_scale",
     ]
     _keys_to_ignore_on_save: ClassVar[list[str]] = [  # type: ignore[misc,assignment]
         "verifier_lm_head.weight",
         "verifier_norm.weight",
+        "hc_head_fn",
+        "hc_head_base",
+        "hc_head_scale",
     ]
 
     t2d: torch.Tensor | None
@@ -52,6 +59,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         self._init_vocab(config)
 
         tl_config = config.transformer_layer_config
+        self.hc_mult = getattr(tl_config, "hc_mult", 1)
 
         # Number of draft layers is encoded in transformer_layer_config
         num_draft_layers = tl_config.num_hidden_layers
@@ -75,8 +83,13 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         )
         self.rotary_emb = Qwen3RotaryEmbedding(config.transformer_layer_config)  # type: ignore[arg-type]
 
+        fc_in = (
+            len(self.target_layer_ids)
+            * self.hc_mult
+            * config.transformer_layer_config.hidden_size
+        )
         self.fc = nn.Linear(
-            len(self.target_layer_ids) * config.transformer_layer_config.hidden_size,
+            fc_in,
             config.transformer_layer_config.hidden_size,
             bias=False,
         )
@@ -89,6 +102,15 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             eps=config.transformer_layer_config.rms_norm_eps,  # type: ignore[arg-type]
         )
         self.verifier_norm.weight.requires_grad = False
+
+        if self.hc_mult > 1:
+            hs = config.transformer_layer_config.hidden_size
+            self.register_buffer(
+                "hc_head_fn", torch.empty(self.hc_mult, self.hc_mult * hs)
+            )
+            self.register_buffer("hc_head_base", torch.empty(self.hc_mult))
+            self.register_buffer("hc_head_scale", torch.empty(1))
+
         self.block_size = config.block_size
         self.post_init()
 
@@ -185,6 +207,65 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         val_kwargs: dict[str, Any] = {}
         return train_kwargs, val_kwargs
 
+    def load_verifier_weights(self):
+        """Load verifier weights, handling DSv4's non-standard weight names."""
+        if self.hc_mult <= 1:
+            super().load_verifier_weights()
+            return
+
+        from speculators.utils.loading import load_model_layers  # noqa: PLC0415
+
+        speculators_config = getattr(
+            getattr(self, "config", None), "speculators_config", None
+        )
+        if speculators_config is None:
+            return
+        verifier_config = speculators_config.verifier
+        if verifier_config.name_or_path is None:
+            return
+
+        verifier_weights = load_model_layers(
+            [
+                "embed.weight",
+                "head.weight",
+                "norm.weight",
+                "hc_head_fn",
+                "hc_head_base",
+                "hc_head_scale",
+            ],
+            verifier_config.name_or_path,
+        )
+
+        embed_weight = verifier_weights["embed.weight"]
+        lm_head_weight = verifier_weights.get("head.weight", embed_weight)
+
+        if self.embed_tokens.weight.isnan().any():
+            self.embed_tokens.load_state_dict({"weight": embed_weight})
+
+        if self.use_draft_vocab:
+            if self.t2d is None or not torch.any(self.t2d).item():
+                raise ValueError(
+                    "t2d tensor hasn't been set. Please call "
+                    "`.load_vocab_mappings(t2d, d2t)` before `.load_verifier_weights()`"
+                )
+            lm_head_weight = lm_head_weight[
+                self.t2d.to(device=lm_head_weight.device, dtype=torch.bool), :
+            ]
+
+        if self.lm_head.weight.isnan().any():
+            self.lm_head.load_state_dict(
+                {"weight": lm_head_weight.detach().clone()}, strict=False
+            )
+        self.verifier_lm_head.load_state_dict(
+            {"weight": lm_head_weight.detach().clone()}, strict=False
+        )
+
+        self.verifier_norm.load_state_dict({"weight": verifier_weights["norm.weight"]})
+
+        self.hc_head_fn.copy_(verifier_weights["hc_head_fn"])
+        self.hc_head_base.copy_(verifier_weights["hc_head_base"])
+        self.hc_head_scale.copy_(verifier_weights["hc_head_scale"])
+
     @property
     def mask_token_id(self) -> int:
         if self.config.mask_token_id is None:
@@ -269,6 +350,14 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         )  # shape: [num_anchors*block_size]
 
         with torch.no_grad():
+            if self.hc_mult > 1:
+                bsz, seq, _ = verifier_last_hidden_states.shape
+                verifier_last_hidden_states = hc_head_project(
+                    verifier_last_hidden_states.reshape(bsz * seq, self.hc_mult, -1),
+                    self.hc_head_fn,
+                    self.hc_head_scale,
+                    self.hc_head_base,
+                ).reshape(bsz, seq, -1)
             verifier_logits = self.verifier_lm_head(
                 self.verifier_norm(verifier_last_hidden_states)
             )

--- a/src/speculators/models/dflash/utils.py
+++ b/src/speculators/models/dflash/utils.py
@@ -3,6 +3,34 @@
 import torch
 
 
+def hc_head_project(
+    hidden_states: torch.Tensor,
+    hc_fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_norm_eps: float = 1e-6,
+    hc_eps: float = 1e-6,
+) -> torch.Tensor:
+    """Collapse multi-channel hidden states via the hc_head projection.
+
+    Pure-PyTorch port of vLLM's ``_hc_head_fused_reference``.
+    """
+    num_tokens, hc_mult, hidden_size = hidden_states.shape
+
+    x = hidden_states.reshape(num_tokens, hc_mult * hidden_size).to(torch.float32)
+
+    mixes = torch.matmul(x, hc_fn.t())
+
+    sqrsum = x.square().sum(dim=-1, keepdim=True)
+    rsqrt = torch.rsqrt(sqrsum / (hc_mult * hidden_size) + rms_norm_eps)
+
+    pre_mix = torch.sigmoid(mixes * rsqrt * hc_scale[0] + hc_base) + hc_eps
+
+    result = torch.sum(pre_mix.unsqueeze(-1) * hidden_states.to(torch.float32), dim=1)
+
+    return result.to(hidden_states.dtype)
+
+
 def get_base_indices_for_anchored_blocks(
     anchor_positions: torch.Tensor,  # shape: [1, num_anchors]
     block_size: int,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Enable training DFlash speculators for DeepSeek-V4-Flash (DSv4), which uses Manifold-Constrained Hyper-Connection (mHC) with `hc_mult=4`. DSv4's hidden states are `(N, hc_mult * hidden_size)` per layer rather than the standard `(N, hidden_size)`, and its checkpoint uses non-standard weight names (`embed.weight`, `head.weight`, `norm.weight`). Without these changes the DFlash pipeline cannot initialize or train a speculator for DSv4.

## Description

- **`scripts/train.py`**: Read `hc_mult` from the verifier config (default 1) and thread it into the draft model's `transformer_layer_config`. Pass `hc_mult * hidden_size` as the effective hidden size to both train and val dataloaders so `create_collate_fn` / `create_empty_sample` create correctly shaped tensors.
- **`src/speculators/models/dflash/core.py`**:
  - `__init__`: Read `self.hc_mult` from config. Expand FC layer input dim to `len(target_layer_ids) * hc_mult * hidden_size`. Register `hc_head_fn`, `hc_head_base`, `hc_head_scale` buffers when `hc_mult > 1`.
  - `forward`: Apply `hc_head_project()` to collapse `verifier_last_hidden_states` from `(N, hc_mult * hidden_size)` → `(N, hidden_size)` before `verifier_norm` in the loss path (only when `hc_mult > 1`).
  - `load_verifier_weights`: New override that handles DSv4's non-standard weight names and loads hc_head parameters. Delegates to `super()` when `hc_mult == 1`.
- **`src/speculators/models/dflash/utils.py`**: `hc_head_project()` added in a prior commit (pure-PyTorch port of vLLM's `_hc_head_fused_reference`).

All changes are backward-compatible: when `hc_mult=1` (all non-DSv4 models), every dimension calculation is algebraically identical to the prior code.

## Related Issue

Part of the DFlash DSv4 code changes effort (Diff 1: Hidden States from the companion PRD).

## Tests

- All 264 existing unit tests pass (`python -m pytest tests/unit/ -x -q`).
- Verified end-to-end with a smoke test script that initializes a DFlash speculator against the real DSv4 checkpoint, loads weights, and runs a dummy forward pass on CUDA — init, weight loading, and forward all pass.

```
--- __init__ checks ---
  hc_mult = 4
  FC: Linear(49152, 4096)
  hc_head_fn:    (4, 16384)
  hc_head_base:  (4,)
  hc_head_scale: (1,)
  PASS

--- load_verifier_weights checks ---
  embed_tokens:     (129280, 4096), loaded
  lm_head:          (32000, 4096), loaded
  verifier_lm_head: (32000, 4096), loaded
  verifier_norm:    (4096,), loaded
  hc_head_fn:       (4, 16384), loaded
  hc_head_base:     (4,), loaded
  hc_head_scale:    (1,), loaded
  PASS

--- forward pass checks ---
  hidden_states:                (1, 64, 49152)
  input_ids:                    (1, 64)
  verifier_last_hidden_states:  (1, 64, 16384)
  draft_tokens: (1, 32)
  loss:         29.4409
  metrics keys: ['full_acc', 'loss', 'position 1 acc', ...]
  PASS
```

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.