### PR TITLE
Add Muon optimizer

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -108,6 +108,22 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 - **`--deterministic-cuda`** (flag) Enable deterministic CUDA operations. May impact performance.
 
+### Optimizer Arguments
+
+- **`--optimizer`** (str, default: `"adamw"`) Optimizer to use. Options: `adamw`, `muon`. The `muon` option applies the Muon optimizer to 2D weight matrices and AdamW to the remaining parameters (norms, biases, embeddings, lm_head).
+
+- **`--weight-decay`** (float, default: `0.01`) Weight decay for the AdamW optimizer (and the AdamW group in muon mode).
+
+- **`--muon-lr`** (float, default: `0.02`) Learning rate for the Muon (2D weights) group. Only used with `--optimizer muon`.
+
+- **`--muon-momentum`** (float, default: `0.95`) Momentum for the Muon optimizer. Only used with `--optimizer muon`.
+
+- **`--muon-weight-decay`** (float, default: `0.1`) Weight decay for the Muon optimizer. Only used with `--optimizer muon`.
+
+- **`--muon-ns-steps`** (int, default: `5`) Number of Newton-Schulz steps for Muon. Only used with `--optimizer muon`.
+
+- **`--muon-adjust-lr-fn`** (str, default: `"match_rms_adamw"`) Muon LR adjustment strategy. Options: `original`, `match_rms_adamw`. Only used with `--optimizer muon`.
+
 ### Eagle3-Specific Arguments
 
 - **`--use-off-policy-tokens`** (flag) Use off-policy tokens during training (required for [regenerated data](response_regeneration.md)).

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -420,6 +420,13 @@ def main(args: argparse.Namespace):
         local_rank=local_rank,
         train_call_kwargs=train_call_kwargs,
         val_call_kwargs=val_call_kwargs,
+        optimizer=args.optimizer,
+        weight_decay=args.weight_decay,
+        muon_lr=args.muon_lr,
+        muon_momentum=args.muon_momentum,
+        muon_weight_decay=args.muon_weight_decay,
+        muon_ns_steps=args.muon_ns_steps,
+        muon_adjust_lr_fn=args.muon_adjust_lr_fn,
         scheduler_type=args.scheduler_type,
         scheduler_warmup_steps=args.scheduler_warmup_steps,
         scheduler_total_steps=args.scheduler_total_steps,
@@ -771,6 +778,40 @@ def parse_args():
     parser.add_argument("--scheduler-warmup-steps", type=int, default=None)
     parser.add_argument("--scheduler-total-steps", type=int, default=None)
     parser.add_argument("--scheduler-num-cosine-cycles", type=float, default=0.5)
+
+    # optimizer
+    parser.add_argument(
+        "--optimizer",
+        type=str,
+        default="adamw",
+        choices=["adamw", "muon"],
+        help=(
+            "Optimizer to use. 'muon' applies Muon to 2D weight matrices and AdamW to "
+            "the remaining params (norms, biases, embeddings, lm_head)."
+        ),
+    )
+    parser.add_argument(
+        "--weight-decay",
+        type=float,
+        default=0.01,
+        help="Weight decay for the AdamW optimizer (and the AdamW group in muon mode).",
+    )
+    parser.add_argument(
+        "--muon-lr",
+        type=float,
+        default=0.02,
+        help="LR for the Muon (2D weights) group. Only used with --optimizer muon.",
+    )
+    parser.add_argument("--muon-momentum", type=float, default=0.95)
+    parser.add_argument("--muon-weight-decay", type=float, default=0.1)
+    parser.add_argument("--muon-ns-steps", type=int, default=5)
+    parser.add_argument(
+        "--muon-adjust-lr-fn",
+        type=str,
+        default="match_rms_adamw",
+        choices=["original", "match_rms_adamw"],
+        help="Muon LR adjustment. 'match_rms_adamw' matches AdamW's update RMS.",
+    )
 
     args = parser.parse_args()
     resolve_loss_fn(args.loss_fn)

