### PR TITLE
Validate default_proposal_method against configured proposal_methods

### DIFF
--- a/src/speculators/config.py
+++ b/src/speculators/config.py
@@ -127,18 +127,7 @@ class SpeculatorsConfig(ReloadableBaseModel):
 
     @model_validator(mode="after")
     def check_default_proposal_method(self) -> "SpeculatorsConfig":
-        """
-        Ensure ``default_proposal_method`` references a proposal that is actually
-        present in ``proposal_methods``.
-
-        Without this check an invalid default (a typo, a stale name, or an empty
-        ``proposal_methods`` list) is accepted at construction/deserialization time
-        and only surfaces later as an opaque lookup failure when the default method
-        is resolved.
-
-        :raises ValueError: If ``default_proposal_method`` is not one of the
-            ``proposal_type`` values in ``proposal_methods``.
-        """
+        """Validate default_proposal_method is one of the proposal_methods."""
         available = [method.proposal_type for method in self.proposal_methods]
         if self.default_proposal_method not in available:
             raise ValueError(

--- a/src/speculators/config.py
+++ b/src/speculators/config.py
@@ -23,7 +23,7 @@ from importlib.metadata import version
 from typing import Any, ClassVar
 
 import torch
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from transformers import PretrainedConfig
 
 from speculators.proposals import TokenProposalConfig
@@ -124,6 +124,30 @@ class SpeculatorsConfig(ReloadableBaseModel):
             "compatibility for a new verifier, if needed."
         ),
     )
+
+    @model_validator(mode="after")
+    def check_default_proposal_method(self) -> "SpeculatorsConfig":
+        """
+        Ensure ``default_proposal_method`` references a proposal that is actually
+        present in ``proposal_methods``.
+
+        Without this check an invalid default (a typo, a stale name, or an empty
+        ``proposal_methods`` list) is accepted at construction/deserialization time
+        and only surfaces later as an opaque lookup failure when the default method
+        is resolved.
+
+        :raises ValueError: If ``default_proposal_method`` is not one of the
+            ``proposal_type`` values in ``proposal_methods``.
+        """
+        available = [method.proposal_type for method in self.proposal_methods]
+        if self.default_proposal_method not in available:
+            raise ValueError(
+                "default_proposal_method "
+                f"'{self.default_proposal_method}' must match the proposal_type of "
+                f"one of the configured proposal_methods. Available proposal types: "
+                f"{available}."
+            )
+        return self
 
 
 class SpeculatorModelConfig(PydanticClassRegistryMixin, PretrainedConfig):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -227,6 +227,58 @@ def test_speculators_config_marshalling(
     )
 
 
+@pytest.mark.smoke
+def test_speculators_config_rejects_unknown_default_proposal_method(
+    sample_token_proposal_config, sample_verifier_config
+):
+    with pytest.raises(ValidationError) as exc_info:
+        SpeculatorsConfig(
+            algorithm="test_algorithm",
+            proposal_methods=[sample_token_proposal_config],
+            default_proposal_method="not_a_real_proposal",
+            verifier=sample_verifier_config,
+        )
+
+    error_str = str(exc_info.value)
+    assert "default_proposal_method" in error_str
+    assert "not_a_real_proposal" in error_str
+
+
+@pytest.mark.smoke
+def test_speculators_config_rejects_default_with_empty_proposal_methods(
+    sample_verifier_config,
+):
+    with pytest.raises(ValidationError) as exc_info:
+        SpeculatorsConfig(
+            algorithm="test_algorithm",
+            proposal_methods=[],
+            default_proposal_method="test_proposal",
+            verifier=sample_verifier_config,
+        )
+
+    assert "default_proposal_method" in str(exc_info.value)
+
+
+@pytest.mark.sanity
+def test_speculators_config_rejects_invalid_default_on_revalidation(
+    sample_token_proposal_config, sample_verifier_config
+):
+    valid_config = SpeculatorsConfig(
+        algorithm="test_algorithm",
+        proposal_methods=[sample_token_proposal_config],
+        default_proposal_method="test_proposal",
+        verifier=sample_verifier_config,
+    )
+
+    config_dict = valid_config.model_dump()
+    config_dict["default_proposal_method"] = "tampered_value"
+
+    with pytest.raises(ValidationError) as exc_info:
+        SpeculatorsConfig.model_validate(config_dict)
+
+    assert "tampered_value" in str(exc_info.value)
+
+
 # ===== SpeculatorModelConfig Tests =====
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -227,58 +227,6 @@ def test_speculators_config_marshalling(
     )
 
 
