### PR TITLE
Support datasets with tool calls

### DIFF
--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -101,12 +101,20 @@ def _normalize_conversation(
             role = "assistant"
         elif role == "system":
             role = "system"
+        elif role == "tool":
+            role = "tool"
         else:
             log.warning(f"Unknown role '{role}', skipping turn")
             continue
 
         # Build normalized turn with role and content
         normalized_turn = {"role": role, "content": content}
+
+        # Preserve tool_calls and tool_call_id if present
+        if turn.get("tool_calls"):
+            normalized_turn["tool_calls"] = turn["tool_calls"]
+        if turn.get("tool_call_id"):
+            normalized_turn["tool_call_id"] = turn["tool_call_id"]
 
         thinking = turn.get("thinking") or turn.get("reasoning_content")
         if thinking:

--- a/tests/integration/datagen/test_preprocessing.py
+++ b/tests/integration/datagen/test_preprocessing.py
@@ -85,14 +85,14 @@ def test_normalize_conversation_unknown_role():
 @pytest.mark.sanity
 def test_normalize_conversation_tool_calls():
     """Test that assistant tool_calls are preserved through normalization."""
-    tool_calls = [
+    tool_calls: list[dict] = [
         {
             "id": "call_123",
             "type": "function",
             "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
         }
     ]
-    conv = [
+    conv: list[dict] = [
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "What is the weather in Paris?"},
         {"role": "assistant", "content": None, "tool_calls": tool_calls},

--- a/tests/integration/datagen/test_preprocessing.py
+++ b/tests/integration/datagen/test_preprocessing.py
@@ -82,6 +82,71 @@ def test_normalize_conversation_unknown_role():
     assert result[1]["role"] == "assistant"
 
 
+@pytest.mark.sanity
+def test_normalize_conversation_tool_calls():
+    """Test that assistant tool_calls are preserved through normalization."""
+    tool_calls = [
+        {
+            "id": "call_123",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+        }
+    ]
+    conv = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "What is the weather in Paris?"},
+        {"role": "assistant", "content": None, "tool_calls": tool_calls},
+        {"role": "tool", "content": '{"temperature": 20}', "tool_call_id": "call_123"},
+        {"role": "assistant", "content": "The weather in Paris is 20°C."},
+    ]
+    result = _normalize_conversation(conv)
+
+    assert len(result) == 5
+    assert result[0]["role"] == "system"
+    assert result[1]["role"] == "user"
+    assert result[2]["role"] == "assistant"
+    assert result[2]["tool_calls"] == tool_calls
+    assert result[2]["content"] == ""
+    assert result[3]["role"] == "tool"
+    assert result[3]["tool_call_id"] == "call_123"
+    assert result[3]["content"] == '{"temperature": 20}'
+    assert result[4]["role"] == "assistant"
+    assert result[4]["content"] == "The weather in Paris is 20°C."
+    assert "tool_calls" not in result[4]
+    assert "tool_call_id" not in result[4]
+
+
+@pytest.mark.sanity
+def test_normalize_conversation_tool_role_preserved():
+    """Test that tool role messages are preserved and not skipped."""
+    conv = [
+        {"role": "user", "content": "Run a search"},
+        {"role": "tool", "content": "search results", "tool_call_id": "call_456"},
+        {"role": "assistant", "content": "Here are the results."},
+    ]
+    result = _normalize_conversation(conv)
+
+    assert len(result) == 3
+    assert result[1]["role"] == "tool"
+    assert result[1]["tool_call_id"] == "call_456"
+
+
+@pytest.mark.sanity
+def test_normalize_conversation_tool_calls_not_leaked():
+    """Test that tool_calls/tool_call_id are not added to turns that don't have them."""
+    conv = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi!"},
+    ]
+    result = _normalize_conversation(conv)
+
+    assert len(result) == 2
+    assert "tool_calls" not in result[0]
+    assert "tool_call_id" not in result[0]
+    assert "tool_calls" not in result[1]
+    assert "tool_call_id" not in result[1]
+
+
 # Tests for _adapt_conv_for_hf
 @pytest.mark.sanity
 def test_adapt_conv_for_hf_text_only_processor():


### PR DESCRIPTION
## Purpose

  Datasets that include tool-call conversations (assistant turns with `tool_calls`, and `tool` role turns returning results) were silently dropped during preprocessing. The `tool` role was treated
  as unknown and skipped, and `tool_calls`/`tool_call_id` fields were stripped from messages before reaching `apply_chat_template`. This meant any training sample containing tool use was either
  discarded or had its tool turns removed, producing incorrect training signal.
  
  ## Description

  - Add `tool` to the recognized roles in `_normalize_conversation` so tool-result turns are no longer skipped
  - Preserve `tool_calls` on assistant turns and `tool_call_id` on tool turns through normalization so `apply_chat_template` can serialize them correctly using the model's native chat template

  ## Related Issue

  N/A

  ## Tests
  
  Added three unit tests to `tests/integration/datagen/test_preprocessing.py`:

  - `test_normalize_conversation_tool_calls` — full round-trip: system/user/assistant-with-tool_calls/tool/assistant, asserts all 5 turns preserved with correct fields
  - `test_normalize_conversation_tool_role_preserved` — verifies `tool` role is no longer skipped
  - `test_normalize_conversation_tool_calls_not_leaked` — verifies `tool_calls`/`tool_call_id` are not added to turns that don't have them

  ```bash
  pytest tests/integration/datagen/test_preprocessing.py \
    -k "test_normalize_conversation_tool" -v

  - [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
  - [x] The test plan/results, such as providing test command and pasting the results.
  - [ ] (Optional) The necessary documentation update.
  - [x] I (a human) have written or reviewed the code in this pr to the best of my ability.