### PR TITLE
feat(train): add cli options to extend --from-pretrained for config-only init

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -36,11 +36,15 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 - **`--speculator-type`** (str, default: `"eagle3"`) Type of speculator model to train. Options: `eagle3`, `dflash`
 
-- **`--from-pretrained`** (str, default: `""`) Path to a pretrained draft model to finetune.
+- **`--from-pretrained`** (str, default: `""`) Path or HF id of an existing draft checkpoint to load weights from and train — either a previously trained draft or the initialized-but-untrained checkpoint produced by `--dry-run`. May also point to a local directory containing only a `config.json`, in which case a fresh draft is initialized from that full speculator config. Takes precedence over all other model-definition options: it is mutually exclusive with `--draft-config` and the decoder-shaping flags (`--num-layers`, `--draft-arch`, `--draft-hidden-act`, `--sliding-window`, `--sliding-window-indices`).
+
+- **`--draft-config`** (str, default: `""`) HF id, directory, or JSON path of a decoder config (`LlamaConfig` for eagle3/peagle, `Qwen3Config` for dflash) used as the draft `transformer_layer_config`; the rest of the speculator is built from the other CLI args. The draft `hidden_size` must match the verifier (mismatch is not yet supported). If a full speculator config is passed, its nested `transformer_layer_config` is extracted. Mutually exclusive with `--from-pretrained` and with the decoder-shaping flags (`--num-layers`, `--draft-arch`, `--draft-hidden-act`, `--sliding-window`, `--sliding-window-indices`).
+
+- **`--dry-run`** (flag) Build the speculator, initialize weights, save a checkpoint to `--save-path`, then exit before training. Useful to validate the config/weights in vLLM before launching a full run; the saved checkpoint can be fed straight back via `--from-pretrained`.
 
 - **`--num-layers`** (int, default: `1`) Number of transformer layers in the draft model.
 
-- **`--draft-arch`** (str, default: `"llama"`) Architecture for draft decoder layers (only applies to Eagle3 currently). Options: `llama`, `qwen3` **Warning:** Only `llama` is currently supported in vLLM for inference.
+- **`--draft-arch`** (str, default: `"llama"`) Architecture for the synthesized draft decoder layers. Options: `llama`, `qwen3`. Used by Eagle3 and P-EAGLE, which select the decoder layer class from this value; DFlash always uses a Qwen3-style decoder regardless. Both are supported in vLLM for inference, and the target and draft architectures do not have to match.
 
 - **`--draft-hidden-act`** (str, default: `"silu"`) Activation function for draft decoder layers. Setting as `None` will inherit activation function from the verifier model.
 
@@ -259,6 +263,29 @@ python scripts/train.py \
   --data-path ./new_training_data \
   --hidden-states-path ./hidden_states \
   --save-path ./finetuned_checkpoints \