-@pytest.mark.smoke
-def test_speculators_config_rejects_unknown_default_proposal_method(
-    sample_token_proposal_config, sample_verifier_config
-):
-    with pytest.raises(ValidationError) as exc_info:
-        SpeculatorsConfig(
-            algorithm="test_algorithm",
-            proposal_methods=[sample_token_proposal_config],
-            default_proposal_method="not_a_real_proposal",
-            verifier=sample_verifier_config,
-        )
-
-    error_str = str(exc_info.value)
-    assert "default_proposal_method" in error_str
-    assert "not_a_real_proposal" in error_str
-
-
-@pytest.mark.smoke
-def test_speculators_config_rejects_default_with_empty_proposal_methods(
-    sample_verifier_config,
-):
-    with pytest.raises(ValidationError) as exc_info:
-        SpeculatorsConfig(
-            algorithm="test_algorithm",
-            proposal_methods=[],
-            default_proposal_method="test_proposal",
-            verifier=sample_verifier_config,
-        )
-
-    assert "default_proposal_method" in str(exc_info.value)
-
-
-@pytest.mark.sanity
-def test_speculators_config_rejects_invalid_default_on_revalidation(
-    sample_token_proposal_config, sample_verifier_config
-):
-    valid_config = SpeculatorsConfig(
-        algorithm="test_algorithm",
-        proposal_methods=[sample_token_proposal_config],
-        default_proposal_method="test_proposal",
-        verifier=sample_verifier_config,
-    )
-
-    config_dict = valid_config.model_dump()
-    config_dict["default_proposal_method"] = "tampered_value"
-
-    with pytest.raises(ValidationError) as exc_info:
-        SpeculatorsConfig.model_validate(config_dict)
-
-    assert "tampered_value" in str(exc_info.value)
-
-
 # ===== SpeculatorModelConfig Tests =====
 
 

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -125,8 +125,8 @@ def test_speculator_model_registered_model_class_from_config_invalid():
         test_param=456,
         speculators_config=SpeculatorsConfig(
             algorithm="test_algorithm",
-            proposal_methods=[],
-            default_proposal_method="test_proposal",
+            proposal_methods=[GreedyTokenProposalConfig()],
+            default_proposal_method="greedy",
             verifier=VerifierConfig(
                 name_or_path="test/verifier",
                 architectures=["TestModel"],
@@ -146,8 +146,8 @@ def test_speculator_model_registered_model_class_from_config_invalid():
     config = UnregisteredConfig(
         speculators_config=SpeculatorsConfig(
             algorithm="test_algorithm",
-            proposal_methods=[],
-            default_proposal_method="test_proposal",
+            proposal_methods=[GreedyTokenProposalConfig()],
+            default_proposal_method="greedy",
             verifier=VerifierConfig(
                 name_or_path="test/verifier",
                 architectures=["TestModel"],


### PR DESCRIPTION
## Summary

`SpeculatorsConfig.default_proposal_method` is documented as *"Must be the proposal_type for one of items in the proposal_methods list"*, but nothing enforces that invariant. As a result an invalid default is silently accepted at construction **and** deserialization time, and the problem only surfaces much later as an opaque lookup failure when the default proposal method is actually resolved.

Three ways the invalid state is currently accepted on `main`:

```python
from speculators.config import SpeculatorsConfig, VerifierConfig
from speculators.proposals.greedy import GreedyTokenProposalConfig

v = VerifierConfig(name_or_path="x", architectures=["L"])
g = GreedyTokenProposalConfig(proposal_type="greedy", speculative_tokens=3)

# 1) default names a method that is not in proposal_methods -> accepted
SpeculatorsConfig(algorithm="eagle3", proposal_methods=[g],
                  default_proposal_method="does_not_exist", verifier=v)

# 2) non-empty default with an empty proposal_methods list -> accepted
SpeculatorsConfig(algorithm="eagle3", proposal_methods=[],
                  default_proposal_method="greedy", verifier=v)

# 3) tampered/stale default round-tripped through a dict -> accepted on re-validate
d = SpeculatorsConfig(algorithm="eagle3", proposal_methods=[g],
                      default_proposal_method="greedy", verifier=v).model_dump()
d["default_proposal_method"] = "bogus"
SpeculatorsConfig(**d)
```

## Change

Add a Pydantic `model_validator(mode="after")` on `SpeculatorsConfig` that checks `default_proposal_method` matches the `proposal_type` of one of the configured `proposal_methods`, raising a clear `ValueError` that names the offending value and lists the available proposal types. This fails fast at config construction / deserialization instead of deep inside the model pathway.

This mirrors the existing use of Pydantic validators elsewhere in the configs (e.g. `models/eagle3/config.py`, `models/dflash/config.py`) and introduces no new dependency.

## Tests

- `test_speculators_config_rejects_unknown_default_proposal_method`
- `test_speculators_config_rejects_default_with_empty_proposal_methods`
- `test_speculators_config_rejects_invalid_default_on_revalidation`

Two pre-existing tests in `tests/unit/test_model.py` constructed a config with `proposal_methods=[]` / `default_proposal_method="test_proposal"` purely as a vehicle to exercise model-class-registration errors. They are updated to a valid `proposal_methods=[GreedyTokenProposalConfig()]` / `default_proposal_method="greedy"` pair so they keep testing what they intend. All existing callers already pair `default_proposal_method="greedy"` with a greedy proposal, so there is no behavioral change for valid configs.

## Maintainer-facing justification

> Is `default_proposal_method` guaranteed to reference an entry in `proposal_methods`? Currently nothing enforces this, so a typo'd or stale default is only caught at runtime.

This PR makes that invariant explicit and enforced at the config boundary.
