### PR TITLE
fix from pretrained model not having target layer ids

### DIFF
--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -100,6 +100,17 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
         """Target layer IDs for auxiliary hidden states."""
         return self.config.eagle_aux_hidden_state_layer_ids
 
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
+        model = super().from_pretrained(
+            pretrained_model_name_or_path, *args, **kwargs
+        )
+        verifier_path = model.config.speculators_config.verifier.name_or_path
+        model.config.eagle_aux_hidden_state_layer_ids = resolve_target_layer_ids(
+            model.config.eagle_aux_hidden_state_layer_ids, verifier_path
+        )
+        return model
+
     def load_verifier_weights(self):
         super().load_verifier_weights()
 

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -102,9 +102,7 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
-        model = super().from_pretrained(
-            pretrained_model_name_or_path, *args, **kwargs
-        )
+        model = super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
         verifier_path = model.config.speculators_config.verifier.name_or_path
         model.config.eagle_aux_hidden_state_layer_ids = resolve_target_layer_ids(
             model.config.eagle_aux_hidden_state_layer_ids, verifier_path

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -104,6 +104,10 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
     def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
         model = super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
         verifier_path = model.config.speculators_config.verifier.name_or_path
+        if verifier_path is None:
+            raise ValueError(
+                "verifier.name_or_path must be set to load a pretrained Eagle3 model"
+            )
         model.config.eagle_aux_hidden_state_layer_ids = resolve_target_layer_ids(
             model.config.eagle_aux_hidden_state_layer_ids, verifier_path
         )

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -104,13 +104,10 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
     def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
         model = super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
         verifier_path = model.config.speculators_config.verifier.name_or_path
-        if verifier_path is None:
-            raise ValueError(
-                "verifier.name_or_path must be set to load a pretrained Eagle3 model"
+        if verifier_path is not None:
+            model.config.eagle_aux_hidden_state_layer_ids = resolve_target_layer_ids(
+                model.config.eagle_aux_hidden_state_layer_ids, verifier_path
             )
-        model.config.eagle_aux_hidden_state_layer_ids = resolve_target_layer_ids(
-            model.config.eagle_aux_hidden_state_layer_ids, verifier_path
-        )
         return model
 
     def load_verifier_weights(self):


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
We're now using `len(target_layer_ids)` for empty sample construction and eagle3 pulls `target_layer_ids` from `eagle_aux_hidden_states_ids` when we use an old eagle3 checkpoint that does not have this field, we get a type error. Fixing this by overwriting `from_pretrained` method to always save `eagle_aux_hidden_state_layer_ids` after finetuning.

## Tests
```
(speculators) [shanjiaz@h100-02 speculators]$ pytest tests/e2e/smoke/test_finetuning_sanity.py::test_finetuning_weight_sanity -s -vv
/home/shanjiaz/speculators/.venv/lib64/python3.12/site-packages/pytest_asyncio/plugin.py:247: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
========================================================================================================================================= test session starts ==========================================================================================================================================
platform linux -- Python 3.12.9, pytest-8.2.2, pluggy-1.6.0 -- /home/shanjiaz/speculators/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/shanjiaz/speculators
configfile: pyproject.toml
plugins: asyncio-1.3.0, mock-3.15.1, anyio-4.13.0, respx-0.23.1, cov-7.1.0, rerunfailures-14.0, Faker-40.15.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item                                                                                                                                                                                                                                                                                       

tests/e2e/smoke/test_finetuning_sanity.py::test_finetuning_weight_sanity INFO httpx HTTP Request: HEAD https://huggingface.co/RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3/resolve/main/config.json "HTTP/1.1 307 Temporary Redirect"
INFO httpx HTTP Request: HEAD https://huggingface.co/api/resolve-cache/models/RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3/f4fa34a8f803a0ba75d048d6b3dbc1ad5149e9ac/config.json "HTTP/1.1 200 OK"
Loading weights: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 16/16 [00:00<00:00, 42799.02it/s]
2026-06-11 10:14:28.098 | INFO     | speculators.utils.loading:_resolve_file:115 - Loading from huggingface directory: meta-llama/Llama-3.1-8B-Instruct: model.safetensors.index.json
INFO httpx HTTP Request: HEAD https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/resolve/main/model.safetensors.index.json "HTTP/1.1 200 OK"
2026-06-11 10:14:28.131 | INFO     | speculators.utils.loading:_resolve_file:115 - Loading from huggingface directory: meta-llama/Llama-3.1-8B-Instruct: model-00001-of-00004.safetensors
INFO httpx HTTP Request: HEAD https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/resolve/main/model-00001-of-00004.safetensors "HTTP/1.1 302 Found"
2026-06-11 10:14:28.166 | INFO     | speculators.utils.loading:_resolve_file:115 - Loading from huggingface directory: meta-llama/Llama-3.1-8B-Instruct: model-00004-of-00004.safetensors
INFO httpx HTTP Request: HEAD https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/resolve/main/model-00004-of-00004.safetensors "HTTP/1.1 302 Found"
INFO httpx HTTP Request: HEAD https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/resolve/main/config.json "HTTP/1.1 200 OK"
INFO httpx HTTP Request: HEAD https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/resolve/main/config.json "HTTP/1.1 200 OK"
INFO tests.e2e.smoke.test_finetuning_sanity Downloading dataset nm-testing/sharegpt_llama3_8b_hidden_states
INFO httpx HTTP Request: GET https://huggingface.co/api/datasets/nm-testing/sharegpt_llama3_8b_hidden_states/revision/main "HTTP/1.1 200 OK"
Fetching 52 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 52/52 [00:00<00:00, 7562.28it/s]
Download complete: : 0.00B [00:00, ?B/s]              INFO tests.e2e.smoke.test_finetuning_sanity Dataset at /home/shanjiaz/.cache/huggingface/hub/datasets--nm-testing--sharegpt_llama3_8b_hidden_states/snapshots/4764848000dd06e30dd831ddb867ffae4d7fa6d7                     | 0/52 [00:00<?, ?it/s]
INFO tests.e2e.smoke.test_finetuning_sanity Running training (1 epoch, lr=1e-5, save_path=/tmp/pytest-of-shanjiaz/pytest-11/test_finetuning_weight_sanity0/ckpt)
INFO tests.e2e.smoke.test_finetuning_sanity Training finished. Loading finetuned weights from /tmp/pytest-of-shanjiaz/pytest-11/test_finetuning_weight_sanity0/ckpt
INFO tests.e2e.smoke.test_finetuning_sanity Loaded 16 parameter tensors from checkpoint
INFO tests.e2e.smoke.test_finetuning_sanity   [frozen] d2t: identical
INFO tests.e2e.smoke.test_finetuning_sanity   [frozen] embed_tokens.weight: identical
INFO tests.e2e.smoke.test_finetuning_sanity   fc.weight: rel_l1=4.768e-04  max|Δ|=4.501e-04  mean|Δ|=9.179e-06
INFO tests.e2e.smoke.test_finetuning_sanity   layers.0.hidden_norm.weight: rel_l1=0.000e+00  max|Δ|=0.000e+00  mean|Δ|=0.000e+00
INFO tests.e2e.smoke.test_finetuning_sanity   layers.0.input_layernorm.weight: rel_l1=1.453e-07  max|Δ|=2.975e-04  mean|Δ|=7.264e-08
INFO tests.e2e.smoke.test_finetuning_sanity   layers.0.mlp.down_proj.weight: rel_l1=3.090e-04  max|Δ|=4.196e-04  mean|Δ|=5.811e-06
INFO tests.e2e.smoke.test_finetuning_sanity   layers.0.mlp.gate_proj.weight: rel_l1=2.708e-04  max|Δ|=3.376e-04  mean|Δ|=5.037e-06
INFO tests.e2e.smoke.test_finetuning_sanity   layers.0.mlp.up_proj.weight: rel_l1=2.537e-04  max|Δ|=3.738e-04  mean|Δ|=4.977e-06
INFO tests.e2e.smoke.test_finetuning_sanity   layers.0.post_attention_layernorm.weight: rel_l1=0.000e+00  max|Δ|=0.000e+00  mean|Δ|=0.000e+00
INFO tests.e2e.smoke.test_finetuning_sanity   layers.0.self_attn.k_proj.weight: rel_l1=9.842e-04  max|Δ|=4.349e-04  mean|Δ|=1.186e-05
INFO tests.e2e.smoke.test_finetuning_sanity   layers.0.self_attn.o_proj.weight: rel_l1=3.605e-04  max|Δ|=4.349e-04  mean|Δ|=6.586e-06
INFO tests.e2e.smoke.test_finetuning_sanity   layers.0.self_attn.q_proj.weight: rel_l1=4.501e-04  max|Δ|=3.891e-04  mean|Δ|=7.033e-06
INFO tests.e2e.smoke.test_finetuning_sanity   layers.0.self_attn.v_proj.weight: rel_l1=6.294e-04  max|Δ|=4.578e-04  mean|Δ|=1.091e-05
INFO tests.e2e.smoke.test_finetuning_sanity   lm_head.weight: rel_l1=0.000e+00  max|Δ|=0.000e+00  mean|Δ|=0.000e+00
INFO tests.e2e.smoke.test_finetuning_sanity   norm.weight: rel_l1=0.000e+00  max|Δ|=0.000e+00  mean|Δ|=0.000e+00
INFO tests.e2e.smoke.test_finetuning_sanity   [frozen] t2d: identical
PASSED
```

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
