### PR TITLE
Multi node data generation offline

### DIFF
--- a/docs/cli/data_generation_offline.md
+++ b/docs/cli/data_generation_offline.md
@@ -51,6 +51,12 @@ python scripts/data_generation_offline.py \
 
 - **`--max-consecutive-errors`** (int, default: value of `--concurrency`) Abort after this many consecutive sample failures (each sample already retried `--max-retries` times). Prevents silently churning through the entire dataset when the server is down. Ignored when `--fail-on-error` is set.
 
+### Multi-Node Arguments
+
+- **`--world-size`** (int, default: `1`) Number of nodes participating in data generation. Each node is assigned a contiguous, non-overlapping chunk of the dataset. This is the number of nodes, not the number of GPUs.
+
+- **`--rank`** (int, default: `0`) Zero-based index of the current node. Must be in the range `[0, world-size)`.
+
 ## Full Example
 
 ```bash

--- a/docs/user_guide/tutorials/train_eagle3_offline.md
+++ b/docs/user_guide/tutorials/train_eagle3_offline.md
@@ -154,6 +154,22 @@ output/hidden_states/
 python scripts/launch_vllm.py model -- --data-parallel-size 8
 ```
 
+**Use multiple nodes:**
+
+If you have access to multiple machines, each with its own vLLM server, you can split the dataset across them with `--world-size` and `--rank`. Each node generates a contiguous, non-overlapping chunk of the data into a shared (or later merged) output directory. See the [data_generation_offline.py cli reference](/cli/data_generation_offline.md) for details.
+
+```bash
+# On node 0
+python scripts/data_generation_offline.py \
+  --preprocessed-data ./output --output ./output/hidden_states \
+  --max-samples 5000 --world-size 2 --rank 0
+
+# On node 1
+python scripts/data_generation_offline.py \
+  --preprocessed-data ./output --output ./output/hidden_states \
+  --max-samples 5000 --world-size 2 --rank 1
+```
+
 **Skip validation:**
 
 Validation loads every single generated output file and confirms that the token ids match the sent request and the hidden states length matches expectation. This is generally not required but is a good sanity check. Turn this off to skip loading generated samples during data gen.

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -26,6 +26,10 @@ from datasets import load_from_disk
 from safetensors import safe_open
 from tqdm import tqdm
 
+from speculators.data_generation.offline import (
+    get_existing_hidden_state_indices,
+    get_indices_to_process,
+)
 from speculators.data_generation.vllm_client import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_REQUEST_TIMEOUT,
@@ -182,77 +186,6 @@ def parse_args():
         ),
     )
     return parser.parse_args()
-
-
-def get_existing_hidden_state_indices(output_path: Path) -> list[int]:
-    """Find existing `hs_i.safetensors` files (where i is the file index)"""
-
-    existing_file_indices = []
-
-    if not output_path.exists():
-        return existing_file_indices
-
-    for file_path in output_path.iterdir():
-        if file_path.name.startswith("hs_") and file_path.name.endswith(".safetensors"):
-            index_str = file_path.stem[3:]  # Remove "hs_" prefix
-            try:
-                file_index = int(index_str)
-                existing_file_indices.append(file_index)
-            except ValueError:
-                continue
-
-    return sorted(existing_file_indices)
-
-
-def get_indices_to_process(
-    num_samples: int,
-    max_samples: int | None,
-    existing: list[int],
-    world_size: int,
-    rank: int,
-) -> list[int]:
-    """Determines which indices should be processed. If max_samples is None
-    returns all dataset indices not in existing. Otherwise gets the first
-    `max_samples - len(existing)` samples not already in existing.
-
-    Args:
-        num_samples: Total size of preprocessed dataset
-        max_samples: (Optional) limit for number of samples to process
-        existing: list of ids that have already been processed
-        world_size: Number of nodes to generate on
-        rank: The rank of the local node
-
-    Returns:
-        list of dataset indices to process
-    """
-
-    if len(existing) >= num_samples:
-        logger.info("All samples already processed!")
-        return []
-
-    target = min(max_samples, num_samples) if max_samples else num_samples
-
-    chunk_size = target // world_size
-    remainder = target % world_size
-    # Distribute remainder across the first `remainder` ranks so chunks differ
-    # by at most 1.
-    start = rank * chunk_size + min(rank, remainder)
-    end = start + chunk_size + (1 if rank < remainder else 0)
-
-    existing_s = set(existing)
-    to_process = [i for i in range(start, end) if i not in existing_s]
-
-    if not to_process:
-        logger.info("All samples for this rank already processed!")
-        return []
-
-    if len(existing_s & set(range(start, end))) > 0:
-        logger.info(
-            f"Found {len(existing_s & set(range(start, end)))} existing samples"
-            f" for rank {rank}."
-        )
-
-    return to_process
 
 
 def check_safetensors_file(path: Path, tokens: list[int]):

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -172,7 +172,7 @@ def parse_args():
         type=int,
         default=1,
         help=(
-            "World size for multi-node data generation offline. IMPORTANT: this"
+            "World size for multi-node data generation offline. IMPORTANT: this "
             "is the number of nodes (not the number of gpus). Defaults to 1"
         ),
     )
