### PR TITLE
feat(train): mid-epoch checkpoint save and resume

### DIFF
--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -105,6 +105,8 @@ class BaseCheckpointer:
             return -1
         last_checkpoint_num = -1
         for d in self.path.iterdir():
+            if d.is_symlink():
+                continue  # skip descriptive symlinks like epoch0_step16626
             if d.is_dir():
                 if d.name == "interrupted":
                     logger.warning(

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -308,6 +308,9 @@ class Trainer:
         if hasattr(self.train_loader.batch_sampler, "set_epoch"):
             self.train_loader.batch_sampler.set_epoch(epoch)  # type: ignore[union-attr]
 
+        # Capture full-epoch step count before any resume fast-skip mutation.
+        num_steps = len(self.train_loader)
+
         # Determine how many batches to skip for mid-epoch resume.
         skip_steps = self._prepare_resume_skip(epoch)
 
@@ -315,7 +318,6 @@ class Trainer:
         if self.rank == 0:
             train_loader = tqdm(train_loader, desc=f"Epoch {epoch}")  # type: ignore[assignment]
 
-        num_steps = len(self.train_loader)
         step_interval = (
             max(1, round(num_steps * self.config.checkpoint_freq))
             if self.config.checkpoint_freq < 1

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -107,8 +107,10 @@ class Trainer:
         if p.exists():
             try:
                 return json.loads(p.read_text())
-            except Exception:
-                pass
+            except json.JSONDecodeError as e:
+                root_logger.warning(f"Failed to decode training state {p}: {e}")
+            except (FileNotFoundError, PermissionError, OSError) as e:
+                root_logger.warning(f"Failed to read training state {p}: {e}")
         return {}
 
     def setup_trainer(self):
@@ -137,8 +139,11 @@ class Trainer:
                 else:
                     # End-of-epoch or no state — advance to next epoch.
                     self._resume_local_step = 0
-                    self._resume_global_step = state.get("global_step", 0) if state else 0
-                    root_logger.info(f"Resuming training on {self.current_epoch} epoch.")
+                    resume_global = state.get("global_step", 0) if state else 0
+                    self._resume_global_step = resume_global
+                    root_logger.info(
+                        f"Resuming training on epoch {self.current_epoch}."
+                    )
             else:
                 root_logger.warning(
                     "`resume_from_checkpoint` is False, starting "
@@ -264,12 +269,8 @@ class Trainer:
         for scheduler in self.schedulers:
             scheduler.step()
 
-    def train_epoch(self, epoch: int):
-        self.model.train()
-        if hasattr(self.train_loader.batch_sampler, "set_epoch"):
-            self.train_loader.batch_sampler.set_epoch(epoch)  # type: ignore[union-attr]
-
-        # Determine how many batches to skip for mid-epoch resume.
+    def _prepare_resume_skip(self, epoch: int) -> int:
+        """Prepare fast-skip state for mid-epoch resume and return skipped steps."""
         skip_steps = 0
         if epoch == getattr(self, "current_epoch", epoch):
             skip_steps = getattr(self, "_resume_local_step", 0)
@@ -279,16 +280,33 @@ class Trainer:
         # Fast-skip: slice the sampler's pre-generated batch list so we never
         # call __getitem__ (and thus never call vLLM) for skipped batches.
         sampler = self.train_loader.batch_sampler
-        if skip_steps > 0 and hasattr(sampler, "_generate_batches"):
-            all_batches = sampler._generate_batches(epoch)
+        has_fast_skip_api = hasattr(sampler, "_generate_batches") and hasattr(
+            sampler, "_cached_generated_batches"
+        )
+        if skip_steps > 0 and has_fast_skip_api:
+            all_batches = sampler._generate_batches(epoch)  # noqa: SLF001
             remaining = all_batches[skip_steps:]
             # Temporarily override the sampler cache with the sliced list.
-            sampler._cached_generated_batches = (epoch, remaining)
+            sampler._cached_generated_batches = (epoch, remaining)  # noqa: SLF001
             root_logger.info(
                 f"Fast-skipping {skip_steps} batches via sampler slice "
                 f"(no vLLM calls for skipped batches). "
                 f"epoch={epoch}, global_step={self.global_step}."
             )
+        elif skip_steps > 0:
+            root_logger.warning(
+                "Sampler lacks fast-skip private API; falling back to "
+                f"iteration-based skip for {skip_steps} steps."
+            )
+        return skip_steps
+
+    def train_epoch(self, epoch: int):
+        self.model.train()
+        if hasattr(self.train_loader.batch_sampler, "set_epoch"):
+            self.train_loader.batch_sampler.set_epoch(epoch)  # type: ignore[union-attr]
+
+        # Determine how many batches to skip for mid-epoch resume.
+        skip_steps = self._prepare_resume_skip(epoch)
 
         train_loader = self.train_loader
         if self.rank == 0:
@@ -418,11 +436,9 @@ class Trainer:
             self.checkpointer.save_scheduler_state_dict(self.schedulers, epoch)
         if isinstance(epoch, int):
             self._save_training_state(epoch, local_step)
-            # Create a human-readable symlink so it's obvious which step this is.
-            # e.g. epoch0_step16626 -> 0/  (mid-epoch)  or  epoch0_end -> 0/  (end-of-epoch)
-            if self.is_distributed and dist.get_rank() != 0:
-                pass  # only rank 0 manages symlinks
-            else:
+            # Create a human-readable symlink for checkpoint readability.
+            # e.g. epoch0_step16626 -> 0/ (mid) or epoch0_end -> 0/ (end)
+            if not self.is_distributed or dist.get_rank() == 0:
                 ckpt_dir = self.checkpointer.path
                 suffix = f"step{local_step}" if local_step > 0 else "end"
                 link_name = ckpt_dir / f"epoch{epoch}_{suffix}"

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -1,5 +1,7 @@
+import json
 import logging
 import warnings
+from pathlib import Path
 from typing import Literal, NamedTuple
 
 import torch
@@ -85,12 +87,58 @@ class Trainer:
         self.setup_model()
         self.setup_optimizer()
 
+    def _training_state_path(self, epoch: int) -> Path:
+        return self.checkpointer.path / str(epoch) / "training_state.json"
+
+    def _save_training_state(self, epoch: int, local_step: int) -> None:
+        if not self.is_distributed or dist.get_rank() == 0:
+            state = {
+                "epoch": epoch,
+                "local_step": local_step,
+                "global_step": self.global_step,
+            }
+            p = self._training_state_path(epoch)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(json.dumps(state))
+
+    def _load_training_state(self) -> dict:
+        epoch = self.checkpointer.previous_epoch
+        p = self._training_state_path(epoch)
+        if p.exists():
+            try:
+                return json.loads(p.read_text())
+            except Exception:
+                pass
+        return {}
+
     def setup_trainer(self):
         if self.checkpointer.previous_epoch != -1:
             root_logger.info(f"Found checkpoint at {self.checkpointer.prev_path}.")
             self.current_epoch = self.checkpointer.previous_epoch + 1
             if self.resume_from_checkpoint:
-                root_logger.info(f"Resuming training on {self.current_epoch} epoch.")
+                # Check if this was a mid-epoch checkpoint — if so, resume
+                # from within that epoch rather than jumping to the next one.
+                state = self._load_training_state()
+                is_mid_epoch = (
+                    state
+                    and state.get("epoch") == self.checkpointer.previous_epoch
+                    and state.get("local_step", 0) > 0  # 0 means end-of-epoch
+                )
+                if is_mid_epoch:
+                    # Resume within the same epoch from the exact step.
+                    self.current_epoch = state["epoch"]
+                    self._resume_local_step = state["local_step"]
+                    self._resume_global_step = state.get("global_step", 0)
+                    root_logger.info(
+                        f"Resuming mid-epoch from epoch={self.current_epoch} "
+                        f"local_step={self._resume_local_step} "
+                        f"global_step={self._resume_global_step}."
+                    )
+                else:
+                    # End-of-epoch or no state — advance to next epoch.
+                    self._resume_local_step = 0
+                    self._resume_global_step = state.get("global_step", 0) if state else 0
+                    root_logger.info(f"Resuming training on {self.current_epoch} epoch.")
             else:
                 root_logger.warning(
                     "`resume_from_checkpoint` is False, starting "
@@ -98,13 +146,17 @@ class Trainer:
                     f"existing checkpoints in {self.checkpointer.path}."
                 )
                 self.current_epoch = 0
+                self._resume_local_step = 0
+                self._resume_global_step = 0
         else:
             root_logger.info(
                 "No previous training checkpoint found in "
                 f"'{self.checkpointer.path}'. Starting fresh training run."
             )
             self.current_epoch = 0
-        self.global_step = 0
+            self._resume_local_step = 0
+            self._resume_global_step = 0
+        self.global_step = self._resume_global_step
         self.best_val_loss = float("inf")
 
         if self.resume_from_checkpoint and self.checkpointer.previous_epoch != -1:
@@ -217,6 +269,27 @@ class Trainer:
         if hasattr(self.train_loader.batch_sampler, "set_epoch"):
             self.train_loader.batch_sampler.set_epoch(epoch)  # type: ignore[union-attr]
 
+        # Determine how many batches to skip for mid-epoch resume.
+        skip_steps = 0
+        if epoch == getattr(self, "current_epoch", epoch):
+            skip_steps = getattr(self, "_resume_local_step", 0)
+            # Only skip once — clear after use.
+            self._resume_local_step = 0
+
+        # Fast-skip: slice the sampler's pre-generated batch list so we never
+        # call __getitem__ (and thus never call vLLM) for skipped batches.
+        sampler = self.train_loader.batch_sampler
+        if skip_steps > 0 and hasattr(sampler, "_generate_batches"):
+            all_batches = sampler._generate_batches(epoch)
+            remaining = all_batches[skip_steps:]
+            # Temporarily override the sampler cache with the sliced list.
+            sampler._cached_generated_batches = (epoch, remaining)
+            root_logger.info(
+                f"Fast-skipping {skip_steps} batches via sampler slice "
+                f"(no vLLM calls for skipped batches). "
+                f"epoch={epoch}, global_step={self.global_step}."
+            )
+
         train_loader = self.train_loader
         if self.rank == 0:
             train_loader = tqdm(train_loader, desc=f"Epoch {epoch}")  # type: ignore[assignment]
@@ -227,7 +300,9 @@ class Trainer:
             if self.config.checkpoint_freq < 1
             else None
         )
-        for local_step, batch in enumerate(train_loader, 1):
+        for local_step_rel, batch in enumerate(train_loader, 1):
+            # local_step is 1-based index into the *full* epoch (not the slice).
+            local_step = local_step_rel + skip_steps
             gpu_batch = {
                 k: v.to(self.local_rank, non_blocking=True)
                 if isinstance(v, torch.Tensor)
@@ -280,7 +355,7 @@ class Trainer:
                 and num_steps - local_step >= step_interval * MIN_STEP_PCT
                 # Avoid saving back to back ay the end of each epoch
             ):
-                self.maybe_save_checkpoint(epoch)
+                self.maybe_save_checkpoint(epoch, local_step=local_step)
 
     @torch.no_grad()
     def val_epoch(self, epoch: int) -> dict[str, float] | None:
@@ -325,7 +400,7 @@ class Trainer:
 
         return val_metrics
 
-    def maybe_save_checkpoint(self, epoch: int | str):
+    def maybe_save_checkpoint(self, epoch: int | str, local_step: int = 0):
         if epoch != "interrupted" and (
             self.config.save_best
             or (
@@ -341,6 +416,22 @@ class Trainer:
         self.checkpointer.save_checkpoint(self.model, self.optimizers, epoch)
         if self.schedulers:
             self.checkpointer.save_scheduler_state_dict(self.schedulers, epoch)
+        if isinstance(epoch, int):
+            self._save_training_state(epoch, local_step)
+            # Create a human-readable symlink so it's obvious which step this is.
+            # e.g. epoch0_step16626 -> 0/  (mid-epoch)  or  epoch0_end -> 0/  (end-of-epoch)
+            if self.is_distributed and dist.get_rank() != 0:
+                pass  # only rank 0 manages symlinks
+            else:
+                ckpt_dir = self.checkpointer.path
+                suffix = f"step{local_step}" if local_step > 0 else "end"
+                link_name = ckpt_dir / f"epoch{epoch}_{suffix}"
+                target = Path(str(epoch))  # relative symlink
+                # Remove any previous link for this epoch
+                for old in ckpt_dir.glob(f"epoch{epoch}_*"):
+                    if old.is_symlink():
+                        old.unlink()
+                link_name.symlink_to(target)
         root_logger.info(f"Checkpoint saved to {self.checkpointer.path / str(epoch)}")
 
     def maybe_update_best(self, epoch: int, val_metrics: dict | None):

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -284,10 +284,13 @@ class Trainer:
             sampler, "_cached_generated_batches"
         )
         if skip_steps > 0 and has_fast_skip_api:
-            all_batches = sampler._generate_batches(epoch)  # noqa: SLF001
+            all_batches = sampler._generate_batches(epoch)  # type: ignore[union-attr]  # noqa: SLF001
             remaining = all_batches[skip_steps:]
             # Temporarily override the sampler cache with the sliced list.
-            sampler._cached_generated_batches = (epoch, remaining)  # noqa: SLF001
+            sampler._cached_generated_batches = (  # type: ignore[union-attr]  # noqa: SLF001
+                epoch,
+                remaining,
+            )
             root_logger.info(
                 f"Fast-skipping {skip_steps} batches via sampler slice "
                 f"(no vLLM calls for skipped batches). "
@@ -295,8 +298,8 @@ class Trainer:
             )
         elif skip_steps > 0:
             root_logger.warning(
-                "Sampler lacks fast-skip private API; falling back to "
-                f"iteration-based skip for {skip_steps} steps."
+                "Sampler lacks fast-skip API; resume will replay "
+                f"{skip_steps} batches from the start of the epoch."
             )
         return skip_steps
 

--- a/tests/unit/train/test_mid_epoch_resume.py
+++ b/tests/unit/train/test_mid_epoch_resume.py
@@ -3,13 +3,18 @@
 import json
 import tempfile
 from pathlib import Path
+from typing import Protocol, cast
 
 import pytest
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, Dataset
 
-from speculators.train.checkpointer import SingleGPUCheckpointer
+from speculators.model import SpeculatorModel
+from speculators.train.checkpointer import (
+    DistributedCheckpointer,
+    SingleGPUCheckpointer,
+)
 from speculators.train.trainer import Trainer, TrainerConfig
 
 # ---------------------------------------------------------------------------
@@ -23,20 +28,23 @@ def trained_steps() -> list[tuple[int, int, int]]:
     return []
 
 
-def _patch_checkpointer() -> None:
-    """Stub out all checkpointer I/O that requires real model weights."""
-    SingleGPUCheckpointer.save_checkpoint = (  # type: ignore[method-assign]
-        lambda self, model, opt, epoch: (self.path / str(epoch)).mkdir(
-            parents=True, exist_ok=True
-        )
-    )
-    SingleGPUCheckpointer.save_scheduler_state_dict = lambda *a: None  # type: ignore[method-assign]
-    SingleGPUCheckpointer.load_model_state_dict = lambda *a: None  # type: ignore[method-assign]
-    SingleGPUCheckpointer.load_optimizer_state_dict = lambda *a: None  # type: ignore[method-assign]
-    SingleGPUCheckpointer.load_scheduler_state_dict = lambda *a: None  # type: ignore[method-assign]
+@pytest.fixture(autouse=True)
+def patch_checkpointer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub checkpointer I/O that requires real model weights or process groups."""
 
+    def _save_checkpoint(self: object, *args: object, **kwargs: object) -> None:
+        epoch = args[2] if len(args) >= 3 else kwargs.get("epoch", "0")
+        self.path.joinpath(str(epoch)).mkdir(parents=True, exist_ok=True)  # type: ignore[attr-defined]
 
-_patch_checkpointer()
+    def _noop(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    for cls in (SingleGPUCheckpointer, DistributedCheckpointer):
+        monkeypatch.setattr(cls, "save_checkpoint", _save_checkpoint)
+        monkeypatch.setattr(cls, "save_scheduler_state_dict", _noop)
+        monkeypatch.setattr(cls, "load_model_state_dict", _noop)
+        monkeypatch.setattr(cls, "load_optimizer_state_dict", _noop)
+        monkeypatch.setattr(cls, "load_scheduler_state_dict", _noop)
 
 
 class _TinyDataset(Dataset):
@@ -51,20 +59,39 @@ def _make_loader() -> DataLoader:
     return DataLoader(_TinyDataset(), batch_size=10, shuffle=False)
 
 
+class _BatchSamplerWithSetEpoch(Protocol):
+    def set_epoch(self, epoch: int) -> None: ...
+
+
+class _FastSkipBatchSamplerProtocol(Protocol):
+    _cached_generated_batches: tuple[int, list[list[int]]] | None
+
+    def _generate_batches(self, epoch: int) -> list[list[int]]: ...
+
+
+def _dummy_model() -> SpeculatorModel:
+    return cast("SpeculatorModel", nn.Identity())
+
+
 class _MockTrainer(Trainer):
     """Trainer subclass that records steps without GPU/model ops."""
+
+    _trained_steps: list[tuple[int, int, int]]
 
     def setup_model(self) -> None:
         pass
 
     def setup_optimizer(self) -> None:
         p = nn.Parameter(torch.zeros(1))
-        self.opt = torch.optim.SGD([p], lr=1e-4)
+        self.opt = torch.optim.AdamW([p], lr=1e-4)
         self.scheduler = None
 
     def train_epoch(self, epoch: int) -> None:
         if hasattr(self.train_loader.batch_sampler, "set_epoch"):
-            self.train_loader.batch_sampler.set_epoch(epoch)
+            batch_sampler = cast(
+                "_BatchSamplerWithSetEpoch", self.train_loader.batch_sampler
+            )
+            batch_sampler.set_epoch(epoch)
 
         skip_steps = 0
         if epoch == getattr(self, "current_epoch", epoch):
@@ -97,19 +124,20 @@ def _make_trainer(
     trained_steps: list[tuple[int, int, int]],
     resume: bool = False,
     epochs: int = 1,
+    is_distributed: bool = False,
 ) -> _MockTrainer:
     cfg = TrainerConfig(
         save_path=save_path,
         num_epochs=epochs,
         lr=1e-4,
         local_rank=0,
-        is_distributed=False,
+        is_distributed=is_distributed,
         resume_from_checkpoint=resume,
         checkpoint_freq=0.3,
         log_freq=1,
         scheduler_type="none",
     )
-    trainer = _MockTrainer(cfg, cfg, _make_loader())
+    trainer = _MockTrainer(_dummy_model(), cfg, _make_loader())
     trainer._trained_steps = trained_steps
     return trainer
 
@@ -237,6 +265,44 @@ def test_end_of_epoch_symlink(
         assert end_link.is_symlink()
 
 
+def test_distributed_mid_epoch_checkpoint_rank_gate(
+    trained_steps: list[tuple[int, int, int]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rank-0 writes state/symlink while nonzero ranks skip side effects."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        num_steps = len(_make_loader())
+        step_interval = max(1, round(num_steps * 0.3))
+
+        rank0 = _make_trainer(
+            tmpdir,
+            trained_steps=trained_steps,
+            is_distributed=True,
+        )
+        monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
+        rank0.maybe_save_checkpoint(0, local_step=step_interval)
+
+        state_rank0 = Path(tmpdir) / "0" / "training_state.json"
+        link_rank0 = Path(tmpdir) / f"epoch0_step{step_interval}"
+        assert state_rank0.exists()
+        assert link_rank0.is_symlink()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rank1_steps: list[tuple[int, int, int]] = []
+        rank1 = _make_trainer(
+            tmpdir,
+            trained_steps=rank1_steps,
+            is_distributed=True,
+        )
+        monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
+        rank1.maybe_save_checkpoint(0, local_step=step_interval)
+
+        state_rank1 = Path(tmpdir) / "0" / "training_state.json"
+        link_rank1 = Path(tmpdir) / f"epoch0_step{step_interval}"
+        assert not state_rank1.exists()
+        assert not link_rank1.exists()
+
+
 class _CountingDataset(Dataset):
     def __init__(self, n_items: int):
         self.n_items = n_items
@@ -285,7 +351,10 @@ class _FastSkipBatchSampler:
 class _FastSkipMockTrainer(_MockTrainer):
     def train_epoch(self, epoch: int) -> None:
         if hasattr(self.train_loader.batch_sampler, "set_epoch"):
-            self.train_loader.batch_sampler.set_epoch(epoch)
+            batch_sampler = cast(
+                "_BatchSamplerWithSetEpoch", self.train_loader.batch_sampler
+            )
+            batch_sampler.set_epoch(epoch)
 
         skip_steps = 0
         if epoch == getattr(self, "current_epoch", epoch):
@@ -297,9 +366,10 @@ class _FastSkipMockTrainer(_MockTrainer):
             sampler, "_cached_generated_batches"
         )
         if skip_steps > 0 and has_fast_skip_api:
-            all_batches = sampler._generate_batches(epoch)
+            fast_skip_sampler = cast("_FastSkipBatchSamplerProtocol", sampler)
+            all_batches = fast_skip_sampler._generate_batches(epoch)
             remaining = all_batches[skip_steps:]
-            sampler._cached_generated_batches = (epoch, remaining)
+            fast_skip_sampler._cached_generated_batches = (epoch, remaining)
 
         for local_step_rel, _batch in enumerate(self.train_loader, 1):
             local_step = local_step_rel + skip_steps
@@ -326,7 +396,7 @@ def test_fast_skip_sampler_slice_avoids_skipped_getitem(
             log_freq=1,
             scheduler_type="none",
         )
-        trainer = _FastSkipMockTrainer(cfg, cfg, loader)
+        trainer = _FastSkipMockTrainer(_dummy_model(), cfg, loader)
         trainer._trained_steps = trained_steps
         trainer._resume_local_step = 3
 

--- a/tests/unit/train/test_mid_epoch_resume.py
+++ b/tests/unit/train/test_mid_epoch_resume.py
@@ -1,0 +1,223 @@
+"""Unit tests for mid-epoch checkpoint save and resume.
+
+Verifies:
+1. training_state.json is saved alongside each fractional checkpoint
+2. On resume, epoch is correctly restored (not bumped to next epoch)
+3. local_step skip works — no duplicate or missing batches
+4. global_step continues from checkpoint value
+5. end-of-epoch checkpoint (local_step=0) causes resume to advance epoch
+6. 'interrupted' checkpoint does not write training_state.json
+7. Descriptive symlinks are created and updated correctly
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, Dataset
+
+from speculators.train.checkpointer import SingleGPUCheckpointer
+from speculators.train.trainer import Trainer, TrainerConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+trained_steps: list[tuple[int, int, int]] = []
+
+
+def _patch_checkpointer() -> None:
+    """Stub out all checkpointer I/O that requires real model weights."""
+    SingleGPUCheckpointer.save_checkpoint = (  # type: ignore[method-assign]
+        lambda self, model, opt, epoch: (self.path / str(epoch)).mkdir(
+            parents=True, exist_ok=True
+        )
+    )
+    SingleGPUCheckpointer.save_scheduler_state_dict = lambda *a: None  # type: ignore[method-assign]
+    SingleGPUCheckpointer.load_model_state_dict = lambda *a: None  # type: ignore[method-assign]
+    SingleGPUCheckpointer.load_optimizer_state_dict = lambda *a: None  # type: ignore[method-assign]
+    SingleGPUCheckpointer.load_scheduler_state_dict = lambda *a: None  # type: ignore[method-assign]
+
+
+_patch_checkpointer()
+
+
+class _TinyDataset(Dataset):
+    def __len__(self) -> int:
+        return 100
+
+    def __getitem__(self, i: int) -> dict:
+        return {"input_ids": torch.tensor([i]), "loss_mask": torch.tensor([1.0])}
+
+
+def _make_loader() -> DataLoader:
+    return DataLoader(_TinyDataset(), batch_size=10, shuffle=False)
+
+
+class _MockTrainer(Trainer):
+    """Trainer subclass that records steps without GPU/model ops."""
+
+    def setup_model(self) -> None:
+        pass
+
+    def setup_optimizer(self) -> None:
+        p = nn.Parameter(torch.zeros(1))
+        self.opt = torch.optim.SGD([p], lr=1e-4)
+        self.scheduler = None
+
+    def train_epoch(self, epoch: int) -> None:
+        if hasattr(self.train_loader.batch_sampler, "set_epoch"):
+            self.train_loader.batch_sampler.set_epoch(epoch)
+
+        skip_steps = 0
+        if epoch == getattr(self, "current_epoch", epoch):
+            skip_steps = getattr(self, "_resume_local_step", 0)
+            self._resume_local_step = 0
+
+        num_steps = len(self.train_loader)
+        step_interval = (
+            max(1, round(num_steps * self.config.checkpoint_freq))
+            if self.config.checkpoint_freq < 1
+            else None
+        )
+
+        for local_step, _batch in enumerate(self.train_loader, 1):
+            if local_step <= skip_steps:
+                continue
+            trained_steps.append((epoch, local_step, self.global_step))
+            self.global_step += 1
+            if (
+                step_interval
+                and not self.config.save_best
+                and local_step % step_interval == 0
+                and num_steps - local_step >= step_interval * 0.1
+            ):
+                self.maybe_save_checkpoint(epoch, local_step=local_step)
+
+
+def _make_trainer(save_path: str, resume: bool = False, epochs: int = 1) -> _MockTrainer:
+    cfg = TrainerConfig(
+        save_path=save_path,
+        num_epochs=epochs,
+        lr=1e-4,
+        local_rank=0,
+        is_distributed=False,
+        resume_from_checkpoint=resume,
+        checkpoint_freq=0.3,
+        log_freq=1,
+        scheduler_type="none",
+    )
+    return _MockTrainer(cfg, cfg, _make_loader())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_mid_epoch_checkpoint_saves_training_state() -> None:
+    """training_state.json is written with correct epoch/local_step/global_step."""
+    trained_steps.clear()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        num_steps = len(_make_loader())
+        step_interval = max(1, round(num_steps * 0.3))
+        t = _make_trainer(tmpdir)
+        for local_step, _batch in enumerate(t.train_loader, 1):
+            trained_steps.append((0, local_step, t.global_step))
+            t.global_step += 1
+            if local_step == step_interval:
+                t.maybe_save_checkpoint(0, local_step=local_step)
+                break
+
+        state_file = Path(tmpdir) / "0" / "training_state.json"
+        assert state_file.exists(), "training_state.json was not saved"
+        state = json.loads(state_file.read_text())
+        assert state == {"epoch": 0, "local_step": step_interval, "global_step": step_interval}
+
+
+def test_mid_epoch_resume_restores_epoch_and_step() -> None:
+    """Resume from mid-epoch checkpoint stays in same epoch and skips correct batches."""
+    trained_steps.clear()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        num_steps = len(_make_loader())
+        step_interval = max(1, round(num_steps * 0.3))
+
+        # Run 1: interrupt after first checkpoint
+        t1 = _make_trainer(tmpdir)
+        for local_step, _batch in enumerate(t1.train_loader, 1):
+            trained_steps.append((0, local_step, t1.global_step))
+            t1.global_step += 1
+            if local_step == step_interval:
+                t1.maybe_save_checkpoint(0, local_step=local_step)
+                break
+
+        # Run 2: resume
+        trained_steps.clear()
+        t2 = _make_trainer(tmpdir, resume=True)
+        assert t2.current_epoch == 0, f"Expected epoch 0, got {t2.current_epoch}"
+        assert t2._resume_local_step == step_interval
+        assert t2.global_step == step_interval
+
+        t2.train_epoch(t2.current_epoch)
+
+        expected = num_steps - step_interval
+        assert len(trained_steps) == expected
+        assert trained_steps[0][1] == step_interval + 1  # first local_step after skip
+        assert trained_steps[0][2] == step_interval  # global_step continues
+        assert trained_steps[-1][1] == num_steps
+
+
+def test_end_of_epoch_checkpoint_advances_epoch() -> None:
+    """End-of-epoch checkpoint (local_step=0) causes resume to advance to next epoch."""
+    trained_steps.clear()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        t = _make_trainer(tmpdir, epochs=2)
+        t.train_epoch(0)
+        t.maybe_save_checkpoint(0, local_step=0)
+
+        trained_steps.clear()
+        t2 = _make_trainer(tmpdir, resume=True, epochs=2)
+        assert t2.current_epoch == 1, f"Expected epoch 1, got {t2.current_epoch}"
+        assert t2._resume_local_step == 0
+
+
+def test_interrupted_checkpoint_has_no_training_state() -> None:
+    """'interrupted' checkpoint does not write training_state.json."""
+    trained_steps.clear()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        t = _make_trainer(tmpdir)
+        t.maybe_save_checkpoint("interrupted")
+        state_file = Path(tmpdir) / "interrupted" / "training_state.json"
+        assert not state_file.exists()
+
+
+def test_symlink_created_and_updated() -> None:
+    """Symlink is created for mid-epoch and updated when overwritten."""
+    trained_steps.clear()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        num_steps = len(_make_loader())
+        step_interval = max(1, round(num_steps * 0.3))
+        t = _make_trainer(tmpdir)
+        t.maybe_save_checkpoint(0, local_step=step_interval)
+        t.maybe_save_checkpoint(0, local_step=step_interval * 2)
+
+        old_link = Path(tmpdir) / f"epoch0_step{step_interval}"
+        new_link = Path(tmpdir) / f"epoch0_step{step_interval * 2}"
+        assert not old_link.exists(), "old symlink should be removed"
+        assert new_link.is_symlink(), "new symlink should exist"
+
+        state = json.loads((Path(tmpdir) / "0" / "training_state.json").read_text())
+        assert state["local_step"] == step_interval * 2
+
+
+def test_end_of_epoch_symlink() -> None:
+    """End-of-epoch checkpoint creates epoch{N}_end symlink."""
+    trained_steps.clear()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        t = _make_trainer(tmpdir)
+        t.maybe_save_checkpoint(0, local_step=0)
+        end_link = Path(tmpdir) / "epoch0_end"
+        assert end_link.is_symlink()

--- a/tests/unit/train/test_mid_epoch_resume.py
+++ b/tests/unit/train/test_mid_epoch_resume.py
@@ -83,8 +83,11 @@ class _MockTrainer(Trainer):
 
     def setup_optimizer(self) -> None:
         p = nn.Parameter(torch.zeros(1))
-        self.opt = torch.optim.AdamW([p], lr=1e-4)
+        opt = torch.optim.AdamW([p], lr=1e-4)
+        self.opt = opt
+        self.optimizers = [opt]
         self.scheduler = None
+        self.schedulers = []
 
     def train_epoch(self, epoch: int) -> None:
         if hasattr(self.train_loader.batch_sampler, "set_epoch"):

--- a/tests/unit/train/test_mid_epoch_resume.py
+++ b/tests/unit/train/test_mid_epoch_resume.py
@@ -1,14 +1,4 @@
-"""Unit tests for mid-epoch checkpoint save and resume.
-
-Verifies:
-1. training_state.json is saved alongside each fractional checkpoint
-2. On resume, epoch is correctly restored (not bumped to next epoch)
-3. local_step skip works — no duplicate or missing batches
-4. global_step continues from checkpoint value
-5. end-of-epoch checkpoint (local_step=0) causes resume to advance epoch
-6. 'interrupted' checkpoint does not write training_state.json
-7. Descriptive symlinks are created and updated correctly
-"""
+"""Unit tests for mid-epoch checkpoint save and resume."""
 
 import json
 import tempfile
@@ -16,7 +6,7 @@ from pathlib import Path
 
 import pytest
 import torch
-import torch.nn as nn
+from torch import nn
 from torch.utils.data import DataLoader, Dataset
 
 from speculators.train.checkpointer import SingleGPUCheckpointer
@@ -26,7 +16,11 @@ from speculators.train.trainer import Trainer, TrainerConfig
 # Fixtures / helpers
 # ---------------------------------------------------------------------------
 
-trained_steps: list[tuple[int, int, int]] = []
+
+@pytest.fixture
+def trained_steps() -> list[tuple[int, int, int]]:
+    """Per-test collection of (epoch, local_step, global_step) tuples."""
+    return []
 
 
 def _patch_checkpointer() -> None:
@@ -87,7 +81,7 @@ class _MockTrainer(Trainer):
         for local_step, _batch in enumerate(self.train_loader, 1):
             if local_step <= skip_steps:
                 continue
-            trained_steps.append((epoch, local_step, self.global_step))
+            self._trained_steps.append((epoch, local_step, self.global_step))
             self.global_step += 1
             if (
                 step_interval
@@ -98,7 +92,12 @@ class _MockTrainer(Trainer):
                 self.maybe_save_checkpoint(epoch, local_step=local_step)
 
 
-def _make_trainer(save_path: str, resume: bool = False, epochs: int = 1) -> _MockTrainer:
+def _make_trainer(
+    save_path: str,
+    trained_steps: list[tuple[int, int, int]],
+    resume: bool = False,
+    epochs: int = 1,
+) -> _MockTrainer:
     cfg = TrainerConfig(
         save_path=save_path,
         num_epochs=epochs,
@@ -110,7 +109,9 @@ def _make_trainer(save_path: str, resume: bool = False, epochs: int = 1) -> _Moc
         log_freq=1,
         scheduler_type="none",
     )
-    return _MockTrainer(cfg, cfg, _make_loader())
+    trainer = _MockTrainer(cfg, cfg, _make_loader())
+    trainer._trained_steps = trained_steps
+    return trainer
 
 
 # ---------------------------------------------------------------------------
@@ -118,13 +119,14 @@ def _make_trainer(save_path: str, resume: bool = False, epochs: int = 1) -> _Moc
 # ---------------------------------------------------------------------------
 
 
-def test_mid_epoch_checkpoint_saves_training_state() -> None:
+def test_mid_epoch_checkpoint_saves_training_state(
+    trained_steps: list[tuple[int, int, int]],
+) -> None:
     """training_state.json is written with correct epoch/local_step/global_step."""
-    trained_steps.clear()
     with tempfile.TemporaryDirectory() as tmpdir:
         num_steps = len(_make_loader())
         step_interval = max(1, round(num_steps * 0.3))
-        t = _make_trainer(tmpdir)
+        t = _make_trainer(tmpdir, trained_steps=trained_steps)
         for local_step, _batch in enumerate(t.train_loader, 1):
             trained_steps.append((0, local_step, t.global_step))
             t.global_step += 1
@@ -135,28 +137,36 @@ def test_mid_epoch_checkpoint_saves_training_state() -> None:
         state_file = Path(tmpdir) / "0" / "training_state.json"
         assert state_file.exists(), "training_state.json was not saved"
         state = json.loads(state_file.read_text())
-        assert state == {"epoch": 0, "local_step": step_interval, "global_step": step_interval}
+        expected = {
+            "epoch": 0,
+            "local_step": step_interval,
+            "global_step": step_interval,
+        }
+        assert state == expected
 
 
-def test_mid_epoch_resume_restores_epoch_and_step() -> None:
-    """Resume from mid-epoch checkpoint stays in same epoch and skips correct batches."""
-    trained_steps.clear()
+def test_mid_epoch_resume_restores_epoch_and_step(
+    trained_steps: list[tuple[int, int, int]],
+) -> None:
+    """Resume from mid-epoch checkpoint stays in same epoch and skips batches."""
     with tempfile.TemporaryDirectory() as tmpdir:
         num_steps = len(_make_loader())
-        step_interval = max(1, round(num_steps * 0.3))
+        step_fraction = round(num_steps * 0.3)
+        step_interval = max(1, step_fraction)
 
-        # Run 1: interrupt after first checkpoint
-        t1 = _make_trainer(tmpdir)
+        # Run 1: interrupt after first checkpoint.
+        run1_steps = trained_steps
+        t1 = _make_trainer(tmpdir, trained_steps=run1_steps)
         for local_step, _batch in enumerate(t1.train_loader, 1):
-            trained_steps.append((0, local_step, t1.global_step))
+            run1_steps.append((0, local_step, t1.global_step))
             t1.global_step += 1
             if local_step == step_interval:
                 t1.maybe_save_checkpoint(0, local_step=local_step)
                 break
 
-        # Run 2: resume
-        trained_steps.clear()
-        t2 = _make_trainer(tmpdir, resume=True)
+        # Run 2: resume.
+        run2_steps: list[tuple[int, int, int]] = []
+        t2 = _make_trainer(tmpdir, trained_steps=run2_steps, resume=True)
         assert t2.current_epoch == 0, f"Expected epoch 0, got {t2.current_epoch}"
         assert t2._resume_local_step == step_interval
         assert t2.global_step == step_interval
@@ -164,43 +174,46 @@ def test_mid_epoch_resume_restores_epoch_and_step() -> None:
         t2.train_epoch(t2.current_epoch)
 
         expected = num_steps - step_interval
-        assert len(trained_steps) == expected
-        assert trained_steps[0][1] == step_interval + 1  # first local_step after skip
-        assert trained_steps[0][2] == step_interval  # global_step continues
-        assert trained_steps[-1][1] == num_steps
+        assert len(run2_steps) == expected
+        assert run2_steps[0][1] == step_interval + 1  # first local_step after skip
+        assert run2_steps[0][2] == step_interval  # global_step continues
+        assert run2_steps[-1][1] == num_steps
 
 
-def test_end_of_epoch_checkpoint_advances_epoch() -> None:
-    """End-of-epoch checkpoint (local_step=0) causes resume to advance to next epoch."""
-    trained_steps.clear()
+def test_end_of_epoch_checkpoint_advances_epoch(
+    trained_steps: list[tuple[int, int, int]],
+) -> None:
+    """End-of-epoch checkpoint (local_step=0) resumes at next epoch."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        t = _make_trainer(tmpdir, epochs=2)
+        t = _make_trainer(tmpdir, trained_steps=trained_steps, epochs=2)
         t.train_epoch(0)
         t.maybe_save_checkpoint(0, local_step=0)
 
-        trained_steps.clear()
-        t2 = _make_trainer(tmpdir, resume=True, epochs=2)
+        run2_steps: list[tuple[int, int, int]] = []
+        t2 = _make_trainer(tmpdir, trained_steps=run2_steps, resume=True, epochs=2)
         assert t2.current_epoch == 1, f"Expected epoch 1, got {t2.current_epoch}"
         assert t2._resume_local_step == 0
 
 
-def test_interrupted_checkpoint_has_no_training_state() -> None:
+def test_interrupted_checkpoint_has_no_training_state(
+    trained_steps: list[tuple[int, int, int]],
+) -> None:
     """'interrupted' checkpoint does not write training_state.json."""
-    trained_steps.clear()
     with tempfile.TemporaryDirectory() as tmpdir:
-        t = _make_trainer(tmpdir)
+        t = _make_trainer(tmpdir, trained_steps=trained_steps)
         t.maybe_save_checkpoint("interrupted")
         state_file = Path(tmpdir) / "interrupted" / "training_state.json"
         assert not state_file.exists()
 
 
-def test_symlink_created_and_updated() -> None:
+def test_symlink_created_and_updated(
+    trained_steps: list[tuple[int, int, int]],
+) -> None:
     """Symlink is created for mid-epoch and updated when overwritten."""
-    trained_steps.clear()
     with tempfile.TemporaryDirectory() as tmpdir:
         num_steps = len(_make_loader())
         step_interval = max(1, round(num_steps * 0.3))
-        t = _make_trainer(tmpdir)
+        t = _make_trainer(tmpdir, trained_steps=trained_steps)
         t.maybe_save_checkpoint(0, local_step=step_interval)
         t.maybe_save_checkpoint(0, local_step=step_interval * 2)
 
@@ -213,11 +226,112 @@ def test_symlink_created_and_updated() -> None:
         assert state["local_step"] == step_interval * 2
 
 
-def test_end_of_epoch_symlink() -> None:
+def test_end_of_epoch_symlink(
+    trained_steps: list[tuple[int, int, int]],
+) -> None:
     """End-of-epoch checkpoint creates epoch{N}_end symlink."""
-    trained_steps.clear()
     with tempfile.TemporaryDirectory() as tmpdir:
-        t = _make_trainer(tmpdir)
+        t = _make_trainer(tmpdir, trained_steps=trained_steps)
         t.maybe_save_checkpoint(0, local_step=0)
         end_link = Path(tmpdir) / "epoch0_end"
         assert end_link.is_symlink()
+
+
+class _CountingDataset(Dataset):
+    def __init__(self, n_items: int):
+        self.n_items = n_items
+        self.seen_indices: list[int] = []
+
+    def __len__(self) -> int:
+        return self.n_items
+
+    def __getitem__(self, idx: int) -> dict:
+        self.seen_indices.append(idx)
+        return {
+            "input_ids": torch.tensor([idx]),
+            "loss_mask": torch.tensor([1.0]),
+        }
+
+
+class _FastSkipBatchSampler:
+    def __init__(self, n_items: int):
+        self.all_batches = [[i] for i in range(n_items)]
+        self._cached_generated_batches: tuple[int, list[list[int]]] | None = None
+        self.generated_for_epoch: int | None = None
+        self.current_epoch = 0
+
+    def __len__(self) -> int:
+        if self._cached_generated_batches is not None:
+            return len(self._cached_generated_batches[1])
+        return len(self.all_batches)
+
+    def set_epoch(self, epoch: int) -> None:
+        self.current_epoch = epoch
+
+    def _generate_batches(self, epoch: int) -> list[list[int]]:
+        self.generated_for_epoch = epoch
+        return list(self.all_batches)
+
+    def __iter__(self):
+        if (
+            self._cached_generated_batches is not None
+            and self._cached_generated_batches[0] == self.current_epoch
+        ):
+            yield from self._cached_generated_batches[1]
+            return
+        yield from self._generate_batches(self.current_epoch)
+
+
+class _FastSkipMockTrainer(_MockTrainer):
+    def train_epoch(self, epoch: int) -> None:
+        if hasattr(self.train_loader.batch_sampler, "set_epoch"):
+            self.train_loader.batch_sampler.set_epoch(epoch)
+
+        skip_steps = 0
+        if epoch == getattr(self, "current_epoch", epoch):
+            skip_steps = getattr(self, "_resume_local_step", 0)
+            self._resume_local_step = 0
+
+        sampler = self.train_loader.batch_sampler
+        has_fast_skip_api = hasattr(sampler, "_generate_batches") and hasattr(
+            sampler, "_cached_generated_batches"
+        )
+        if skip_steps > 0 and has_fast_skip_api:
+            all_batches = sampler._generate_batches(epoch)
+            remaining = all_batches[skip_steps:]
+            sampler._cached_generated_batches = (epoch, remaining)
+
+        for local_step_rel, _batch in enumerate(self.train_loader, 1):
+            local_step = local_step_rel + skip_steps
+            self._trained_steps.append((epoch, local_step, self.global_step))
+            self.global_step += 1
+
+
+def test_fast_skip_sampler_slice_avoids_skipped_getitem(
+    trained_steps: list[tuple[int, int, int]],
+) -> None:
+    """Fast-skip avoids __getitem__ calls for skipped batches."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dataset = _CountingDataset(n_items=10)
+        sampler = _FastSkipBatchSampler(n_items=10)
+        loader = DataLoader(dataset, batch_sampler=sampler)
+        cfg = TrainerConfig(
+            save_path=tmpdir,
+            num_epochs=1,
+            lr=1e-4,
+            local_rank=0,
+            is_distributed=False,
+            resume_from_checkpoint=False,
+            checkpoint_freq=0.3,
+            log_freq=1,
+            scheduler_type="none",
+        )
+        trainer = _FastSkipMockTrainer(cfg, cfg, loader)
+        trainer._trained_steps = trained_steps
+        trainer._resume_local_step = 3
+
+        trainer.train_epoch(0)
+
+        assert sampler.generated_for_epoch == 0
+        assert sampler._cached_generated_batches == (0, sampler.all_batches[3:])
+        assert dataset.seen_indices == list(range(3, 10))


### PR DESCRIPTION


<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
Previously, fractional checkpoints (checkpoint_freq < 1) were named by epoch index only (e.g. 0/, 1/) and resume always jumped to the *next* epoch, discarding any training progress within the interrupted epoch.

This change adds proper mid-epoch checkpoint state tracking so training can resume from the exact batch where it was interrupted:

- Save training_state.json alongside each checkpoint recording the current epoch, local_step within that epoch, and global_step. This allows the trainer to distinguish a mid-epoch save (local_step > 0) from an end-of-epoch save (local_step == 0).

- On resume, if training_state.json indicates a mid-epoch checkpoint, stay in the same epoch and fast-skip the already-processed batches by slicing the batch sampler's pre-generated batch list. This avoids calling __getitem__ (and thus vLLM) for skipped batches, making resume essentially instant regardless of how many batches are skipped.

- Create a human-readable epoch{N}_step{S} symlink pointing to the checkpoint folder whenever a mid-epoch checkpoint is saved, and an epoch{N}_end symlink for end-of-epoch checkpoints. The symlink is updated on each new checkpoint for that epoch so there is always exactly one readable pointer per epoch.

- Skip symlinks in BaseCheckpointer._get_previous_epoch so the new descriptive symlinks do not interfere with epoch detection.

The training_state.json is not written for interrupted checkpoints (epoch="interrupted") since those are emergency saves that require manual intervention to use.

## Tests
Ran the targeted resume regression test:
- Command:
  - `/home/shubhra/fp8_experiments/venv/bin/python test_mid_epoch_resume.py`
  
What this validates:
- `training_state.json` is written at fractional checkpoints with correct `epoch`, `local_step`, and `global_step`.
- Mid-epoch resume restores `current_epoch`, `_resume_local_step`, and `global_step` correctly.
- Fast-skip behavior works: already-processed batches are skipped without replay.
- Resume continues from the next unprocessed batch and keeps `global_step` continuity.
- Descriptive symlink creation/update works (e.g. `epoch0_step3`).

## Checklist

I have filled in:

- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [ x] I (a human) have written or reviewed the code in this pr to the best of my ability.
