### PR TITLE
feat(mtp): add torch.compile and integration tests for MTP forward

### DIFF
--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -16,6 +16,7 @@ from speculators.models.mtp.model_definitions import (
     mtp_model_classes,
     resolve_model_type,
 )
+from speculators.models.utils import conditional_torch_compile
 from speculators.proposals.greedy import GreedyTokenProposalConfig
 
 logger = logging.getLogger(__name__)
@@ -106,6 +107,7 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
         super().load_verifier_weights()
         del self.verifier_lm_head
 
+    @conditional_torch_compile
     def forward(
         self,
         input_ids: torch.Tensor,
@@ -158,38 +160,41 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
                 torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
             )
 
-        causal_mask = create_causal_mask(
-            config=self.config.transformer_layer_config,
-            inputs_embeds=hidden_states,
-            attention_mask=attention_mask,
-            past_key_values=None,
-            position_ids=position_ids,
-        )
-
         all_logits: list[torch.Tensor] = []
         total_loss = torch.tensor(0.0, device=device)
         metrics: dict[str, float | torch.Tensor] = {}
 
+        # Uniform valid_len keeps tensor shapes identical across loop
+        # iterations, which torch.compile requires for stable codegen.
+        # Cap steps so short sequences still produce partial results.
+        effective_steps = min(num_steps, max(0, seq_len - 2))
+        valid_len = seq_len - effective_steps - 1
+        if valid_len <= 0 or effective_steps == 0:
+            metrics["loss_sum"] = total_loss.detach().clone()
+            metrics["loss_total"] = torch.tensor(1.0, device=device)
+            return (all_logits, total_loss, metrics)
+
+        step_pos_ids = position_ids[:, :valid_len]
+        causal_mask = create_causal_mask(
+            config=self.config.transformer_layer_config,
+            inputs_embeds=hidden_states[:, :valid_len],
+            attention_mask=attention_mask,
+            past_key_values=None,
+            position_ids=step_pos_ids,
+        )
+
         current_hidden = hidden_states
-        for step in range(num_steps):
-            valid_len = seq_len - step - 2
-            if valid_len <= 0:
-                break
+        for step in range(effective_steps):
             step_hidden = current_hidden[:, :valid_len]
             step_embeds = self.embed_tokens(
                 input_ids[:, step + 1 : step + 1 + valid_len]
             )
-            step_pos_ids = position_ids[:, :valid_len]
             step_pos_emb = self.rotary_emb(step_hidden, step_pos_ids)
-            if causal_mask is not None:
-                step_attn_mask = causal_mask[:, :, :valid_len, :valid_len]
-            else:
-                step_attn_mask = None
 
             mtp_output = self.mtp_layers[0](
                 hidden_states=step_hidden,
                 token_embeddings=step_embeds,
-                attention_mask=step_attn_mask,
+                attention_mask=causal_mask,
                 position_ids=step_pos_ids,
                 position_embeddings=step_pos_emb,
             )
@@ -204,12 +209,12 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
                 step_targets[step_mask == 0] = _IGNORE_INDEX
             weight = step_weights[step] if step_weights is not None else 1.0
             unreduced = nn.functional.cross_entropy(
-                logits.reshape(-1, self.config.vocab_size),
-                step_targets.reshape(-1),
+                logits.permute(0, 2, 1),
+                step_targets,
                 ignore_index=_IGNORE_INDEX,
                 reduction="none",
             )
-            valid_count = (step_targets.reshape(-1) != _IGNORE_INDEX).sum()
+            valid_count = (step_targets != _IGNORE_INDEX).sum()
             step_loss = weight * unreduced.sum() / valid_count.clamp(min=1)
             total_loss = total_loss + step_loss
             metrics[f"loss_step_{step}"] = step_loss.detach().clone()

