### PR TITLE
Update training to use global rank for multi-node sharding and logging

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -70,7 +70,7 @@ def set_seed(seed: int, deterministic: bool = False):
 def setup_dataloader(
     dataset: BaseDataset,
     world_size: int,
-    local_rank: int,
+    rank: int,
     hidden_size: int,
     num_workers: int = 12,
     num_target_layers: int = 3,
@@ -81,7 +81,7 @@ def setup_dataloader(
     Args:
         file_list: List of file paths to load data from.
         world_size: Number of processes in the distributed training.
-        local_rank: Rank of the current process.
+        rank: Global rank of the current process (shards data across nodes).
         add_noise: Whether to add noise to the data.
         noise_std: Standard deviation for noise augmentation.
         num_workers: Number of dataloader workers.
@@ -95,7 +95,7 @@ def setup_dataloader(
         batch_max_length=args.total_seq_len,
         lengths=dataset.approx_lengths,
         num_replicas=world_size,
-        rank=local_rank,
+        rank=rank,
     )
     return DataLoader(
         dataset,
@@ -421,7 +421,7 @@ def main(args: argparse.Namespace):
     train_loader = setup_dataloader(
         train_dataset,
         world_size,
-        local_rank,
+        rank,
         transformer_layer_config.hidden_size,
         num_target_layers=num_target_layers,
         num_workers=args.num_workers,
@@ -431,7 +431,7 @@ def main(args: argparse.Namespace):
     val_loader = setup_dataloader(
         val_dataset,
         world_size,
-        local_rank,
+        rank,
         transformer_layer_config.hidden_size,
         num_target_layers=num_target_layers,
         num_workers=args.num_workers,
@@ -449,6 +449,7 @@ def main(args: argparse.Namespace):
         resume_from_checkpoint=not args.no_resume_from_checkpoint,
         is_distributed=is_distributed,
         local_rank=local_rank,
+        rank=rank,
         train_call_kwargs=train_call_kwargs,
         val_call_kwargs=val_call_kwargs,
         optimizer=args.optimizer,

--- a/src/speculators/train/logger.py
+++ b/src/speculators/train/logger.py
@@ -491,7 +491,7 @@ def setup_root_logger(level="INFO"):
     """
     handler = RichHandler()
     handler.addFilter(FormatDictFilter())
-    handler.addFilter(IsRank0Filter(local_rank=True))
+    handler.addFilter(IsRank0Filter())
     logging.basicConfig(
         level=level, format="%(message)s", datefmt="[%X]", handlers=[handler]
     )

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -40,6 +40,7 @@ class TrainerConfig(NamedTuple):
     resume_from_checkpoint: bool = False
     is_distributed: bool = False
     local_rank: int = 0
+    rank: int = 0
     train_call_kwargs: dict = {}
     val_call_kwargs: dict = {}
     optimizer: Literal["adamw", "muon"] = "adamw"
@@ -70,6 +71,7 @@ class Trainer:
         self.model = model
         self.config = config
         self.local_rank = config.local_rank
+        self.rank = config.rank
         self.train_loader = train_loader
         self.val_loader = val_loader
         self.is_distributed = config.is_distributed
@@ -216,7 +218,7 @@ class Trainer:
             self.train_loader.batch_sampler.set_epoch(epoch)  # type: ignore[union-attr]
 
         train_loader = self.train_loader
-        if self.local_rank == 0:
+        if self.rank == 0:
             train_loader = tqdm(train_loader, desc=f"Epoch {epoch}")  # type: ignore[assignment]
 
         num_steps = len(self.train_loader)
@@ -288,7 +290,7 @@ class Trainer:
         if hasattr(self.val_loader.batch_sampler, "set_epoch"):
             self.val_loader.batch_sampler.set_epoch(epoch)  # type: ignore[union-attr]
         val_loader = self.val_loader
-        if self.local_rank == 0:
+        if self.rank == 0:
             val_loader = tqdm(val_loader, desc=f"Epoch {epoch}")  # type: ignore[assignment]
 
         val_metrics: dict[str, float] = {}

--- a/src/speculators/train/utils.py
+++ b/src/speculators/train/utils.py
@@ -38,7 +38,8 @@ def maybe_setup_distributed() -> tuple[int, int, int, bool]:
     rank = dist.get_rank()
 
     logger.info(
-        f"Started distributed with local_rank={local_rank}, world_size={world_size}",
+        f"Started distributed with local_rank={local_rank},"
+        f" world_size={world_size}, rank={rank}",
         extra={"override_rank0_filter": True},
     )
     return local_rank, world_size, rank, True

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -20,6 +20,7 @@ def _make_minimal_trainer(tmp_path: Path, checkpoint_freq: int, save_best: bool)
         save_path=str(tmp_path),
         resume_from_checkpoint=False,
         is_distributed=False,
+        rank=0,
         local_rank=0,
         checkpoint_freq=checkpoint_freq,
         save_best=save_best,
@@ -28,6 +29,7 @@ def _make_minimal_trainer(tmp_path: Path, checkpoint_freq: int, save_best: bool)
     trainer.current_epoch = 0
     trainer.global_step = 0
     trainer.is_distributed = False
+    trainer.rank = 0
     trainer.local_rank = 0
     trainer.resume_from_checkpoint = False
     trainer.train_loader = cast("DataLoader[Any]", [])
@@ -240,6 +242,7 @@ def test_best_val_loss_restored_on_resume(tmp_path: Path):
     trainer = Trainer.__new__(Trainer)
     trainer.resume_from_checkpoint = True
     trainer.is_distributed = False
+    trainer.rank = 0
     trainer.local_rank = 0
     trainer.checkpointer = cp
 

--- a/tests/unit/train/test_logger.py
+++ b/tests/unit/train/test_logger.py
@@ -1,0 +1,36 @@
+import logging
+
+import pytest
+
+from speculators.train.logger import IsRank0Filter
+
+
+def _record(**extra):
+    record = logging.LogRecord(
+        "speculators", logging.INFO, __file__, 0, "msg", None, None
+    )
+    for k, v in extra.items():
+        setattr(record, k, v)
+    return record
+
+
+@pytest.fixture
+def clean_rank_env(monkeypatch):
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+
+
+def test_global_rank0_filter_passes_only_global_rank0(monkeypatch, clean_rank_env):
+    # Multi-node: a non-zero global rank that happens to be local_rank 0
+    # must still be filtered out (the bug this guards against).
+    monkeypatch.setenv("RANK", "1")
+    monkeypatch.setenv("LOCAL_RANK", "0")
+    assert IsRank0Filter().filter(_record()) is False
+
+    monkeypatch.setenv("RANK", "0")
+    assert IsRank0Filter().filter(_record()) is True
+
+
+def test_override_bypasses_filter(clean_rank_env, monkeypatch):
+    monkeypatch.setenv("RANK", "3")
+    assert IsRank0Filter().filter(_record(override_rank0_filter=True)) is True

--- a/tests/unit/train/test_setup_model.py
+++ b/tests/unit/train/test_setup_model.py
@@ -121,10 +121,13 @@ def _make_trainer_no_init(
     is_distributed=False,
     resume_from_checkpoint=False,
     local_rank=0,
+    rank=None,
     save_path="/tmp/test_ckpt",
     hidden_states_dtype=torch.bfloat16,
 ):
     """Create a Trainer instance bypassing __init__ to control setup order."""
+    if rank is None:
+        rank = local_rank
     config = TrainerConfig(
         lr=1e-4,
         num_epochs=1,
@@ -132,17 +135,40 @@ def _make_trainer_no_init(
         resume_from_checkpoint=resume_from_checkpoint,
         is_distributed=is_distributed,
         local_rank=local_rank,
+        rank=rank,
         hidden_states_dtype=hidden_states_dtype,
     )
     trainer = Trainer.__new__(Trainer)
     trainer.model = model
     trainer.config = config
     trainer.local_rank = config.local_rank
+    trainer.rank = config.rank
     trainer.is_distributed = config.is_distributed
     trainer.resume_from_checkpoint = config.resume_from_checkpoint
     trainer.train_loader = MagicMock(__len__=MagicMock(return_value=1))
     trainer.val_loader = None
     return trainer
+
+
+def test_trainer_uses_rank_from_config(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    monkeypatch.setattr(Trainer, "setup_trainer", lambda self: None)
+    monkeypatch.setattr(Trainer, "setup_model", lambda self: None)
+    monkeypatch.setattr(Trainer, "setup_optimizer", lambda self: None)
+
+    trainer = Trainer(
+        MagicMock(),
+        TrainerConfig(
+            lr=1e-4,
+            num_epochs=1,
+            save_path=str(tmp_path),
+            rank=3,
+            local_rank=1,
+        ),
+        MagicMock(),
+    )
+
+    assert trainer.rank == 3
+    assert trainer.local_rank == 1
 
 
 def _param_checksums(state_dict: dict[str, torch.Tensor]) -> dict[str, float]:


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

related #599 

In multi-node training local_rank is per-node, so passing it instead of the global rank made every node's GPU 0 load the same data shard and emit duplicate logs; this routes sharding and rank-0 logging through the global rank while keeping local_rank for device placement.

## Tests

- `test_logger.py`: global-rank-0 filter rejects RANK=1, LOCAL_RANK=0 (the multi-node bug case).
- `test_trainer_uses_rank_from_config`: Trainer reads rank/local_rank independently.
- Run on real 2-GPU run (Qwen3-0.6B, eagle3) with RANK={0,1}, LOCAL_RANK=0: ranks got disjoint data shards (overlap empty) and only global rank 0 logged.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
