### PR TITLE
refactor: move shared utils out of algorithm-specific modules

### DIFF
--- a/src/speculators/convert/eagle/eagle3_converter.py
+++ b/src/speculators/convert/eagle/eagle3_converter.py
@@ -13,8 +13,10 @@ from speculators.convert.eagle.eagle3_legacy_model import Eagle3Speculator
 from speculators.convert.eagle.utils import (
     build_llama_config_dtype_kwarg,
     build_llama_config_rope_kwargs,
-    ensure_checkpoint_is_local,
     find_vocab_size,
+)
+from speculators.convert.utils import (
+    ensure_checkpoint_is_local,
     load_checkpoint_config,
     load_checkpoint_weights,
 )

--- a/src/speculators/convert/eagle/eagle_converter.py
+++ b/src/speculators/convert/eagle/eagle_converter.py
@@ -16,6 +16,8 @@ from speculators.convert.eagle.eagle_legacy_model import (
 from speculators.convert.eagle.utils import (
     build_llama_config_rope_kwargs,
     detect_fusion_bias_and_layernorms,
+)
+from speculators.convert.utils import (
     ensure_checkpoint_is_local,
     load_checkpoint_config,
     load_checkpoint_weights,

--- a/src/speculators/convert/eagle/utils.py
+++ b/src/speculators/convert/eagle/utils.py
@@ -1,18 +1,14 @@
 """
-Utility functions for checkpoint conversion operations.
+Eagle-specific utility functions for checkpoint conversion.
 """
 
 from __future__ import annotations
 
 import inspect
-import json
-from pathlib import Path
 from typing import Any
 
 import torch
-from huggingface_hub import snapshot_download
 from loguru import logger
-from safetensors import safe_open
 from transformers import LlamaConfig
 
 _LLAMA_CONFIG_PARAMS = set(inspect.signature(LlamaConfig.__init__).parameters)
@@ -67,139 +63,6 @@ def find_vocab_size(config_dict: dict) -> int | None:
                 if result is not None:
                     return result
     return None
-
-
-def download_checkpoint_from_hub(model_id: str, cache_dir: str | None = None) -> Path:
-    """
-    Download a checkpoint from HuggingFace Hub.
-
-    :param model_id: HuggingFace model ID
-    :param cache_dir: Optional directory to cache downloads
-    :return: Local path to the downloaded checkpoint
-    :raises FileNotFoundError: If the checkpoint cannot be downloaded
-
-    :Example:
-
-        >>> path = download_checkpoint_from_hub("yuhuili/EAGLE-LLaMA3.1-Instruct-8B")
-        >>> print(path)
-        /home/user/.cache/huggingface/hub/models--yuhuili--EAGLE-LLaMA3.1-Instruct-8B/snapshots/...
-    """
-    logger.info(f"Downloading checkpoint from HuggingFace: {model_id}")
-    try:
-        local_path = snapshot_download(
-            repo_id=model_id,
-            allow_patterns=["*.json", "*.safetensors", "*.bin", "*.index.json"],
-            cache_dir=cache_dir,
-        )
-        logger.debug(f"Downloaded to: {local_path}")
-        return Path(local_path)
-    except Exception as hf_exception:
-        logger.error(f"Failed to download checkpoint: {hf_exception}")
-        raise FileNotFoundError(f"Checkpoint not found: {model_id}") from hf_exception
-
-
-def ensure_checkpoint_is_local(
-    checkpoint_path: str | Path, cache_dir: str | Path | None = None
-) -> Path:
-    """
-    Ensure we have a local copy of the checkpoint.
-
-    If the path exists locally, return it. Otherwise, treat it as a
-    HuggingFace model ID and download it.
-
-    :param checkpoint_path: Local path or HuggingFace model ID
-    :param cache_dir: Optional cache directory for downloads
-    :return: Path to local checkpoint directory
-
-    :Example:
-
-        >>> # Local path - returned as-is
-        >>> local = ensure_checkpoint_is_local("./my_checkpoint")
-
-        >>> # HuggingFace ID - downloaded first
-        >>> downloaded = ensure_checkpoint_is_local(
-        ...     "yuhuili/EAGLE-LLaMA3.1-Instruct-8B"
-        ... )
-    """
-    checkpoint_path = Path(checkpoint_path)
-
-    if checkpoint_path.exists():
-        logger.debug(f"Using local checkpoint: {checkpoint_path}")
-        return checkpoint_path
-
-    return download_checkpoint_from_hub(
-        model_id=str(checkpoint_path), cache_dir=str(cache_dir) if cache_dir else None
-    )
-
-
-def load_checkpoint_config(checkpoint_dir: Path) -> dict:
-    """
-    Load the config.json from a checkpoint directory.
-
-    :param checkpoint_dir: Path to checkpoint directory
-    :return: Config dictionary
-    :raises FileNotFoundError: If config.json is not found
-
-    :Example:
-
-        >>> config = load_checkpoint_config(Path("./checkpoint"))
-        >>> print(config["model_type"])
-        llama
-    """
-    config_path = checkpoint_dir / "config.json"
-    if not config_path.exists():
-        raise FileNotFoundError(f"No config.json found at {checkpoint_dir}")
-
-    logger.debug(f"Loading config from: {config_path}")
-    with config_path.open() as f:
-        return json.load(f)
-
-
-def load_checkpoint_weights(checkpoint_dir: Path) -> dict[str, torch.Tensor]:
-    """
-    Load model weights from a checkpoint directory.
-
-    Supports both safetensors and PyTorch bin formats.
-
-    :param checkpoint_dir: Path to checkpoint directory
-    :return: Dictionary mapping weight names to tensors
-    :raises FileNotFoundError: If no weights are found
-    :raises NotImplementedError: If checkpoint is sharded
-
-    :Example:
-
-        >>> weights = load_checkpoint_weights(Path("./checkpoint"))
-        >>> print(f"Loaded {len(weights)} weights")
-        Loaded 50 weights
-    """
-    weights = {}
-
-    safetensors_path = checkpoint_dir / "model.safetensors"
-    if safetensors_path.exists():
-        logger.debug(f"Loading safetensors weights from: {safetensors_path}")
-        with safe_open(safetensors_path, framework="pt") as f:
-            # safetensors requires iterating over keys() method
-            for key in f.keys():  # noqa: SIM118
-                weights[key] = f.get_tensor(key)
-        return weights
-
-    pytorch_path = checkpoint_dir / "pytorch_model.bin"
-    if pytorch_path.exists():
-        logger.debug(f"Loading PyTorch weights from: {pytorch_path}")
-        return torch.load(pytorch_path, map_location="cpu")
-
-    index_paths = [
-        checkpoint_dir / "model.safetensors.index.json",
-        checkpoint_dir / "pytorch_model.bin.index.json",
-    ]
-    for index_path in index_paths:
-        if index_path.exists():
-            raise NotImplementedError(
-                f"Sharded checkpoint detected: {index_path}. "
-                "Please use a single-file checkpoint."
-            )
-
-    raise FileNotFoundError(f"No weights found at {checkpoint_dir}")
 
 
 def detect_fusion_bias_and_layernorms(

--- a/src/speculators/convert/mtp/converter.py
+++ b/src/speculators/convert/mtp/converter.py
@@ -20,7 +20,7 @@ from safetensors import safe_open
 from transformers import PretrainedConfig
 
 from speculators.config import SpeculatorsConfig, VerifierConfig
-from speculators.convert.eagle.utils import (
+from speculators.convert.utils import (
     ensure_checkpoint_is_local,
     load_checkpoint_config,
 )

--- a/src/speculators/convert/utils.py
+++ b/src/speculators/convert/utils.py
@@ -1,0 +1,144 @@
+"""Shared utility functions for checkpoint conversion operations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import torch
+from huggingface_hub import snapshot_download
+from loguru import logger
+from safetensors import safe_open
+
+
+def download_checkpoint_from_hub(model_id: str, cache_dir: str | None = None) -> Path:
+    """
+    Download a checkpoint from HuggingFace Hub.
+
+    :param model_id: HuggingFace model ID
+    :param cache_dir: Optional directory to cache downloads
+    :return: Local path to the downloaded checkpoint
+    :raises FileNotFoundError: If the checkpoint cannot be downloaded
+
+    :Example:
+
+        >>> path = download_checkpoint_from_hub("yuhuili/EAGLE-LLaMA3.1-Instruct-8B")
+        >>> print(path)
+        /home/user/.cache/huggingface/hub/models--yuhuili--EAGLE-LLaMA3.1-Instruct-8B/snapshots/...
+    """
+    logger.info(f"Downloading checkpoint from HuggingFace: {model_id}")
+    try:
+        local_path = snapshot_download(
+            repo_id=model_id,
+            allow_patterns=["*.json", "*.safetensors", "*.bin", "*.index.json"],
+            cache_dir=cache_dir,
+        )
+        logger.debug(f"Downloaded to: {local_path}")
+        return Path(local_path)
+    except Exception as hf_exception:
+        logger.error(f"Failed to download checkpoint: {hf_exception}")
+        raise FileNotFoundError(f"Checkpoint not found: {model_id}") from hf_exception
+
+
+def ensure_checkpoint_is_local(
+    checkpoint_path: str | Path, cache_dir: str | Path | None = None
+) -> Path:
+    """
+    Ensure we have a local copy of the checkpoint.
+
+    If the path exists locally, return it. Otherwise, treat it as a
+    HuggingFace model ID and download it.
+
+    :param checkpoint_path: Local path or HuggingFace model ID
+    :param cache_dir: Optional cache directory for downloads
+    :return: Path to local checkpoint directory
+
+    :Example:
+
+        >>> # Local path - returned as-is
+        >>> local = ensure_checkpoint_is_local("./my_checkpoint")
+
+        >>> # HuggingFace ID - downloaded first
+        >>> downloaded = ensure_checkpoint_is_local(
+        ...     "yuhuili/EAGLE-LLaMA3.1-Instruct-8B"
+        ... )
+    """
+    checkpoint_path = Path(checkpoint_path)
+
+    if checkpoint_path.exists():
+        logger.debug(f"Using local checkpoint: {checkpoint_path}")
+        return checkpoint_path
+
+    return download_checkpoint_from_hub(
+        model_id=str(checkpoint_path), cache_dir=str(cache_dir) if cache_dir else None
+    )
+
+
+def load_checkpoint_config(checkpoint_dir: Path) -> dict:
+    """
+    Load the config.json from a checkpoint directory.
+
+    :param checkpoint_dir: Path to checkpoint directory
+    :return: Config dictionary
+    :raises FileNotFoundError: If config.json is not found
+
+    :Example:
+
+        >>> config = load_checkpoint_config(Path("./checkpoint"))
+        >>> print(config["model_type"])
+        llama
+    """
+    config_path = checkpoint_dir / "config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"No config.json found at {checkpoint_dir}")
+
+    logger.debug(f"Loading config from: {config_path}")
+    with config_path.open() as f:
+        return json.load(f)
+
+
+def load_checkpoint_weights(checkpoint_dir: Path) -> dict[str, torch.Tensor]:
+    """
+    Load model weights from a checkpoint directory.
+
+    Supports both safetensors and PyTorch bin formats.
+
+    :param checkpoint_dir: Path to checkpoint directory
+    :return: Dictionary mapping weight names to tensors
+    :raises FileNotFoundError: If no weights are found
+    :raises NotImplementedError: If checkpoint is sharded
+
+    :Example:
+
+        >>> weights = load_checkpoint_weights(Path("./checkpoint"))
+        >>> print(f"Loaded {len(weights)} weights")
+        Loaded 50 weights
+    """
+    weights = {}
+
+    safetensors_path = checkpoint_dir / "model.safetensors"
+    if safetensors_path.exists():
+        logger.debug(f"Loading safetensors weights from: {safetensors_path}")
+        with safe_open(safetensors_path, framework="pt") as f:
+            # safetensors requires iterating over keys() method
+            for key in f.keys():  # noqa: SIM118
+                weights[key] = f.get_tensor(key)
+        return weights
+
+    pytorch_path = checkpoint_dir / "pytorch_model.bin"
+    if pytorch_path.exists():
+        logger.debug(f"Loading PyTorch weights from: {pytorch_path}")
+        return torch.load(pytorch_path, map_location="cpu")
+
+    index_paths = [
+        checkpoint_dir / "model.safetensors.index.json",
+        checkpoint_dir / "pytorch_model.bin.index.json",
+    ]
+    for index_path in index_paths:
+        if index_path.exists():
+            raise NotImplementedError(
+                f"Sharded checkpoint detected: {index_path}. "
+                "Please use a single-file checkpoint."
+            )
+
+    raise FileNotFoundError(f"No weights found at {checkpoint_dir}")

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -15,15 +15,8 @@ from speculators.models.eagle3.attention import (
 from speculators.models.eagle3.metrics import compute_metrics
 from speculators.models.eagle3.model_definitions import model_classes
 from speculators.models.metrics import kl_div_loss, resolve_loss_fn
-from speculators.models.utils import resolve_target_layer_ids
+from speculators.models.utils import conditional_torch_compile, resolve_target_layer_ids
 from speculators.proposals.greedy import GreedyTokenProposalConfig
-
-
-def conditional_torch_compile(func):
-    if torch.cuda.is_available() and hasattr(torch, "compile"):
-        return torch.compile(func)
-    else:
-        return func
 
 
 @SpeculatorModel.register("eagle3")

--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -10,12 +10,12 @@ from transformers.masking_utils import create_causal_mask
 from speculators import SpeculatorModel
 from speculators.config import SpeculatorsConfig, VerifierConfig
 from speculators.model import DraftVocabMixin
-from speculators.models.eagle3.core import conditional_torch_compile
 from speculators.models.mtp.config import MTPSpeculatorConfig
 from speculators.models.mtp.model_definitions import (
     mtp_model_classes,
     resolve_model_type,
 )
+from speculators.models.utils import conditional_torch_compile
 from speculators.proposals.greedy import GreedyTokenProposalConfig
 
 __all__ = ["MTPDraftModel", "compute_step_weights"]

--- a/src/speculators/models/peagle/core.py
+++ b/src/speculators/models/peagle/core.py
@@ -8,13 +8,13 @@ from transformers import PretrainedConfig
 
 from speculators.config import SpeculatorsConfig, VerifierConfig
 from speculators.model import SpeculatorModel
-from speculators.models.eagle3.core import Eagle3DraftModel, conditional_torch_compile
+from speculators.models.eagle3.core import Eagle3DraftModel
 from speculators.models.metrics import kl_div_loss, resolve_loss_fn
 from speculators.models.peagle.attention import create_peagle_mask_mod
 from speculators.models.peagle.config import PEagleSpeculatorConfig
 from speculators.models.peagle.data import generate_cod_sample_indices
 from speculators.models.peagle.metrics import compute_metrics
-from speculators.models.utils import resolve_target_layer_ids
+from speculators.models.utils import conditional_torch_compile, resolve_target_layer_ids
 from speculators.proposals.greedy import GreedyTokenProposalConfig
 
 

--- a/src/speculators/models/utils.py
+++ b/src/speculators/models/utils.py
@@ -1,6 +1,14 @@
 import warnings
 
+import torch
 from transformers import AutoConfig, PretrainedConfig
+
+
+def conditional_torch_compile(func):
+    if torch.cuda.is_available() and hasattr(torch, "compile"):
+        return torch.compile(func)
+    else:
+        return func
 
 
 def get_verifier_config(verifier_name_or_path: str) -> PretrainedConfig:

--- a/tests/unit/convert/test_eagle3_converter.py
+++ b/tests/unit/convert/test_eagle3_converter.py
@@ -14,9 +14,7 @@ import pytest
 import torch
 
 from speculators.convert.eagle.eagle3_converter import Eagle3Converter
-from speculators.convert.eagle.utils import (
-    load_checkpoint_config,
-)
+from speculators.convert.utils import load_checkpoint_config
 
 
 class TestEagle3ConverterFixes:

--- a/tests/unit/convert/test_eagle_utils.py
+++ b/tests/unit/convert/test_eagle_utils.py
@@ -10,8 +10,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 
-from speculators.convert.eagle.utils import (
-    detect_fusion_bias_and_layernorms,
+from speculators.convert.eagle.utils import detect_fusion_bias_and_layernorms
+from speculators.convert.utils import (
     download_checkpoint_from_hub,
     ensure_checkpoint_is_local,
     load_checkpoint_config,
@@ -22,7 +22,7 @@ from speculators.convert.eagle.utils import (
 class TestDownloadCheckpointFromHub:
     """Test download_checkpoint_from_hub function."""
 
-    @patch("speculators.convert.eagle.utils.snapshot_download")
+    @patch("speculators.convert.utils.snapshot_download")
     def test_successful_download(self, mock_snapshot_download, tmp_path):
         """Test successful checkpoint download."""
         mock_snapshot_download.return_value = str(tmp_path / "checkpoint")
@@ -37,7 +37,7 @@ class TestDownloadCheckpointFromHub:
             cache_dir=None,
         )
 
-    @patch("speculators.convert.eagle.utils.snapshot_download")
+    @patch("speculators.convert.utils.snapshot_download")
     def test_download_with_cache_dir(self, mock_snapshot_download, tmp_path):
         """Test download with custom cache directory."""
         cache_dir = tmp_path / "cache"
@@ -51,7 +51,7 @@ class TestDownloadCheckpointFromHub:
             cache_dir=str(cache_dir),
         )
 
-    @patch("speculators.convert.eagle.utils.snapshot_download")
+    @patch("speculators.convert.utils.snapshot_download")
     def test_download_failure(self, mock_snapshot_download):
         """Test handling of download failures."""
         mock_snapshot_download.side_effect = Exception("Network error")
@@ -72,7 +72,7 @@ class TestEnsureCheckpointIsLocal:
 
         assert result == checkpoint_dir
 
-    @patch("speculators.convert.eagle.utils.download_checkpoint_from_hub")
+    @patch("speculators.convert.utils.download_checkpoint_from_hub")
     def test_download_when_not_local(self, mock_download, tmp_path):
         """Test downloading when path doesn't exist locally."""
         mock_download.return_value = tmp_path / "downloaded"
@@ -84,7 +84,7 @@ class TestEnsureCheckpointIsLocal:
             model_id="test-model/checkpoint", cache_dir=None
         )
 
-    @patch("speculators.convert.eagle.utils.download_checkpoint_from_hub")
+    @patch("speculators.convert.utils.download_checkpoint_from_hub")
     def test_download_with_cache_dir(self, mock_download, tmp_path):
         """Test downloading with cache directory."""
         cache_dir = tmp_path / "cache"
@@ -135,7 +135,7 @@ class TestLoadCheckpointConfig:
 class TestLoadCheckpointWeights:
     """Test load_checkpoint_weights function."""
 
-    @patch("speculators.convert.eagle.utils.safe_open")
+    @patch("speculators.convert.utils.safe_open")
     def test_load_safetensors_weights(self, mock_safe_open, tmp_path):
         """Test loading weights from safetensors format."""
         checkpoint_dir = tmp_path / "checkpoint"
@@ -155,7 +155,7 @@ class TestLoadCheckpointWeights:
         assert "weight2" in weights
         assert all(isinstance(w, torch.Tensor) for w in weights.values())
 
-    @patch("speculators.convert.eagle.utils.torch.load")
+    @patch("speculators.convert.utils.torch.load")
     def test_load_pytorch_weights(self, mock_torch_load, tmp_path):
         """Test loading weights from PyTorch bin format."""
         checkpoint_dir = tmp_path / "checkpoint"
@@ -208,7 +208,7 @@ class TestLoadCheckpointWeights:
         (checkpoint_dir / "model.safetensors").touch()
         (checkpoint_dir / "pytorch_model.bin").touch()
 
-        with patch("speculators.convert.eagle.utils.safe_open") as mock_safe_open:
+        with patch("speculators.convert.utils.safe_open") as mock_safe_open:
             mock_file = MagicMock()
             mock_file.keys.return_value = ["weight1"]
             mock_file.get_tensor.return_value = torch.randn(10, 10)


### PR DESCRIPTION
## Purpose

Address review feedback to stop MTP and other models from importing shared
utilities via algorithm-specific modules. These functions are not
Eagle-specific and should live in shared locations.

## Description

**Checkpoint I/O utils** (`convert/utils.py`):
Move `download_checkpoint_from_hub`, `ensure_checkpoint_is_local`,
`load_checkpoint_config`, and `load_checkpoint_weights` from
`convert/eagle/utils.py` to a new `convert/utils.py` module.
Eagle-specific helpers (`build_llama_config_*`, `find_vocab_size`,
`detect_fusion_bias_and_layernorms`) stay in `eagle/utils.py`.

**`conditional_torch_compile`** (`models/utils.py`):
Move the `conditional_torch_compile` decorator from `eagle3/core.py` to the
shared `models/utils.py`. Previously mtp and peagle imported it from
`eagle3/core.py`, creating an unnecessary cross-model dependency.

All consumers (eagle, eagle3, mtp, peagle and their tests) are updated to
import from the canonical shared locations. No re-exports left behind.

## Related Issue

Review comment: https://github.com/vllm-project/speculators/pull/452#discussion_r3305165644

## Tests

No behavior change -- purely a refactor of import paths. Existing unit tests
for eagle, eagle3, mtp converters and models cover the moved functions.

```
python -m pytest tests/unit/models/test_mtp_model.py \
  tests/unit/models/test_mtp_config.py \
  tests/unit/convert/test_mtp_converter.py \
  tests/unit/convert/test_eagle3_converter.py -x -q
# 61 passed
```

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.