### PR TITLE
Update vllm_client.py

### DIFF
--- a/src/speculators/data_generation/vllm_client.py
+++ b/src/speculators/data_generation/vllm_client.py
@@ -7,7 +7,7 @@ import openai
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_REQUEST_TIMEOUT = 15  # seconds
+DEFAULT_REQUEST_TIMEOUT = 120  # seconds
 DEFAULT_MAX_RETRIES = 3
 RETRY_BACKOFF_BASE = 2  # seconds
 


### PR DESCRIPTION
Extend vllm request time out so runs stop failing for no good reason.

<!-- markdownlint-disable -->

## Purpose

Increase timeout on the vllm client for slower training runs.  


## Description



## Related Issue



## Tests



I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
