### PR TITLE
raise error for nan hidden states

### DIFF
--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -23,10 +23,11 @@ from typing import Any
 
 import openai
 from datasets import load_from_disk
+from safetensors.torch import load_file
 from tqdm import tqdm
 
 from speculators.data_generation.offline import (
-    check_safetensors_file,
+    check_hidden_states,
     get_existing_hidden_state_indices,
     get_indices_to_process,
 )
@@ -241,9 +242,12 @@ async def worker(  # noqa: C901
                     shutil.move, hidden_states_path, target_hidden_states_path
                 )
                 if validate_outputs:
+                    loaded = await asyncio.to_thread(
+                        load_file, target_hidden_states_path
+                    )
                     await asyncio.to_thread(
-                        check_safetensors_file,
-                        target_hidden_states_path,
+                        check_hidden_states,
+                        loaded,
                         item["input_ids"],
                     )
         except Exception as e:

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -242,14 +242,15 @@ async def worker(  # noqa: C901
                     shutil.move, hidden_states_path, target_hidden_states_path
                 )
                 if validate_outputs:
-                    loaded = await asyncio.to_thread(
-                        load_file, target_hidden_states_path
-                    )
-                    await asyncio.to_thread(
-                        check_hidden_states,
-                        loaded,
-                        item["input_ids"],
-                    )
+
+                    def _load_and_check(
+                        path=target_hidden_states_path,
+                        tokens=item["input_ids"],
+                    ):
+                        loaded = load_file(path)
+                        check_hidden_states(loaded, tokens)
+
+                    await asyncio.to_thread(_load_and_check)
         except Exception as e:
             if fail_on_error:
                 logger.exception(

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -23,10 +23,10 @@ from typing import Any
 
 import openai
 from datasets import load_from_disk
-from safetensors import safe_open
 from tqdm import tqdm
 
 from speculators.data_generation.offline import (
+    check_safetensors_file,
     get_existing_hidden_state_indices,
     get_indices_to_process,
 )
@@ -189,23 +189,6 @@ def parse_args():
         ),
     )
     return parser.parse_args()