@@ -181,8 +181,9 @@ def parse_args():
         type=int,
         default=0,
         help=(
-            "Rank for multi-node data generation offline. IMPORTANT: this is"
-            "the node index, not an index for a gpu. Defaults to 0"
+            "Rank for multi-node data generation offline. IMPORTANT: this is "
+            "the node index, not an index for a gpu. Must be in range[0, world_size)."
+            " Defaults to 0"
         ),
     )
     return parser.parse_args()
@@ -400,6 +401,8 @@ async def generate_and_save_hidden_states(args, dataset):
 
 def main():
     args = parse_args()
+    if int(args.rank) < 0 or int(args.rank) >= int(args.world_size):
+        raise ValueError("--rank must be in range [0, world_size)")
     setup_root_logger()
 
     logger.info("EAGLE Offline Data Generation")

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -163,6 +163,24 @@ def parse_args():
             "(default: value of --concurrency)"
         ),
     )
+    parser.add_argument(
+        "--world-size",
+        type=int,
+        default=1,
+        help=(
+            "World size for multi-node data generation offline. IMPORTANT: this"
+            "is the number of nodes (not the number of gpus). Defaults to 1"
+        ),
+    )
+    parser.add_argument(
+        "--rank",
+        type=int,
+        default=0,
+        help=(
+            "Rank for multi-node data generation offline. IMPORTANT: this is"
+            "the node index, not an index for a gpu. Defaults to 0"
+        ),
+    )
     return parser.parse_args()
 
 
@@ -187,7 +205,11 @@ def get_existing_hidden_state_indices(output_path: Path) -> list[int]:
 
 
 def get_indices_to_process(
-    num_samples: int, max_samples: int | None, existing: list[int]
+    num_samples: int,
+    max_samples: int | None,
+    existing: list[int],
+    world_size: int,
+    rank: int,
 ) -> list[int]:
     """Determines which indices should be processed. If max_samples is None
     returns all dataset indices not in existing. Otherwise gets the first
@@ -197,6 +219,8 @@ def get_indices_to_process(
         num_samples: Total size of preprocessed dataset
         max_samples: (Optional) limit for number of samples to process
         existing: list of ids that have already been processed
+        world_size: Number of nodes to generate on
+        rank: The rank of the local node
 
     Returns:
         list of dataset indices to process
@@ -205,26 +229,28 @@ def get_indices_to_process(
     if len(existing) >= num_samples:
         logger.info("All samples already processed!")
         return []
-    if max_samples and len(existing) >= max_samples:
-        logger.info("At least max_samples already processed!")
-        return []
 
-    if len(existing) > 0:
-        logger.info(f"Found {len(existing)} existing samples.")
+    target = min(max_samples, num_samples) if max_samples else num_samples
+
+    chunk_size = target // world_size
+    remainder = target % world_size
+    # Distribute remainder across the first `remainder` ranks so chunks differ
+    # by at most 1.
+    start = rank * chunk_size + min(rank, remainder)
+    end = start + chunk_size + (1 if rank < remainder else 0)
 
     existing_s = set(existing)
-    if max_samples is None:
-        return [i for i in range(num_samples) if i not in existing_s]
+    to_process = [i for i in range(start, end) if i not in existing_s]
 
-    num_remaining = min(max_samples, num_samples) - len(existing)
-    to_process = []
-    cur = 0
-    while num_remaining > 0 and cur < num_samples:
-        if cur not in existing_s:
-            to_process.append(cur)
-            num_remaining -= 1
+    if not to_process:
+        logger.info("All samples for this rank already processed!")
+        return []
 
-        cur += 1
+    if len(existing_s & set(range(start, end))) > 0:
+        logger.info(
+            f"Found {len(existing_s & set(range(start, end)))} existing samples"
+            f" for rank {rank}."
+        )
 
     return to_process
 
@@ -370,7 +396,11 @@ async def generate_and_save_hidden_states(args, dataset):
     num_samples = len(dataset)
 
     to_process = get_indices_to_process(
-        num_samples, args.max_samples, existing_file_indices
+        num_samples,
+        args.max_samples,
+        existing_file_indices,
+        args.world_size,
+        args.rank,
     )
     if not to_process:
         return

--- a/src/speculators/data_generation/offline.py
+++ b/src/speculators/data_generation/offline.py
@@ -46,11 +46,10 @@ def get_indices_to_process(
         list of dataset indices to process
     """
 
