### PR TITLE
Fix conditional-accuracy denominator to respect loss_mask

### DIFF
--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -23,12 +23,24 @@ def compute_accuracy_single_step(
         counts suitable for distributed reduction before computing ratios.
     """
     correct = pred_ids == target_ids
-    cond_total = torch.tensor(correct.numel(), dtype=torch.float, device=correct.device)
+    mask = loss_mask.to(torch.bool) if loss_mask is not None else None
+
     if prev_correct is not None:
-        cond_total = prev_correct.sum().float()
+        # Conditional accuracy only ranges over positions that survive loss_mask,
+        # so its denominator must count previously-correct AND masked positions.
+        # Read prev_correct here, before the in-place logical_and below mutates it.
+        eligible = prev_correct & mask if mask is not None else prev_correct
+        cond_total = eligible.sum().float()
         correct = torch.logical_and(prev_correct, correct, out=prev_correct)
-    if loss_mask is not None:
-        correct = torch.masked_select(correct, loss_mask.to(torch.bool))
+    elif mask is not None:
+        cond_total = mask.sum().float()
+    else:
+        cond_total = torch.tensor(
+            correct.numel(), dtype=torch.float, device=correct.device
+        )
+
+    if mask is not None:
+        correct = torch.masked_select(correct, mask)
 
     correct_sum = correct.float().sum()
     full_total = torch.tensor(correct.numel(), dtype=torch.float, device=correct.device)

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -50,12 +50,24 @@ def compute_accuracy_single_step(
         counts suitable for distributed reduction before computing ratios.
     """
     correct = pred_ids == target_ids
-    cond_total = torch.tensor(correct.numel(), dtype=torch.float, device=correct.device)
+    mask = loss_mask.to(torch.bool) if loss_mask is not None else None
+
     if prev_correct is not None:
-        cond_total = prev_correct.sum().float()
+        # Conditional accuracy only ranges over positions that survive loss_mask,
+        # so its denominator must count previously-correct AND masked positions.
+        # Read prev_correct here, before the in-place logical_and below mutates it.
+        eligible = prev_correct & mask if mask is not None else prev_correct
+        cond_total = eligible.sum().float()
         correct = torch.logical_and(prev_correct, correct, out=prev_correct)
-    if loss_mask is not None:
-        correct = torch.masked_select(correct, loss_mask.to(torch.bool))
+    elif mask is not None:
+        cond_total = mask.sum().float()
+    else:
+        cond_total = torch.tensor(
+            correct.numel(), dtype=torch.float, device=correct.device
+        )
+
+    if mask is not None:
+        correct = torch.masked_select(correct, mask)
 
     correct_sum = correct.float().sum()
     full_total = torch.tensor(correct.numel(), dtype=torch.float, device=correct.device)

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -369,6 +369,82 @@ class TestComputeAccuracySingleStep:
         assert cond_correct_1.item() == pytest.approx(2, abs=1e-4)
         assert cond_total_1.item() == pytest.approx(3, abs=1e-4)
 
+    def test_cond_total_respects_loss_mask(self):
+        """cond_total must count only positions that survive loss_mask.
+
+        Real tokens [0,1,2,3]: preds [1,2,3,9] vs tgt [1,2,3,4] -> [0,1,2]
+        correct, [3] wrong. Positions [4,5] are padding (masked out) and must
+        not enter the conditional denominator. With prev_correct all True the
+        conditional accuracy is 3 correct / 4 eligible, NOT 3 / 6.
+        """
+        pred = torch.tensor([[1, 2, 3, 9, 0, 0]])
+        tgt = torch.tensor([[1, 2, 3, 4, 7, 8]])
+        mask = torch.tensor([[1, 1, 1, 1, 0, 0]], dtype=torch.bool)
+        prev = torch.ones(1, 6, dtype=torch.bool)
+
+        _, _, cond_correct, cond_total = compute_accuracy_single_step(
+            pred, tgt, loss_mask=mask, prev_correct=prev
+        )
+        assert cond_correct.item() == pytest.approx(3, abs=1e-4)
+        assert cond_total.item() == pytest.approx(4, abs=1e-4)
+
+    def test_cond_acc_invariant_to_padding(self):
+        """Conditional accuracy must not change when only padding count changes."""
+        pred4 = torch.tensor([[1, 2, 3, 9]])
+        tgt4 = torch.tensor([[1, 2, 3, 4]])
+        mask4 = torch.ones(1, 4, dtype=torch.bool)
+        _, _, c4, t4 = compute_accuracy_single_step(
+            pred4,
+            tgt4,
+            loss_mask=mask4,
+            prev_correct=torch.ones(1, 4, dtype=torch.bool),
+        )
+
+        # Same 4 real tokens, now with 4 masked-out padding positions appended.
+        pred8 = torch.tensor([[1, 2, 3, 9, 0, 0, 0, 0]])
+        tgt8 = torch.tensor([[1, 2, 3, 4, 7, 8, 7, 8]])
+        mask8 = torch.tensor([[1, 1, 1, 1, 0, 0, 0, 0]], dtype=torch.bool)
+        _, _, c8, t8 = compute_accuracy_single_step(
+            pred8,
+            tgt8,
+            loss_mask=mask8,
+            prev_correct=torch.ones(1, 8, dtype=torch.bool),
+        )
+
+        assert (c4 / t4).item() == pytest.approx((c8 / t8).item(), abs=1e-4)
+        assert (c4 / t4).item() == pytest.approx(0.75, abs=1e-4)
+
+    def test_cond_total_first_step_respects_loss_mask(self):
+        """On the first step (prev_correct=None) cond_total equals masked count."""
+        pred = torch.tensor([[1, 2, 9, 0]])
+        tgt = torch.tensor([[1, 2, 3, 7]])
+        mask = torch.tensor([[1, 1, 1, 0]], dtype=torch.bool)
+
+        _, _, cond_correct, cond_total = compute_accuracy_single_step(
+            pred, tgt, loss_mask=mask, prev_correct=None
+        )
+        assert cond_correct.item() == pytest.approx(2, abs=1e-4)
+        assert cond_total.item() == pytest.approx(3, abs=1e-4)
+
+    def test_cond_total_uses_pre_and_prev_correct(self):
+        """Denominator must use previously-correct positions, not post-AND ones.
+
+        prev_correct = [T, T]; the current step gets only position 0 right.
+        The eligible (pre-AND) count is 2, so cond_acc is 1/2. A naive
+        denominator read after the in-place logical_and would be 1, wrongly
+        inflating cond_acc to 1.0.
+        """
+        pred = torch.tensor([[1, 9]])
+        tgt = torch.tensor([[1, 2]])
+        mask = torch.ones(1, 2, dtype=torch.bool)
+        prev = torch.ones(1, 2, dtype=torch.bool)
+
+        _, _, cond_correct, cond_total = compute_accuracy_single_step(
+            pred, tgt, loss_mask=mask, prev_correct=prev
+        )
+        assert cond_correct.item() == pytest.approx(1, abs=1e-4)
+        assert cond_total.item() == pytest.approx(2, abs=1e-4)
+
 
 class TestDecayFunctions:
     def test_dflash_anchor_zero_and_exp_values(self):


### PR DESCRIPTION
## Summary

`compute_accuracy_single_step` (the shared metrics primitive used by eagle3 training) restricts the conditional-accuracy **numerator** to `loss_mask` positions but computes the **denominator** (`cond_total`) over *all* positions. When `loss_mask` excludes any position — the normal case, where prompt/padding tokens are masked out — the reported `cond_acc_{ttt_step}` metric is deflated, and it even drifts with the amount of padding while real-token accuracy is unchanged.

This is a metrics/observability fix only: the loss is masked separately and correctly (`loss_function`), so model quality and gradients are unaffected — only the logged accuracy number was wrong.

## The bug

In `compute_accuracy_single_step`:

```python
cond_total = correct.numel()                 # all positions
if prev_correct is not None:
    cond_total = prev_correct.sum().float()  # all positions
    correct = torch.logical_and(prev_correct, correct, out=prev_correct)
if loss_mask is not None:
    correct = torch.masked_select(correct, loss_mask.to(torch.bool))  # numerator masked
```

The numerator is masked; `cond_total` is not. `eagle3/metrics.py` passes a real `s_loss_mask` (sourced from the dataset) plus `s_prev_correct`, so this path is hit in normal eagle3 training.

Reproduction (4 real tokens, 3 correct; only padding count varies):

| input | `cond_total` (before) | `cond_acc` (before) | `cond_acc` (after) |
|------|----------------------|---------------------|--------------------|
| 4 real + 2 padding | 6 | 0.500 | **0.750** |
| 4 real + 4 padding | 8 | 0.375 | **0.750** |

The metric should be `0.750` in both cases.

## The fix

Count `cond_total` over `prev_correct & loss_mask`, read **before** the in-place `logical_and` mutates `prev_correct`, and over `loss_mask` alone on the first step (`prev_correct is None`). Behaviour is unchanged when `loss_mask is None`. `full_total` was already mask-aware (it is `numel()` *after* `masked_select`) and is left untouched.

## Tests

The existing `compute_accuracy_single_step` test only exercised `loss_mask=None`, so the masked path was untested. Added regression tests covering:

- `cond_total` respects `loss_mask` with `prev_correct` given;
- conditional accuracy is invariant to padding count;
- first-step (`prev_correct=None`) masked denominator;
- the denominator uses the *previously-correct* mask, not the post-AND mask (the in-place `out=prev_correct` aliasing) — a case where the two differ.

The three masked tests are red on `main` and green here; the pre-existing `loss_mask=None` test stays green.

```
$ pytest tests/unit/models/test_metrics.py
10 passed
```