--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -80,7 +80,7 @@ class BaseCheckpointer:
         loaded = torch.load(scheduler_path, weights_only=True)
         schedulers = _as_list(scheduler)
         loaded_list = loaded if isinstance(loaded, list) else [loaded]
-        for sched, state_dict in zip(schedulers, loaded_list, strict=False):
+        for sched, state_dict in zip(schedulers, loaded_list, strict=True):
             sched.load_state_dict(state_dict)
 
     def save_scheduler_state_dict(self, scheduler: SchedulerOrList, epoch: int | str):
@@ -269,7 +269,7 @@ class SingleGPUCheckpointer(BaseCheckpointer):
         optimizers = _as_list(optimizer)
         loaded_list = loaded if isinstance(loaded, list) else [loaded]
         dtype = float_dtype or model.dtype
-        for opt, state_dict in zip(optimizers, loaded_list, strict=False):
+        for opt, state_dict in zip(optimizers, loaded_list, strict=True):
             opt.load_state_dict(convert_float_dtype(state_dict, dtype))
 
     def save_checkpoint(

--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -21,6 +21,17 @@ from speculators.utils.util import get_current_device
 
 logger = logging.getLogger("speculators")
 
+# Optimizers/schedulers may be a single object (legacy) or a list (e.g. Muon + AdamW).
+OptimizerOrList = torch.optim.Optimizer | list[torch.optim.Optimizer]
+SchedulerOrList = (
+    torch.optim.lr_scheduler.LRScheduler | list[torch.optim.lr_scheduler.LRScheduler]
+)
+
+
+def _as_list(value):
+    """Normalize a single object or a list/tuple of objects into a list."""
+    return list(value) if isinstance(value, (list, tuple)) else [value]
+
 
 class BaseCheckpointer:
     """Helper class to save and load checkpoints.
@@ -57,31 +68,33 @@ class BaseCheckpointer:
     def load_optimizer_state_dict(
         self,
         model: PreTrainedModel,
-        optimizer: torch.optim.Optimizer,
+        optimizer: OptimizerOrList,
         float_dtype: torch.dtype | None = None,
     ):
         raise NotImplementedError
 
-    def load_scheduler_state_dict(
-        self, scheduler: torch.optim.lr_scheduler.LRScheduler
-    ):
+    def load_scheduler_state_dict(self, scheduler: SchedulerOrList):
         scheduler_path = self.scheduler_path(self.previous_epoch)
         if not scheduler_path.exists():
             return
-        full_state_dict = torch.load(scheduler_path, weights_only=True)
-        scheduler.load_state_dict(full_state_dict)
+        loaded = torch.load(scheduler_path, weights_only=True)
+        schedulers = _as_list(scheduler)
+        loaded_list = loaded if isinstance(loaded, list) else [loaded]
+        for sched, state_dict in zip(schedulers, loaded_list, strict=False):
+            sched.load_state_dict(state_dict)
 
-    def save_scheduler_state_dict(
-        self, scheduler: torch.optim.lr_scheduler.LRScheduler, epoch: int | str
-    ):
-        scheduler_path = self.scheduler_path(epoch)
-        torch.save(scheduler.state_dict(), scheduler_path)
+    def save_scheduler_state_dict(self, scheduler: SchedulerOrList, epoch: int | str):
+        schedulers = _as_list(scheduler)
+        state_dicts = [sched.state_dict() for sched in schedulers]
+        # Preserve the legacy single-scheduler format when there is only one.
+        payload = state_dicts[0] if len(state_dicts) == 1 else state_dicts
+        torch.save(payload, self.scheduler_path(epoch))
 
     @abstractmethod
     def save_checkpoint(
         self,
         model: PreTrainedModel,
-        optimizer: torch.optim.Optimizer,
+        optimizer: OptimizerOrList,
         epoch: int | str,
         float_dtype: torch.dtype = torch.bfloat16,
     ):
@@ -244,31 +257,37 @@ class SingleGPUCheckpointer(BaseCheckpointer):
     def load_optimizer_state_dict(
         self,
         model: PreTrainedModel,
-        optimizer: torch.optim.Optimizer,
+        optimizer: OptimizerOrList,
         float_dtype: torch.dtype | None = None,
     ):
         device = get_current_device()
-        full_state_dict = torch.load(
+        loaded = torch.load(
             self.optimizer_path(self.previous_epoch),
             weights_only=True,
             map_location=device,
         )
-        full_state_dict = convert_float_dtype(
-            full_state_dict, float_dtype or model.dtype
-        )
-        optimizer.load_state_dict(full_state_dict)
+        optimizers = _as_list(optimizer)
+        loaded_list = loaded if isinstance(loaded, list) else [loaded]
+        dtype = float_dtype or model.dtype
+        for opt, state_dict in zip(optimizers, loaded_list, strict=False):
+            opt.load_state_dict(convert_float_dtype(state_dict, dtype))
 
     def save_checkpoint(
         self,
         model: PreTrainedModel,
-        optimizer: torch.optim.Optimizer,
+        optimizer: OptimizerOrList,
         epoch: int | str,
         float_dtype: torch.dtype = torch.bfloat16,
     ):
         model_state_dict = convert_float_dtype(model.state_dict(), float_dtype)
         model.save_pretrained(self.path / str(epoch), state_dict=model_state_dict)
-        optimizer_state_dict = convert_float_dtype(optimizer.state_dict(), float_dtype)
-        torch.save(optimizer_state_dict, self.optimizer_path(epoch))
+        optimizers = _as_list(optimizer)
+        state_dicts = [
+            convert_float_dtype(opt.state_dict(), float_dtype) for opt in optimizers
+        ]
+        # Preserve the legacy single-optimizer format when there is only one.
+        payload = state_dicts[0] if len(state_dicts) == 1 else state_dicts
+        torch.save(payload, self.optimizer_path(epoch))
 
 
 class DistributedCheckpointer(BaseCheckpointer):
@@ -295,9 +314,10 @@ class DistributedCheckpointer(BaseCheckpointer):
     def load_optimizer_state_dict(
         self,
         model,
-        optimizer: torch.optim.Optimizer,
+        optimizer: OptimizerOrList,
         float_dtype: torch.dtype | None = None,
     ):
+        optimizers = _as_list(optimizer)
         full_state_dict = torch.load(
             self.optimizer_path(self.previous_epoch),
             mmap=True,
@@ -310,22 +330,23 @@ class DistributedCheckpointer(BaseCheckpointer):
 
         set_optimizer_state_dict(
             model,
-            optimizer,
+            optimizers,
             full_state_dict,
             options=StateDictOptions(full_state_dict=True, broadcast_from_rank0=True),
         )
 
         # Cast step counters back to float32
-        for state in optimizer.state.values():
-            if "step" in state and isinstance(state["step"], torch.Tensor):
-                state["step"] = state["step"].float()
+        for opt in optimizers:
+            for state in opt.state.values():
+                if "step" in state and isinstance(state["step"], torch.Tensor):
+                    state["step"] = state["step"].float()
 
         dist.barrier()
 
     def save_checkpoint(
         self,
         model: PreTrainedModel,
-        optimizer: torch.optim.Optimizer,
+        optimizer: OptimizerOrList,
         epoch: int | str,
         float_dtype: torch.dtype = torch.bfloat16,
     ):
@@ -336,7 +357,7 @@ class DistributedCheckpointer(BaseCheckpointer):
 
         optimizer_state_dict = get_optimizer_state_dict(
             model,
-            optimizer,
+            _as_list(optimizer),
             options=StateDictOptions(full_state_dict=True, cpu_offload=True),
         )
         optimizer_state_dict = convert_float_dtype(optimizer_state_dict, float_dtype)
@@ -365,9 +386,7 @@ class DistributedCheckpointer(BaseCheckpointer):
             super().save_val_metrics(epoch, val_metrics)
         dist.barrier()
 
-    def save_scheduler_state_dict(
-        self, scheduler: torch.optim.lr_scheduler.LRScheduler, epoch: int | str
-    ):
+    def save_scheduler_state_dict(self, scheduler: SchedulerOrList, epoch: int | str):
         if dist.get_rank() == 0:
             super().save_scheduler_state_dict(scheduler, epoch)
 

--- a/src/speculators/train/optimizers.py
+++ b/src/speculators/train/optimizers.py
@@ -29,26 +29,28 @@ _ADAMW_NAME_HINTS = ("embed_tokens", "lm_head")
 _MATRIX_NDIM = 2
 
 
-def split_named_params_for_muon(model: Module) -> tuple[list[Tensor], list[Tensor]]:
+def split_named_params_for_muon(
+    model: Module,
+) -> tuple[list[tuple[str, Tensor]], list[tuple[str, Tensor]]]:
     """Split a model's trainable parameters into Muon and AdamW groups.
 
     A parameter goes to the Muon group iff it requires gradients, is 2D, and is not an
     embedding or LM-head weight. All other trainable parameters go to the AdamW group.
 
     :param model: The model whose parameters should be partitioned.
-    :return: A ``(muon_params, adamw_params)`` tuple of parameter lists.
+    :return: A ``(muon_params, adamw_params)`` tuple of named parameter lists.
     """
-    muon_params: list[Tensor] = []
-    adamw_params: list[Tensor] = []
+    muon_params: list[tuple[str, Tensor]] = []
+    adamw_params: list[tuple[str, Tensor]] = []
     for name, param in model.named_parameters():
         if not param.requires_grad:
             continue
         if param.ndim == _MATRIX_NDIM and not any(
             hint in name for hint in _ADAMW_NAME_HINTS
         ):
-            muon_params.append(param)
+            muon_params.append((name, param))
         else:
-            adamw_params.append(param)
+            adamw_params.append((name, param))
     return muon_params, adamw_params
 
 
@@ -76,6 +78,7 @@ def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
             len(muon_params),
             len(adamw_params),
         )
+
         optimizers: list[torch.optim.Optimizer] = []
         if muon_params:
             optimizers.append(

--- a/src/speculators/train/optimizers.py
+++ b/src/speculators/train/optimizers.py
@@ -1,0 +1,103 @@
+"""Optimizer construction for speculator training.
+
+Provides a single entry point, :func:`build_optimizers`, that returns the list of
+optimizers the trainer should drive. The default ("adamw") returns a single AdamW
+optimizer over all parameters, preserving the historical behavior. The "muon" option
+returns two optimizers: ``torch.optim.Muon`` over the 2D weight matrices (which is all
+Muon supports) and ``torch.optim.AdamW`` over everything else (norms, biases, and the
+embedding / LM-head matrices, following standard Muon practice).
+
+Muon works transparently for both single-GPU and multi-GPU (FSDP2) training: when the
+model is sharded with ``fully_shard`` the parameters become ``DTensor``s and Muon's
+Newton-Schulz orthogonalization dispatches across ranks automatically.
+"""
+
+import logging
+
+import torch
+from torch import Tensor
+from torch.nn import Module
+
+logger = logging.getLogger("speculators")
+
+# Names of parameters that are 2D but should still be optimized with AdamW rather than
+# Muon, following the convention from Keller Jordan's Muon (embeddings and the output
+# head are excluded from the orthogonalized update).
+_ADAMW_NAME_HINTS = ("embed_tokens", "lm_head")
+
+# Muon only orthogonalizes 2D weight matrices.
+_MATRIX_NDIM = 2
+
+
+def split_named_params_for_muon(model: Module) -> tuple[list[Tensor], list[Tensor]]:
+    """Split a model's trainable parameters into Muon and AdamW groups.
+
+    A parameter goes to the Muon group iff it requires gradients, is 2D, and is not an
+    embedding or LM-head weight. All other trainable parameters go to the AdamW group.
+
+    :param model: The model whose parameters should be partitioned.
+    :return: A ``(muon_params, adamw_params)`` tuple of parameter lists.
+    """
+    muon_params: list[Tensor] = []
+    adamw_params: list[Tensor] = []
+    for name, param in model.named_parameters():
+        if not param.requires_grad:
+            continue
+        if param.ndim == _MATRIX_NDIM and not any(
+            hint in name for hint in _ADAMW_NAME_HINTS
+        ):
+            muon_params.append(param)
+        else:
+            adamw_params.append(param)
+    return muon_params, adamw_params
+
+
+def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
+    """Build the optimizer(s) for a training run based on ``config.optimizer``.
+
+    :param model: The model to optimize.
+    :param config: A ``TrainerConfig`` holding the optimizer hyperparameters.
+    :return: A list of optimizers for the trainer to step in tandem. The default
+        "adamw" returns a single optimizer; "muon" returns ``[Muon, AdamW]``.
+    """
+    if config.optimizer == "adamw":
+        return [
+            torch.optim.AdamW(
+                model.named_parameters(),
+                lr=config.lr,
+                weight_decay=config.weight_decay,
+            )
+        ]
+
+    if config.optimizer == "muon":
+        muon_params, adamw_params = split_named_params_for_muon(model)
+        logger.info(
+            "Muon optimizer: %d 2D params via Muon, %d params via AdamW.",
+            len(muon_params),
+            len(adamw_params),
+        )
+        optimizers: list[torch.optim.Optimizer] = []
+        if muon_params:
+            optimizers.append(
+                torch.optim.Muon(
+                    muon_params,
+                    lr=config.muon_lr,
+                    momentum=config.muon_momentum,
+                    weight_decay=config.muon_weight_decay,
+                    ns_steps=config.muon_ns_steps,
+                    adjust_lr_fn=config.muon_adjust_lr_fn,
+                )
+            )
+        if adamw_params:
+            optimizers.append(
+                torch.optim.AdamW(
+                    adamw_params,
+                    lr=config.lr,
+                    weight_decay=config.weight_decay,
+                )
+            )
+        if not optimizers:
+            raise ValueError("No trainable parameters found to optimize.")
+        return optimizers
+
+    raise ValueError(f"Unsupported optimizer: {config.optimizer!r}")

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -23,6 +23,7 @@ from speculators.train.checkpointer import (
     SingleGPUCheckpointer,
 )
 from speculators.train.graceful_shutdown import with_graceful_shutdown
+from speculators.train.optimizers import build_optimizers
 from speculators.train.utils import apply_fully_sharded, normalize_counted_metrics
 
 root_logger = logging.getLogger("speculators")
@@ -41,6 +42,13 @@ class TrainerConfig(NamedTuple):
     local_rank: int = 0
     train_call_kwargs: dict = {}
     val_call_kwargs: dict = {}
+    optimizer: Literal["adamw", "muon"] = "adamw"
+    weight_decay: float = 0.01
+    muon_lr: float = 0.02
+    muon_momentum: float = 0.95
+    muon_weight_decay: float = 0.1
+    muon_ns_steps: int = 5
+    muon_adjust_lr_fn: str = "match_rms_adamw"
     scheduler_type: Literal["linear", "cosine", "none"] = "linear"
     scheduler_warmup_steps: int | None = None
     scheduler_total_steps: int | None = None
@@ -143,16 +151,18 @@ class Trainer:
             dist.barrier()
 
     def setup_optimizer(self):
-        # Setup optimizer
-        self.opt = torch.optim.AdamW(self.model.named_parameters(), lr=self.config.lr)
+        # Setup optimizer(s). The "muon" option returns two optimizers (Muon for the
+        # 2D weight matrices, AdamW for everything else); "adamw" returns a single one.
+        self.optimizers = build_optimizers(self.model, self.config)
         last_epoch = -1
         if self.resume_from_checkpoint and self.checkpointer.previous_epoch != -1:
-            self.checkpointer.load_optimizer_state_dict(self.model, self.opt)
+            self.checkpointer.load_optimizer_state_dict(self.model, self.optimizers)
             last_epoch = self.checkpointer.previous_epoch
 
-        # Setup scheduler
+        # Setup scheduler(s) — one per optimizer so each optimizer's base LR (e.g.
+        # Muon's higher LR vs AdamW's) is warmed up / decayed independently.
         if self.config.scheduler_type == "none":
-            self.scheduler = None
+            self.schedulers: list[torch.optim.lr_scheduler.LRScheduler] = []
             return
 
         # Compute defaults if None
@@ -164,24 +174,38 @@ class Trainer:
             self.config.num_epochs * len(self.train_loader)
         )
 
-        if self.config.scheduler_type == "linear":
-            self.scheduler = get_linear_schedule_with_warmup(
-                self.opt,
-                num_warmup_steps=scheduler_warmup_steps,
-                num_training_steps=scheduler_total_steps,
-                last_epoch=last_epoch,
-            )
-        else:
-            self.scheduler = get_cosine_schedule_with_warmup(
-                self.opt,
+        def make_scheduler(opt: torch.optim.Optimizer):
+            if self.config.scheduler_type == "linear":
+                return get_linear_schedule_with_warmup(
+                    opt,
+                    num_warmup_steps=scheduler_warmup_steps,
+                    num_training_steps=scheduler_total_steps,
+                    last_epoch=last_epoch,
+                )
+            return get_cosine_schedule_with_warmup(
+                opt,
                 num_warmup_steps=scheduler_warmup_steps,
                 num_training_steps=scheduler_total_steps,
                 num_cycles=self.config.scheduler_num_cosine_cycles,
                 last_epoch=last_epoch,
             )
 
+        self.schedulers = [make_scheduler(opt) for opt in self.optimizers]
+
         if self.resume_from_checkpoint and self.checkpointer.previous_epoch != -1:
-            self.checkpointer.load_scheduler_state_dict(self.scheduler)
+            self.checkpointer.load_scheduler_state_dict(self.schedulers)
+
+    def _optimizers_zero_grad(self):
+        for opt in self.optimizers:
+            opt.zero_grad()
+
+    def _optimizers_step(self):
+        for opt in self.optimizers:
+            opt.step()
+
+    def _schedulers_step(self):
+        for scheduler in self.schedulers:
+            scheduler.step()
 
     def train_epoch(self, epoch: int):
         self.model.train()
@@ -210,14 +234,13 @@ class Trainer:
                 **gpu_batch, **self.config.train_call_kwargs
             )
 
-            self.opt.zero_grad()
+            self._optimizers_zero_grad()
             loss.backward()
             torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
-            self.opt.step()
+            self._optimizers_step()
 
-            current_lr = self.opt.param_groups[0]["lr"]
-            if self.scheduler is not None:
-                self.scheduler.step()
+            current_lr = self.optimizers[0].param_groups[0]["lr"]
+            self._schedulers_step()
 
             if self.global_step % self.config.log_freq == 0:
                 if self.is_distributed:
@@ -303,9 +326,9 @@ class Trainer:
             return
 
         root_logger.info(f"Saving checkpoint to {self.checkpointer.path / str(epoch)}")
-        self.checkpointer.save_checkpoint(self.model, self.opt, epoch)
-        if self.scheduler is not None:
-            self.checkpointer.save_scheduler_state_dict(self.scheduler, epoch)
+        self.checkpointer.save_checkpoint(self.model, self.optimizers, epoch)
+        if self.schedulers:
+            self.checkpointer.save_scheduler_state_dict(self.schedulers, epoch)
         root_logger.info(f"Checkpoint saved to {self.checkpointer.path / str(epoch)}")
 
     def maybe_update_best(self, epoch: int, val_metrics: dict | None):
@@ -315,9 +338,9 @@ class Trainer:
             return
 
         if self.config.save_best:
-            self.checkpointer.save_checkpoint(self.model, self.opt, epoch)
-            if self.scheduler is not None:
-                self.checkpointer.save_scheduler_state_dict(self.scheduler, epoch)
+            self.checkpointer.save_checkpoint(self.model, self.optimizers, epoch)
+            if self.schedulers:
+                self.checkpointer.save_scheduler_state_dict(self.schedulers, epoch)
         elif self.config.checkpoint_freq >= 1 and not (
             epoch == 0 or (epoch + 1) % int(self.config.checkpoint_freq) == 0
         ):

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -239,7 +239,9 @@ class Trainer:
             torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
             self._optimizers_step()
 
-            current_lr = self.optimizers[0].param_groups[0]["lr"]
+            current_lrs = {
+                type(opt).__name__: opt.param_groups[0]["lr"] for opt in self.optimizers
+            }
             self._schedulers_step()
 
             if self.global_step % self.config.log_freq == 0:
@@ -250,11 +252,16 @@ class Trainer:
                 metrics = {k: v.item() for k, v in metrics.items()}
                 world_size = dist.get_world_size() if self.is_distributed else 1
                 metrics = normalize_counted_metrics(metrics, world_size)
+                lr_info = (
+                    current_lrs
+                    if len(current_lrs) > 1
+                    else next(iter(current_lrs.values()))
+                )
                 metric_logger.info(
                     {
                         "train": metrics,
                         "epoch": epoch,
-                        "lr": current_lr,
+                        "lr": lr_info,
                         "global_step": self.global_step,
                     },
                     extra={"step": self.global_step},

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -35,8 +35,8 @@ def _make_minimal_trainer(tmp_path: Path, checkpoint_freq: int, save_best: bool)
     trainer.checkpointer = SingleGPUCheckpointer(str(tmp_path))
 
     trainer.model = cast("SpeculatorModel", object())
-    trainer.opt = cast("torch.optim.AdamW", object())
-    trainer.scheduler = None
+    trainer.optimizers = cast("list[torch.optim.Optimizer]", [object()])
+    trainer.schedulers = []
     return trainer
 
 


### PR DESCRIPTION
We recently found and validated that Muon optimizer performs much better than Adam in training of speculator models.
Validated on two models: decoder-only (Qwen3-8B) and an MoE (Laguna-XS.2). 
Training setup is the standard Magpie dataset, 50k samples for 1 epoch.
Validation setup: an extensive LR sweep for both Adam and Muon. 

Test example 1: 
a) Qwen3-8B, DFlash, LR sweep, metric=accuracy
<img width="1138" height="703" alt="image" src="https://github.com/user-attachments/assets/cf40ea1b-4b88-485b-a72c-8ec282156a44" />

b) Qwen3-8B, DFlash, LR sweep, metric=loss
<img width="1136" height="708" alt="image" src="https://github.com/user-attachments/assets/260e0c81-549e-4298-9873-a754e380436f" />

Test example 2:
a) Laguna-XS.2, DFlash, LR sweep, metric=accuracy
<img width="1114" height="682" alt="image" src="https://github.com/user-attachments/assets/cf0574f7-3f70-4d2e-a14d-e8349a3e26e2" />

b) Laguna-XS.2, DFlash, LR sweep, metric=loss
<img width="1111" height="707" alt="image" src="https://github.com/user-attachments/assets/601213ac-91e3-4dee-b59a-9410b14cf357" />


A few notes regarding the implementation:
- it supports single and multi-gpu training
- Muon optimizer can be used only for 2D weight matrices, so Adam is used for others
- this means we need to enable support for "a list of optimizers"