-    if len(existing) >= num_samples:
-        logger.info("All samples already processed!")
-        return []
+    target = min(max_samples, num_samples) if max_samples is not None else num_samples
 
-    target = min(max_samples, num_samples) if max_samples else num_samples
+    if target <= 0:
+        return []
 
     chunk_size = target // world_size
     remainder = target % world_size

--- a/src/speculators/data_generation/offline.py
+++ b/src/speculators/data_generation/offline.py
@@ -1,0 +1,75 @@
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def get_existing_hidden_state_indices(output_path: Path) -> list[int]:
+    """Find existing `hs_i.safetensors` files (where i is the file index)"""
+
+    existing_file_indices: list[int] = []
+
+    if not output_path.exists():
+        return existing_file_indices
+
+    for file_path in output_path.iterdir():
+        if file_path.name.startswith("hs_") and file_path.name.endswith(".safetensors"):
+            index_str = file_path.stem[3:]  # Remove "hs_" prefix
+            try:
+                file_index = int(index_str)
+                existing_file_indices.append(file_index)
+            except ValueError:
+                continue
+
+    return sorted(existing_file_indices)
+
+
+def get_indices_to_process(
+    num_samples: int,
+    max_samples: int | None,
+    existing: list[int],
+    world_size: int,
+    rank: int,
+) -> list[int]:
+    """Determines which indices should be processed. If max_samples is None
+    returns all dataset indices not in existing. Otherwise gets the first
+    `max_samples - len(existing)` samples not already in existing.
+
+    Args:
+        num_samples: Total size of preprocessed dataset
+        max_samples: (Optional) limit for number of samples to process
+        existing: list of ids that have already been processed
+        world_size: Number of nodes to generate on
+        rank: The rank of the local node
+
+    Returns:
+        list of dataset indices to process
+    """
+
+    if len(existing) >= num_samples:
+        logger.info("All samples already processed!")
+        return []
+
+    target = min(max_samples, num_samples) if max_samples else num_samples
+
+    chunk_size = target // world_size
+    remainder = target % world_size
+    # Distribute remainder across the first `remainder` ranks so chunks differ
+    # by at most 1.
+    start = rank * chunk_size + min(rank, remainder)
+    end = start + chunk_size + (1 if rank < remainder else 0)
+
+    existing_s = set(existing)
+    to_process = [i for i in range(start, end) if i not in existing_s]
+
+    if not to_process:
+        logger.info("All samples for this rank already processed!")
+        return []
+
+    if len(existing_s & set(range(start, end))) > 0:
+        logger.info(
+            f"Found {len(existing_s & set(range(start, end)))} existing samples"
+            f" for rank {rank}."
+        )
+
+    return to_process