-
-
-def check_safetensors_file(path: Path, tokens: list[int]):
-    with safe_open(path, "pt") as f:
-        t_ids = f.get_tensor("token_ids").tolist()
-        if t_ids != tokens:
-            raise ValueError(
-                f"Token ids in {path} don't match expected token ids {tokens}"
-            )
-
-        hs_slice = f.get_slice("hidden_states")
-        hs_shape = list(hs_slice.get_shape())
-        if len(tokens) != hs_shape[0]:
-            raise ValueError(
-                f"Sequence length of hidden states {hs_shape[0]} in {path}"
-                f" doesn't match num tokens {len(tokens)}"
-            )
 
 
 async def worker(  # noqa: C901

--- a/src/speculators/data_generation/offline.py
+++ b/src/speculators/data_generation/offline.py
@@ -1,28 +1,22 @@
 import logging
 from pathlib import Path
 
-from safetensors import safe_open
-
 logger = logging.getLogger(__name__)
 
 
-def check_safetensors_file(path: Path, tokens: list[int]):
-    with safe_open(path, "pt") as f:
-        t_ids = f.get_tensor("token_ids").tolist()
-        if t_ids != tokens:
-            raise ValueError(
-                f"Token ids in {path} don't match expected token ids {tokens}"
-            )
+def check_hidden_states(data: dict, tokens: list[int]):
+    t_ids = data["token_ids"].tolist()
+    if t_ids != tokens:
+        raise ValueError(f"Token ids don't match expected token ids {tokens}")
 
-        hs = f.get_tensor("hidden_states")
-        if hs.isnan().any():
-            raise ValueError(f"Hidden states in {path} contain NaN values")
-        hs_shape = list(hs.shape)
-        if len(tokens) != hs_shape[0]:
-            raise ValueError(
-                f"Sequence length of hidden states {hs_shape[0]} in {path}"
-                f" doesn't match num tokens {len(tokens)}"
-            )
+    hs = data["hidden_states"]
+    if hs.isnan().any():
+        raise ValueError("Hidden states contain NaN values")
+    if len(tokens) != hs.shape[0]:
+        raise ValueError(
+            f"Sequence length of hidden states {hs.shape[0]}"
+            f" doesn't match num tokens {len(tokens)}"
+        )
 
 
 def get_existing_hidden_state_indices(output_path: Path) -> list[int]:

--- a/src/speculators/data_generation/offline.py
+++ b/src/speculators/data_generation/offline.py
@@ -1,7 +1,30 @@
 import logging
 from pathlib import Path
 
+from safetensors import safe_open
+
 logger = logging.getLogger(__name__)
+
+
+def check_safetensors_file(path: Path, tokens: list[int]):
+    with safe_open(path, "pt") as f:
+        t_ids = f.get_tensor("token_ids").tolist()
+        if t_ids != tokens:
+            raise ValueError(
+                f"Token ids in {path} don't match expected token ids {tokens}"
+            )
+
+        hs = f.get_tensor("hidden_states")
+        if hs.isnan().any():
+            raise ValueError(
+                f"Hidden states in {path} contain NaN values"
+            )
+        hs_shape = list(hs.shape)
+        if len(tokens) != hs_shape[0]:
+            raise ValueError(
+                f"Sequence length of hidden states {hs_shape[0]} in {path}"
+                f" doesn't match num tokens {len(tokens)}"
+            )
 
 
 def get_existing_hidden_state_indices(output_path: Path) -> list[int]:

--- a/src/speculators/data_generation/offline.py
+++ b/src/speculators/data_generation/offline.py
@@ -16,9 +16,7 @@ def check_safetensors_file(path: Path, tokens: list[int]):
 
         hs = f.get_tensor("hidden_states")
         if hs.isnan().any():
-            raise ValueError(
-                f"Hidden states in {path} contain NaN values"
-            )
+            raise ValueError(f"Hidden states in {path} contain NaN values")
         hs_shape = list(hs.shape)
         if len(tokens) != hs_shape[0]:
             raise ValueError(

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -16,6 +16,7 @@ from datasets import load_from_disk
 from safetensors.torch import load_file
 from torch.utils.data import Dataset
 
+from speculators.data_generation.offline import check_safetensors_file
 from speculators.data_generation.vllm_client import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_REQUEST_TIMEOUT,
@@ -323,6 +324,11 @@ class ArrowDataset(BaseDataset):
 
             loaded_hs = _maybe_load_hs_file(Path(hs_filepath))
 
+            check_safetensors_file(
+                Path(hs_filepath),
+                dataset_item["input_ids"].tolist(),
+            )
+
             match self.on_generate:
                 case "cache":
                     file_idx = self._map_to_file_idx(index)
@@ -331,6 +337,8 @@ class ArrowDataset(BaseDataset):
                 case "delete":
                     Path(hs_filepath).unlink()
         except Exception as e:  # noqa: BLE001
+            if isinstance(e, ValueError) and "NaN" in str(e):
+                raise
             warnings.warn(
                 f"Failed to load/cache hidden states for sample {index}: {e}",
                 stacklevel=1,
@@ -365,7 +373,7 @@ class ArrowDataset(BaseDataset):
             return loaded_hs
 
         # loaded_hs structure: {
-        #   "hidden_states": [seq_len, 4, hidden_size]
+        #   "hidden_states": [seq_len, num_layers, hidden_size]
         #   "token_ids": [seq_len]
         # }
 

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -323,6 +323,8 @@ class ArrowDataset(BaseDataset):
             )
 
             loaded_hs = _maybe_load_hs_file(Path(hs_filepath))
+            if loaded_hs is None:
+                raise ValueError(f"Failed to load hidden states from {hs_filepath}")
 
             check_hidden_states(loaded_hs, dataset_item["input_ids"].tolist())
 

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -336,7 +336,7 @@ class ArrowDataset(BaseDataset):
                     shutil.move(hs_filepath, target_path)
                 case "delete":
                     Path(hs_filepath).unlink()
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             if isinstance(e, ValueError) and "NaN" in str(e):
                 raise
             warnings.warn(

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -16,7 +16,7 @@ from datasets import load_from_disk
 from safetensors.torch import load_file
 from torch.utils.data import Dataset
 
-from speculators.data_generation.offline import check_safetensors_file
+from speculators.data_generation.offline import check_hidden_states
 from speculators.data_generation.vllm_client import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_REQUEST_TIMEOUT,
@@ -324,10 +324,7 @@ class ArrowDataset(BaseDataset):
 
             loaded_hs = _maybe_load_hs_file(Path(hs_filepath))
 
-            check_safetensors_file(
-                Path(hs_filepath),
-                dataset_item["input_ids"].tolist(),
-            )
+            check_hidden_states(loaded_hs, dataset_item["input_ids"].tolist())
 
             match self.on_generate:
                 case "cache":


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
We had a failure early this week due to hiddenstatesconnector sending nan hidden states. However, our training kept going. We should explicitly fair when getting garbage hidden states

## Tests
Tested locally and ran the e2e smoke tests.

Now failes directly:
``` bash
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/shanjiaz/speculators/src/speculators/train/data.py", line 327, in _maybe_generate_hs
    check_hidden_states(loaded_hs, dataset_item["input_ids"].tolist())
  File "/home/shanjiaz/speculators/src/speculators/data_generation/offline.py", line 17, in check_hidden_states
    raise ValueError("Hidden states contain NaN values")
ValueError: Hidden states contain NaN values
================================================== 1 failed, 16 warnings in 180.86s (0:03:00) ==================================================
```

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
