### PR TITLE
Generalize weight re-freezing after from_pretrained load

### DIFF
--- a/src/speculators/model.py
+++ b/src/speculators/model.py
@@ -121,7 +121,7 @@ class DraftVocabMixin(nn.Module):
 
         self.load_state_dict({"t2d": t2d, "d2t": d2t}, strict=False)
 
-    def load_verifier_weights(self):
+    def load_verifier_weights(self):  # noqa: C901
         """Load verifier model weights (embeddings, lm_head, etc.).
 
         Loads embed_tokens, lm_head, and verifier_lm_head weights from the
@@ -190,6 +190,14 @@ class DraftVocabMixin(nn.Module):
             else:
                 verifier_norm_sd = {"weight": verifier_weights["model.norm.weight"]}
                 self.verifier_norm.load_state_dict(verifier_norm_sd)  # type: ignore[union-attr]
+
+        # HF's from_pretrained resets requires_grad=True on all parameters.
+        # Re-freeze verifier weights that should never be trained.
+        self.embed_tokens.weight.requires_grad_(False)
+        self.lm_head.weight.requires_grad_(False)
+        self.verifier_lm_head.weight.requires_grad_(False)
+        if hasattr(self, "verifier_norm"):
+            self.verifier_norm.weight.requires_grad_(False)  # type: ignore[union-attr]
 
 
 class SpeculatorModel(ClassRegistryMixin, PreTrainedModel):  # type: ignore[misc]

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -98,6 +98,8 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
     def load_verifier_weights(self):
         super().load_verifier_weights()
 
+        self.embed_tokens.weight.requires_grad_(self.config.embed_requires_grad)
+
         verifier_config = self.config.speculators_config.verifier
         verifier_model_config = AutoConfig.from_pretrained(verifier_config.name_or_path)  # type: ignore[arg-type]
 

--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -94,18 +94,12 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
     def load_verifier_weights(self) -> None:
         """Re-set NaN sentinel before loading — meta-device init may clear
         it. Deletes verifier_lm_head after loading since MTP does not use it.
-
-        Re-freezes embed_tokens and lm_head after loading because HF's
-        from_pretrained resets requires_grad=True on all parameters,
-        overriding the intentional freeze set by _init_vocab.
         """
         with torch.no_grad():
             self.embed_tokens.weight.fill_(torch.nan)
             self.lm_head.weight.fill_(torch.nan)
         super().load_verifier_weights()
         del self.verifier_lm_head
-        self.embed_tokens.weight.requires_grad_(False)
-        self.lm_head.weight.requires_grad_(False)
 
     def forward(
         self,


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

#593 added weight re-freezing after `from_pretrained` runs because `from_pretrained` resets the weights `requires_grad` field to `True`. However, #593 only targeted MTP models. This pr generalizes the fix to all spec types. 

## Tests

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