--- a/tests/unit/data_generation/test_offline.py
+++ b/tests/unit/data_generation/test_offline.py
@@ -1,0 +1,112 @@
+from speculators.data_generation.offline import (
+    get_existing_hidden_state_indices,
+    get_indices_to_process,
+)
+
+# ===== get_indices_to_process Tests =====
+
+
+class TestGetIndicesToProcess:
+    def test_single_node_no_max_samples(self):
+        result = get_indices_to_process(10, None, [], world_size=1, rank=0)
+        assert result == list(range(10))
+
+    def test_single_node_with_max_samples(self):
+        result = get_indices_to_process(10, 5, [], world_size=1, rank=0)
+        assert result == [0, 1, 2, 3, 4]
+
+    def test_single_node_max_samples_exceeds_num_samples(self):
+        result = get_indices_to_process(5, 10, [], world_size=1, rank=0)
+        assert result == list(range(5))
+
+    def test_single_node_with_existing(self):
+        result = get_indices_to_process(10, None, [2, 5, 7], world_size=1, rank=0)
+        assert result == [0, 1, 3, 4, 6, 8, 9]
+
+    def test_all_samples_already_processed(self):
+        result = get_indices_to_process(5, None, list(range(5)), world_size=1, rank=0)
+        assert result == []
+
+    def test_multi_node_even_split(self):
+        r0 = get_indices_to_process(10, None, [], world_size=2, rank=0)
+        r1 = get_indices_to_process(10, None, [], world_size=2, rank=1)
+        assert r0 == [0, 1, 2, 3, 4]
+        assert r1 == [5, 6, 7, 8, 9]
+
+    def test_multi_node_uneven_split(self):
+        r0 = get_indices_to_process(10, None, [], world_size=3, rank=0)
+        r1 = get_indices_to_process(10, None, [], world_size=3, rank=1)
+        r2 = get_indices_to_process(10, None, [], world_size=3, rank=2)
+        assert r0 == [0, 1, 2, 3]
+        assert r1 == [4, 5, 6]
+        assert r2 == [7, 8, 9]
+
+    def test_multi_node_no_overlap_and_full_coverage(self):
+        num_samples = 17
+        world_size = 4
+        all_indices = []
+        for rank in range(world_size):
+            chunk = get_indices_to_process(
+                num_samples, None, [], world_size=world_size, rank=rank
+            )
+            all_indices.extend(chunk)
+        assert sorted(all_indices) == list(range(num_samples))
+        assert len(all_indices) == len(set(all_indices))
+
+    def test_multi_node_with_max_samples(self):
+        r0 = get_indices_to_process(100, 10, [], world_size=2, rank=0)
+        r1 = get_indices_to_process(100, 10, [], world_size=2, rank=1)
+        assert r0 == [0, 1, 2, 3, 4]
+        assert r1 == [5, 6, 7, 8, 9]
+
+    def test_multi_node_with_existing(self):
+        result = get_indices_to_process(10, None, [1, 3], world_size=2, rank=0)
+        assert result == [0, 2, 4]
+
+    def test_multi_node_rank_fully_processed(self):
+        result = get_indices_to_process(10, None, [0, 1, 2, 3, 4], world_size=2, rank=0)
+        assert result == []
+
+    def test_existing_exceeds_num_samples(self):
+        result = get_indices_to_process(5, None, list(range(10)), world_size=1, rank=0)
+        assert result == []
+
+
+# ===== get_existing_hidden_state_indices Tests =====
+
+
+class TestGetExistingHiddenStateIndices:
+    def test_nonexistent_directory(self, tmp_path):
+        result = get_existing_hidden_state_indices(tmp_path / "nonexistent")
+        assert result == []
+
+    def test_empty_directory(self, tmp_path):
+        result = get_existing_hidden_state_indices(tmp_path)
+        assert result == []
+
+    def test_finds_safetensor_files(self, tmp_path):
+        (tmp_path / "hs_0.safetensors").touch()
+        (tmp_path / "hs_3.safetensors").touch()
+        (tmp_path / "hs_7.safetensors").touch()
+        result = get_existing_hidden_state_indices(tmp_path)
+        assert result == [0, 3, 7]
+
+    def test_ignores_non_numeric_suffixes(self, tmp_path):
+        (tmp_path / "hs_0.safetensors").touch()
+        (tmp_path / "hs_abc.safetensors").touch()
+        (tmp_path / "hs_.safetensors").touch()
+        result = get_existing_hidden_state_indices(tmp_path)
+        assert result == [0]
+
+    def test_ignores_unrelated_files(self, tmp_path):
+        (tmp_path / "hs_0.safetensors").touch()
+        (tmp_path / "other_file.txt").touch()
+        (tmp_path / "hs_1.pt").touch()
+        result = get_existing_hidden_state_indices(tmp_path)
+        assert result == [0]
+
+    def test_results_are_sorted(self, tmp_path):
+        for i in [9, 2, 5, 0]:
+            (tmp_path / f"hs_{i}.safetensors").touch()
+        result = get_existing_hidden_state_indices(tmp_path)
+        assert result == [0, 2, 5, 9]


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

To speed up offline hidden states generation, this pr adds support for partitioning the data generation process across multiple nodes. 

<!--- Why your changes are needed -->

## Description

This pr adds `--world-size` and `--rank` args to the script. When set, they will partition the dataset so the first `N//k` (or plus 1) samples get processed by the first node, the second batch by the second node, etc, where `N` is the total dataset size and `k` is the world size. 

The script should handle partitioning when `N` is not divisible by `k` by increasing the size of the first `N % k` nodes batches by 1. 

The changes shouldn't interfere with the ability to resume data generation that has been stopped. 

<!--- High-level concise summary of changes -->

## Related Issue
<!--- Link related issue if applicable -->

## Tests
Added tests for the partitioning / finding existing samples logic.

<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
