### PR TITLE
Add --no-enable-chunked-prefill to launch script

### DIFF
--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -104,6 +104,10 @@ def main():
         *vllm_args,
     ]
 
+    disable_cp_arg = "--no-enable-chunked-prefill"
+    if disable_cp_arg not in cmd:
+        cmd.append(disable_cp_arg)
+
     print("Running command:")
     print(" ".join(cmd))
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

https://github.com/vllm-project/vllm/pull/37374 added the requirement that hidden states extraction disabled chunked prefill. This pr makes that happen automatically. Should also fix e2e tests that are failing. 


<!--- Why your changes are needed -->


## Description

If it isn't already explicitly provided, add the `--no-enable-chunked-prefill` flag. 

<!--- High-level concise summary of changes -->

## Related Issue

<!--- Link related issue if applicable -->

## Tests

I have tested offline datagen locally with this. 

E2E run: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/26757749981

<!--- Please describe in detail how you tested your changes. -->

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
