### PR TITLE
docs(mtp): update GPU references from H100 to H200

### DIFF
--- a/docs/user_guide/tutorials/index.md
+++ b/docs/user_guide/tutorials/index.md
@@ -36,7 +36,7 @@ Learn how to train a P-eagle speculator model with COD sampling.
 
 Learn how to finetune a model's native MTP head on domain-specific data using online training.
 
-**Time required:** ~8 mins for Qwen3.5-9B on 2x H100 GPUs (varies by model size)
+**Time required:** ~8 mins for Qwen3.5-9B on 2x H200 GPUs (varies by model size)
 
 ## [Response Regeneration](response_regeneration.md)
 

--- a/docs/user_guide/tutorials/train_mtp_online.md
+++ b/docs/user_guide/tutorials/train_mtp_online.md
@@ -8,7 +8,7 @@ For a ready-to-run version of this tutorial, see [`examples/train/mtp_qwen3_5_9b
 
 ## Overview
 
-**Time required:** Varies by model size. ~8 mins for Qwen3.5-9B on 2x H100 GPUs.
+**Time required:** Varies by model size. ~8 mins for Qwen3.5-9B on 2x H200 GPUs.
 
 **Prerequisites:**
 

--- a/examples/train/mtp_qwen3_5_9b_gsm8k_online.sh
+++ b/examples/train/mtp_qwen3_5_9b_gsm8k_online.sh
@@ -19,7 +19,7 @@
 
 ### Example E2E run for Qwen3.5-9B on GSM8K ###
 
-# Timing (on 2x NVIDIA H100 80GB GPUs)
+# Timing (on 2x NVIDIA H200 141GB GPUs)
 # Data Preprocessing: 31 seconds
 # vLLM Server Startup: 114 seconds (1 min 54 secs)
 # Training (3 epochs): 256 seconds (4 mins 16 secs)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Update MTP documentation and example script GPU references from 2x NVIDIA H100 80GB to 2x NVIDIA H200 141GB to reflect the hardware used for benchmarking.

**Files changed:**
- `examples/train/mtp_qwen3_5_9b_gsm8k_online.sh`
- `docs/user_guide/tutorials/train_mtp_online.md`
- `docs/user_guide/tutorials/index.md`

## Tests

Documentation-only change, no tests required.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.