### PR TITLE
fix resume

### DIFF
--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -115,8 +115,8 @@ def load_seen(path: str):
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            # Match the actual output format: "id" field and "idx" in metadata
-            key = obj.get("id") or obj.get("metadata", {}).get("idx")
+            # Match the actual output format: "id" field
+            key = obj.get("id")
             if key is not None:
                 seen.add(str(key))
     return seen

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -115,7 +115,8 @@ def load_seen(path: str):
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            key = obj.get("uuid") or obj.get("idx")
+            # Match the actual output format: "id" field and "idx" in metadata
+            key = obj.get("id") or obj.get("metadata", {}).get("idx")
             if key is not None:
                 seen.add(str(key))
     return seen
@@ -296,7 +297,8 @@ async def main():
                     continue
 
                 uuid = row.get("uuid")
-                key = str(uuid or index)
+                # Match the ID format used in output: uuid or "sample_{index}"
+                key = str(uuid) if uuid else f"sample_{index}"
                 if key in seen_ids:
                     continue
 


### PR DESCRIPTION
## Purpose

This PR fixes a bug with the --resume flag where it does it correctly locate the ids of rows with already generated responses


## Description


The load_seen() function tries to read:
  key = obj.get("uuid") or obj.get("idx")

  But the output file actually writes:
  output = {
      "id": item.get("uuid") or f"sample_{idx}",  # Top-level "id", not "uuid"

  }

This means that the response generation starts from the beginning as the ids do not exist 

## Related Issue

<!--- Link related issue if applicable -->

## Tests

<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
