### PR TITLE
Fix AttributeError in ArrowDataset on default split_ratio

### DIFF
--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -191,6 +191,7 @@ class ArrowDataset(BaseDataset):
             hidden_states_dtype: The dtype of the hidden states.
         """
         self.data = load_from_disk(datapath)
+        self.start_file_idx = 0
         if split_ratio == 1.0:
             pass
         elif 1.0 > split_ratio > 0:

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -4,9 +4,11 @@ import json
 from pathlib import Path
 
 import torch
+from datasets import Dataset
 
 from speculators.models.eagle3.data import shift_batch
 from speculators.train.data import (
+    ArrowDataset,
     SampleFileDataset,
     create_collate_fn,
     standardize_data_v1,
@@ -434,3 +436,26 @@ def test_dataset_fallback_when_sample_lengths_json_malformed(tmp_path: Path):
     file_list = sorted([str(f) for f in tmp_path.glob("data_*.pt")])
     dataset = SampleFileDataset(max_len=50, file_list=file_list)
     assert len(dataset.approx_lengths) == 2
+
+
+def test_arrow_dataset_default_split_ratio_does_not_crash(tmp_path: Path):
+    """ArrowDataset with default split_ratio=1.0 should support indexing."""
+    ds = Dataset.from_dict(
+        {
+            "input_ids": [[1, 2, 3]],
+            "loss_mask": [[1, 1, 1]],
+            "seq_len": [3],
+        }
+    )
+    ds.save_to_disk(str(tmp_path / "data"))
+    (tmp_path / "data" / "hidden_states").mkdir()
+
+    arrow_ds = ArrowDataset(
+        max_len=128,
+        datapath=str(tmp_path / "data"),
+        on_missing="skip",
+    )
+
+    # Should not raise AttributeError
+    assert arrow_ds._map_to_file_idx(0) == 0
+    assert arrow_ds._map_to_file_idx(5) == 5


### PR DESCRIPTION
## Purpose

Fix a crash in `ArrowDataset` when constructed with the default `split_ratio=1.0`. `_map_to_file_idx` (and therefore `__getitem__`) reads `self.start_file_idx` unconditionally, but `__init__` only sets that attribute inside the branches handling a non-trivial split. With `split_ratio == 1.0`, the attribute is never assigned and the first sample access raises `AttributeError`.

The bug is latent in current in-repo usage because `scripts/train.py` is the only caller and always passes `split_ratio=0.9` or `-0.1`. It surfaces for any user constructing `ArrowDataset` directly with default arguments.

## Description

Initialize `self.start_file_idx = 0` once before the `if/elif/else` block in `ArrowDataset.__init__`. The existing assignments inside the non-trivial-split branches harmlessly override it, so behavior is unchanged on the current code paths.

Single-line fix in `src/speculators/train/data.py`.

## Related Issue

None — bug found while reading the code.

## Tests

Added `test_arrow_dataset_default_split_ratio_does_not_crash` in `tests/unit/train/test_data.py`. The test constructs a real `ArrowDataset` with the default `split_ratio=1.0` against a small on-disk fixture and asserts `_map_to_file_idx` returns sensible values instead of raising.

Verified locally:

​```
pytest tests/unit/train/test_data.py -v
# new test passes; existing tests still pass

ruff check src/speculators/train/data.py tests/unit/train/test_data.py
ruff format --check src/speculators/train/data.py tests/unit/train/test_data.py
# all clean
​```

I have filled in:
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.