+  --epochs 5 \
+  --lr 5e-6
+```
+
+### Initializing From a Decoder Config (with Dry-Run Validation)
+
+```bash
+# Build the speculator from a plain decoder config, initialize weights, save a
+# checkpoint, and exit before training so it can be validated in vLLM first.
+python scripts/train.py \
+  --verifier-name-or-path Qwen/Qwen3-8B \
+  --speculator-type dflash \
+  --draft-config ./qwen3_draft_decoder_config.json \
+  --draft-vocab-size 32000 \
+  --save-path ./draft_init \
+  --dry-run
+
+# After validating ./draft_init in vLLM, train starting from it:
+python scripts/train.py \
+  --verifier-name-or-path Qwen/Qwen3-8B \
+  --speculator-type dflash \
+  --from-pretrained ./draft_init \
+  --data-path ./training_data \
   --epochs 5 \
   --lr 5e-6
 ```

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -686,6 +686,9 @@ def validate_draft_init_args(
     options: it is mutually exclusive with ``--draft-config`` and with the
     decoder-shaping flags, since those values come from the checkpoint.
     ``--draft-config`` is likewise incompatible with the decoder-shaping flags.
+    MTP from scratch (``--speculator-type mtp`` without ``--from-pretrained``)
+    reuses the verifier's own decoder config, so ``--draft-config`` and the
+    decoder-shaping flags do not apply and are rejected.
 
     ``provided`` is the set of decoder-shaping dests the user explicitly passed
     (see :func:`speculators.utils.argparse_utils.explicitly_provided_dests`); a flag
@@ -698,15 +701,24 @@ def validate_draft_init_args(
             parser.error(
                 "--from-pretrained loads a complete draft model and takes precedence "
                 "over all other model-definition options, so these conflict with it "
-                f"(remove them): "
-                f"{', '.join(conflicting)}"
+                f"(remove them): {', '.join(conflicting)}"
+            )
+        return
+    if args.speculator_type == "mtp":
+        # MTP-from-scratch reuses the verifier's own decoder config and extracts the
+        # native MTP head weights; --draft-config and the decoder-shaping flags do not
+        # apply, so reject them rather than silently ignoring them.
+        conflicting = shaping + (["--draft-config"] if args.draft_config else [])
+        if conflicting:
+            parser.error(
+                "--speculator-type mtp reuses the verifier's decoder config, so these "
+                f"options do not apply (remove them): {', '.join(conflicting)}"
             )
         return
     if args.draft_config and shaping:
         parser.error(
             "--draft-config defines the draft decoder, so these flags conflict with "
-            "it (remove them): "
-            f"{', '.join(shaping)}"
+            f"it (remove them): {', '.join(shaping)}"
         )
 
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -23,6 +23,10 @@ from speculators.model import SpeculatorModel
 from speculators.models.eagle3.data import shift_batch
 from speculators.models.metrics import resolve_loss_fn
 from speculators.models.mtp.data import shift_batch_mtp
+from speculators.models.utils import (
+    get_verifier_config,
+    resolve_draft_intermediate_size,
+)
 from speculators.train.data import (
     ArrowDataset,
     BaseDataset,
@@ -45,6 +49,8 @@ from speculators.train.vocab_mapping import (
     build_vocab_mappings_from_distribution,
     get_target_vocab_size,
 )
+from speculators.utils.argparse_utils import explicitly_provided_dests
+from speculators.utils.loading import is_config_only_dir
 
 logger = logging.getLogger(__name__)
 
@@ -128,11 +134,11 @@ def create_transformer_layer_config(  # noqa: C901
             f"Available: {list(DRAFT_ARCH_CONFIGS.keys())}"
         )
 
-    if draft_arch != "llama":
+    if draft_arch not in ("llama", "qwen3"):
         warnings.warn(
             f"Draft architecture '{draft_arch}' is not yet supported in vLLM. "
             "The trained model may not be usable for inference in vLLM. "
-            "Consider using 'llama' (the default) for full vLLM compatibility.",
+            "Consider using 'llama' or 'qwen3' for full vLLM compatibility.",
             stacklevel=2,
         )
 
@@ -182,7 +188,7 @@ def create_transformer_layer_config(  # noqa: C901
     config = config_class(
         vocab_size=verifier_config.vocab_size,
         hidden_size=verifier_config.hidden_size,
-        intermediate_size=verifier_config.intermediate_size,
+        intermediate_size=resolve_draft_intermediate_size(verifier_config),
         num_hidden_layers=num_layers,
         num_attention_heads=num_attention_heads,
         num_key_value_heads=num_key_value_heads,
@@ -209,6 +215,52 @@ def create_transformer_layer_config(  # noqa: C901
         config.rope_theta = getattr(verifier_config, "rope_theta", 10000.0)
 
     return config
+
+
+def load_draft_transformer_layer_config(
+    draft_config: str,
+    verifier_name_or_path: str,
+) -> PretrainedConfig:
+    """Load the draft decoder ``transformer_layer_config`` from a config source.
+
+    ``draft_config`` may be a HF hub id, a local directory containing a
+    ``config.json``, or a path to a config JSON file. It is expected to hold a
+    plain decoder config (``LlamaConfig`` for eagle3/peagle, ``Qwen3Config`` for
+    dflash). If a full speculator config is given instead, its nested
+    ``transformer_layer_config`` is extracted as a convenience.
+
+    The decoder is reconciled against the verifier: ``hidden_size`` must match
+    (draft/verifier hidden-size mismatch is not yet supported) and ``vocab_size``
+    is aligned to the verifier's target vocabulary. The pruned draft vocabulary
+    is controlled separately via ``--draft-vocab-size``.
+    """
+    config_dict, _ = PretrainedConfig.get_config_dict(draft_config)
+    if "transformer_layer_config" in config_dict:
+        # A full speculator config was passed; use only the decoder definition.
+        config_dict = config_dict["transformer_layer_config"]
+
+    model_type = config_dict.get("model_type")
+    config_class: type[PretrainedConfig] = (
+        type(AutoConfig.for_model(model_type)) if model_type else Qwen3Config
+    )
+    draft_config_obj = config_class.from_dict(config_dict)
+
+    verifier_config = get_verifier_config(verifier_name_or_path)
+    if draft_config_obj.hidden_size != verifier_config.hidden_size:
+        raise ValueError(
+            f"--draft-config hidden_size ({draft_config_obj.hidden_size}) must match "
+            f"the verifier hidden_size ({verifier_config.hidden_size}). Draft/verifier "
+            "hidden-size mismatch is not yet supported."
+        )
+    if draft_config_obj.vocab_size != verifier_config.vocab_size:
+        logger.warning(
+            "Overriding --draft-config vocab_size (%s) with the verifier vocab_size "
+            "(%s). Use --draft-vocab-size to control the pruned draft vocabulary.",
+            draft_config_obj.vocab_size,
+            verifier_config.vocab_size,
+        )
+        draft_config_obj.vocab_size = verifier_config.vocab_size
+    return draft_config_obj
 
 
 def _load_mappings(d2t_path, t2d_path, expected_draft_vocab_size: int | None):
@@ -283,6 +335,112 @@ def parse_vocab_mappings(args: argparse.Namespace):
     return None, None, verifier_config.vocab_size
 
 
+def _build_from_config_only(
+    model_class: type[SpeculatorModel],
+    path: str,
+    t2d: torch.Tensor | None,
+    d2t: torch.Tensor | None,
+    verifier_name_or_path: str | None = None,
+) -> SpeculatorModel:
+    """Initialize a fresh draft from a saved speculator *config* (no weights).
+
+    Mirrors the tail of ``from_training_args``: build the model from the full
+    speculator config, load vocab mappings, and pull verifier weights -- but with
+    no trained draft weights to restore (decoder weights are randomly initialized).
+    """
+    config = model_class.config_class.from_pretrained(path)
+    speculators_config = getattr(config, "speculators_config", None)
+    # Fall back to the CLI --verifier-name-or-path only when the saved config has
+    # no verifier path -- either null or blanked to "". A real path in the config
+    # takes precedence and the CLI value is ignored.
+    if (
+        verifier_name_or_path
+        and speculators_config is not None
+        and not getattr(speculators_config.verifier, "name_or_path", None)
+    ):
+        speculators_config.verifier.name_or_path = verifier_name_or_path
+    model = model_class(config=config)
+    if hasattr(model, "load_vocab_mappings"):
+        model.load_vocab_mappings(t2d, d2t)  # type: ignore[attr-defined]
+    if hasattr(model, "load_verifier_weights"):
+        model.load_verifier_weights()  # type: ignore[attr-defined]
+    return model
+
+
+def build_draft_model(
+    args: argparse.Namespace,
+    model_class: type[SpeculatorModel],
+    t2d: torch.Tensor | None,
+    d2t: torch.Tensor | None,
+    draft_vocab_size: int | None,
+) -> SpeculatorModel:
+    """Resolve the draft model from one of these sources:
+
+    * ``--from-pretrained``: finetune existing weights, or -- when the path is a
+      config-only directory -- initialize fresh weights from a full saved
+      speculator config.
+    * ``--draft-config``: take the decoder ``transformer_layer_config`` from a
+      config file; build the rest of the speculator from the other CLI args.
+    * neither: synthesize the decoder from the verifier config + CLI flags.
+
+    MTP is special-cased: when not loading ``--from-pretrained``, it reuses the
+    verifier's own decoder config as the draft ``transformer_layer_config`` and
+    extracts the native MTP head weights from the verifier, so the decoder-shaping
+    flags and ``--draft-config`` do not apply.
+    """
+    if args.from_pretrained:
+        if is_config_only_dir(args.from_pretrained):
+            logger.info(
+                "--from-pretrained points to a config-only directory ('%s'); "
+                "initializing fresh draft weights from the saved speculator config.",
+                args.from_pretrained,
+            )
+            return _build_from_config_only(
+                model_class,
+                args.from_pretrained,
+                t2d=t2d,
+                d2t=d2t,
+                verifier_name_or_path=args.verifier_name_or_path,
+            )
+        return model_class.from_pretrained(args.from_pretrained, t2d=t2d, d2t=d2t)
+
+    if args.speculator_type == "mtp":
+        # MTP uses the verifier's own decoder config as the draft
+        # transformer_layer_config and extracts the native MTP head weights from
+        # the verifier; the decoder-shaping flags and --draft-config do not apply,
+        # and there is no draft mask token to resolve.
+        transformer_layer_config = get_verifier_config(args.verifier_name_or_path)
+    else:
+        if args.draft_config:
+            transformer_layer_config = load_draft_transformer_layer_config(
+                args.draft_config, args.verifier_name_or_path
+            )
+        else:
+            transformer_layer_config = create_transformer_layer_config(
+                verifier_name_or_path=args.verifier_name_or_path,
+                num_layers=args.num_layers,
+                draft_arch=args.draft_arch,
+                hidden_act=args.draft_hidden_act,
+                sliding_window=args.sliding_window,
+                sliding_window_indices=args.sliding_window_indices,
+            )
+
+        args.mask_token_id = resolve_mask_token_id(
+            args.verifier_name_or_path,
+            transformer_layer_config.vocab_size,
+            args.mask_token_id,
+            trust_remote_code=args.trust_remote_code,
+        )
+
+    args.draft_vocab_size = draft_vocab_size
+    return model_class.from_training_args(
+        verifier_config=transformer_layer_config,
+        t2d=t2d,
+        d2t=d2t,
+        **vars(args),
+    )
+
+
 def main(args: argparse.Namespace):  # noqa: C901, PLR0912
     # Set random seed for reproducibility
     set_seed(args.seed, args.deterministic_cuda)
@@ -307,11 +465,13 @@ def main(args: argparse.Namespace):  # noqa: C901, PLR0912
                 "--draft-attn-impl is not configurable for MTP. "
                 "Must be left with the default value ('simple_flex_attention')."
             )
-        verifier_config = AutoConfig.from_pretrained(args.verifier_name_or_path)
-        if hasattr(verifier_config, "text_config"):
-            verifier_config = verifier_config.text_config
-        d2t, t2d, draft_vocab_size = None, None, verifier_config.vocab_size
-        transformer_layer_config = verifier_config
+        # MTP reuses the verifier's own decoder as the draft and extracts the
+        # native MTP head weights from the verifier, so there are no vocab
+        # mappings or draft mask token to resolve from the CLI. This works both
+        # with --from-pretrained (a previously converted checkpoint) and without
+        # it (weights are extracted from the verifier on the fly). The decoder
+        # transformer_layer_config is resolved later in build_draft_model.
+        d2t, t2d, draft_vocab_size = None, None, None
         args.mask_token_id = None
     else:
         d2t, t2d, draft_vocab_size = parse_vocab_mappings(args)
@@ -322,22 +482,6 @@ def main(args: argparse.Namespace):  # noqa: C901, PLR0912
                 "draft models. Please open an issue/pr if you would like to use "
                 "sliding window attention with a different speculator type"
             )
-        # Setup speculator config
-        transformer_layer_config = create_transformer_layer_config(
-            verifier_name_or_path=args.verifier_name_or_path,
-            num_layers=args.num_layers,
-            draft_arch=args.draft_arch,
-            hidden_act=args.draft_hidden_act,
-            sliding_window=args.sliding_window,
-            sliding_window_indices=args.sliding_window_indices,
-        )
-
-        args.mask_token_id = resolve_mask_token_id(
-            args.verifier_name_or_path,
-            transformer_layer_config.vocab_size,
-            args.mask_token_id,
-            trust_remote_code=args.trust_remote_code,
-        )
 
     registry = SpeculatorModel.registry
     if registry is None or args.speculator_type not in registry:
@@ -348,24 +492,38 @@ def main(args: argparse.Namespace):  # noqa: C901, PLR0912
 
     model_class = registry[args.speculator_type]
 
-    if args.from_pretrained:
-        draft_model = model_class.from_pretrained(
-            args.from_pretrained, t2d=t2d, d2t=d2t
-        )
-    else:
-        args.draft_vocab_size = draft_vocab_size
-        draft_model = model_class.from_training_args(
-            verifier_config=transformer_layer_config,
-            t2d=t2d,
-            d2t=d2t,
-            **vars(args),
-        )
+    draft_model = build_draft_model(args, model_class, t2d, d2t, draft_vocab_size)
 
     # Get target layer IDs from the model (resolved at model level)
     num_target_layers = len(draft_model.target_layer_ids)
 
     if args.speculator_type == "mtp":
         args.num_speculative_steps = draft_model.config.num_speculative_steps
+
+    # Dry-run: persist an initialized checkpoint and exit before training so the
+    # config/weights can be validated (e.g. in vLLM). The saved checkpoint can be
+    # fed straight back via --from-pretrained to start training.
+    if args.dry_run:
+        # Match Trainer.setup_model: weights are (re)initialized in
+        # hidden_states_dtype, so save the dry-run checkpoint in that dtype too
+        # rather than the float32 the model is built in.
+        draft_model.to(hidden_states_dtype)
+        if local_rank == 0:
+            logger.info(
+                "[dry-run] Saving initialized checkpoint (%s) to '%s'",
+                hidden_states_dtype,
+                args.save_path,
+            )
+            draft_model.save_pretrained(args.save_path)
+            logger.info(
+                "[dry-run] Done. Validate this checkpoint, then train with "
+                "'--from-pretrained %s'.",
+                args.save_path,
+            )
+        maybe_destroy_distributed()
+        return
+
+    hidden_size = draft_model.config.transformer_layer_config.hidden_size
 
     # Setup dataloaders
     preprocess_fns = {
@@ -427,7 +585,7 @@ def main(args: argparse.Namespace):  # noqa: C901, PLR0912
         train_dataset,
         world_size,
         rank,
-        transformer_layer_config.hidden_size,
+        hidden_size,
         num_target_layers=num_target_layers,
         num_workers=args.num_workers,
         prefetch_factor=args.prefetch_factor,
@@ -437,7 +595,7 @@ def main(args: argparse.Namespace):  # noqa: C901, PLR0912
         val_dataset,
         world_size,
         rank,
-        transformer_layer_config.hidden_size,
+        hidden_size,
         num_target_layers=num_target_layers,
         num_workers=args.num_workers,
         prefetch_factor=args.prefetch_factor,
@@ -498,6 +656,60 @@ def _checkpoint_freq(value: str) -> float:
     return fvalue
 
 
+# CLI flags that synthesize the draft decoder shape. They conflict with both
+# --from-pretrained and --draft-config, each of which fully defines the draft.
+DECODER_SHAPING_FLAGS: dict[str, str] = {
+    "num_layers": "--num-layers",
+    "draft_arch": "--draft-arch",
+    "draft_hidden_act": "--draft-hidden-act",
+    "sliding_window": "--sliding-window",
+    "sliding_window_indices": "--sliding-window-indices",
+}
+
+
+def validate_draft_init_args(
+    parser: argparse.ArgumentParser,
+    args: argparse.Namespace,
+    provided: set[str],
+) -> None:
+    """Enforce the draft-init contract.
+
+    The draft model may be defined in exactly one way:
+
+    * ``--from-pretrained`` -- load a complete speculator checkpoint (or a
+      config-only directory); or
+    * ``--draft-config`` -- load just the decoder config and build the rest of
+      the speculator from the other CLI args; or
+    * the decoder-shaping flags (``--num-layers`` etc.) -- synthesize everything.
+
+    ``--from-pretrained`` takes precedence over all other model-definition
+    options: it is mutually exclusive with ``--draft-config`` and with the
+    decoder-shaping flags, since those values come from the checkpoint.
+    ``--draft-config`` is likewise incompatible with the decoder-shaping flags.
+
+    ``provided`` is the set of decoder-shaping dests the user explicitly passed
+    (see :func:`speculators.utils.argparse_utils.explicitly_provided_dests`); a flag
+    passed at its default value still counts as a conflict.
+    """
+    shaping = [flag for dest, flag in DECODER_SHAPING_FLAGS.items() if dest in provided]
+    if args.from_pretrained:
+        conflicting = shaping + (["--draft-config"] if args.draft_config else [])
+        if conflicting:
+            parser.error(
+                "--from-pretrained loads a complete draft model and takes precedence "
+                "over all other model-definition options, so these conflict with it "
+                f"(remove them): "
+                f"{', '.join(conflicting)}"
+            )
+        return
+    if args.draft_config and shaping:
+        parser.error(
+            "--draft-config defines the draft decoder, so these flags conflict with "
+            "it (remove them): "
+            f"{', '.join(shaping)}"
+        )
+
+
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--verifier-name-or-path", type=str, required=True)
@@ -516,7 +728,32 @@ def parse_args():
         "--from-pretrained",
         type=str,
         default="",
-        help="The pretrained draft model to finetune",
+        help="Path or HF id of a pretrained draft. May also point to a "
+        "local directory containing only a config.json, in which case a "
+        "fresh draft is initialized from that full speculator config. Takes precedence "
+        "over and is mutually exclusive with --draft-config and the decoder-shaping "
+        "flags (--num-layers, --draft-arch, --draft-hidden-act, --sliding-window, "
+        "--sliding-window-indices).",
+    )
+    parser.add_argument(
+        "--draft-config",
+        type=str,
+        default="",
+        help="HF id, directory, or JSON path of a decoder config (LlamaConfig for "
+        "eagle3/peagle, Qwen3Config for dflash) to use as the draft "
+        "transformer_layer_config; the rest of the speculator is built from the other "
+        "CLI args. Mutually exclusive with --from-pretrained and with the "
+        "decoder-shaping flags (--num-layers, --draft-arch, --draft-hidden-act, "
+        "--sliding-window, --sliding-window-indices).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Build the speculator, initialize weights, save a checkpoint to "
+        "--save-path, then exit before training. Useful to validate the config and "
+        "weights (e.g. in vLLM) before launching a full run. Can be combined with "
+        "--draft-config or --from-pretrained.",
     )
     parser.add_argument(
         "--data-path",
@@ -885,6 +1122,8 @@ def parse_args():
     )
 
     args = parser.parse_args()
+    provided = explicitly_provided_dests(parser, DECODER_SHAPING_FLAGS)
+    validate_draft_init_args(parser, args, provided)
     resolve_loss_fn(args.loss_fn)
     return args
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -240,9 +240,13 @@ def load_draft_transformer_layer_config(
         config_dict = config_dict["transformer_layer_config"]
 
     model_type = config_dict.get("model_type")
-    config_class: type[PretrainedConfig] = (
-        type(AutoConfig.for_model(model_type)) if model_type else Qwen3Config
-    )
+    if not model_type:
+        raise ValueError(
+            "--draft-config must define a 'model_type' (e.g. 'llama' for "
+            "eagle3/peagle, 'qwen3' for dflash); none was found in the config "
+            f"loaded from '{draft_config}'."
+        )
+    config_class: type[PretrainedConfig] = type(AutoConfig.for_model(model_type))
     draft_config_obj = config_class.from_dict(config_dict)
 
     verifier_config = get_verifier_config(verifier_name_or_path)
@@ -441,7 +445,7 @@ def build_draft_model(
     )
 
 
-def main(args: argparse.Namespace):  # noqa: C901, PLR0912
+def main(args: argparse.Namespace):  # noqa: C901
     # Set random seed for reproducibility
     set_seed(args.seed, args.deterministic_cuda)
 

--- a/src/speculators/config.py
+++ b/src/speculators/config.py
@@ -75,6 +75,28 @@ class VerifierConfig(BaseModel):
             architectures=config_dict.get("architectures") or [],
         )
 
+    @classmethod
+    def from_pretrained(cls, name_or_path: str, **kwargs: Any) -> "VerifierConfig":
+        """
+        Create a VerifierConfig by reading the verifier's published config.json.
+
+        Unlike :meth:`from_config`, which extracts fields from an already-loaded
+        ``PretrainedConfig`` object (e.g. a freshly built draft decoder config that
+        has no ``architectures`` set), this reads the verifier's ``config.json``
+        directly so ``architectures`` reflects the real verifier (for example
+        ``["Qwen3ForCausalLM"]``).
+
+        :param name_or_path: The Hugging Face id or local path of the verifier model.
+        :param kwargs: Forwarded to ``PretrainedConfig.get_config_dict`` (e.g.
+            ``cache_dir``, ``revision``).
+        :return: A VerifierConfig with the verifier's name_or_path and architectures.
+        """
+        config_dict, _ = PretrainedConfig.get_config_dict(name_or_path, **kwargs)
+        return cls(
+            name_or_path=name_or_path,
+            architectures=config_dict.get("architectures") or [],
+        )
+
     name_or_path: str | None = Field(
         description=(
             "The name as a Hugging Face id or path to the verifier model "

--- a/src/speculators/model.py
+++ b/src/speculators/model.py
@@ -95,12 +95,11 @@ class DraftVocabMixin(nn.Module):
             )
 
         if not self.use_draft_vocab:
-            raise RuntimeError(
-                "Vocab mappings (t2d/d2t) are not needed because "
-                "draft_vocab_size equals verifier vocab_size. "
-                "Set draft_vocab_size < verifier_vocab_size or "
-                "omit t2d/d2t arguments."
-            )
+            # draft_vocab_size == verifier_vocab_size, so the mappings would be
+            # identity no-ops; accept and ignore them rather than erroring. Real
+            # data directories may carry full-vocab t2d/d2t files alongside a
+            # checkpoint that does not prune the vocabulary.
+            return
 
         if t2d.shape[0] != self.verifier_vocab_size:
             raise ValueError(

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -29,6 +29,9 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
     _keys_to_ignore_on_load_missing: ClassVar[list[str]] = [  # type: ignore[misc]
         "embed_tokens.weight",
         "verifier_norm.weight",
+        # verifier_lm_head is reloaded from the verifier (see load_verifier_weights)
+        # and excluded on save, so it is expected to be absent from checkpoints.
+        "verifier_lm_head.weight",
         "t2d",
         "d2t",
     ]
@@ -169,8 +172,8 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
                     )
                 ],
                 default_proposal_method="greedy",
-                verifier=VerifierConfig.from_config(
-                    verifier_config, name_or_path=kwargs["verifier_name_or_path"]
+                verifier=VerifierConfig.from_pretrained(
+                    kwargs["verifier_name_or_path"]
                 ),
             ),
         )

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -337,8 +337,8 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
                     )
                 ],
                 default_proposal_method="greedy",
-                verifier=VerifierConfig.from_config(
-                    verifier_config, name_or_path=kwargs["verifier_name_or_path"]
+                verifier=VerifierConfig.from_pretrained(
+                    kwargs["verifier_name_or_path"]
                 ),
             ),
         )

--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -252,10 +252,12 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
                     )
                 ],
                 default_proposal_method="greedy",
-                verifier=VerifierConfig.from_config(
-                    verifier_config,
-                    name_or_path=verifier_name_or_path,
-                ),
+                # Read architectures from the verifier's published config.json (like
+                # eagle3/dflash/peagle and the MTP converter). from_config would read
+                # them off verifier_config, but that is the unwrapped text_config for
+                # composite verifiers (e.g. Qwen3.5-MoE), which carries no
+                # architectures -- leaving verifier.architectures empty.
+                verifier=VerifierConfig.from_pretrained(verifier_name_or_path),
             ),
         )
 

--- a/src/speculators/models/peagle/core.py
+++ b/src/speculators/models/peagle/core.py
@@ -226,8 +226,8 @@ class PEagleDraftModel(Eagle3DraftModel):
                     )
                 ],
                 default_proposal_method="greedy",
-                verifier=VerifierConfig.from_config(
-                    verifier_config, name_or_path=kwargs["verifier_name_or_path"]
+                verifier=VerifierConfig.from_pretrained(
+                    kwargs["verifier_name_or_path"]
                 ),
             ),
         )

--- a/src/speculators/models/utils.py
+++ b/src/speculators/models/utils.py
@@ -41,3 +41,40 @@ def resolve_target_layer_ids(
         stacklevel=3,
     )
     return target_layer_ids
+
+
+def resolve_draft_intermediate_size(verifier_config: PretrainedConfig) -> int:
+    """Resolve a dense draft MLP ``intermediate_size`` from a verifier config.
+
+    The draft is an independent small *dense* decoder, so its FFN width is a design
+    choice rather than something to reconcile with the verifier's routed capacity:
+
+    * Dense verifiers expose ``intermediate_size`` directly; the draft mirrors it.
+    * MoE verifiers have no dense ``intermediate_size`` (their FFN is a routed set of
+      small experts), so the draft falls back to the widely used ``3 * hidden_size``
+      gated-MLP ratio -- the Qwen3 dense convention that the dflash draft decoder
+      follows. Pass ``--draft-config`` to set it explicitly instead.
+
+    :raises ValueError: when the verifier config exposes neither ``intermediate_size``
+        nor ``hidden_size`` (degenerate config; pass ``--draft-config``).
+    """
+    dense = getattr(verifier_config, "intermediate_size", None)
+    if dense is not None:
+        return int(dense)
+
+    hidden_size = getattr(verifier_config, "hidden_size", None)
+    if hidden_size is None:
+        raise ValueError(
+            "Verifier config exposes neither `intermediate_size` nor `hidden_size`, "
+            "so a draft intermediate_size cannot be inferred. Pass --draft-config to "
+            "set the draft architecture explicitly."
+        )
+
+    intermediate_size = 3 * int(hidden_size)
+    warnings.warn(
+        "Verifier config has no dense intermediate_size (likely MoE); using draft "
+        f"intermediate_size={intermediate_size} (3 x hidden_size = {hidden_size}). "
+        "Pass --draft-config to override.",
+        stacklevel=3,
+    )
+    return intermediate_size

--- a/src/speculators/utils/argparse_utils.py
+++ b/src/speculators/utils/argparse_utils.py
@@ -5,23 +5,28 @@ from collections.abc import Iterable
 
 
 def explicitly_provided_dests(
-    parser: argparse.ArgumentParser, dests: Iterable[str]
+    parser: argparse.ArgumentParser,
+    dests: Iterable[str],
+    argv: list[str] | None = None,
 ) -> set[str]:
     """Return the subset of ``dests`` whose option actually appeared on the CLI.
 
-    Re-parses ``sys.argv`` into a throwaway namespace pre-seeded with a unique sentinel
+    Re-parses ``argv`` into a throwaway namespace pre-seeded with a unique sentinel
     per dest. argparse skips applying an action's default when the attribute is already
     present on the namespace, and only overwrites it when the option is provided -- so a
     value that merely *equals* the default is still detected as explicitly provided
     (unlike comparing the parsed value against ``parser.get_default(dest)``).
 
-    :param parser: The parser to re-run against ``sys.argv``.
+    :param parser: The parser to re-run.
     :param dests: Argparse destination names to check (e.g. ``"num_layers"``).
-    :return: The subset of ``dests`` that were explicitly provided on the command line.
+    :param argv: Arguments to re-parse; defaults to ``None`` (i.e. ``sys.argv``). Pass
+        the same ``argv`` the parser was originally invoked with so the detected
+        destinations match the arguments actually parsed.
+    :return: The subset of ``dests`` that were explicitly provided.
     """
     sentinels = {dest: object() for dest in dests}
     namespace = argparse.Namespace(**sentinels)
-    parser.parse_args(namespace=namespace)
+    parser.parse_args(args=argv, namespace=namespace)
     return {
         dest
         for dest, sentinel in sentinels.items()

--- a/src/speculators/utils/argparse_utils.py
+++ b/src/speculators/utils/argparse_utils.py
@@ -1,0 +1,29 @@
+"""Small, reusable argparse helpers."""
+
+import argparse
+from collections.abc import Iterable
+
+
+def explicitly_provided_dests(
+    parser: argparse.ArgumentParser, dests: Iterable[str]
+) -> set[str]:
+    """Return the subset of ``dests`` whose option actually appeared on the CLI.
+
+    Re-parses ``sys.argv`` into a throwaway namespace pre-seeded with a unique sentinel
+    per dest. argparse skips applying an action's default when the attribute is already
+    present on the namespace, and only overwrites it when the option is provided -- so a
+    value that merely *equals* the default is still detected as explicitly provided
+    (unlike comparing the parsed value against ``parser.get_default(dest)``).
+
+    :param parser: The parser to re-run against ``sys.argv``.
+    :param dests: Argparse destination names to check (e.g. ``"num_layers"``).
+    :return: The subset of ``dests`` that were explicitly provided on the command line.
+    """
+    sentinels = {dest: object() for dest in dests}
+    namespace = argparse.Namespace(**sentinels)
+    parser.parse_args(namespace=namespace)
+    return {
+        dest
+        for dest, sentinel in sentinels.items()
+        if getattr(namespace, dest) is not sentinel
+    }

--- a/src/speculators/utils/loading.py
+++ b/src/speculators/utils/loading.py
@@ -23,7 +23,16 @@ def is_config_only_dir(path: str | Path) -> bool:
     if not directory.is_dir():
         return False
     has_config = (directory / "config.json").is_file()
-    has_weights = any(directory.glob("*.safetensors")) or any(directory.glob("*.bin"))
+    # Weight files, plus sharded-checkpoint index files (e.g.
+    # model.safetensors.index.json) -- the latter end in .json and would not match
+    # the *.safetensors / *.bin globs, so a shard manifest must be checked explicitly
+    # to avoid treating an incomplete sharded checkpoint as config-only.
+    has_weights = (
+        any(directory.glob("*.safetensors"))
+        or any(directory.glob("*.bin"))
+        or any(directory.glob("*.safetensors.index.json"))
+        or any(directory.glob("*.bin.index.json"))
+    )
     return has_config and not has_weights
 
 

--- a/src/speculators/utils/loading.py
+++ b/src/speculators/utils/loading.py
@@ -9,6 +9,24 @@ from loguru import logger
 from safetensors import safe_open
 
 
+def is_config_only_dir(path: str | Path) -> bool:
+    """Return True if ``path`` is a local directory with a ``config.json`` but no
+    weight files (``*.safetensors`` / ``*.bin``).
+
+    Used to distinguish a saved speculator *config* (from which a fresh draft is
+    initialized) from a full checkpoint whose weights should be loaded.
+
+    :param path: A local directory path. Hub ids and non-directories return False.
+    :return: True when the directory holds a config but no weights.
+    """
+    directory = Path(path)
+    if not directory.is_dir():
+        return False
+    has_config = (directory / "config.json").is_file()
+    has_weights = any(directory.glob("*.safetensors")) or any(directory.glob("*.bin"))
+    return has_config and not has_weights
+
+
 def list_checkpoint_keys(checkpoint_dir: str | Path) -> list[str]:
     """List all tensor keys in a checkpoint without loading weights.
 

--- a/tests/unit/models/test_utils.py
+++ b/tests/unit/models/test_utils.py
@@ -1,10 +1,18 @@
 """Unit tests for speculators.models.utils config-resolution helpers."""
 
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
+from transformers import PretrainedConfig
 
 from speculators.models.utils import resolve_draft_intermediate_size
+
+
+def _fake_verifier(**fields) -> PretrainedConfig:
+    """Lightweight stand-in verifier config (the resolver only reads attributes)."""
+    return cast("PretrainedConfig", SimpleNamespace(**fields))
+
 
 # ---------------------------------------------------------------------------
 # resolve_draft_intermediate_size
@@ -15,7 +23,7 @@ from speculators.models.utils import resolve_draft_intermediate_size
 def test_resolve_uses_dense_intermediate_size_directly():
     # A dense verifier's intermediate_size is mirrored verbatim, even when a
     # hidden_size is also present (dense takes precedence over the 3x fallback).
-    verifier = SimpleNamespace(intermediate_size=11008, hidden_size=4096)
+    verifier = _fake_verifier(intermediate_size=11008, hidden_size=4096)
 
     assert resolve_draft_intermediate_size(verifier) == 11008
 
@@ -23,7 +31,7 @@ def test_resolve_uses_dense_intermediate_size_directly():
 @pytest.mark.smoke
 def test_resolve_moe_falls_back_to_3x_hidden_size():
     # MoE verifier: no dense intermediate_size -> draft uses 3 * hidden_size.
-    verifier = SimpleNamespace(hidden_size=2048)
+    verifier = _fake_verifier(hidden_size=2048)
 
     with pytest.warns(UserWarning, match="3 x hidden_size"):
         assert resolve_draft_intermediate_size(verifier) == 6144
@@ -33,7 +41,7 @@ def test_resolve_moe_falls_back_to_3x_hidden_size():
 def test_resolve_ignores_moe_expert_fields():
     # Expert fields are irrelevant now: with no dense intermediate_size the draft
     # width is purely 3 * hidden_size regardless of the MoE routing config.
-    verifier = SimpleNamespace(
+    verifier = _fake_verifier(
         hidden_size=1024,
         moe_intermediate_size=768,
         num_experts_per_tok=8,
@@ -48,7 +56,7 @@ def test_resolve_ignores_moe_expert_fields():
 @pytest.mark.smoke
 def test_resolve_requires_intermediate_or_hidden_size():
     # Degenerate config with neither field -> explicit error pointing at --draft-config.
-    verifier = SimpleNamespace()
+    verifier = _fake_verifier()
 
     with pytest.raises(ValueError, match="--draft-config"):
         resolve_draft_intermediate_size(verifier)

--- a/tests/unit/models/test_utils.py
+++ b/tests/unit/models/test_utils.py
@@ -1,0 +1,54 @@
+"""Unit tests for speculators.models.utils config-resolution helpers."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from speculators.models.utils import resolve_draft_intermediate_size
+
+# ---------------------------------------------------------------------------
+# resolve_draft_intermediate_size
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.smoke
+def test_resolve_uses_dense_intermediate_size_directly():
+    # A dense verifier's intermediate_size is mirrored verbatim, even when a
+    # hidden_size is also present (dense takes precedence over the 3x fallback).
+    verifier = SimpleNamespace(intermediate_size=11008, hidden_size=4096)
+
+    assert resolve_draft_intermediate_size(verifier) == 11008
+
+
+@pytest.mark.smoke
+def test_resolve_moe_falls_back_to_3x_hidden_size():
+    # MoE verifier: no dense intermediate_size -> draft uses 3 * hidden_size.
+    verifier = SimpleNamespace(hidden_size=2048)
+
+    with pytest.warns(UserWarning, match="3 x hidden_size"):
+        assert resolve_draft_intermediate_size(verifier) == 6144
+
+
+@pytest.mark.smoke
+def test_resolve_ignores_moe_expert_fields():
+    # Expert fields are irrelevant now: with no dense intermediate_size the draft
+    # width is purely 3 * hidden_size regardless of the MoE routing config.
+    verifier = SimpleNamespace(
+        hidden_size=1024,
+        moe_intermediate_size=768,
+        num_experts_per_tok=8,
+        num_experts=128,
+        shared_expert_intermediate_size=2048,
+    )
+
+    with pytest.warns(UserWarning, match="3 x hidden_size"):
+        assert resolve_draft_intermediate_size(verifier) == 3072
+
+
+@pytest.mark.smoke
+def test_resolve_requires_intermediate_or_hidden_size():
+    # Degenerate config with neither field -> explicit error pointing at --draft-config.
+    verifier = SimpleNamespace()
+
+    with pytest.raises(ValueError, match="--draft-config"):
+        resolve_draft_intermediate_size(verifier)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
-from transformers import PretrainedConfig
+from transformers import LlamaConfig, PretrainedConfig
 
 from speculators import (
     SpeculatorModelConfig,
@@ -117,6 +117,32 @@ def test_verifier_config_from_verifier_config(mock_pretrained_config):
 
     assert config.name_or_path == "test/verifier"
     assert config.architectures == ["TestModel"]
+
+
+@pytest.mark.smoke
+def test_verifier_config_from_pretrained_reads_architectures(tmp_path):
+    """from_pretrained reads architectures from the verifier's own config.json
+    (not from a draft decoder config, which has none)."""
+    LlamaConfig(
+        hidden_size=32,
+        num_hidden_layers=2,
+        architectures=["LlamaForCausalLM"],
+    ).save_pretrained(tmp_path)
+
+    config = VerifierConfig.from_pretrained(str(tmp_path))
+
+    assert config.name_or_path == str(tmp_path)
+    assert config.architectures == ["LlamaForCausalLM"]
+
+
+@pytest.mark.smoke
+def test_verifier_config_from_pretrained_defaults_to_empty(tmp_path):
+    """A config without an ``architectures`` entry yields an empty list."""
+    LlamaConfig(hidden_size=32, num_hidden_layers=2).save_pretrained(tmp_path)
+
+    config = VerifierConfig.from_pretrained(str(tmp_path))
+
+    assert config.architectures == []
 
 
 @pytest.mark.smoke

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -16,6 +16,10 @@ from speculators import (
     VerifierConfig,
     reload_schemas,
 )
+from speculators.models.dflash.core import DFlashDraftModel
+from speculators.models.eagle3.core import Eagle3DraftModel
+from speculators.models.mtp.core import MTPDraftModel
+from speculators.models.peagle.core import PEagleDraftModel
 from speculators.proposals import GreedyTokenProposalConfig
 
 # ===== Test Helper Classes =====
@@ -296,3 +300,27 @@ def test_speculator_model_forward_abstract(speculator_model_test_config):
         NotImplementedError, match="The forward method is only supported on concrete"
     ):
         model.forward()
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "model_class",
+    [Eagle3DraftModel, DFlashDraftModel, PEagleDraftModel, MTPDraftModel],
+)
+def test_save_ignore_keys_are_ignored_on_load_missing(model_class):
+    """Weights excluded from saved checkpoints (e.g. verifier_lm_head, which is
+    reloaded from the verifier via load_verifier_weights) must also be ignored when
+    missing on load. Otherwise loading an initialized/trained checkpoint flags the
+    absent key as missing.
+    """
+    save_ignore = set(getattr(model_class, "_keys_to_ignore_on_save", None) or [])
+    load_missing_ignore = set(
+        getattr(model_class, "_keys_to_ignore_on_load_missing", None) or []
+    )
+
+    not_ignored_on_load = save_ignore - load_missing_ignore
+    assert not not_ignored_on_load, (
+        f"{model_class.__name__} excludes {sorted(not_ignored_on_load)} from saved "
+        "checkpoints but does not list them in _keys_to_ignore_on_load_missing; "
+        "loading a checkpoint will raise on the absent key(s)."
+    )

--- a/tests/unit/train/test_draft_config_init.py
+++ b/tests/unit/train/test_draft_config_init.py
@@ -1,0 +1,396 @@
+"""Tests for the draft-model initialization sources in ``scripts/train.py``.
+
+Covers the three mutually exclusive init paths and their guard rails:
+- ``--draft-config``: decoder ``transformer_layer_config`` loaded from a file,
+  reconciled against the verifier (hidden-size match, vocab-size alignment).
+- ``--from-pretrained`` pointing at a config-only directory: fresh weights
+  initialized from a full saved speculator config.
+- ``--dry-run`` flag parsing.
+- CLI validation: ``--from-pretrained`` takes precedence over and is mutually
+  exclusive with ``--draft-config`` and the decoder-shaping flags; and
+  ``--draft-config`` is mutually exclusive with the decoder-shaping flags.
+"""
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from transformers.models.llama.configuration_llama import LlamaConfig
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+
+from scripts.train import (
+    DECODER_SHAPING_FLAGS,
+    _build_from_config_only,
+    build_draft_model,
+    create_transformer_layer_config,
+    load_draft_transformer_layer_config,
+    parse_args,
+)
+from speculators import SpeculatorsConfig, VerifierConfig
+from speculators.models.eagle3 import Eagle3DraftModel, Eagle3SpeculatorConfig
+from speculators.proposals.greedy import GreedyTokenProposalConfig
+from speculators.utils.loading import is_config_only_dir
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TINY_LLAMA_KWARGS = {
+    "vocab_size": 64,
+    "hidden_size": 32,
+    "intermediate_size": 128,
+    "num_hidden_layers": 2,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "head_dim": 8,
+    "max_position_embeddings": 32,
+    "tie_word_embeddings": False,
+}
+
+
+def _parse(monkeypatch, extra: list[str]):
+    monkeypatch.setattr(
+        "sys.argv", ["train.py", "--verifier-name-or-path", "dummy"] + extra
+    )
+    return parse_args()
+
+
+def _make_eagle3_config(verifier_name_or_path: str | None = "some-verifier"):
+    return Eagle3SpeculatorConfig(
+        transformer_layer_config=LlamaConfig(
+            _attn_implementation="eager", **TINY_LLAMA_KWARGS
+        ),
+        draft_vocab_size=64,
+        norm_before_residual=False,
+        embed_requires_grad=False,
+        speculators_config=SpeculatorsConfig(
+            algorithm="eagle3",
+            proposal_methods=[GreedyTokenProposalConfig(speculative_tokens=1)],
+            default_proposal_method="greedy",
+            verifier=VerifierConfig(
+                name_or_path=verifier_name_or_path,
+                architectures=["LlamaForCausalLM"],
+            ),
+        ),
+    )
+
+
+def _save_config_only_dir(
+    tmp_path: Path, verifier_name_or_path="some-verifier"
+) -> Path:
+    """Save a full speculator checkpoint then strip the weight files, leaving a
+    config-only directory."""
+    model = Eagle3DraftModel(_make_eagle3_config(verifier_name_or_path))
+    model_dir = tmp_path / "config_only"
+    model.save_pretrained(str(model_dir))
+    weight_files = list(model_dir.glob("*.safetensors")) + list(model_dir.glob("*.bin"))
+    for weights in weight_files:
+        weights.unlink()
+    return model_dir
+
+
+# ---------------------------------------------------------------------------
+# CLI validation: --draft-config exclusivity
+# ---------------------------------------------------------------------------
+
+
+def test_draft_config_alone_parses(monkeypatch):
+    args = _parse(monkeypatch, ["--draft-config", "some/decoder/config"])
+    assert args.draft_config == "some/decoder/config"
+    assert args.from_pretrained == ""
+
+
+def test_dry_run_flag_parses(monkeypatch):
+    assert _parse(monkeypatch, []).dry_run is False
+    assert _parse(monkeypatch, ["--dry-run"]).dry_run is True
+
+
+def test_draft_config_with_from_pretrained_errors(monkeypatch):
+    with pytest.raises(SystemExit):
+        _parse(monkeypatch, ["--draft-config", "c", "--from-pretrained", "p"])
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        ["--num-layers", "5"],
+        ["--draft-arch", "qwen3"],
+        ["--draft-hidden-act", "gelu"],
+        ["--sliding-window", "1024"],
+        ["--sliding-window-indices", "0", "1"],
+    ],
+)
+def test_draft_config_with_decoder_flag_errors(monkeypatch, extra):
+    with pytest.raises(SystemExit):
+        _parse(monkeypatch, ["--draft-config", "c", *extra])
+
+
+def test_draft_config_with_explicit_default_flag_errors(monkeypatch):
+    """Explicitly passing a decoder-shaping flag conflicts with --draft-config even
+    when its value equals the argparse default (--num-layers default is 1):
+    detection is based on what was provided, not on the resulting value."""
+    with pytest.raises(SystemExit):
+        _parse(monkeypatch, ["--draft-config", "c", "--num-layers", "1"])
+
+
+def test_decoder_shaping_flags_dests_exist(monkeypatch):
+    """Every dest in DECODER_SHAPING_FLAGS is a real parsed attribute."""
+    args = _parse(monkeypatch, [])
+    for dest in DECODER_SHAPING_FLAGS:
+        assert hasattr(args, dest), dest
+
+
+# ---------------------------------------------------------------------------
+# CLI validation: --from-pretrained precedence
+# ---------------------------------------------------------------------------
+
+
+def test_from_pretrained_alone_parses(monkeypatch):
+    args = _parse(monkeypatch, ["--from-pretrained", "some/checkpoint"])
+    assert args.from_pretrained == "some/checkpoint"
+    assert args.draft_config == ""
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        ["--num-layers", "5"],
+        ["--draft-arch", "qwen3"],
+        ["--draft-hidden-act", "gelu"],
+        ["--sliding-window", "1024"],
+        ["--sliding-window-indices", "0", "1"],
+        ["--draft-config", "c"],
+    ],
+)
+def test_from_pretrained_takes_precedence_over_model_flags(monkeypatch, extra):
+    """--from-pretrained defines the whole draft and takes precedence over every
+    other model-definition option, erroring if combined with any of them."""
+    with pytest.raises(SystemExit):
+        _parse(monkeypatch, ["--from-pretrained", "p", *extra])
+
+
+def test_from_pretrained_with_explicit_default_flag_errors(monkeypatch):
+    """--from-pretrained conflicts with an explicitly-passed decoder-shaping flag
+    even when its value equals the argparse default (--num-layers default is 1)."""
+    with pytest.raises(SystemExit):
+        _parse(monkeypatch, ["--from-pretrained", "p", "--num-layers", "1"])
+
+
+# ---------------------------------------------------------------------------
+# load_draft_transformer_layer_config
+# ---------------------------------------------------------------------------
+
+
+def _patch_verifier(monkeypatch, hidden_size: int, vocab_size: int):
+    monkeypatch.setattr(
+        "scripts.train.get_verifier_config",
+        lambda _path: SimpleNamespace(hidden_size=hidden_size, vocab_size=vocab_size),
+    )
+
+
+def test_load_draft_config_from_dir(tmp_path, monkeypatch):
+    Qwen3Config(hidden_size=64, num_hidden_layers=3, vocab_size=100).save_pretrained(
+        tmp_path
+    )
+    _patch_verifier(monkeypatch, hidden_size=64, vocab_size=200)
+
+    out = load_draft_transformer_layer_config(str(tmp_path), "dummy-verifier")
+
+    assert isinstance(out, Qwen3Config)
+    assert out.num_hidden_layers == 3
+    # vocab_size is aligned to the verifier's target vocabulary
+    assert out.vocab_size == 200
+
+
+def test_load_draft_config_hidden_size_mismatch_raises(tmp_path, monkeypatch):
+    Qwen3Config(hidden_size=64, num_hidden_layers=2, vocab_size=100).save_pretrained(
+        tmp_path
+    )
+    _patch_verifier(monkeypatch, hidden_size=128, vocab_size=100)
+
+    with pytest.raises(ValueError, match="hidden_size"):
+        load_draft_transformer_layer_config(str(tmp_path), "dummy-verifier")
+
+
+def test_load_draft_config_extracts_nested_from_full_config(tmp_path, monkeypatch):
+    """A full speculator config (with nested transformer_layer_config) is accepted;
+    only the decoder definition is used."""
+    nested = Qwen3Config(hidden_size=64, num_hidden_layers=5, vocab_size=100).to_dict()
+    full = {"speculators_model_type": "dflash", "transformer_layer_config": nested}
+    (tmp_path / "config.json").write_text(json.dumps(full))
+    _patch_verifier(monkeypatch, hidden_size=64, vocab_size=64)
+
+    out = load_draft_transformer_layer_config(str(tmp_path), "dummy-verifier")
+
+    assert isinstance(out, Qwen3Config)
+    assert out.num_hidden_layers == 5
+
+
+# ---------------------------------------------------------------------------
+# _build_from_config_only
+# ---------------------------------------------------------------------------
+
+
+def test_build_from_config_only(tmp_path):
+    model_dir = _save_config_only_dir(tmp_path)
+    assert is_config_only_dir(str(model_dir))
+
+    with patch.object(Eagle3DraftModel, "load_verifier_weights"):
+        built = _build_from_config_only(Eagle3DraftModel, str(model_dir), None, None)
+
+    assert isinstance(built, Eagle3DraftModel)
+    # decoder (trainable) weights are freshly/randomly initialized, not NaN
+    assert not built.fc.weight.isnan().any()
+
+
+def test_build_from_config_only_fills_missing_verifier_name(tmp_path):
+    model_dir = _save_config_only_dir(tmp_path, verifier_name_or_path=None)
+
+    with patch.object(Eagle3DraftModel, "load_verifier_weights"):
+        built = _build_from_config_only(
+            Eagle3DraftModel,
+            str(model_dir),
+            None,
+            None,
+            verifier_name_or_path="fallback-verifier",
+        )
+
+    assert built.config.speculators_config.verifier.name_or_path == "fallback-verifier"
+
+
+@pytest.mark.parametrize("blanked", ["", None])
+def test_build_from_config_only_fills_blank_verifier_name(tmp_path, blanked):
+    # Manually blanking name_or_path in config.json yields "" (not null), so the
+    # fallback must treat any empty value -- not just None -- as "use the CLI arg".
+    model_dir = _save_config_only_dir(tmp_path, verifier_name_or_path=blanked)
+
+    with patch.object(Eagle3DraftModel, "load_verifier_weights"):
+        built = _build_from_config_only(
+            Eagle3DraftModel,
+            str(model_dir),
+            None,
+            None,
+            verifier_name_or_path="fallback-verifier",
+        )
+
+    assert built.config.speculators_config.verifier.name_or_path == "fallback-verifier"
+
+
+def test_build_from_config_only_preserves_existing_verifier_name(tmp_path):
+    model_dir = _save_config_only_dir(tmp_path, verifier_name_or_path="real-verifier")
+
+    with patch.object(Eagle3DraftModel, "load_verifier_weights"):
+        built = _build_from_config_only(
+            Eagle3DraftModel,
+            str(model_dir),
+            None,
+            None,
+            verifier_name_or_path="fallback-verifier",
+        )
+
+    assert built.config.speculators_config.verifier.name_or_path == "real-verifier"
+
+
+# ---------------------------------------------------------------------------
+# build_draft_model: MTP-from-scratch routing
+# ---------------------------------------------------------------------------
+
+
+def test_build_draft_model_mtp_from_scratch_uses_verifier_decoder(monkeypatch):
+    """MTP without --from-pretrained reuses the verifier's own decoder config and
+    must not synthesize a decoder or resolve a draft mask token."""
+    verifier_cfg = object()
+    monkeypatch.setattr("scripts.train.get_verifier_config", lambda _p: verifier_cfg)
+
+    def _must_not_call(*_a, **_k):
+        raise AssertionError("not expected for MTP-from-scratch")
+
+    monkeypatch.setattr("scripts.train.create_transformer_layer_config", _must_not_call)
+    monkeypatch.setattr("scripts.train.resolve_mask_token_id", _must_not_call)
+
+    captured = {}
+
+    class _FakeMTP:
+        @classmethod
+        def from_training_args(cls, *, verifier_config, t2d, d2t, **kwargs):
+            captured["verifier_config"] = verifier_config
+            captured["num_speculative_steps"] = kwargs.get("num_speculative_steps")
+            return "MTP_MODEL"
+
+    args = SimpleNamespace(
+        speculator_type="mtp",
+        from_pretrained="",
+        draft_config="",
+        verifier_name_or_path="some-verifier",
+        mask_token_id=None,
+        num_speculative_steps=3,
+    )
+
+    built = build_draft_model(args, _FakeMTP, None, None, None)
+
+    assert built == "MTP_MODEL"
+    assert captured["verifier_config"] is verifier_cfg
+    assert captured["num_speculative_steps"] == 3
+    # mask token stays unset for MTP (resolve_mask_token_id was never called)
+    assert args.mask_token_id is None
+
+
+# ---------------------------------------------------------------------------
+# intermediate_size resolution (dense + MoE verifiers)
+# ---------------------------------------------------------------------------
+
+
+def _make_verifier_namespace(**overrides) -> SimpleNamespace:
+    """A minimal stand-in for a verifier PretrainedConfig as consumed by
+    create_transformer_layer_config (no text_config / rope fields)."""
+    base = {
+        "vocab_size": 128,
+        "hidden_size": 32,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "hidden_act": "silu",
+        "max_position_embeddings": 128,
+        "initializer_range": 0.02,
+        "rms_norm_eps": 1e-6,
+        "head_dim": 8,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _create_layer_config_for(verifier: SimpleNamespace):
+    with patch("scripts.train.AutoConfig.from_pretrained", return_value=verifier):
+        return create_transformer_layer_config(
+            "target",
+            num_layers=2,
+            draft_arch="qwen3",
+            hidden_act=None,
+            sliding_window=None,
+            sliding_window_indices=[],
+        )
+
+
+def test_create_layer_config_uses_dense_intermediate_size():
+    verifier = _make_verifier_namespace(intermediate_size=48)
+
+    config = _create_layer_config_for(verifier)
+
+    assert config.intermediate_size == 48
+
+
+def test_create_layer_config_infers_moe_intermediate_size():
+    # MoE verifier (no dense intermediate_size): the draft MLP width falls back to
+    # 3 * hidden_size. Detailed resolver behavior is covered in
+    # tests/unit/models/test_utils.py.
+    verifier = _make_verifier_namespace(
+        moe_intermediate_size=768,  # present but irrelevant to the fallback
+        num_experts_per_tok=8,
+        num_experts=128,
+    )
+
+    with pytest.warns(UserWarning, match="3 x hidden_size"):
+        config = _create_layer_config_for(verifier)
+
+    assert config.intermediate_size == 3 * 32

--- a/tests/unit/train/test_draft_config_init.py
+++ b/tests/unit/train/test_draft_config_init.py
@@ -14,6 +14,7 @@ Covers the three mutually exclusive init paths and their guard rails:
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -37,7 +38,7 @@ from speculators.utils.loading import is_config_only_dir
 # Helpers
 # ---------------------------------------------------------------------------
 
-TINY_LLAMA_KWARGS = {
+TINY_LLAMA_KWARGS: dict[str, Any] = {
     "vocab_size": 64,
     "hidden_size": 32,
     "intermediate_size": 128,
@@ -60,7 +61,7 @@ def _parse(monkeypatch, extra: list[str]):
 def _make_eagle3_config(verifier_name_or_path: str | None = "some-verifier"):
     return Eagle3SpeculatorConfig(
         transformer_layer_config=LlamaConfig(
-            _attn_implementation="eager", **TINY_LLAMA_KWARGS
+            **{"_attn_implementation": "eager", **TINY_LLAMA_KWARGS}
         ),
         draft_vocab_size=64,
         norm_before_residual=False,
@@ -264,6 +265,17 @@ def test_load_draft_config_extracts_nested_from_full_config(tmp_path, monkeypatc
     assert out.num_hidden_layers == 5
 
 
+def test_load_draft_config_missing_model_type_raises(tmp_path, monkeypatch):
+    """A --draft-config without a model_type fails loudly rather than silently
+    defaulting to a particular decoder class."""
+    cfg = {"hidden_size": 64, "num_hidden_layers": 2, "vocab_size": 100}
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+    _patch_verifier(monkeypatch, hidden_size=64, vocab_size=100)
+
+    with pytest.raises(ValueError, match="model_type"):
+        load_draft_transformer_layer_config(str(tmp_path), "dummy-verifier")
+
+
 # ---------------------------------------------------------------------------
 # _build_from_config_only
 # ---------------------------------------------------------------------------
@@ -364,7 +376,7 @@ def test_build_draft_model_mtp_from_scratch_uses_verifier_decoder(monkeypatch):
         num_speculative_steps=3,
     )
 
-    built = build_draft_model(args, _FakeMTP, None, None, None)
+    built = build_draft_model(args, _FakeMTP, None, None, None)  # type: ignore[arg-type]
 
     assert built == "MTP_MODEL"
     assert captured["verifier_config"] is verifier_cfg
@@ -403,7 +415,7 @@ def _create_layer_config_for(verifier: SimpleNamespace):
             num_layers=2,
             draft_arch="qwen3",
             hidden_act=None,
-            sliding_window=None,
+            sliding_window=2048,
             sliding_window_indices=[],
         )
 

--- a/tests/unit/train/test_draft_config_init.py
+++ b/tests/unit/train/test_draft_config_init.py
@@ -179,6 +179,42 @@ def test_from_pretrained_with_explicit_default_flag_errors(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# CLI validation: MTP-from-scratch rejects inapplicable draft-definition flags
+# ---------------------------------------------------------------------------
+
+
+def test_mtp_from_scratch_alone_parses(monkeypatch):
+    args = _parse(monkeypatch, ["--speculator-type", "mtp"])
+    assert args.speculator_type == "mtp"
+    assert args.draft_config == ""
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        ["--draft-config", "c"],
+        ["--num-layers", "5"],
+        ["--draft-arch", "qwen3"],
+        ["--sliding-window", "1024"],
+    ],
+)
+def test_mtp_from_scratch_rejects_inapplicable_flags(monkeypatch, extra):
+    """MTP-from-scratch reuses the verifier decoder config, so --draft-config and
+    decoder-shaping flags do not apply and must error instead of being ignored."""
+    with pytest.raises(SystemExit):
+        _parse(monkeypatch, ["--speculator-type", "mtp", *extra])
+
+
+def test_mtp_with_from_pretrained_parses(monkeypatch):
+    """MTP + --from-pretrained (a converted checkpoint) parses; the MTP-from-scratch
+    rejection only applies when not loading from a checkpoint."""
+    args = _parse(
+        monkeypatch, ["--speculator-type", "mtp", "--from-pretrained", "ckpt"]
+    )
+    assert args.from_pretrained == "ckpt"
+
+
+# ---------------------------------------------------------------------------
 # load_draft_transformer_layer_config
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/train/test_setup_model.py
+++ b/tests/unit/train/test_setup_model.py
@@ -757,13 +757,15 @@ def test_load_vocab_mappings_validation(draft_vocab_config, vocab_mappings):
 
 
 def test_load_vocab_mappings_not_needed():
-    """load_vocab_mappings raises when vocab sizes match (no mapping needed)."""
+    """load_vocab_mappings is a no-op when vocab sizes match."""
     config = _make_eagle3_config(draft_vocab_size=64)  # same as verifier
     model = Eagle3DraftModel(config)
     t2d, d2t = _make_vocab_mappings(verifier_vocab_size=64, draft_vocab_size=64)
 
-    with pytest.raises(RuntimeError, match="not needed"):
-        model.load_vocab_mappings(t2d, d2t)
+    model.load_vocab_mappings(t2d, d2t)
+
+    assert model.t2d is None
+    assert model.d2t is None
 
 
 def test_from_training_args_loads_vocab_mappings(vocab_mappings):

--- a/tests/unit/utils/test_argparse_utils.py
+++ b/tests/unit/utils/test_argparse_utils.py
@@ -1,0 +1,53 @@
+"""Unit tests for the argparse helpers in the Speculators library."""
+
+import argparse
+
+import pytest
+
+from speculators.utils.argparse_utils import explicitly_provided_dests
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-layers", type=int, default=3)
+    parser.add_argument("--draft-arch", type=str, default="llama")
+    parser.add_argument("--flag", action="store_true")
+    return parser
+
+
+@pytest.mark.smoke
+def test_returns_only_options_present_on_argv(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["prog", "--num-layers", "5"])
+
+    provided = explicitly_provided_dests(_parser(), ["num_layers", "draft_arch"])
+
+    assert provided == {"num_layers"}
+
+
+@pytest.mark.smoke
+def test_value_equal_to_default_still_counts_as_provided(monkeypatch):
+    # Passing the default value explicitly must still be detected (the whole point:
+    # provided-based, not value-vs-default comparison).
+    monkeypatch.setattr("sys.argv", ["prog", "--draft-arch", "llama"])
+
+    provided = explicitly_provided_dests(_parser(), ["num_layers", "draft_arch"])
+
+    assert provided == {"draft_arch"}
+
+
+@pytest.mark.smoke
+def test_empty_when_nothing_provided(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["prog"])
+
+    provided = explicitly_provided_dests(_parser(), ["num_layers", "draft_arch"])
+
+    assert provided == set()
+
+
+@pytest.mark.smoke
+def test_store_true_flag_detected(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["prog", "--flag"])
+
+    provided = explicitly_provided_dests(_parser(), ["flag", "num_layers"])
+
+    assert provided == {"flag"}

--- a/tests/unit/utils/test_loading.py
+++ b/tests/unit/utils/test_loading.py
@@ -6,11 +6,41 @@ import pytest
 import torch
 from transformers import AutoModelForCausalLM
 
-from speculators.utils.loading import _resolve_file, load_model_layers
+from speculators.utils.loading import (
+    _resolve_file,
+    is_config_only_dir,
+    load_model_layers,
+)
 
 # Test model from HuggingFace
 TEST_MODEL_REPO = "nm-testing/tiny-testing-random-weights"
 SMALL_MODEL_REPO = "nm-testing/tinysmokellama-3.2"
+
+# is_config_only_dir Tests
+
+
+@pytest.mark.smoke
+def test_is_config_only_dir(tmp_path):
+    # Missing directory and a directory without config.json are not config-only.
+    assert is_config_only_dir(tmp_path / "does-not-exist") is False
+    assert is_config_only_dir(tmp_path) is False
+
+    # config.json present, no weights -> config-only.
+    (tmp_path / "config.json").write_text("{}")
+    assert is_config_only_dir(tmp_path) is True
+
+    # A weight file makes it a full checkpoint.
+    (tmp_path / "model.safetensors").write_text("")
+    assert is_config_only_dir(tmp_path) is False
+
+
+@pytest.mark.smoke
+def test_is_config_only_dir_detects_bin_weights(tmp_path):
+    (tmp_path / "config.json").write_text("{}")
+    (tmp_path / "pytorch_model.bin").write_text("")
+
+    assert is_config_only_dir(tmp_path) is False
+
 
 # _resolve_file Tests
 

--- a/tests/unit/utils/test_loading.py
+++ b/tests/unit/utils/test_loading.py
@@ -42,6 +42,20 @@ def test_is_config_only_dir_detects_bin_weights(tmp_path):
     assert is_config_only_dir(tmp_path) is False
 
 
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "index_file",
+    ["model.safetensors.index.json", "pytorch_model.bin.index.json"],
+)
+def test_is_config_only_dir_detects_sharded_index(tmp_path, index_file):
+    # A sharded-checkpoint manifest ends in .json (so it dodges the *.safetensors /
+    # *.bin globs); it must still count as weights, not config-only.
+    (tmp_path / "config.json").write_text("{}")
+    (tmp_path / index_file).write_text("{}")
+
+    assert is_config_only_dir(tmp_path) is False
+
+
 # _resolve_file Tests
 
 


### PR DESCRIPTION
## Summary
Adds two ways to define a draft model up front and a way to validate it before training:

- **`--draft-config <hf id | dir | json>`** — load just the decoder
  `transformer_layer_config` (LlamaConfig for eagle3/peagle, Qwen3Config for
  dflash); the rest of the speculator is built from the other CLI args. The draft
  `hidden_size` must match the verifier (hard error); `vocab_size` is aligned to
  the verifier (use `--draft-vocab-size` for pruning).
- **`--from-pretrained` extended** — in addition to a full checkpoint, it now
  accepts a directory containing only a `config.json` (no weights), in which case
  a fresh draft is initialized from that full speculator config.
- **`--dry-run`** — build the speculator, initialize weights, save a checkpoint to
  `--save-path`, and exit before training. The output can be validated (e.g. in
  vLLM) and fed straight back via `--from-pretrained`. Combinable with the above.

### Draft-init contract
The draft is defined in exactly one way: `--from-pretrained` (takes precedence) **or**
`--draft-config` **or** the decoder-shaping flags (`--num-layers`, `--draft-arch`,
`--draft-hidden-act`, `--sliding-window`, `--sliding-window-indices`). Conflicting
combinations are rejected at parse time. Detection is provided-based (an explicitly
passed flag conflicts even at its default value).

## Fixes folded in (surfaced while implementing/validating)
- **Verifier `architectures` propagation:** new `VerifierConfig.from_pretrained`
  reads the verifier's real `config.json`, so eagle3/dflash/peagle **and** MTP now
  record `verifier.architectures` instead of an empty list.
- **DFlash load symmetry:** `verifier_lm_head.weight` added to
  `_keys_to_ignore_on_load_missing` (excluded on save, reloaded from the verifier),
  fixing a "missing verifier lm_head" error on reload; invariant test added.
- **`--dry-run` dtype:** the saved checkpoint is cast to `--hidden-states-dtype`.
- **Draft `intermediate_size` resolution:** the *synthesized draft decoder's* MLP
  `intermediate_size` is copied from the verifier when the verifier is dense; MoE
  verifiers expose no single dense `intermediate_size`, so the draft falls back to
  `3 × hidden_size` (the Qwen3 dense / gated-MLP ratio the dflash draft already uses).
- **Vocab-mapping no-op:** `load_vocab_mappings` ignores full-vocab t2d/d2t when
  `draft_vocab_size == verifier_vocab_size` instead of raising.
- **`--draft-arch`** now treats both `llama` and `qwen3` as vLLM-supported.

## Backwards compatibility
Default behavior is unchanged: with none of the new flags, training synthesizes the
draft from the verifier + CLI flags exactly as before.

## Test plan
- [ ] Unit suite green (`tests/unit/train/test_draft_config_init.py`,
  `test_utils.py`, `test_argparse_utils.py`, `test_config.py`, `test_model.py`,
  `test_setup_model.py`, `test_loading.py`).
- [ ] `--dry-run` init → reload via `--from-pretrained` round-trips (dense + MoE).
- [ ] Config-only `--from-pretrained` initializes fresh weights.
- [ ] Conflicting flag combinations error at parse time.