### PR TITLE
silu default for --draft-hidden-act

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -42,6 +42,8 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 - **`--draft-arch`** (str, default: `"llama"`) Architecture for draft decoder layers (only applies to Eagle3 currently). Options: `llama`, `qwen3` **Warning:** Only `llama` is currently supported in vLLM for inference.
 
+- **`--draft-hidden-act`** (str, default: `"silu"`) Activation function for draft decoder layers. Setting as `None` will inherit activation function from the verifier model.
+
 ### Data Arguments
 
 - **`--data-path`** (str, default: `"./data"`) Path to the processed training data directory.

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -531,10 +531,11 @@ def parse_args():
     parser.add_argument(
         "--draft-hidden-act",
         type=str,
-        default=None,
-        help="Activation function for draft decoder layers. Defaults to the verifier's "
-        "activation. Useful for dflash which uses Qwen3 layers that expects 'silu' for "
-        "vLLM deployment.",
+        default="silu",
+        help="Activation function for draft decoder layers. Defaults to 'silu' for "
+        "sigmoid linear unit. Qwen3 layers of dflash expect 'silu' activation for "
+        "vLLM deployment. If another function is desired, set as a string or leave "
+        "as None to automatically fall back to the verifier's activation function.",
     )
     parser.add_argument(
         "--target-layer-ids",


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

#551 Both Qwen-style and Llama-style draft layers use the Sigmoid Linear Unit (`silu`) as an activation function. Current behavior defaults the draft activation function, `--draft-hidden-act` as None, inheriting from the verifier model. However, if the verifier's hidden_activation cannot be found, in this case, an `AttributeError` is thrown. Considering this risk and the popularity of `silu` in practical cases, it makes a more sensible default for this attribute.

## Description

Changes the default and corresponding CLI help text in `train.py`. Adds documentation for the attribute in `train.md`.

## Related Issue

NA

## Tests

Speculators e2e tests passed on all 14 training runs (screenshot below). 1 expected failure for `peagle` due to lack of support in vLLM.

<img width="592" height="19" alt="Screenshot 2026-05-27 at 7 53 24 AM" src="https://github.com/user-attachments/assets/93b8b3b2-9223-46d1-99a2-114ee14bef92" />

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
