### PR TITLE
bug: Fix dflash not use conditional_torch_compile and will break on Ascend NPU

### DIFF
--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -19,7 +19,7 @@ from speculators.models.dflash.utils import (
     select_anchors,
 )
 from speculators.models.metrics import kl_div_loss, resolve_loss_fn
-from speculators.models.utils import resolve_target_layer_ids
+from speculators.models.utils import conditional_torch_compile, resolve_target_layer_ids
 
 
 @SpeculatorModel.register("dflash")
@@ -230,7 +230,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
 
         return full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid
 
-    @torch.compile
+    @conditional_torch_compile
     def forward(
         self,
         hidden_states: torch.Tensor,  # shape: [1,total_seq_len,num_hidden*hidden_size]

--- a/src/speculators/models/utils.py
+++ b/src/speculators/models/utils.py
@@ -1,14 +1,16 @@
 import warnings
+from functools import partial
 
 import torch
 from transformers import AutoConfig, PretrainedConfig
 
 
-def conditional_torch_compile(func):
+def conditional_torch_compile(func=None, *args, **kwargs):
+    if func is None:
+        return partial(conditional_torch_compile, *args, **kwargs)
     if torch.cuda.is_available() and hasattr(torch, "compile"):
-        return torch.compile(func)
-    else:
-        return func
+        return torch.compile(func, *args, **kwargs)
+    return func
 
 
 def get_verifier_config(verifier_name_or_path: str) -> PretrainedConfig:


### PR DESCRIPTION
Fix dflash not use conditional_torch_compile and will break on Ascend NPU. And also make conditional_torch_compile to support original torch.compile args.

<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Ascend NPU doesn't support torch.compile, dflash training on NPU will raise inductor error.

## Tests

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