--- a/tests/e2e/regression/test_mtp_online_acceptance.py
+++ b/tests/e2e/regression/test_mtp_online_acceptance.py
@@ -1,11 +1,11 @@
 """Weekly regression test for MTP online finetuning acceptance rates.
 
 Imports and calls the shared ``run_mtp_finetuning_e2e()`` pipeline from the
-smoke module with Qwen3.5-9B parameters. Evaluates on generic (non-GSM8k)
+smoke module with Qwen3.5-4B parameters. Evaluates on generic (non-GSM8k)
 prompts to verify finetuning doesn't cause catastrophic forgetting of the
 base model's speculative decoding quality.
 
-Base model acceptance rates on generic prompts: 87%, 77%, 62%.
+Base model acceptance rates on generic prompts (4B): ~88%, ~75%, ~59%.
 Thresholds are set conservatively to catch catastrophic regressions.
 """
 
@@ -21,7 +21,7 @@ from tests.conftest import (
 from tests.e2e.smoke.test_mtp_finetuning import run_mtp_finetuning_e2e
 from tests.utils import requires_cadence
 
-TRAINING_DATA_REPO = "inference-optimization/Qwen3.5-9B-responses"
+TRAINING_DATA_REPO = "inference-optimization/Qwen3.5-4B-responses"
 
 
 @requires_cadence("weekly")
@@ -35,7 +35,7 @@ def test_mtp_online_regression(
 ):
     run_mtp_finetuning_e2e(
         tmp_path=tmp_path,
-        verifier="Qwen/Qwen3.5-9B",
+        verifier="Qwen/Qwen3.5-4B",
         training_data_repo=TRAINING_DATA_REPO,
         num_speculative_tokens=3,
         target_layer_ids=[32],
@@ -44,7 +44,7 @@ def test_mtp_online_regression(
         epochs=1,
         lr=1e-5,
         prompts=prompts,
-        acceptance_thresholds=[0.89, 0.75, 0.59],
+        acceptance_thresholds=[0.85, 0.70, 0.56],
         max_tokens=512,
         train_timeout=60 * 60,
         gpu_memory_utilization=0.3,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 """Shared fixtures and factories for integration tests."""
 
 import copy
+from collections.abc import Callable
 
 import pytest
 import torch
@@ -12,6 +13,8 @@ from speculators.models.dflash import DFlashSpeculatorConfig
 from speculators.models.dflash.core import DFlashDraftModel
 from speculators.models.eagle3 import Eagle3SpeculatorConfig
 from speculators.models.eagle3.core import Eagle3DraftModel
+from speculators.models.mtp import MTPSpeculatorConfig
+from speculators.models.mtp.core import MTPDraftModel
 from speculators.models.peagle.config import PEagleSpeculatorConfig
 from speculators.models.peagle.core import PEagleDraftModel
 from speculators.proposals.greedy import GreedyTokenProposalConfig
@@ -47,6 +50,31 @@ TINY_QWEN3_CONFIG = Qwen3Config(
     rms_norm_eps=1e-6,
     tie_word_embeddings=False,
 )
+
+TINY_QWEN3_5_KWARGS: dict = {
+    "vocab_size": 128,
+    "hidden_size": 64,
+    "intermediate_size": 256,
+    "num_hidden_layers": 4,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "head_dim": 16,
+    "max_position_embeddings": 256,
+    "rms_norm_eps": 1e-6,
+    "tie_word_embeddings": True,
+    "layer_types": [
+        "linear_attention",
+        "full_attention",
+        "linear_attention",
+        "full_attention",
+    ],
+    "linear_key_head_dim": 16,
+    "linear_value_head_dim": 16,
+    "linear_num_key_heads": 4,
+    "linear_num_value_heads": 4,
+    "linear_conv_kernel_dim": 4,
+    "partial_rotary_factor": 0.25,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -159,6 +187,38 @@ def make_peagle_model(
     return model.to(device=device, dtype=dtype)  # type: ignore[call-arg]
 
 
+def make_mtp_model(
+    *,
+    num_speculative_steps: int = 3,
+    device: str = "cuda:0",
+    dtype: torch.dtype = torch.bfloat16,
+) -> MTPDraftModel:
+    """Create a tiny MTP model mirroring Qwen3.5-0.8B architecture."""
+    from transformers.models.qwen3_5.configuration_qwen3_5 import (  # noqa: PLC0415
+        Qwen3_5TextConfig,
+    )
+
+    config = MTPSpeculatorConfig(
+        transformer_layer_config=Qwen3_5TextConfig(**TINY_QWEN3_5_KWARGS),
+        speculators_config=SpeculatorsConfig(
+            algorithm="mtp",
+            proposal_methods=[
+                GreedyTokenProposalConfig(
+                    speculative_tokens=num_speculative_steps,
+                )
+            ],
+            default_proposal_method="greedy",
+            verifier=VerifierConfig(
+                name_or_path=None,
+                architectures=["Qwen3_5ForCausalLM"],
+            ),
+        ),
+    )
+    model = MTPDraftModel(config)
+    _fill_nan_weights(model)
+    return model.to(device=device, dtype=dtype)  # type: ignore[call-arg]
+
+
 # ---------------------------------------------------------------------------
 # Synthetic data factory
 # ---------------------------------------------------------------------------
@@ -227,6 +287,7 @@ def make_batch(
     samples: list[dict[str, torch.Tensor]],
     hidden_size: int,
     num_target_layers: int = 3,
+    preprocess: Callable | None = None,
     device: str = "cuda:0",
 ) -> dict[str, torch.Tensor]:
     """Collate a list of samples into a single batch using the real collate_fn.
@@ -240,13 +301,17 @@ def make_batch(
         hidden_size: Model hidden size (needed by collate for empty batches).
         num_target_layers: Num of target layers in the speculative decode
             algorithm (e.g 3 for Eagle).
+        preprocess: Optional per-sample transform (e.g. ``shift_batch_mtp``).
         device: Target device for the output tensors.
 
     Returns:
         Dict with keys matching model forward() signatures, all on ``device``.
     """
     collate_fn = create_collate_fn(
-        max_len=max_len, hidden_size=hidden_size, num_target_layers=num_target_layers
+        max_len=max_len,
+        hidden_size=hidden_size,
+        num_target_layers=num_target_layers,
+        preprocess=preprocess,
     )
     batch = collate_fn(samples)
     return {k: v.to(device) for k, v in batch.items()}

--- a/tests/integration/models/test_model_forward.py
+++ b/tests/integration/models/test_model_forward.py
@@ -1,24 +1,29 @@
 """Integration tests for draft model forward passes with real weights.
 
-Covers DFlash, Eagle3, and PEagle models with shared parametrized tests
+Covers DFlash, Eagle3, PEagle, and MTP models with shared parametrized tests
 for training, multi-batch, and vocab boundary scenarios, plus model-specific
 parameter variation tests.
 """
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import partial
 from typing import Any
 
 import pytest
 import torch
 
-from tests.conftest import requires_cuda
+from speculators.models.mtp import shift_batch_mtp
+from speculators.models.mtp.core import compute_step_weights
+from tests.conftest import requires_cuda, requires_transformers_version
 from tests.integration.conftest import (
     HIDDEN_SIZE,
+    TINY_QWEN3_5_KWARGS,
     VOCAB_SIZE,
     make_batch,
     make_dflash_model,
     make_eagle3_model,
+    make_mtp_model,
     make_peagle_model,
     make_sample,
 )
@@ -48,12 +53,17 @@ MULTI_BATCH_CONFIGS: list[list[int]] = [
 # Model specs
 # ---------------------------------------------------------------------------
 
+_requires_qwen3_5 = requires_transformers_version("5.2.0")
+
 
 @dataclass(frozen=True)
 class ModelSpec:
     name: str
     factory: Callable[..., Any]
     forward_kwargs: dict[str, Any] = field(default_factory=dict)
+    hidden_size: int = HIDDEN_SIZE
+    hidden_multiplier: int = HIDDEN_MULTIPLIER
+    batch_factory: Callable[..., Any] = make_batch
 
 
 DFLASH_SPEC = ModelSpec(name="dflash", factory=make_dflash_model)
@@ -61,8 +71,23 @@ EAGLE3_SPEC = ModelSpec(
     name="eagle3", factory=make_eagle3_model, forward_kwargs={"ttt_steps": 2}
 )
 PEAGLE_SPEC = ModelSpec(name="peagle", factory=make_peagle_model)
+MTP_SPEC = ModelSpec(
+    name="mtp",
+    factory=make_mtp_model,
+    forward_kwargs={"step_weights": [0.51, 0.31, 0.18]},
+    hidden_size=TINY_QWEN3_5_KWARGS["hidden_size"],
+    hidden_multiplier=1,
+    batch_factory=partial(make_batch, num_target_layers=1, preprocess=shift_batch_mtp),
+)
 
 ALL_SPECS = [
+    pytest.param(DFLASH_SPEC, id="dflash"),
+    pytest.param(EAGLE3_SPEC, id="eagle3"),
+    pytest.param(PEAGLE_SPEC, id="peagle"),
+    pytest.param(MTP_SPEC, id="mtp", marks=_requires_qwen3_5),
+]
+
+VOCAB_SPECS = [
     pytest.param(DFLASH_SPEC, id="dflash"),
     pytest.param(EAGLE3_SPEC, id="eagle3"),
     pytest.param(PEAGLE_SPEC, id="peagle"),
@@ -78,13 +103,15 @@ def _make_samples(
     seq_lengths: list[int],
     loss_mask_pattern: str = "all",
     vocab_size: int = VOCAB_SIZE,
+    hidden_size: int = HIDDEN_SIZE,
+    hidden_multiplier: int = HIDDEN_MULTIPLIER,
     boundary_token_ids: list[int] | None = None,
 ) -> list[dict[str, torch.Tensor]]:
     return [
         make_sample(
             seq_len=sl,
-            hidden_size=HIDDEN_SIZE,
-            hidden_multiplier=HIDDEN_MULTIPLIER,
+            hidden_size=hidden_size,
+            hidden_multiplier=hidden_multiplier,
             vocab_size=vocab_size,
             loss_mask_pattern=loss_mask_pattern,
             include_verifier_states=True,
@@ -134,8 +161,15 @@ class TestTraining:
     @pytest.mark.parametrize("loss_mask_pattern", LOSS_MASK_CASES)
     def test_forward_backward(self, model_and_spec, seq_lengths, loss_mask_pattern):
         model, spec = model_and_spec
-        samples = _make_samples(seq_lengths, loss_mask_pattern=loss_mask_pattern)
-        batch = make_batch(max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE)
+        samples = _make_samples(
+            seq_lengths,
+            loss_mask_pattern=loss_mask_pattern,
+            hidden_size=spec.hidden_size,
+            hidden_multiplier=spec.hidden_multiplier,
+        )
+        batch = spec.batch_factory(
+            max_len=MAX_LEN, samples=samples, hidden_size=spec.hidden_size
+        )
         draft_tokens, loss, metrics = model(**batch, **spec.forward_kwargs)
 
         assert loss.isfinite(), f"Loss is not finite: {loss.item()}"
@@ -152,9 +186,13 @@ class TestMultiBatch:
         model, spec = model_and_spec
         torch.compiler.reset()
         for seq_lengths in MULTI_BATCH_CONFIGS:
-            samples = _make_samples(seq_lengths)
-            batch = make_batch(
-                max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE
+            samples = _make_samples(
+                seq_lengths,
+                hidden_size=spec.hidden_size,
+                hidden_multiplier=spec.hidden_multiplier,
+            )
+            batch = spec.batch_factory(
+                max_len=MAX_LEN, samples=samples, hidden_size=spec.hidden_size
             )
             draft_tokens, loss, metrics = model(**batch, **spec.forward_kwargs)
             assert loss.isfinite(), f"Loss not finite for seq_lengths={seq_lengths}"
@@ -164,9 +202,14 @@ class TestMultiBatch:
         model, spec = model_and_spec
         torch.compiler.reset()
         for pattern in LOSS_MASK_CASES:
-            samples = _make_samples([64, 64], loss_mask_pattern=pattern)
-            batch = make_batch(
-                max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE
+            samples = _make_samples(
+                [64, 64],
+                loss_mask_pattern=pattern,
+                hidden_size=spec.hidden_size,
+                hidden_multiplier=spec.hidden_multiplier,
+            )
+            batch = spec.batch_factory(
+                max_len=MAX_LEN, samples=samples, hidden_size=spec.hidden_size
             )
             draft_tokens, loss, metrics = model(**batch, **spec.forward_kwargs)
             assert loss.isfinite(), f"Loss not finite for loss_mask_pattern={pattern}"
@@ -177,7 +220,7 @@ class TestMultiBatch:
 class TestVocabBoundary:
     """Tests with draft vocab mapping."""
 
-    @pytest.mark.parametrize("draft_vocab_model", ALL_SPECS, indirect=True)
+    @pytest.mark.parametrize("draft_vocab_model", VOCAB_SPECS, indirect=True)
     def test_boundary_tokens(self, draft_vocab_model):
         model, spec = draft_vocab_model
         samples = _make_samples([128], vocab_size=32, boundary_token_ids=[0, 31])
@@ -251,6 +294,32 @@ class TestPEagleParams:
         samples = _make_samples([128])
         batch = make_batch(max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE)
         draft_tokens, loss, metrics = model(**batch)
+
+        assert loss.isfinite()
+        loss.backward()
+
+
+@requires_cuda
+@requires_transformers_version("5.2.0")
+class TestMTPParams:
+    @pytest.mark.parametrize("num_speculative_steps", [1, 2, 5])
+    def test_varying_num_speculative_steps(self, num_speculative_steps):
+        model = make_mtp_model(num_speculative_steps=num_speculative_steps)
+        step_weights = compute_step_weights(num_steps=num_speculative_steps)
+        samples = _make_samples(
+            [128],
+            hidden_size=TINY_QWEN3_5_KWARGS["hidden_size"],
+            hidden_multiplier=1,
+            vocab_size=TINY_QWEN3_5_KWARGS["vocab_size"],
+        )
+        batch = make_batch(
+            max_len=MAX_LEN,
+            samples=samples,
+            hidden_size=TINY_QWEN3_5_KWARGS["hidden_size"],
+            num_target_layers=1,
+            preprocess=shift_batch_mtp,
+        )
+        logits_list, loss, metrics = model(**batch, step_weights=step_weights)
 
         assert loss.isfinite()
         loss.backward()

--- a/tests/unit/models/test_mtp_model.py
+++ b/tests/unit/models/test_mtp_model.py
@@ -24,8 +24,8 @@ def test_forward_output_structure(mtp_model, seed):
         )
 
     assert len(logits_list) == num_steps
+    expected_len = SEQ_LEN - num_steps - 1
     for step in range(num_steps):
-        expected_len = SEQ_LEN - step - 2
         assert logits_list[step].shape == (BATCH, expected_len, vocab_size)
 
     assert total_loss.dim() == 0


### PR DESCRIPTION
## Purpose

Make MTP forward `torch.compile`-compatible and add integration tests on par with Eagle3/DFlash/PEagle.

## Changes

**`src/speculators/models/mtp/core.py`**
- Add `@conditional_torch_compile` decorator to `forward()`
- Use uniform `valid_len = seq_len - num_steps - 1` across all loop iterations for stable compiled codegen
- Pre-compute causal mask once outside the loop (same shape every iteration)
- Use 3D `cross_entropy` via `logits.permute(0, 2, 1)` to avoid `reshape(-1, vocab_size)`

**`tests/integration/conftest.py`**
- Add `TINY_QWEN3_5_KWARGS` config dict and `make_mtp_model()` factory
- Add `preprocess` parameter to `make_batch()` for MTP's `shift_batch_mtp`

**`tests/integration/models/test_model_forward.py`**
- Add MTP to shared `ALL_SPECS` with `requires_transformers_version("5.2.0")` guard
- Add `hidden_size`, `hidden_multiplier`, `batch_factory` fields to `ModelSpec`
- Add `VOCAB_SPECS` (MTP excluded — vocab reduction not supported)
- Add `TestMTPParams` for varying `num_speculative_steps` [1, 2, 5]

**`tests/e2e/regression/test_mtp_online_acceptance.py`**
- Switch from Qwen3.5-9B to Qwen3.5-4B (fits 80GB GPUs)
- Adjust acceptance thresholds to match 4B base rates

## Tests

```bash
pytest tests/integration/models/test_model_forward.py -k mtp -v
pytest tests/integration/models/test_model_forward.py -v  # all models
```

## Checklist

- [x] Tests pass locally
- [x] `make style && make quality` pass
- [x] No new dependencies