### PR TITLE
Reuse verifier RoPE parameters in drafter

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -2,8 +2,8 @@ import argparse
 import logging
 import random
 import warnings
-from pathlib import Path
 from copy import deepcopy
+from pathlib import Path
 
 import numpy as np
 import torch

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -3,9 +3,12 @@ import logging
 import random
 import warnings
 from pathlib import Path
+from copy import deepcopy
 
 import numpy as np
 import torch
+import transformers
+from packaging import version
 from torch.utils.data import DataLoader
 from transformers import LlamaConfig, PretrainedConfig
 from transformers.models.auto.configuration_auto import AutoConfig
@@ -139,7 +142,7 @@ def create_transformer_layer_config(
             "nor 'hidden_activation'"
         )
 
-    return config_class(
+    config = config_class(
         vocab_size=verifier_config.vocab_size,
         hidden_size=verifier_config.hidden_size,
         intermediate_size=verifier_config.intermediate_size,
@@ -153,6 +156,17 @@ def create_transformer_layer_config(
         head_dim=getattr(verifier_config, "head_dim", None),
         tie_word_embeddings=False,
     )
+
+    # New rope parameters definition introduced in transformers 5.0
+    if version.parse(transformers.__version__) >= version.parse("5.0.0"):
+        if hasattr(verifier_config, "rope_parameters"):
+            config.rope_parameters = deepcopy(verifier_config.rope_parameters)
+    else:
+        if hasattr(verifier_config, "rope_scaling"):
+            config.rope_scaling = deepcopy(verifier_config.rope_scaling)
+        config.rope_theta = getattr(verifier_config, "rope_theta", 10000.0)
+
+    return config
 
 
 def _load_mappings(d2t_path, t2d_path, expected_draft_vocab_size: int | None):


### PR DESCRIPTION
## Purpose

Rotary Positional Embeddings (RoPE) are an essential part of many modern LLMs, encoding both absolute and relative positional information of tokens. While `train.py` currently has the drafter model inherit parameters like `vocab_size` and `hidden_size` from the verifier, it does not currently inherit RoPE parameters. This PR remedies that behavior.

## Description

Adds a short segment of code to `create_transformer_layer_config` that copies the RoPE parameters from the verifier model to the created instance of `config_class`. For `transformers > 5.0.0`, executes a deepcopy of `rope_parameters`. For `transformers < 5.0.0, >= 4.56.1`, executes a deepcopy of `rope_scaling` and copies the float `rope_theta` directly.

I did not change any documentation, as I could not find any that pertained to this change.

## Related Issue

#553 

## Tests

I ran the [Eagle3 online training example](https://docs.vllm.ai/projects/speculators/en/latest/user_guide/tutorials/train_eagle3_online/#step-1-prepare-your-data) with both `transformers 5.9` and `transformers 4.56.1`. For both, I checked the `config.json` of the first checkpoint and ensured that `rope_parameters` was set for 5.9 and both `rope_scaling` and `rope_theta` were set for 4.56.1. 

I also ran the speculators e2e tests with 14 passes and 1 expected failure from lack of `peagle` support in vLLM.

I did not see existing tests for other functionality in `create_transformer_layer_config`, so I did not add any tests for this change. However, I am happy to add unit tests if they would be useful.

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
