### PR TITLE
Fix empty sample creation

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -102,7 +102,11 @@ def setup_dataloader(
         prefetch_factor=prefetch_factor,
         pin_memory=True,
         collate_fn=create_collate_fn(
-            args.total_seq_len, hidden_size, dataset.hidden_states_dtype, preprocess
+            args.total_seq_len,
+            hidden_size,
+            dataset.hidden_states_dtype,
+            args.num_layers,
+            preprocess,
         ),
         persistent_workers=True,
     )

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -104,8 +104,8 @@ def setup_dataloader(
         collate_fn=create_collate_fn(
             args.total_seq_len,
             hidden_size,
-            dataset.hidden_states_dtype,
             args.num_layers,
+            dataset.hidden_states_dtype,
             preprocess,
         ),
         persistent_workers=True,

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -66,7 +66,9 @@ def split_files(datapath: str, ratio: float = 0.9, seed: int = 0):
 StandardizeFnSig = Callable[[dict[str, Any]], dict[str, Any]]
 
 
-def create_empty_sample(hidden_size: int, dtype: torch.dtype = torch.bfloat16):
+def create_empty_sample(
+    hidden_size: int, num_layers: int, dtype: torch.dtype = torch.bfloat16
+):
     # data structure: {
     #     "hidden_states": [seq_len, 3 * hidden_size],
     #     "input_ids": [seq_len],
@@ -81,7 +83,7 @@ def create_empty_sample(hidden_size: int, dtype: torch.dtype = torch.bfloat16):
     # bf16 EAGLE-3 layers (fc, verifier_lm_head) with a dtype mismatch.
 
     return {
-        "hidden_states": torch.empty(0, 3 * hidden_size, dtype=dtype),
+        "hidden_states": torch.empty(0, num_layers * hidden_size, dtype=dtype),
         "input_ids": torch.empty(0, dtype=torch.long),
         "verifier_last_hidden_states": torch.empty(0, hidden_size, dtype=dtype),
         "loss_mask": torch.empty(0, dtype=torch.bool),
@@ -487,6 +489,7 @@ class SampleFileDataset(BaseDataset):
 def create_collate_fn(
     max_len: int,
     hidden_size: int,
+    num_layers: int,
     dtype: torch.dtype = torch.bfloat16,
     preprocess: Callable[[BatchType], BatchType] | None = None,
 ):
@@ -500,7 +503,7 @@ def create_collate_fn(
             # Match the configured `dtype` so the placeholder doesn't crash
             # downstream layers loaded at a different precision (e.g. bf16
             # weights vs fp32 default placeholders).
-            empty = create_empty_sample(hidden_size, dtype=dtype)
+            empty = create_empty_sample(hidden_size, num_layers, dtype=dtype)
             if preprocess:
                 empty = preprocess(empty)
             batch = [empty]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -226,6 +226,7 @@ def make_batch(
     max_len: int,
     samples: list[dict[str, torch.Tensor]],
     hidden_size: int,
+    num_layers: int = 3,
     device: str = "cuda:0",
 ) -> dict[str, torch.Tensor]:
     """Collate a list of samples into a single batch using the real collate_fn.
@@ -237,12 +238,15 @@ def make_batch(
         max_len: Target sequence length to pad/truncate to.
         samples: List of per-sample dicts (from ``make_sample``).
         hidden_size: Model hidden size (needed by collate for empty batches).
+        num_layers: Num of layers in the speculative decode algorithm (e.g 3 for Eagle).
         device: Target device for the output tensors.
 
     Returns:
         Dict with keys matching model forward() signatures, all on ``device``.
     """
-    collate_fn = create_collate_fn(max_len=max_len, hidden_size=hidden_size)
+    collate_fn = create_collate_fn(
+        max_len=max_len, hidden_size=hidden_size, num_layers=num_layers
+    )
     batch = collate_fn(samples)
     return {k: v.to(device) for k, v in batch.items()}
 

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -131,7 +131,8 @@ def test_collate_fn_basic():
     """Test basic collation functionality."""
     max_len = 10
     hidden_size = 1
-    collate_fn = create_collate_fn(max_len, hidden_size)
+    num_layers = 3
+    collate_fn = create_collate_fn(max_len, hidden_size, num_layers)
 
     batch = [
         {
@@ -206,12 +207,13 @@ def test_collate_fn_length_truncation():
     """Test that lengths are truncated when they exceed max_len."""
     max_len = 11
     hidden_size = 8
-    collate_fn = create_collate_fn(max_len, hidden_size)
+    num_layers = 3
+    collate_fn = create_collate_fn(max_len, hidden_size, num_layers)
 
     batch = [
         {
             "input_ids": torch.arange(5, dtype=torch.long),
-            "hidden_states": torch.randn(5, 3 * hidden_size),
+            "hidden_states": torch.randn(5, num_layers * hidden_size),
             "verifier_last_hidden_states": torch.randn(5, hidden_size),
             "loss_mask": torch.ones(5, dtype=torch.long),
             "lengths": torch.tensor([5], dtype=torch.long),
@@ -219,7 +221,7 @@ def test_collate_fn_length_truncation():
         },
         {
             "input_ids": torch.arange(7, dtype=torch.long),
-            "hidden_states": torch.randn(7, 3 * hidden_size),
+            "hidden_states": torch.randn(7, num_layers * hidden_size),
             "verifier_last_hidden_states": torch.randn(7, hidden_size),
             "loss_mask": torch.ones(7, dtype=torch.long),
             "lengths": torch.tensor([7], dtype=torch.long),


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

The purpose of this PR is to fix the creation of an empty sample if an error occurs such as if the vllm hidden-state extraction times out. The current implementation uses `3 * hidden_size`  which seems to be hardcoded for an Eagle implementation whereas Dflash should be 5. The proposed solution creates the empty batch from `num_layers * hidden_size` instead, in order to be agnostic of the speculative decoding algorithm. 

```
[rank0]:E0608 10:44:59.043000 4122456 torch/_subclasses/fake_tensor.py:2908] [1/1] RuntimeError: a and b must have same reduction dim, but got [8192, s33] X [10240, 2048].
```
## Tests

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
