### PR TITLE
Remove mrope parameters from draft config

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -194,6 +194,9 @@ def create_transformer_layer_config(  # noqa: C901
     if version.parse(transformers.__version__) >= version.parse("5.0.0"):
         if hasattr(verifier_config, "rope_parameters"):
             config.rope_parameters = deepcopy(verifier_config.rope_parameters)
+            _MROPE_KEYS = ("mrope_section", "mrope_interleaved", "type")  # noqa: N806
+            for key in _MROPE_KEYS:
+                config.rope_parameters.pop(key, None)
     else:
         if hasattr(verifier_config, "rope_scaling"):
             config.rope_scaling = deepcopy(verifier_config.rope_scaling)


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
Modification of #571 pr. This pr just always pops the mrope related values.

vLLM is currently checking for mrope parameters and failing if they exist using this logic:

```python
def _uses_mrope(config):
    rope_parameters = getattr(config, "rope_parameters", None)
    if rope_parameters is None:
        return False
    return "mrope_section" in rope_parameters
```

Removed fields:
- `mrope_section` — triggers vllm's M-RoPE detection; defines per-axis rotation dimensions for multimodal positional encoding
- `mrope_interleaved` — controls M-RoPE interleaving order
- `type` — legacy alias, only appears with value `"mrope"` on VL models; transformers treats it as backwards compat and strips it during validation



## Tests

Example results of removed fields / the fields used by different models:
```
=== meta-llama/Llama-3.1-8B-Instruct ===
  verifier: {'factor': 8.0, 'low_freq_factor': 1.0, 'high_freq_factor': 4.0, 'original_max_position_embeddings': 8192, 'rope_type': 'llama3', 'rope_theta': 500000.0}
  filtered: {'factor': 8.0, 'low_freq_factor': 1.0, 'high_freq_factor': 4.0, 'original_max_position_embeddings': 8192, 'rope_type': 'llama3', 'rope_theta': 500000.0}
  dropped:  (none)

=== Qwen/Qwen3-8B ===
  verifier: {'rope_theta': 1000000, 'rope_type': 'default'}
  filtered: {'rope_theta': 1000000, 'rope_type': 'default'}
  dropped:  (none)

=== Qwen/Qwen2.5-VL-3B-Instruct ===
  verifier: {'type': 'mrope', 'mrope_section': [16, 24, 24], 'rope_theta': 1000000.0, 'rope_type': 'default'}
  filtered: {'rope_theta': 1000000.0, 'rope_type': 'default'}
  dropped:  {'type', 'mrope_section'}

=== Qwen/Qwen2.5-VL-7B-Instruct ===
  verifier: {'type': 'mrope', 'mrope_section': [16, 24, 24], 'rope_theta': 1000000.0, 'rope_type': 'default'}
  filtered: {'rope_theta': 1000000.0, 'rope_type': 'default'}
  dropped:  {'type', 'mrope_section'}

=== mistralai/Mistral-7B-v0.1 ===
  verifier: {'rope_theta': 10000.0, 'rope_type': 'default'}
  filtered: {'rope_theta': 10000.0, 'rope_type': 'default'}
  dropped:  (none)

=== google/gemma-2-9b ===
  verifier: {'rope_theta': 10000.0, 'rope_type': 'default'}
  filtered: {'rope_theta': 10000.0, 'rope_type': 'default'}
  dropped:  (none)
```

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
