### PR TITLE
feat(dflash): selectable attention backend (sdpa/eager) with dense mask

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -726,6 +726,14 @@ def parse_args():
         default=256,
         help="Maximum anchor positions for DFlash training (default: 256)",
     )
+    parser.add_argument(
+        "--draft-attn-impl",
+        type=str,
+        default="simple_flex_attention",
+        choices=["simple_flex_attention", "sdpa", "eager"],
+        help="Attention implementation for the DFlash draft layers. "
+        "Use 'sdpa' or 'eager' for non-flex backends.",
+    )
     # P-EAGLE specific parameters
     parser.add_argument(
         "--num-depths",

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -2,7 +2,7 @@ from typing import ClassVar
 
 import torch
 from torch import nn
-from torch.nn.attention.flex_attention import create_block_mask
+from torch.nn.attention.flex_attention import create_block_mask, create_mask
 from transformers import PretrainedConfig
 from transformers.models.qwen3.modeling_qwen3 import (
     Qwen3RMSNorm,
@@ -49,6 +49,12 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             config.transformer_layer_config._attn_implementation = (  # noqa: SLF001
                 "simple_flex_attention"
             )
+        self._attn_impl = config.transformer_layer_config._attn_implementation  # noqa: SLF001
+        self._create_mask_fn = (
+            create_block_mask
+            if self._attn_impl == "simple_flex_attention"
+            else create_mask
+        )
         super().__init__(config=config)
         self._init_vocab(config)
 
@@ -144,6 +150,10 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             kwargs["verifier_name_or_path"],
         )
 
+        verifier_config._attn_implementation = kwargs.get(  # noqa: SLF001
+            "draft_attn_impl", "simple_flex_attention"
+        )
+
         config = DFlashSpeculatorConfig(
             transformer_layer_config=verifier_config,
             draft_vocab_size=kwargs["draft_vocab_size"],
@@ -195,6 +205,32 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             )
         return self.config.mask_token_id
 
+    def _create_attention_mask(
+        self,
+        lengths: torch.Tensor,
+        total_seq_len: int,
+        anchor_positions: torch.Tensor,
+        device: torch.device,
+        sliding_window: int | None = None,
+        sliding_window_non_causal: bool = False,
+    ):
+        mask_mod, q_len, kv_len = create_anchor_block_mask_mod(
+            lengths=lengths.to(device),
+            total_seq_len=total_seq_len,
+            anchor_positions=anchor_positions,
+            block_size=self.block_size,
+            sliding_window=sliding_window,
+            sliding_window_non_causal=sliding_window_non_causal,
+        )
+        return self._create_mask_fn(
+            mask_mod,
+            B=None,
+            H=None,
+            Q_LEN=q_len,
+            KV_LEN=kv_len,
+            device=device,
+        )
+
     @torch.compiler.disable
     def _build_attention_mask(self, loss_mask, lengths, device):
         total_seq_len = loss_mask.shape[1]
@@ -205,29 +241,23 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
 
         full_attn_mask = None
         if self.uses_full_attn:
-            mask_mod, q_len, kv_len = create_anchor_block_mask_mod(
-                lengths=lengths.to(device),
+            full_attn_mask = self._create_attention_mask(
+                lengths=lengths,
                 total_seq_len=total_seq_len,
                 anchor_positions=anchor_positions,
-                block_size=self.block_size,
+                device=device,
                 sliding_window=None,
-            )
-            full_attn_mask = create_block_mask(
-                mask_mod, B=None, H=None, Q_LEN=q_len, KV_LEN=kv_len, device=device
             )
 
         sliding_window_attn_mask = None
         if self.uses_sliding_window_attn:
-            mask_mod, q_len, kv_len = create_anchor_block_mask_mod(
-                lengths=lengths.to(device),
+            sliding_window_attn_mask = self._create_attention_mask(
+                lengths=lengths,
                 total_seq_len=total_seq_len,
                 anchor_positions=anchor_positions,
-                block_size=self.block_size,
+                device=device,
                 sliding_window=self.sliding_window,
                 sliding_window_non_causal=self.sliding_window_non_causal,
-            )
-            sliding_window_attn_mask = create_block_mask(
-                mask_mod, B=None, H=None, Q_LEN=q_len, KV_LEN=kv_len, device=device
             )
 
         return full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -98,12 +98,16 @@ def make_dflash_model(
     draft_vocab_size: int = 64,
     block_size: int = 4,
     max_anchors: int = 8,
+    draft_attn_impl: str | None = None,
     device: str = "cuda:0",
     dtype: torch.dtype = torch.bfloat16,
 ) -> DFlashDraftModel:
     """Create a tiny DFlash model with real initialized weights."""
+    transformer_config = copy.deepcopy(TINY_QWEN3_CONFIG)
+    if draft_attn_impl is not None:
+        transformer_config._attn_implementation = draft_attn_impl  # noqa: SLF001
     config = DFlashSpeculatorConfig(
-        transformer_layer_config=copy.deepcopy(TINY_QWEN3_CONFIG),
+        transformer_layer_config=transformer_config,
         draft_vocab_size=draft_vocab_size,
         block_size=block_size,
         max_anchors=max_anchors,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -105,7 +105,7 @@ def make_dflash_model(
     """Create a tiny DFlash model with real initialized weights."""
     transformer_config = copy.deepcopy(TINY_QWEN3_CONFIG)
     if draft_attn_impl is not None:
-        transformer_config._attn_implementation = draft_attn_impl  # noqa: SLF001
+        transformer_config._attn_implementation = draft_attn_impl
     config = DFlashSpeculatorConfig(
         transformer_layer_config=transformer_config,
         draft_vocab_size=draft_vocab_size,

--- a/tests/integration/models/test_model_forward.py
+++ b/tests/integration/models/test_model_forward.py
@@ -215,6 +215,46 @@ class TestDFlashParams:
         assert loss.isfinite()
         loss.backward()
 
+    @pytest.mark.parametrize("draft_attn_impl", ["sdpa", "eager"])
+    @pytest.mark.parametrize("seq_lengths", SAMPLE_CONFIGS)
+    def test_attention_backend(self, draft_attn_impl, seq_lengths):
+        model = make_dflash_model(draft_attn_impl=draft_attn_impl)
+        samples = _make_samples(seq_lengths)
+        batch = make_batch(max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE)
+        draft_tokens, loss, metrics = model(**batch)
+
+        assert loss.isfinite()
+        loss.backward()
+
+    ATTN_BACKENDS = ["simple_flex_attention", "sdpa", "eager"]
+
+    @pytest.mark.parametrize("seq_lengths", SAMPLE_CONFIGS)
+    def test_attention_backends_match(self, seq_lengths):
+        """All attention backends produce equivalent outputs for the same input."""
+        samples = _make_samples(seq_lengths)
+
+        results = {}
+        for backend in self.ATTN_BACKENDS:
+            torch.manual_seed(0)
+            model = make_dflash_model(draft_attn_impl=backend)
+            batch = make_batch(
+                max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE
+            )
+            _, loss, _ = model(**batch)
+            results[backend] = loss.detach().cpu()
+            del model
+            torch.cuda.empty_cache()
+
+        ref_backend = self.ATTN_BACKENDS[0]
+        for backend in self.ATTN_BACKENDS[1:]:
+            torch.testing.assert_close(
+                results[backend],
+                results[ref_backend],
+                atol=1e-3,
+                rtol=1e-3,
+                msg=f"{backend} loss diverges from {ref_backend}",
+            )
+
 
 @requires_cuda
 class TestEagle3Params:

--- a/tests/unit/models/test_dflash_attention.py
+++ b/tests/unit/models/test_dflash_attention.py
@@ -1,0 +1,138 @@
+"""Unit tests for the DFlash anchor-block attention mask."""
+
+import pytest
+import torch
+from torch.nn.attention.flex_attention import create_mask
+
+from speculators.models.dflash.attention import create_anchor_block_mask_mod
+
+
+def _reference_dense_from_mask_mod(
+    lengths,
+    total_seq_len,
+    anchor_positions,
+    block_size,
+    sliding_window=None,
+    sliding_window_non_causal=False,
+):
+    """Ground truth: evaluate the flex mask_mod element-wise over the q x kv grid."""
+    mask_mod, q_len, kv_len = create_anchor_block_mask_mod(
+        lengths=lengths,
+        total_seq_len=total_seq_len,
+        anchor_positions=anchor_positions,
+        block_size=block_size,
+        sliding_window=sliding_window,
+        sliding_window_non_causal=sliding_window_non_causal,
+    )
+    zero = torch.zeros((), dtype=torch.long)
+    ref = torch.zeros(q_len, kv_len, dtype=torch.bool)
+    for q in range(q_len):
+        for kv in range(kv_len):
+            ref[q, kv] = bool(mask_mod(zero, zero, torch.tensor(q), torch.tensor(kv)))
+    return ref
+
+
+def _dense_from_create_mask(
+    lengths,
+    total_seq_len,
+    anchor_positions,
+    block_size,
+    sliding_window=None,
+    sliding_window_non_causal=False,
+):
+    mask_mod, q_len, kv_len = create_anchor_block_mask_mod(
+        lengths=lengths,
+        total_seq_len=total_seq_len,
+        anchor_positions=anchor_positions,
+        block_size=block_size,
+        sliding_window=sliding_window,
+        sliding_window_non_causal=sliding_window_non_causal,
+    )
+    return create_mask(
+        mask_mod,
+        B=None,
+        H=None,
+        Q_LEN=q_len,
+        KV_LEN=kv_len,
+        device=lengths.device,
+    )
+
+
+def test_create_mask_matches_mask_mod_full_attention():
+    """Dense mask equals the mask_mod for the full-attention case."""
+    device = torch.device("cpu")
+    total_seq_len, block_size = 16, 4
+    lengths = torch.tensor([10, 6])  # two packed documents summing to total_seq_len
+    anchor_positions = torch.tensor([3, 8, 12])
+
+    ref = _reference_dense_from_mask_mod(
+        lengths, total_seq_len, anchor_positions, block_size
+    )
+    dense = _dense_from_create_mask(
+        lengths.to(device), total_seq_len, anchor_positions, block_size
+    )
+
+    assert dense.shape == (1, 1, ref.shape[0], ref.shape[1])
+    assert torch.equal(dense[0, 0].bool(), ref)
+
+
+def test_create_mask_matches_mask_mod_sliding_window():
+    """Dense mask equals the mask_mod when a sliding window is set."""
+    device = torch.device("cpu")
+    total_seq_len, block_size = 16, 4
+    lengths = torch.tensor([16])  # single document
+    anchor_positions = torch.tensor([5, 9, 14])
+    sliding_window = 4
+
+    ref = _reference_dense_from_mask_mod(
+        lengths,
+        total_seq_len,
+        anchor_positions,
+        block_size,
+        sliding_window=sliding_window,
+    )
+    dense = _dense_from_create_mask(
+        lengths.to(device),
+        total_seq_len,
+        anchor_positions,
+        block_size,
+        sliding_window=sliding_window,
+    )
+
+    assert torch.equal(dense[0, 0].bool(), ref)
+
+
+def test_create_mask_each_query_sees_its_own_block():
+    """Every query must attend to at least its own synthetic block."""
+    device = torch.device("cpu")
+    total_seq_len, block_size = 12, 4
+    lengths = torch.tensor([12])
+    anchor_positions = torch.tensor([2, 7, 10])
+
+    dense = _dense_from_create_mask(
+        lengths.to(device), total_seq_len, anchor_positions, block_size
+    )
+
+    assert bool(dense[0, 0].any(dim=-1).all())
+
+
+def test_mask_mod_rejects_lengths_overflow():
+    """sum(lengths) > total_seq_len raises."""
+    with pytest.raises(ValueError, match="exceeds total_seq_len"):
+        create_anchor_block_mask_mod(
+            lengths=torch.tensor([10, 10]),  # sum = 20 > total_seq_len
+            total_seq_len=16,
+            anchor_positions=torch.tensor([3, 8]),
+            block_size=4,
+        )
+
+
+def test_mask_mod_rejects_out_of_range_anchor():
+    """anchor_positions outside [0, total_seq_len) raises."""
+    with pytest.raises(ValueError, match="out of range"):
+        create_anchor_block_mask_mod(
+            lengths=torch.tensor([16]),
+            total_seq_len=16,
+            anchor_positions=torch.tensor([3, 20]),  # 20 >= total_seq_len
+            block_size=4,
+        )


### PR DESCRIPTION
  ## What this does
  Lets you pick the attention backend for the DFlash draft via `--draft-attn-impl`.
  The default doesn't change (still flex) — this just adds `sdpa`/`eager` for cases
  where flex attention can't run.

  ## Why
  On Ascend NPU, `flex_attention` flat-out errors (`FlexAttention is only supported on
  CUDA, CPU or HPU devices`, #531), and DFlash hardcodes flex — so there was no way to
  train it on NPU. The `@torch.compile`'d forward is also unhappy on NPU, and flex +
  compile has been flaky on CUDA too (#544). So I added a path that doesn't need flex.

  ## How
  - Added `build_anchor_block_dense_mask` — it builds the same anchor-block mask that
    `create_anchor_block_mask_mod` already builds, just as a plain dense boolean tensor
    instead of a flex `BlockMask`. Same rules (a query sees context before its anchor +
    its own block, sliding-window supported), with a unit test checking it matches the
    flex version exactly.
  - Added a `--draft-attn-impl {simple_flex_attention,sdpa,eager}` flag. Default is
    flex, so CUDA behavior is unchanged. `sdpa`/`eager` use the dense mask instead of a
    flex `BlockMask`.
  - With `sdpa`, the op becomes a fused FlashAttention kernel on NPU, so the full
    attention scores never get materialized — `max_anchors` can stay large.

  ## Tested
  - Unit test: dense mask matches the flex `mask_mod` exactly (full attention + sliding
    window).
  - End-to-end: trained Qwen3-8B DFlash on Ascend (CANN 9.0.0 / vllm-ascend 0.20.2rc1)
    with `--draft-attn-impl sdpa` — runs, loss ~1.3, position_1 acc ~0.40 and climbing.

  ## Notes
  - flex is block-sparse and faster when it works, so it stays the default; sdpa/eager
    is the fallback for when flex isn't available.
  - EAGLE3 and PEAGLE hardcode flex the same way; this PR is DFlash-only, but the same
    approach drops in for them as a follow-up.