### PR TITLE
[Features] Add Qwen3-VL Multimodal Training Support with vLLM 0.20

### DIFF
--- a/examples/train/eagle3_qwen3_vl_4b_llava_cot_48k_online_full.sh
+++ b/examples/train/eagle3_qwen3_vl_4b_llava_cot_48k_online_full.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Online Eagle3 training for Qwen3-VL-4B on the full 48k LLaVA-CoT dataset.
+#
+# This follows the same five-step pipeline as the 5k validation example, but
+# processes all 47,905 rows and therefore needs substantially more time/disk.
+
+set -euo pipefail
+
+# Override these values through the environment when needed.
+MODEL="${MODEL:-Qwen/Qwen3-VL-4B-Instruct}"
+DATASET_REVISION="${DATASET_REVISION:-main}"
+DATASET_DIR="${DATASET_DIR:-./data/llava-cot-48k-reannotated}"
+OUTPUT_DIR="${OUTPUT_DIR:-./output_qwen3_vl_4b_llava_cot_48k_online_full}"
+MAX_SAMPLES="${MAX_SAMPLES:-47905}"
+SEQ_LENGTH="${SEQ_LENGTH:-8192}"
+NUM_PREPROCESSING_WORKERS="${NUM_PREPROCESSING_WORKERS:-12}"
+EPOCHS="${EPOCHS:-5}"
+LR="${LR:-1e-4}"
+
+VLLM_GPUS="${VLLM_GPUS:-0,1}"
+TRAIN_GPUS="${TRAIN_GPUS:-2}"
+VLLM_PORT="${VLLM_PORT:-8000}"
+VLLM_TP="${VLLM_TP:-2}"
+VLLM_STARTUP_TIMEOUT="${VLLM_STARTUP_TIMEOUT:-600}"
+if [[ -z "${VLLM_EXTRA_ARGS+x}" ]]; then
+    VLLM_EXTRA_ARGS="--enforce-eager"
+fi
+
+DATASET_JSONL="$DATASET_DIR/train.absolute_paths.jsonl"
+HIDDEN_STATES_DIR="$OUTPUT_DIR/hidden_states_online"
+CHECKPOINT_DIR="$OUTPUT_DIR/checkpoints"
+VLLM_LOG_FILE="$OUTPUT_DIR/vllm_server.log"
+VLLM_MAX_MODEL_LEN="$((SEQ_LENGTH + 1024))"
+
+IFS=',' read -r -a TRAIN_GPU_ARR <<< "$TRAIN_GPUS"
+NUM_TRAIN_GPUS="${#TRAIN_GPU_ARR[@]}"
+read -r -a VLLM_EXTRA_ARR <<< "$VLLM_EXTRA_ARGS"
+
+mkdir -p "$DATASET_DIR" "$OUTPUT_DIR"
+VLLM_ALLOWED_LOCAL_MEDIA_PATH="$(cd "$DATASET_DIR" && pwd)"
+
+echo "=== Step 1: Downloading dataset snapshot ==="
+hf download hao05/llava-cot-48k-reannotated \
+    --repo-type dataset \
+    --revision "$DATASET_REVISION" \
+    --local-dir "$DATASET_DIR" \
+    --include "README.md" \
+    --include "data/*.parquet"
+
+echo "=== Step 2: Materializing Parquet dataset ==="
+python scripts/materialize_multimodal_parquet.py \
+    --dataset-dir "$DATASET_DIR" \
+    --max-samples "$MAX_SAMPLES"
+
+if [[ ! -s "$DATASET_JSONL" ]]; then
+    echo "Materializer did not produce $DATASET_JSONL" >&2
+    exit 1
+fi
+
+echo "=== Step 3: Preparing multimodal data ==="
+python scripts/prepare_data.py \
+    --model "$MODEL" \
+    --data "$DATASET_JSONL" \
+    --output "$OUTPUT_DIR" \
+    --max-samples "$MAX_SAMPLES" \
+    --seq-length "$SEQ_LENGTH" \
+    --num-preprocessing-workers "$NUM_PREPROCESSING_WORKERS" \
+    --multimodal
+
+if curl -sf "http://localhost:${VLLM_PORT}/health" >/dev/null 2>&1; then
+    echo "Port $VLLM_PORT already has a healthy server." >&2
+    exit 1
+fi
+
+echo "=== Step 4: Launching vLLM server ==="
+CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm.py "$MODEL" \
+    --hidden-states-path "$HIDDEN_STATES_DIR" \
+    -- \
+    --port "$VLLM_PORT" \
+    --tensor-parallel-size "$VLLM_TP" \
+    --max-model-len "$VLLM_MAX_MODEL_LEN" \
+    --limit-mm-per-prompt '{"image":1}' \
+    --allowed-local-media-path "$VLLM_ALLOWED_LOCAL_MEDIA_PATH" \
+    "${VLLM_EXTRA_ARR[@]}" \
+    >"$VLLM_LOG_FILE" 2>&1 &
+VLLM_PID=$!
+
+cleanup() {
+    echo "Stopping vLLM server..."
+    kill "$VLLM_PID" 2>/dev/null || true
+    wait "$VLLM_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Waiting for vLLM server to be ready..."
+VLLM_START_TIME="$(date +%s)"
+until curl -sf "http://localhost:${VLLM_PORT}/health" >/dev/null 2>&1; do
+    if ! kill -0 "$VLLM_PID" 2>/dev/null; then
+        echo "vLLM exited before becoming healthy. See $VLLM_LOG_FILE" >&2
+        wait "$VLLM_PID" 2>/dev/null || true
+        exit 1
+    fi
+
+    if (( $(date +%s) - VLLM_START_TIME >= VLLM_STARTUP_TIMEOUT )); then
+        echo "Timed out waiting for vLLM. See $VLLM_LOG_FILE" >&2
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "=== Step 5: Online training ==="
+CUDA_VISIBLE_DEVICES="$TRAIN_GPUS" torchrun \
+    --standalone --nproc_per_node "$NUM_TRAIN_GPUS" \
+    scripts/train.py \
+    --verifier-name-or-path "$MODEL" \
+    --data-path "$OUTPUT_DIR" \
+    --hidden-states-path "$HIDDEN_STATES_DIR" \
+    --vllm-endpoint "http://localhost:${VLLM_PORT}/v1" \
+    --save-path "$CHECKPOINT_DIR" \
+    --epochs "$EPOCHS" \
+    --lr "$LR" \
+    --total-seq-len "$SEQ_LENGTH" \
+    --on-missing generate \
+    --on-generate cache \
+    --run-name eagle3_qwen3_vl_4b_llava_cot_48k_online_full
+
+echo "Done. Checkpoints saved to $CHECKPOINT_DIR"

--- a/examples/train/eagle3_qwen3_vl_4b_llava_cot_48k_online_full.sh
+++ b/examples/train/eagle3_qwen3_vl_4b_llava_cot_48k_online_full.sh
@@ -57,22 +57,12 @@ if [[ ! -s "$DATASET_JSONL" ]]; then
     exit 1
 fi
 
-echo "=== Step 3: Preparing multimodal data ==="
-python scripts/prepare_data.py \
-    --model "$MODEL" \
-    --data "$DATASET_JSONL" \
-    --output "$OUTPUT_DIR" \
-    --max-samples "$MAX_SAMPLES" \
-    --seq-length "$SEQ_LENGTH" \
-    --num-preprocessing-workers "$NUM_PREPROCESSING_WORKERS" \
-    --multimodal
-
 if curl -sf "http://localhost:${VLLM_PORT}/health" >/dev/null 2>&1; then
     echo "Port $VLLM_PORT already has a healthy server." >&2
     exit 1
 fi
 
-echo "=== Step 4: Launching vLLM server ==="
+echo "=== Step 3: Launching vLLM server ==="
 CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm.py "$MODEL" \
     --hidden-states-path "$HIDDEN_STATES_DIR" \
     -- \
@@ -107,6 +97,17 @@ until curl -sf "http://localhost:${VLLM_PORT}/health" >/dev/null 2>&1; do
     fi
     sleep 2
 done
+
+echo "=== Step 4: Preparing multimodal data ==="
+python scripts/prepare_data.py \
+    --model "$MODEL" \
+    --data "$DATASET_JSONL" \
+    --output "$OUTPUT_DIR" \
+    --max-samples "$MAX_SAMPLES" \
+    --seq-length "$SEQ_LENGTH" \
+    --num-preprocessing-workers "$NUM_PREPROCESSING_WORKERS" \
+    --render-endpoint "http://localhost:${VLLM_PORT}" \
+    --multimodal
 
 echo "=== Step 5: Online training ==="
 CUDA_VISIBLE_DEVICES="$TRAIN_GPUS" torchrun \

--- a/examples/train/eagle3_qwen3_vl_4b_llava_cot_5k_online.sh
+++ b/examples/train/eagle3_qwen3_vl_4b_llava_cot_5k_online.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Online Eagle3 training for Qwen3-VL-4B on the 5k LLaVA-CoT dataset.
+#
+# This is a small end-to-end validation run: download and materialize the
+# multimodal dataset, prepare Arrow data, start vLLM, and train Eagle3.
+#
+# Latest server validation (2026-07-17, RTX 5090 x4, 5k VL run):
+# MAX_SAMPLES=5000, EPOCHS=10, SEQ_LENGTH=7680, VLLM_MAX_MODEL_LEN=8704.
+# Runtime: 31m05s (2026-07-17T01:20:16+08:00 to 01:51:21+08:00).
+# Result: rc=0, hidden_states=5000/5000, vLLM POST 500=0,
+# hidden-state cache failures=0, prompt token mismatches=0.
+# Final epoch: val/loss_epoch=6.038,
+# val/full_acc_0_epoch=0.738, val/cond_acc_0_epoch=0.738,
+# val/full_acc_1_epoch=0.512, val/cond_acc_1_epoch=0.693,
+# val/full_acc_2_epoch=0.361, val/cond_acc_2_epoch=0.705.
+# Best loss: val/loss_epoch=5.686 at epoch 6/10.
+
+set -euo pipefail
+
+# Override these values through the environment when needed.
+MODEL="${MODEL:-Qwen/Qwen3-VL-4B-Instruct}"
+DATASET_REVISION="${DATASET_REVISION:-main}"
+DATASET_DIR="${DATASET_DIR:-./data/llava-cot-5k-reannotated}"
+OUTPUT_DIR="${OUTPUT_DIR:-./output_qwen3_vl_4b_llava_cot_5k_online}"
+MAX_SAMPLES="${MAX_SAMPLES:-5000}"
+SEQ_LENGTH="${SEQ_LENGTH:-7680}"
+EPOCHS="${EPOCHS:-10}"
+LR="${LR:-1e-4}"
+
+VLLM_GPUS="${VLLM_GPUS:-0,1}"
+TRAIN_GPUS="${TRAIN_GPUS:-2}"
+VLLM_PORT="${VLLM_PORT:-8000}"
+VLLM_TP="${VLLM_TP:-2}"
+VLLM_STARTUP_TIMEOUT="${VLLM_STARTUP_TIMEOUT:-600}"
+if [[ -z "${VLLM_EXTRA_ARGS+x}" ]]; then
+    VLLM_EXTRA_ARGS="--enforce-eager"
+fi
+
+DATASET_JSONL="$DATASET_DIR/train.absolute_paths.jsonl"
+HIDDEN_STATES_DIR="$OUTPUT_DIR/hidden_states_online"
+CHECKPOINT_DIR="$OUTPUT_DIR/checkpoints"
+VLLM_LOG_FILE="$OUTPUT_DIR/vllm_server.log"
+VLLM_MAX_MODEL_LEN="$((SEQ_LENGTH + 1024))"
+
+IFS=',' read -r -a TRAIN_GPU_ARR <<< "$TRAIN_GPUS"
+NUM_TRAIN_GPUS="${#TRAIN_GPU_ARR[@]}"
+read -r -a VLLM_EXTRA_ARR <<< "$VLLM_EXTRA_ARGS"
+
+mkdir -p "$DATASET_DIR" "$OUTPUT_DIR"
+VLLM_ALLOWED_LOCAL_MEDIA_PATH="$(cd "$DATASET_DIR" && pwd)"
+
+echo "=== Step 1: Downloading dataset snapshot ==="
+hf download hao05/llava-cot-5k-reannotated \
+    --repo-type dataset \
+    --revision "$DATASET_REVISION" \
+    --local-dir "$DATASET_DIR" \
+    --include "README.md" \
+    --include "data/*.parquet"
+
+echo "=== Step 2: Materializing Parquet dataset ==="
+python scripts/materialize_multimodal_parquet.py \
+    --dataset-dir "$DATASET_DIR" \
+    --max-samples "$MAX_SAMPLES"
+
+if [[ ! -s "$DATASET_JSONL" ]]; then
+    echo "Materializer did not produce $DATASET_JSONL" >&2
+    exit 1
+fi
+
+echo "=== Step 3: Preparing multimodal data ==="
+python scripts/prepare_data.py \
+    --model "$MODEL" \
+    --data "$DATASET_JSONL" \
+    --output "$OUTPUT_DIR" \
+    --max-samples "$MAX_SAMPLES" \
+    --seq-length "$SEQ_LENGTH" \
+    --multimodal
+
+if curl -sf "http://localhost:${VLLM_PORT}/health" >/dev/null 2>&1; then
+    echo "Port $VLLM_PORT already has a healthy server." >&2
+    exit 1
+fi
+
+echo "=== Step 4: Launching vLLM server ==="
+CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm.py "$MODEL" \
+    --hidden-states-path "$HIDDEN_STATES_DIR" \
+    -- \
+    --port "$VLLM_PORT" \
+    --tensor-parallel-size "$VLLM_TP" \
+    --max-model-len "$VLLM_MAX_MODEL_LEN" \
+    --limit-mm-per-prompt '{"image":1}' \
+    --allowed-local-media-path "$VLLM_ALLOWED_LOCAL_MEDIA_PATH" \
+    "${VLLM_EXTRA_ARR[@]}" \
+    >"$VLLM_LOG_FILE" 2>&1 &
+VLLM_PID=$!
+
+cleanup() {
+    echo "Stopping vLLM server..."
+    kill "$VLLM_PID" 2>/dev/null || true
+    wait "$VLLM_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Waiting for vLLM server to be ready..."
+VLLM_START_TIME="$(date +%s)"
+until curl -sf "http://localhost:${VLLM_PORT}/health" >/dev/null 2>&1; do
+    if ! kill -0 "$VLLM_PID" 2>/dev/null; then
+        echo "vLLM exited before becoming healthy. See $VLLM_LOG_FILE" >&2
+        wait "$VLLM_PID" 2>/dev/null || true
+        exit 1
+    fi
+
+    if (( $(date +%s) - VLLM_START_TIME >= VLLM_STARTUP_TIMEOUT )); then
+        echo "Timed out waiting for vLLM. See $VLLM_LOG_FILE" >&2
+        exit 1
+    fi
+    sleep 2
+done
+
+echo "=== Step 5: Online training ==="
+CUDA_VISIBLE_DEVICES="$TRAIN_GPUS" torchrun \
+    --standalone --nproc_per_node "$NUM_TRAIN_GPUS" \
+    scripts/train.py \
+    --verifier-name-or-path "$MODEL" \
+    --data-path "$OUTPUT_DIR" \
+    --hidden-states-path "$HIDDEN_STATES_DIR" \
+    --vllm-endpoint "http://localhost:${VLLM_PORT}/v1" \
+    --save-path "$CHECKPOINT_DIR" \
+    --epochs "$EPOCHS" \
+    --lr "$LR" \
+    --total-seq-len "$SEQ_LENGTH" \
+    --on-missing generate \
+    --on-generate cache \
+    --run-name eagle3_qwen3_vl_4b_llava_cot_5k_online
+
+echo "Done. Checkpoints saved to $CHECKPOINT_DIR"

--- a/examples/train/eagle3_qwen3_vl_4b_llava_cot_5k_online.sh
+++ b/examples/train/eagle3_qwen3_vl_4b_llava_cot_5k_online.sh
@@ -67,21 +67,12 @@ if [[ ! -s "$DATASET_JSONL" ]]; then
     exit 1
 fi
 
-echo "=== Step 3: Preparing multimodal data ==="
-python scripts/prepare_data.py \
-    --model "$MODEL" \
-    --data "$DATASET_JSONL" \
-    --output "$OUTPUT_DIR" \
-    --max-samples "$MAX_SAMPLES" \
-    --seq-length "$SEQ_LENGTH" \
-    --multimodal
-
 if curl -sf "http://localhost:${VLLM_PORT}/health" >/dev/null 2>&1; then
     echo "Port $VLLM_PORT already has a healthy server." >&2
     exit 1
 fi
 
-echo "=== Step 4: Launching vLLM server ==="
+echo "=== Step 3: Launching vLLM server ==="
 CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm.py "$MODEL" \
     --hidden-states-path "$HIDDEN_STATES_DIR" \
     -- \
@@ -116,6 +107,16 @@ until curl -sf "http://localhost:${VLLM_PORT}/health" >/dev/null 2>&1; do
     fi
     sleep 2
 done
+
+echo "=== Step 4: Preparing multimodal data ==="
+python scripts/prepare_data.py \
+    --model "$MODEL" \
+    --data "$DATASET_JSONL" \
+    --output "$OUTPUT_DIR" \
+    --max-samples "$MAX_SAMPLES" \
+    --seq-length "$SEQ_LENGTH" \
+    --render-endpoint "http://localhost:${VLLM_PORT}" \
+    --multimodal
 
 echo "=== Step 5: Online training ==="
 CUDA_VISIBLE_DEVICES="$TRAIN_GPUS" torchrun \

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -24,11 +24,11 @@ from typing import Any
 
 import openai
 from datasets import load_from_disk
-from safetensors.torch import load_file
+from safetensors.torch import load_file, save_file
 from tqdm import tqdm
 
 from speculators.data_generation.offline import (
-    check_hidden_states,
+    align_hidden_states_to_tokens,
     get_existing_hidden_state_indices,
     get_indices_to_process,
 )
@@ -42,6 +42,36 @@ from speculators.train.data import build_client_item
 from speculators.train.logger import setup_root_logger
 
 logger = logging.getLogger(__name__)
+
+
+def _align_and_write_hidden_states(
+    source_path: Path,
+    target_path: Path,
+    tokens: list[int],
+    *,
+    allow_prefix_truncation: bool,
+    validate_outputs: bool,
+) -> None:
+    if not allow_prefix_truncation and not validate_outputs:
+        if source_path != target_path:
+            shutil.move(source_path, target_path)
+        return
+
+    loaded = load_file(source_path)
+    aligned, truncated = align_hidden_states_to_tokens(
+        loaded,
+        tokens,
+        allow_prefix_truncation=allow_prefix_truncation,
+    )
+    if truncated:
+        save_file(
+            {key: value.contiguous() for key, value in aligned.items()},
+            target_path,
+        )
+        if source_path != target_path:
+            source_path.unlink()
+    elif source_path != target_path:
+        shutil.move(source_path, target_path)
 
 
 class _FailureTracker:
@@ -193,7 +223,7 @@ def parse_args():
     return parser.parse_args()
 
 
-async def worker(  # noqa: C901
+async def worker(
     client,
     model: str,
     queue: "asyncio.Queue[dict[str, Any]]",
@@ -243,8 +273,15 @@ async def worker(  # noqa: C901
 
             async with write_semaphore:  # Limit number of active disk writes
                 t_write = time.perf_counter()
+                allow_prefix_truncation = "messages" in item
+
                 await asyncio.to_thread(
-                    shutil.move, hidden_states_path, target_hidden_states_path
+                    _align_and_write_hidden_states,
+                    Path(hidden_states_path),
+                    target_hidden_states_path,
+                    item["input_ids"],
+                    allow_prefix_truncation=allow_prefix_truncation,
+                    validate_outputs=validate_outputs,
                 )
                 write_s = time.perf_counter() - t_write
                 if validate_outputs:
@@ -350,6 +387,8 @@ async def generate_and_save_hidden_states(args, dataset):
 
     existing_file_indices = get_existing_hidden_state_indices(hidden_states_dir)
     num_samples = len(dataset)
+    if "messages" in dataset.column_names:
+        logger.info("Detected multimodal preprocessed dataset")
 
     to_process = get_indices_to_process(
         num_samples,
@@ -433,7 +472,7 @@ async def generate_and_save_hidden_states(args, dataset):
         )
 
     num_saved = len(to_process) - len(skipped_indices)
-    logger.info(f"Saved {num_saved} new data points to {args.output}")
+    logger.info(f"Saved {num_saved} new data points to {hidden_states_dir}")
     if skipped_indices:
         logger.warning(
             f"Skipped {len(skipped_indices)} samples due to errors: {skipped_indices}"

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -93,6 +93,54 @@ def parse_args():
     return parser.parse_known_args()
 
 
+def _is_multimodal_config(config) -> bool:
+    if any(
+        hasattr(config, field_name)
+        for field_name in (
+            "vision_config",
+            "visual_config",
+            "image_token_id",
+            "video_token_id",
+        )
+    ):
+        return True
+
+    model_type = str(getattr(config, "model_type", "")).lower()
+    if any(
+        marker in model_type
+        for marker in ("vision", "llava", "mllama", "paligemma", "pixtral")
+    ):
+        return True
+
+    architectures = getattr(config, "architectures", []) or []
+    return any(
+        any(
+            marker in str(architecture).lower()
+            for marker in (
+                "vision",
+                "llava",
+                "mllama",
+                "paligemma",
+                "pixtral",
+            )
+        )
+        for architecture in architectures
+    )
+
+
+def _ensure_hidden_state_extraction_defaults(cmd: list[str]) -> None:
+    disable_cp_arg = "--no-enable-chunked-prefill"
+    if disable_cp_arg not in cmd:
+        cmd.append(disable_cp_arg)
+
+    # Prefix caching can make vLLM return full prompt IDs while the hidden-state
+    # connector only writes uncached slots, so default extraction to full prompts.
+    if not any(
+        arg in cmd for arg in ("--enable-prefix-caching", "--no-enable-prefix-caching")
+    ):
+        cmd.append("--no-enable-prefix-caching")
+
+
 def main():
     args, vllm_args = parse_args()
     if "--" in vllm_args:
@@ -101,9 +149,16 @@ def main():
     from transformers import AutoConfig  # noqa: PLC0415
 
     config = AutoConfig.from_pretrained(args.model)
-    if hasattr(config, "text_config"):
-        config = config.text_config
-    num_hidden_layers = config.num_hidden_layers
+    text_config = config.text_config if hasattr(config, "text_config") else config
+    num_hidden_layers = text_config.num_hidden_layers
+
+    if _is_multimodal_config(config) and "--enforce-eager" not in vllm_args:
+        warnings.warn(
+            "Detected a multimodal verifier config. If your vLLM version has "
+            "CUDA graph shape issues for multimodal hidden-state extraction, "
+            "pass --enforce-eager explicitly after the launcher '--'.",
+            stacklevel=2,
+        )
 
     if args.target_layer_ids:
         target_layer_ids = args.target_layer_ids
@@ -111,7 +166,9 @@ def main():
             target_layer_ids.append(num_hidden_layers)
         warnings.warn(
             f"Using custom target layer ids {target_layer_ids}. These "
-            "must also be explicitly passed into the training script.",
+            "must also be explicitly aligned in the training script. "
+            "If the final verifier layer is included here, pass only the "
+            "auxiliary layers to training.",
             stacklevel=2,
         )
     else:
@@ -122,12 +179,29 @@ def main():
             num_hidden_layers,
         ]
 
+    draft_hf_config = {"eagle_aux_hidden_state_layer_ids": target_layer_ids}
+    if text_config is not config:
+        # vLLM's ExtractHiddenStatesConfig flattens the draft config and does not
+        # preserve nested text_config for multimodal verifiers. Clear the nested
+        # text_config and copy the text-only shape fields onto the draft config so
+        # hidden-state extraction can derive the draft model shape from the
+        # flattened config.
+        draft_hf_config["text_config"] = None
+        for field_name in (
+            "num_attention_heads",
+            "num_hidden_layers",
+            "hidden_size",
+            "num_key_value_heads",
+            "head_dim",
+        ):
+            field_value = getattr(text_config, field_name, None)
+            if field_value is not None:
+                draft_hf_config[field_name] = field_value
+
     speculative_config = {
         "method": "extract_hidden_states",
         "num_speculative_tokens": 1,
-        "draft_model_config": {
-            "hf_config": {"eagle_aux_hidden_state_layer_ids": target_layer_ids}
-        },
+        "draft_model_config": {"hf_config": draft_hf_config},
     }
     backend_cls = _backend_registry[args.hidden_states_backend]
     kv_transfer_config = backend_cls.build_kv_transfer_config(args)
@@ -144,6 +218,8 @@ def main():
         json.dumps(kv_transfer_config),
         *vllm_args,
     ]
+
+    _ensure_hidden_state_extraction_defaults(cmd)
 
     print("Running command:")
     print(" ".join(cmd))

--- a/scripts/materialize_multimodal_parquet.py
+++ b/scripts/materialize_multimodal_parquet.py
@@ -1,0 +1,293 @@
+"""Materialize embedded Parquet images for multimodal training."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import tempfile
+from itertools import islice
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+MATERIALIZED_IMAGES_DIRNAME = "materialized_images"
+OUTPUT_JSONL_FILENAME = "train.absolute_paths.jsonl"
+SUPPORTED_IMAGE_PART_TYPES = {"image", "image_url", "input_image"}
+SUPPORTED_IMAGE_SUFFIXES = {
+    ".avif",
+    ".bmp",
+    ".gif",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".tif",
+    ".tiff",
+    ".webp",
+}
+
+
+class MaterializationError(ValueError):
+    """Raised when a row cannot be safely materialized."""
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("expected a positive integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer")
+    return parsed
+
+
+def _relative_image_path(reference: object, *, field: str) -> PurePosixPath:
+    if not isinstance(reference, str) or not reference.strip():
+        raise MaterializationError(f"{field} must be a non-empty path")
+    if "\\" in reference or "\x00" in reference:
+        raise MaterializationError(f"{field} must be a POSIX relative path")
+
+    parsed = urlsplit(reference)
+    path = PurePosixPath(reference)
+    if (
+        parsed.scheme
+        or parsed.netloc
+        or parsed.query
+        or parsed.fragment
+        or path.is_absolute()
+        or ".." in path.parts
+    ):
+        raise MaterializationError(f"{field} must be a local relative path")
+    if path.suffix.lower() not in SUPPORTED_IMAGE_SUFFIXES:
+        raise MaterializationError(f"{field} has an unsupported image suffix")
+    return path
+
+
+def _part_reference(part: dict[str, Any], *, field: str) -> object:
+    candidates = [
+        part[key] for key in ("image", "path", "url") if part.get(key) is not None
+    ]
+    image_url = part.get("image_url")
+    if isinstance(image_url, dict):
+        if "url" in image_url:
+            candidates.append(image_url["url"])
+    elif image_url is not None:
+        candidates.append(image_url)
+    if len(candidates) != 1:
+        raise MaterializationError(f"{field} has an ambiguous image reference")
+    return candidates[0]
+
+
+def _single_image_part(
+    sample: dict[str, Any],
+    *,
+    row_idx: int,
+) -> tuple[dict[str, Any], PurePosixPath]:
+    conversations = sample.get("conversations")
+    if not isinstance(conversations, list):
+        raise MaterializationError(f"row {row_idx}: conversations must be a list")
+
+    matches: list[tuple[dict[str, Any], object]] = []
+    for turn in conversations:
+        if not isinstance(turn, dict) or not isinstance(turn.get("content"), list):
+            continue
+        for part in turn["content"]:
+            if (
+                isinstance(part, dict)
+                and part.get("type") in SUPPORTED_IMAGE_PART_TYPES
+            ):
+                matches.append((part, _part_reference(part, field=f"row {row_idx}")))
+
+    if len(matches) != 1:
+        raise MaterializationError(
+            f"row {row_idx}: expected exactly one image part, found {len(matches)}",
+        )
+    part, reference = matches[0]
+    return part, _relative_image_path(reference, field=f"row {row_idx} image")
+
+
+def _embedded_bytes(sample: dict[str, Any], *, row_idx: int) -> tuple[bytes, object]:
+    image = sample.get("image")
+    if not isinstance(image, dict):
+        raise MaterializationError(f"row {row_idx}: image must contain embedded bytes")
+    payload = image.get("bytes")
+    if not isinstance(payload, (bytes, bytearray, memoryview)) or not payload:
+        raise MaterializationError(f"row {row_idx}: image.bytes must be non-empty")
+    return bytes(payload), image.get("path")
+
+
+def _validate_path_metadata(
+    sample: dict[str, Any],
+    *,
+    conversation_path: PurePosixPath,
+    storage_reference: object,
+    row_idx: int,
+) -> None:
+    top_level_reference = sample.get("image_path")
+    if top_level_reference is not None:
+        top_level_path = _relative_image_path(
+            top_level_reference,
+            field=f"row {row_idx} image_path",
+        )
+        if top_level_path != conversation_path:
+            raise MaterializationError(
+                f"row {row_idx}: image_path does not match the conversation image",
+            )
+
+    if storage_reference is None:
+        return
+    storage_path = _relative_image_path(
+        storage_reference,
+        field=f"row {row_idx} image.path",
+    )
+    # datasets.Image.embed_storage may reduce the stored path to its basename.
+    if storage_path != conversation_path and storage_path != PurePosixPath(
+        conversation_path.name,
+    ):
+        raise MaterializationError(
+            f"row {row_idx}: image.path does not match the conversation image",
+        )
+
+
+def _prepare_output_directory(dataset_dir: Path) -> Path:
+    output_dir = dataset_dir / MATERIALIZED_IMAGES_DIRNAME
+    if output_dir.is_symlink():
+        raise MaterializationError(f"output directory is a symlink: {output_dir}")
+    output_dir.mkdir(exist_ok=True)
+    if not output_dir.is_dir():
+        raise MaterializationError(f"output path is not a directory: {output_dir}")
+    return output_dir
+
+
+def _materialize_row(
+    raw_sample: Mapping[str, Any],
+    *,
+    row_idx: int,
+    output_dir: Path,
+) -> tuple[dict[str, Any], Path]:
+    sample = copy.deepcopy(dict(raw_sample))
+    image_part, conversation_path = _single_image_part(sample, row_idx=row_idx)
+    payload, storage_reference = _embedded_bytes(sample, row_idx=row_idx)
+    _validate_path_metadata(
+        sample,
+        conversation_path=conversation_path,
+        storage_reference=storage_reference,
+        row_idx=row_idx,
+    )
+
+    digest = hashlib.sha256(payload).hexdigest()
+    filename = f"{row_idx:08d}-{digest}{conversation_path.suffix.lower()}"
+    image_path = output_dir / filename
+    if image_path.is_symlink():
+        raise MaterializationError(f"image output is a symlink: {image_path}")
+    image_path.write_bytes(payload)
+
+    for key in ("image", "path", "url", "image_url"):
+        image_part.pop(key, None)
+    image_part.update(type="image", image=str(image_path))
+    sample["image"] = str(image_path)
+    sample.pop("image_path", None)
+    return sample, image_path
+
+
+def _remove_stale_images(output_dir: Path, expected: set[Path]) -> None:
+    for entry in output_dir.iterdir():
+        if entry.is_symlink() or not entry.is_file():
+            raise MaterializationError(f"unexpected output entry: {entry}")
+        if entry not in expected:
+            entry.unlink()
+
+
+def materialize_rows(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    dataset_dir: Path,
+    max_samples: int,
+) -> tuple[Path, int]:
+    """Materialize ``max_samples`` rows and atomically replace the JSONL."""
+    if max_samples <= 0:
+        raise MaterializationError("max_samples must be positive")
+    if dataset_dir.is_symlink():
+        raise MaterializationError(f"dataset directory is a symlink: {dataset_dir}")
+    dataset_dir = dataset_dir.resolve(strict=True)
+    if not dataset_dir.is_dir():
+        raise MaterializationError(f"not a dataset directory: {dataset_dir}")
+
+    output_dir = _prepare_output_directory(dataset_dir)
+    destination = dataset_dir / OUTPUT_JSONL_FILENAME
+    if destination.is_symlink():
+        raise MaterializationError(f"output JSONL is a symlink: {destination}")
+
+    fd, tmp_name = tempfile.mkstemp(dir=dataset_dir, suffix=".jsonl.tmp")
+    tmp_path = Path(tmp_name)
+    expected_images: set[Path] = set()
+    count = 0
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as output:
+            for row_idx, row in enumerate(islice(rows, max_samples)):
+                sample, image_path = _materialize_row(
+                    row,
+                    row_idx=row_idx,
+                    output_dir=output_dir,
+                )
+                expected_images.add(image_path)
+                output.write(json.dumps(sample, ensure_ascii=False) + "\n")
+                count += 1
+        if count != max_samples:
+            raise MaterializationError(
+                f"expected {max_samples} rows, but the input provided {count}",
+            )
+        os.replace(tmp_path, destination)
+        _remove_stale_images(output_dir, expected_images)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    return destination, count
+
+
+def _load_parquet_rows(dataset_dir: Path):
+    parquet_dir = dataset_dir / "data"
+    parquet_files = sorted(parquet_dir.glob("train-*.parquet"))
+    if not parquet_files:
+        raise FileNotFoundError(f"no Parquet shards found under {parquet_dir}")
+    if parquet_dir.is_symlink() or any(
+        path.is_symlink() or not path.is_file() for path in parquet_files
+    ):
+        raise MaterializationError(f"unsafe Parquet input under {parquet_dir}")
+
+    from datasets import Image, load_dataset  # noqa: PLC0415
+
+    return load_dataset(
+        "parquet",
+        data_files={"train": [str(path) for path in parquet_files]},
+        split="train",
+    ).cast_column("image", Image(decode=False))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Materialize embedded multimodal Parquet images",
+    )
+    parser.add_argument("--dataset-dir", type=Path, required=True)
+    parser.add_argument("--max-samples", type=_positive_int, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dataset_dir = args.dataset_dir.expanduser()
+    destination, count = materialize_rows(
+        _load_parquet_rows(dataset_dir),
+        dataset_dir=dataset_dir,
+        max_samples=args.max_samples,
+    )
+    print(f"Wrote {count} rows to {destination}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -197,6 +197,14 @@ def parse_args():
             "raises when normalization or filtering removes every sample."
         ),
     )
+    parser.add_argument(
+        "--multimodal",
+        action="store_true",
+        help=(
+            "Enable multimodal preprocessing with AutoProcessor and preserve "
+            "messages needed for vLLM chat hidden-state generation."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -246,6 +254,7 @@ def main():
         minimum_valid_tokens=args.minimum_valid_tokens,
         allow_empty_output=args.allow_empty_output,
         trust_remote_code=args.trust_remote_code,
+        is_multimodal=True if args.multimodal else None,
     )
 
     log.info("Done preparing data")

--- a/src/speculators/data_generation/media.py
+++ b/src/speculators/data_generation/media.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+
+def get_image_ref(item: dict[str, Any]) -> Any | None:
+    """Extract a serializable image reference from a multimodal content item."""
+    if item.get("type") not in ("image", "image_url", "input_image"):
+        return None
+
+    for key in ("image", "path", "url"):
+        image_ref = item.get(key)
+        if image_ref is not None:
+            return image_ref
+
+    image_url = item.get("image_url")
+    if isinstance(image_url, dict):
+        return image_url.get("url")
+    return image_url

--- a/src/speculators/data_generation/offline.py
+++ b/src/speculators/data_generation/offline.py
@@ -19,6 +19,34 @@ def check_hidden_states(data: dict, tokens: list[int]):
         )
 
 
+def align_hidden_states_to_tokens(
+    data: dict,
+    tokens: list[int],
+    *,
+    allow_prefix_truncation: bool = False,
+) -> tuple[dict, bool]:
+    """Validate and optionally trim hidden states to the preprocessed token prefix."""
+    t_ids = data["token_ids"].tolist()
+    if t_ids == tokens:
+        check_hidden_states(data, tokens)
+        return data, False
+
+    expected_len = len(tokens)
+    if (
+        allow_prefix_truncation
+        and t_ids[:expected_len] == tokens
+        and data["hidden_states"].shape[0] >= expected_len
+    ):
+        aligned = dict(data)
+        aligned["token_ids"] = data["token_ids"][:expected_len].contiguous()
+        aligned["hidden_states"] = data["hidden_states"][:expected_len].contiguous()
+        check_hidden_states(aligned, tokens)
+        return aligned, True
+
+    check_hidden_states(data, tokens)
+    return data, False
+
+
 def get_existing_hidden_state_indices(output_path: Path) -> list[int]:
     """Find existing `hs_i.safetensors` files (where i is the file index)"""
 

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -2,7 +2,8 @@ import json
 from collections.abc import Callable
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict, cast
+from urllib.parse import unquote, urlparse
 
 import torch
 from datasets import Dataset as HFDataset
@@ -15,6 +16,7 @@ from transformers import (
 
 from speculators.data_generation.configs import DATASET_CONFIGS
 from speculators.data_generation.logging_utils import PipelineLogger
+from speculators.data_generation.media import get_image_ref
 from speculators.data_generation.render_client import render_conversation
 from speculators.data_generation.torch_utils import set_default_torch_num_threads
 from speculators.train.vocab_mapping import save_token_frequency_distribution
@@ -119,6 +121,30 @@ def _normalize_conversation(
     return normalized
 
 
+def _get_conversations_from_examples(examples: dict) -> list:
+    """Extract conversations/messages from a batched dataset example."""
+    if "conversations" in examples:
+        return examples.get("conversations", [])
+    if "messages" in examples:
+        return examples.get("messages", [])
+    return []
+
+
+def _local_media_path_to_uri(media_path: str | Path) -> str:
+    """Return a canonical, percent-encoded file URI for a local media path."""
+    media_text = str(media_path)
+    parsed = urlparse(media_text)
+    if parsed.scheme == "file":
+        if parsed.netloc not in ("", "localhost"):
+            raise ValueError(f"Unsupported file URI host: {parsed.netloc}")
+        if parsed.query or parsed.fragment:
+            raise ValueError("Local file URIs must not contain query/fragment")
+        media_text = unquote(parsed.path)
+    elif parsed.scheme:
+        raise ValueError(f"Unsupported local media URI scheme: {parsed.scheme}")
+    return Path(media_text).expanduser().resolve().as_uri()
+
+
 def _adapt_part_for_vllm(part: str | dict):
     if isinstance(part, str):
         return {"type": "text", "text": part}
@@ -128,13 +154,28 @@ def _adapt_part_for_vllm(part: str | dict):
     if part_type == "text":
         return {"type": "text", "text": part["text"]}
 
+    image_ref = get_image_ref(part)
+    if image_ref is not None:
+        image_text = str(image_ref)
+        if image_text.startswith(("http://", "https://", "data:")):
+            file_url = image_text
+        else:
+            file_url = _local_media_path_to_uri(image_text)
+        return {"type": "image_url", "image_url": {"url": file_url}}
+
     for modality in ("image", "video", "audio"):
         if part_type == modality:
             if local_path := part.get("path"):
-                file_url = f"file://{Path(local_path).absolute()}"
+                file_url = _local_media_path_to_uri(local_path)
                 return {"type": f"{modality}_url", f"{modality}_url": {"url": file_url}}
             if url := part.get("url"):
-                return {"type": f"{modality}_url", f"{modality}_url": {"url": url}}
+                url_text = str(url)
+                if not url_text.startswith(("http://", "https://", "data:")):
+                    url_text = _local_media_path_to_uri(url_text)
+                return {
+                    "type": f"{modality}_url",
+                    f"{modality}_url": {"url": url_text},
+                }
 
             if part.get("base64"):
                 expr = {"type": modality, "base64": "..."}
@@ -282,27 +323,53 @@ def _render_boundary_rows(
     return rows
 
 
-def _parse_conv_tools(conv_tools: object, idx: int) -> list | None:
+def _parse_conv_tools(conv_tools: object, idx: int) -> list[dict] | None:
     """Parse the tools JSON string for one conversation; warn and return None
     on invalid JSON or unexpected types."""
     if not conv_tools:
         return None
+
+    parsed_tools: object
     if isinstance(conv_tools, list):
-        return conv_tools
-    if not isinstance(conv_tools, str):
+        parsed_tools = conv_tools
+    elif not isinstance(conv_tools, str):
         log.warning(
             f"Non-string value in tools column for conversation {idx}: "
             f"{type(conv_tools).__name__}, proceeding without tools"
         )
         return None
-    try:
-        return json.loads(conv_tools)
-    except json.JSONDecodeError as e:
+    else:
+        try:
+            parsed_tools = json.loads(conv_tools)
+        except json.JSONDecodeError as e:
+            log.warning(
+                f"Invalid JSON in tools column for conversation {idx}: {e}, "
+                "proceeding without tools"
+            )
+            return None
+
+    if not isinstance(parsed_tools, list) or not all(
+        isinstance(tool, dict) for tool in parsed_tools
+    ):
         log.warning(
-            f"Invalid JSON in tools column for conversation {idx}: {e}, "
-            "proceeding without tools"
+            f"Invalid tools schema for conversation {idx}: expected a list of "
+            "objects, proceeding without tools"
         )
         return None
+
+    return cast("list[dict]", parsed_tools)
+
+
+def _canonicalize_conv_tools(
+    conv_tools: object, idx: int
+) -> tuple[list[dict] | None, str]:
+    """Return template tools plus a stable JSON representation for persistence."""
+    parsed_tools = _parse_conv_tools(conv_tools, idx)
+    canonical_json = json.dumps(
+        parsed_tools or [], ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    )
+    canonical_tools = cast("list[dict]", json.loads(canonical_json))
+    return (canonical_tools or None), canonical_json
 
 
 def _render_conversation_rows(
@@ -311,7 +378,7 @@ def _render_conversation_rows(
     idx: int,
     render_endpoint: str,
     max_length: int,
-) -> list[BoundaryRow] | None:
+) -> tuple[list[BoundaryRow], str] | None:
     """Render one valid conversation; return ``None`` when it is unusable."""
     if not conv or not isinstance(conv, list):
         return None
@@ -320,20 +387,18 @@ def _render_conversation_rows(
     if not normalized_conv:
         return None
 
-    parsed_tools = _parse_conv_tools(conv_tools, idx)
+    parsed_tools, canonical_tools_json = _canonicalize_conv_tools(conv_tools, idx)
     try:
-        return _render_boundary_rows(
-            normalized_conv,
-            render_endpoint,
-            max_length,
-            tools=parsed_tools,
+        rows = _render_boundary_rows(
+            normalized_conv, render_endpoint, max_length, tools=parsed_tools
         )
+        return rows, canonical_tools_json
     # One row the render endpoint or boundary derivation can't handle must
     # not kill the run. The failure modes can't be enumerated -- templates
     # are swappable and raise arbitrary types -- so catch broadly and skip.
     except Exception as e:
         log.error(f"Failed to process conversation {idx}: {type(e).__name__}: {e}")
-        return []
+        return [], "[]"
 
 
 def _append_row(
@@ -366,6 +431,8 @@ def _append_boundary_rows(
     rows: list[BoundaryRow],
     max_length: int,
     minimum_valid_tokens: int | None,
+    *,
+    tools_json: str | None = None,
 ) -> tuple[int, int, int]:
     """Append rendered rows and return kept, unsupervised, and clipped counts."""
     num_kept = 0
@@ -388,6 +455,7 @@ def _append_boundary_rows(
             num_kept += 1
             if "messages" in results:
                 results["messages"].append(_adapt_conv_for_vllm(row["conv"]))
+                results["tools"].append(tools_json or "[]")
 
     return num_kept, num_unsupervised, num_clipped
 
@@ -459,12 +527,13 @@ def _preprocess_batch(
         )
 
     results: dict[str, list] = {"input_ids": [], "loss_mask": [], "seq_len": []}
-    conversations: list[list[dict]] = examples.get("conversations", [])
+    conversations: list[list[dict]] = _get_conversations_from_examples(examples)
 
     # MM inputs are extracted via the Chat Completions API, which needs the
     # original messages -- token ids alone cannot carry the images.
     if is_multimodal:
         results["messages"] = []
+        results["tools"] = []
 
     if not conversations:
         log.warning(f"No conversations key found. Keys: {list(examples.keys())}")
@@ -485,15 +554,16 @@ def _preprocess_batch(
 
     for idx, conv in enumerate(conversations):
         conv_tools = tools_col[idx] if tools_col is not None else None
-        rows = _render_conversation_rows(
+        rendered = _render_conversation_rows(
             conv,
             conv_tools,
             idx,
             render_endpoint,
             max_length,
         )
-        if rows is None:
+        if rendered is None:
             continue
+        rows, canonical_tools_json = rendered
 
         num_convs_in += 1
         num_kept, row_unsupervised, row_clipped = _append_boundary_rows(
@@ -501,6 +571,7 @@ def _preprocess_batch(
             rows,
             max_length,
             minimum_valid_tokens,
+            tools_json=canonical_tools_json,
         )
         num_unsupervised += row_unsupervised
         num_clipped += row_clipped
@@ -528,6 +599,7 @@ def build_speculator_training_dataset(
     *,
     render_endpoint: str | None = None,
     minimum_valid_tokens: int | None = None,
+    is_multimodal: bool | None = None,
 ) -> HFDataset:
     """Build a speculator training dataset with render-boundary loss masks.
 
@@ -555,7 +627,10 @@ def build_speculator_training_dataset(
     # Multimodal rows keep their `messages` so the images survive to hidden-state
     # extraction. Compute once here rather than pickling the heavyweight processor
     # into every map worker just to recheck it.
-    is_multimodal = isinstance(processor, ProcessorMixin)
+    processor_is_multimodal = isinstance(processor, ProcessorMixin)
+    if is_multimodal is True and not processor_is_multimodal:
+        raise ValueError("Requested multimodal preprocessing with a text processor.")
+    raw_multimodal = processor_is_multimodal if is_multimodal is None else is_multimodal
 
     if pretokenized:
         log.info("Speculator-format rows: using their loss mask, skipping render")
@@ -570,11 +645,11 @@ def build_speculator_training_dataset(
 
     # Avoid CPU contention for MM processing:
     # https://github.com/vllm-project/vllm/pull/31879
-    with set_default_torch_num_threads() if is_multimodal else nullcontext():
+    with set_default_torch_num_threads() if raw_multimodal else nullcontext():
         dataset = dataset.map(
             lambda examples: _preprocess_batch(
                 examples,
-                is_multimodal,
+                raw_multimodal,
                 render_endpoint,
                 max_length,
                 minimum_valid_tokens,
@@ -736,6 +811,7 @@ def load_and_preprocess_dataset(
     minimum_valid_tokens: int | None = None,
     allow_empty_output: bool = False,
     trust_remote_code: bool = False,
+    is_multimodal: bool | None = None,
 ) -> tuple[HFDataset, ProcessorLike]:
     """Load, tokenize, and preprocess a dataset for speculator training.
 
@@ -775,6 +851,12 @@ def load_and_preprocess_dataset(
 
     log.subsection("Loading processor")
     processor = load_processor(target_model_path, trust_remote_code=trust_remote_code)
+    processor_is_multimodal = isinstance(processor, ProcessorMixin)
+    if is_multimodal and not processor_is_multimodal:
+        raise ValueError(
+            f"Processor for {target_model_path} is not a multimodal ProcessorMixin."
+        )
+    log.info(f"Using multimodal mode: {processor_is_multimodal}")
 
     if render_endpoint is not None:
         log.info(f"Rendering conversations via vLLM endpoint: {render_endpoint}")
@@ -807,6 +889,7 @@ def load_and_preprocess_dataset(
             num_proc=build_dataset_num_proc,
             render_endpoint=render_endpoint,
             minimum_valid_tokens=minimum_valid_tokens,
+            is_multimodal=is_multimodal,
         )
         if minimum_valid_tokens is not None:
             log.info(f"Kept {len(preprocessed_dataset)} samples after filtering")

--- a/src/speculators/data_generation/vllm_client.py
+++ b/src/speculators/data_generation/vllm_client.py
@@ -4,12 +4,16 @@ import functools
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, Any, TypedDict
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, TypedDict, cast
+from urllib.parse import unquote, urlparse
 
 import openai
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 from openai.types.completion import Completion
 from typing_extensions import NotRequired
+
+from speculators.data_generation.media import get_image_ref
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
@@ -23,6 +27,94 @@ RETRY_BACKOFF_BASE = 2  # seconds
 
 class InvalidResponseError(Exception):
     pass
+
+
+def _get_field(obj: Any, key: str) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key)
+    return getattr(obj, key, None)
+
+
+def _to_token_id_list(token_ids: Any) -> list[int]:
+    if hasattr(token_ids, "tolist"):
+        token_ids = token_ids.tolist()
+    return list(token_ids)
+
+
+def _image_ref_to_chat_url(image_ref: Any) -> str:
+    """Convert a dataset image reference to an OpenAI-compatible image URL."""
+    ref = str(image_ref)
+    parsed = urlparse(ref)
+    if not parsed.scheme and parsed.netloc:
+        raise ValueError(f"Unsupported schemeless image URI authority: {parsed.netloc}")
+    if parsed.scheme in {"http", "https", "data"}:
+        return ref
+
+    if parsed.scheme == "file":
+        if parsed.netloc not in {"", "localhost"}:
+            raise ValueError(f"Unsupported file URI host: {parsed.netloc}")
+        if parsed.query or parsed.fragment:
+            raise ValueError("Local file URIs must not contain query/fragment")
+        decoded_path = unquote(parsed.path)
+        if not decoded_path or "\x00" in decoded_path:
+            raise ValueError("Local file URI contains an invalid path")
+        path = Path(decoded_path)
+        if not path.is_absolute():
+            raise ValueError("Local file URI path must be absolute")
+        return path.resolve().as_uri()
+
+    if parsed.scheme:
+        raise ValueError(f"Unsupported image URL scheme: {parsed.scheme}")
+
+    return Path(ref).expanduser().resolve().as_uri()
+
+
+def _prepare_chat_message_content(content: Any) -> Any:
+    if not isinstance(content, list):
+        return content
+
+    prepared: list[Any] = []
+    for part in content:
+        if isinstance(part, str):
+            prepared.append({"type": "text", "text": part})
+            continue
+
+        if not isinstance(part, dict):
+            prepared.append(part)
+            continue
+
+        image_ref = get_image_ref(part)
+        if image_ref is not None:
+            prepared.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": _image_ref_to_chat_url(image_ref)},
+                }
+            )
+            continue
+
+        text = part.get("text")
+        if text is not None:
+            prepared.append({"type": "text", "text": str(text)})
+            continue
+
+        prepared.append(part)
+
+    return prepared
+
+
+def _prepare_chat_messages(
+    messages: list[ChatCompletionMessageParam],
+) -> list[dict[str, Any]]:
+    """Convert processor-style multimodal messages to vLLM chat messages."""
+    prepared = []
+    for message in messages:
+        prepared_message = dict(cast("dict[str, Any]", message))
+        prepared_message["content"] = _prepare_chat_message_content(
+            prepared_message.get("content", "")
+        )
+        prepared.append(prepared_message)
+    return prepared
 
 
 def _handle_retry_error(
@@ -94,32 +186,61 @@ def with_retries(fn):
 def extract_output(
     response: Completion | ChatCompletion,
     token_ids: list[int],
+    *,
+    allow_prefix_truncation: bool = False,
 ) -> str:
-    if isinstance(response, Completion):
-        prompt_token_ids = getattr(response.choices[0], "prompt_token_ids", None)
-    else:
-        prompt_token_ids = getattr(response, "prompt_token_ids", None)
+    token_ids = _to_token_id_list(token_ids)
+    prompt_token_ids = _get_field(response, "prompt_token_ids")
+    if prompt_token_ids is None:
+        choices = _get_field(response, "choices")
+        if choices:
+            prompt_token_ids = _get_field(choices[0], "prompt_token_ids")
 
     if prompt_token_ids is None:
         raise InvalidResponseError("Response missing prompt_token_ids")
 
-    if prompt_token_ids != token_ids:
-        raise InvalidResponseError(
-            f"Prompt token IDs mismatch: expected {token_ids}, got {prompt_token_ids}"
-        )
-
-    kv_transfer_params = getattr(response, "kv_transfer_params", None)
+    kv_transfer_params = _get_field(response, "kv_transfer_params")
     if kv_transfer_params is None:
         raise InvalidResponseError("Response missing kv_transfer_params")
 
-    handle = kv_transfer_params.get("hidden_states_path") or kv_transfer_params.get(
-        "handle"
-    )
+    hidden_states_path = _get_field(kv_transfer_params, "hidden_states_path")
+    handle = hidden_states_path or _get_field(kv_transfer_params, "handle")
     if handle is None:
         raise InvalidResponseError(
             "Response kv_transfer_params missing both 'hidden_states_path' and 'handle'"
         )
-    return handle
+
+    prompt_token_ids = _to_token_id_list(prompt_token_ids)
+    if prompt_token_ids == token_ids:
+        return handle
+
+    if (
+        hidden_states_path is not None
+        and allow_prefix_truncation
+        and prompt_token_ids[: len(token_ids)] == token_ids
+    ):
+        logger.debug(
+            "vLLM returned %d prompt tokens for a %d-token preprocessed prompt; "
+            "hidden states will be aligned after the output lock is released.",
+            len(prompt_token_ids),
+            len(token_ids),
+        )
+        return hidden_states_path
+
+    if hidden_states_path is not None and allow_prefix_truncation:
+        logger.debug(
+            "vLLM returned prompt token IDs that differ from the preprocessed "
+            "multimodal token IDs; hidden states will be validated and aligned "
+            "against vLLM token IDs after the output lock is released. "
+            "preprocessed_len=%d, vllm_len=%d",
+            len(token_ids),
+            len(prompt_token_ids),
+        )
+        return hidden_states_path
+
+    raise InvalidResponseError(
+        f"Prompt token IDs mismatch: expected {token_ids}, got {prompt_token_ids}"
+    )
 
 
 class ClientItem(TypedDict):
@@ -129,6 +250,9 @@ class ClientItem(TypedDict):
     messages: NotRequired[list[ChatCompletionMessageParam]]
     """If provided, pass `messages` to Chat Completions API
     instead of passing `token_ids` to Completions API."""
+
+    tools: NotRequired[list[dict[str, Any]]]
+    """Tool schemas used to render a multimodal Chat Completions prompt."""
 
 
 async def _poll_lock_async(fd, poll_interval):
@@ -206,6 +330,7 @@ async def generate_hidden_states_async(
     """
     token_ids = client_item["input_ids"]
     messages = client_item.get("messages")
+    tools = client_item.get("tools")
 
     coro: Coroutine[Any, Any, Completion | ChatCompletion]
     if messages is None:
@@ -217,18 +342,22 @@ async def generate_hidden_states_async(
             timeout=timeout,
         )
     else:
-        coro = client.chat.completions.create(
-            model=model,
-            messages=messages,
-            max_tokens=1,
-            extra_body={
+        chat_messages = _prepare_chat_messages(messages)
+        chat_kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": chat_messages,
+            "max_tokens": 1,
+            "extra_body": {
                 "add_generation_prompt": False,
                 # Re-render to match the stored ``input_ids`` (model-dependent).
                 "continue_final_message": _continue_final_message_for(model),
                 "return_token_ids": True,
             },
-            timeout=timeout,
-        )
+            "timeout": timeout,
+        }
+        if tools:
+            chat_kwargs["tools"] = tools
+        coro = client.chat.completions.create(**cast("Any", chat_kwargs))
 
     res: Completion | ChatCompletion
     if timeout is not None:
@@ -236,7 +365,11 @@ async def generate_hidden_states_async(
     else:
         res = await coro
 
-    return extract_output(res, token_ids)
+    return extract_output(
+        res,
+        token_ids,
+        allow_prefix_truncation=messages is not None,
+    )
 
 
 @with_retries
@@ -253,6 +386,7 @@ def generate_hidden_states(
     """
     token_ids = client_item["input_ids"]
     messages = client_item.get("messages")
+    tools = client_item.get("tools")
 
     res: Completion | ChatCompletion
     if messages is None:
@@ -264,17 +398,25 @@ def generate_hidden_states(
             timeout=timeout,
         )
     else:
-        res = client.chat.completions.create(
-            model=model,
-            messages=messages,
-            max_tokens=1,
-            extra_body={
+        chat_messages = _prepare_chat_messages(messages)
+        chat_kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": chat_messages,
+            "max_tokens": 1,
+            "extra_body": {
                 "add_generation_prompt": False,
                 # Re-render to match the stored ``input_ids`` (model-dependent).
                 "continue_final_message": _continue_final_message_for(model),
                 "return_token_ids": True,
             },
-            timeout=timeout,
-        )
+            "timeout": timeout,
+        }
+        if tools:
+            chat_kwargs["tools"] = tools
+        res = client.chat.completions.create(**cast("Any", chat_kwargs))
 
-    return extract_output(res, token_ids)
+    return extract_output(
+        res,
+        token_ids,
+        allow_prefix_truncation=messages is not None,
+    )

--- a/src/speculators/models/attention.py
+++ b/src/speculators/models/attention.py
@@ -5,6 +5,7 @@ speculator architectures (EAGLE3, DFlash, etc.) to avoid code duplication.
 """
 
 from collections.abc import Callable
+from typing import cast
 
 import torch
 from torch.nn.attention.flex_attention import (
@@ -61,7 +62,7 @@ def flex_attention_forward(
         enable_gqa=enable_gqa,
         scale=scaling,
     )
-    attention_output: torch.Tensor = flex_attention_output
+    attention_output = cast("torch.Tensor", flex_attention_output)
     attention_output = attention_output.transpose(1, 2).contiguous()
     return attention_output, None
 

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -21,6 +21,7 @@ from speculators.models.utils import (
     conditional_torch_compile,
     flatten_rope_parameters,
     resolve_target_layer_ids,
+    strip_verifier_final_layer_id,
 )
 from speculators.proposals.greedy import GreedyTokenProposalConfig
 
@@ -391,6 +392,10 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
         target_layer_ids = resolve_target_layer_ids(
             kwargs.get("target_layer_ids"), kwargs["verifier_name_or_path"]
         )
+        if kwargs.get("target_layer_ids") is not None:
+            target_layer_ids = strip_verifier_final_layer_id(
+                target_layer_ids, kwargs["verifier_name_or_path"]
+            )
 
         verifier_config._attn_implementation = kwargs.get(  # noqa: SLF001
             "draft_attn_impl", "simple_flex_attention"

--- a/src/speculators/models/utils.py
+++ b/src/speculators/models/utils.py
@@ -99,3 +99,23 @@ def resolve_draft_intermediate_size(verifier_config: PretrainedConfig) -> int:
         stacklevel=3,
     )
     return intermediate_size
+
+
+def strip_verifier_final_layer_id(
+    target_layer_ids: list[int],
+    verifier_name_or_path: str,
+) -> list[int]:
+    """Remove the verifier final layer from training auxiliary layer IDs."""
+    num_layers = get_verifier_config(verifier_name_or_path).num_hidden_layers
+    aux_target_layer_ids = [
+        layer_id for layer_id in target_layer_ids if layer_id != num_layers
+    ]
+    if len(aux_target_layer_ids) != len(target_layer_ids):
+        warnings.warn(
+            "Stripping the verifier's final layer "
+            f"({num_layers}) from --target-layer-ids for training. "
+            "The last extracted layer is consumed separately as "
+            "`verifier_last_hidden_states`.",
+            stacklevel=2,
+        )
+    return aux_target_layer_ids

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -10,7 +10,7 @@ from datasets import load_from_disk
 from torch.utils.data import Dataset
 
 from hs_connectors import FileTransfer, HiddenStatesTransfer
-from speculators.data_generation.offline import check_hidden_states
+from speculators.data_generation.offline import align_hidden_states_to_tokens
 from speculators.data_generation.vllm_client import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_REQUEST_TIMEOUT,
@@ -55,7 +55,36 @@ def _has_multimodal_content(messages: list[dict]) -> bool:
     (produced by ``_adapt_conv_for_vllm``) store it as a list of typed parts,
     e.g. ``[{"type": "text", ...}, {"type": "image_url", ...}]``.
     """
-    return any(isinstance(m.get("content"), list) for m in messages)
+    multimodal_types = {
+        "audio",
+        "audio_url",
+        "image",
+        "image_url",
+        "input_audio",
+        "input_image",
+        "input_video",
+        "video",
+        "video_url",
+    }
+    text_types = {None, "input_text", "text"}
+
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+
+        for part in content:
+            if isinstance(part, str):
+                continue
+            if not isinstance(part, dict):
+                return True
+            part_type = part.get("type")
+            if part_type in multimodal_types:
+                return True
+            if part_type not in text_types:
+                return True
+
+    return False
 
 
 def build_client_item(dataset_item: dict) -> ClientItem:
@@ -80,10 +109,18 @@ def build_client_item(dataset_item: dict) -> ClientItem:
     Text-only EAGLE-3 models (e.g. Llama) use a plain tokenizer, so
     ``messages`` is never created and this guard is a no-op.
     """
-    out_dict: dict = {"input_ids": dataset_item["input_ids"].tolist()}
+    input_ids = dataset_item["input_ids"]
+    out_dict: dict = {
+        "input_ids": input_ids.tolist()
+        if hasattr(input_ids, "tolist")
+        else list(input_ids)
+    }
 
     if "messages" in dataset_item and _has_multimodal_content(dataset_item["messages"]):
         out_dict["messages"] = dataset_item["messages"]
+        tools = dataset_item.get("tools")
+        if tools:
+            out_dict["tools"] = json.loads(tools) if isinstance(tools, str) else tools
 
     return cast("ClientItem", out_dict)
 
@@ -141,6 +178,139 @@ class BaseDataset(Dataset):
             data = self.transform(data)
 
         return data
+
+def _check_hidden_states_self_consistent(data: dict[str, torch.Tensor]) -> None:
+    token_ids = data["token_ids"]
+    hidden_states = data["hidden_states"]
+    if hidden_states.isnan().any():
+        raise ValueError("Hidden states contain NaN values")
+    if token_ids.shape[0] != hidden_states.shape[0]:
+        raise ValueError(
+            f"Sequence length of hidden states {hidden_states.shape[0]}"
+            f" doesn't match num tokens {token_ids.shape[0]}"
+        )
+
+
+def _is_multimodal_dataset_item(dataset_item: dict[str, Any]) -> bool:
+    return "messages" in dataset_item and _has_multimodal_content(
+        dataset_item["messages"]
+    )
+
+
+def _as_list(value: Any) -> list[int]:
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    return list(value)
+
+
+def _align_loss_mask_to_token_ids(  # noqa: C901
+    source_token_ids: list[int],
+    source_loss_mask: list[int],
+    target_token_ids: list[int],
+    *,
+    min_match_run: int = 4,
+    max_resync_scan: int = 2048,
+) -> torch.Tensor:
+    """Map a preprocessed loss mask onto vLLM's actual multimodal token IDs.
+
+    vLLM Chat Completions re-tokenizes multimodal messages and can expand image
+    placeholders to a different number of image tokens than the HF preprocessing
+    path.  Hidden states are valid for vLLM's token IDs, so training must use the
+    same token IDs and a loss mask projected from the preprocessed sample.
+
+    The projection only permits skipping source spans whose loss mask is all 0;
+    target-only spans are assigned 0.  This keeps assistant text supervision
+    intact while tolerating differences in user-side vision-token blocks and
+    Chat Completions continuation suffixes.
+    """
+    if len(source_token_ids) != len(source_loss_mask):
+        raise ValueError(
+            "Cannot align loss mask with mismatched source lengths: "
+            f"input_ids={len(source_token_ids)}, loss_mask={len(source_loss_mask)}"
+        )
+
+    def source_span_is_masked(start: int, end: int) -> bool:
+        return all(int(value) == 0 for value in source_loss_mask[start:end])
+
+    def following_run_matches(src_pos: int, tgt_pos: int) -> bool:
+        remaining = min(
+            min_match_run,
+            len(source_token_ids) - src_pos,
+            len(target_token_ids) - tgt_pos,
+        )
+        if remaining <= 0:
+            return True
+        return (
+            source_token_ids[src_pos : src_pos + remaining]
+            == target_token_ids[tgt_pos : tgt_pos + remaining]
+        )
+
+    def find_resync(src_pos: int, tgt_pos: int) -> tuple[int, int] | None:
+        best: tuple[int, int] | None = None
+        best_cost: int | None = None
+        max_src = min(len(source_token_ids), src_pos + max_resync_scan)
+        max_tgt = min(len(target_token_ids), tgt_pos + max_resync_scan)
+        for next_src in range(src_pos, max_src):
+            if not source_span_is_masked(src_pos, next_src):
+                break
+            for next_tgt in range(tgt_pos, max_tgt):
+                if next_tgt > tgt_pos and int(source_loss_mask[src_pos]) != 0:
+                    continue
+                if source_token_ids[next_src] != target_token_ids[next_tgt]:
+                    continue
+                if not following_run_matches(next_src, next_tgt):
+                    continue
+                cost = (next_src - src_pos) + (next_tgt - tgt_pos)
+                if best_cost is None or cost < best_cost:
+                    best = (next_src, next_tgt)
+                    best_cost = cost
+                    break
+            if best is not None and best_cost == next_src - src_pos:
+                break
+        return best
+
+    aligned: list[int] = []
+    src_idx = 0
+    tgt_idx = 0
+
+    while src_idx < len(source_token_ids) and tgt_idx < len(target_token_ids):
+        if source_token_ids[src_idx] == target_token_ids[tgt_idx]:
+            aligned.append(int(source_loss_mask[src_idx]))
+            src_idx += 1
+            tgt_idx += 1
+            continue
+
+        resync = find_resync(src_idx, tgt_idx)
+        if resync is None:
+            break
+        next_src, next_tgt = resync
+        aligned.extend([0] * (next_tgt - tgt_idx))
+        src_idx = next_src
+        tgt_idx = next_tgt
+
+    if tgt_idx < len(target_token_ids):
+        if not source_span_is_masked(src_idx, len(source_token_ids)):
+            raise ValueError(
+                "Unable to align vLLM multimodal token IDs without dropping "
+                f"trainable source tokens at source={src_idx}, target={tgt_idx}"
+            )
+        aligned.extend([0] * (len(target_token_ids) - tgt_idx))
+        tgt_idx = len(target_token_ids)
+
+    if src_idx < len(source_token_ids) and not source_span_is_masked(
+        src_idx, len(source_token_ids)
+    ):
+        raise ValueError(
+            "Unable to align vLLM multimodal token IDs; remaining source suffix "
+            f"contains trainable tokens at source={src_idx}"
+        )
+
+    if len(aligned) != len(target_token_ids):
+        raise ValueError(
+            "Aligned loss mask length mismatch: "
+            f"mask={len(aligned)}, target_ids={len(target_token_ids)}"
+        )
+    return torch.tensor(aligned, dtype=torch.long)
 
 
 class ArrowDataset(BaseDataset):
@@ -217,7 +387,7 @@ class ArrowDataset(BaseDataset):
         """Get lengths of the dataset samples."""
         return list(self.data.with_format(None)["seq_len"])
 
-    def _maybe_generate_hs(self, index: int) -> dict[str, torch.Tensor] | None:
+    def _maybe_generate_hs(self, index: int) -> dict[str, torch.Tensor] | None:  # noqa: C901
         if not self.client:
             self._setup_client()
 
@@ -237,7 +407,14 @@ class ArrowDataset(BaseDataset):
             if loaded_hs is None:
                 raise ValueError(f"Failed to load hidden states for handle {handle}")
 
-            check_hidden_states(loaded_hs, dataset_item["input_ids"].tolist())
+            if "messages" in client_item:
+                _check_hidden_states_self_consistent(loaded_hs)
+            else:
+                loaded_hs, _ = align_hidden_states_to_tokens(
+                    loaded_hs,
+                    dataset_item["input_ids"].tolist(),
+                    allow_prefix_truncation=False,
+                )
 
             file_idx = self._map_to_file_idx(index)
             match self.on_generate:
@@ -283,10 +460,27 @@ class ArrowDataset(BaseDataset):
         #   "token_ids": [seq_len]
         # }
 
-        if not torch.equal(loaded_hs["token_ids"], self.data[index]["input_ids"]):
+        input_ids = self.data[index]["input_ids"]
+        loss_mask = self.data[index]["loss_mask"]
+        if torch.equal(loaded_hs["token_ids"], input_ids):
+            aligned_loss_mask = loss_mask
+        elif _is_multimodal_dataset_item(self.data[index]):
+            try:
+                aligned_loss_mask = _align_loss_mask_to_token_ids(
+                    _as_list(input_ids),
+                    _as_list(loss_mask),
+                    _as_list(loaded_hs["token_ids"]),
+                )
+            except ValueError as e:
+                warnings.warn(
+                    f"Failed to align multimodal token ids for index {index}: {e}",
+                    stacklevel=1,
+                )
+                return None
+        else:
             warnings.warn(
                 f"Loaded token ids {loaded_hs['token_ids']} for index {index} don't"
-                f"match input ids {self.data[index]['input_ids']}",
+                f"match input ids {input_ids}",
                 stacklevel=1,
             )
             return None
@@ -299,7 +493,7 @@ class ArrowDataset(BaseDataset):
             "verifier_last_hidden_states": loaded_hs["hidden_states"][
                 :, -1
             ],  # [seq_len, hidden_size]
-            "loss_mask": self.data[index]["loss_mask"],  # [seq_len]
+            "loss_mask": aligned_loss_mask,  # [seq_len]
         }
 
 

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -1,3 +1,4 @@
+import json
 import warnings
 from collections.abc import Callable, Sequence
 from os import PathLike

--- a/tests/unit/data_generation/test_vllm_client.py
+++ b/tests/unit/data_generation/test_vllm_client.py
@@ -1,0 +1,221 @@
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from speculators.data_generation.vllm_client import (
+    InvalidResponseError,
+    generate_hidden_states,
+    generate_hidden_states_async,
+)
+
+
+class _RequestState:
+    def __init__(
+        self,
+        *,
+        response_ids: list[int] | None = None,
+        nested_prompt_ids: bool = False,
+    ):
+        self.response_ids = response_ids
+        self.nested_prompt_ids = nested_prompt_ids
+        self.calls: list[dict[str, Any]] = []
+
+    def request(self, kwargs: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        prompt_ids = self.response_ids
+        if prompt_ids is None:
+            prompt_ids = list(kwargs["prompt"])
+        response: dict[str, Any] = {
+            "kv_transfer_params": {"hidden_states_path": "/tmp/hs_0.safetensors"}
+        }
+        if self.nested_prompt_ids:
+            response["choices"] = [{"prompt_token_ids": prompt_ids}]
+        else:
+            response["prompt_token_ids"] = prompt_ids
+        return response
+
+
+class _SyncEndpoint:
+    def __init__(self, state: _RequestState):
+        self.state = state
+
+    def create(self, **kwargs):
+        return self.state.request(kwargs)
+
+
+class _AsyncEndpoint:
+    def __init__(self, state: _RequestState):
+        self.state = state
+
+    async def create(self, **kwargs):
+        return self.state.request(kwargs)
+
+
+def _make_client(
+    mode: str,
+    *,
+    text_response_ids: list[int] | None = None,
+    chat_response_ids: list[int] | None = None,
+) -> tuple[Any, _RequestState, _RequestState]:
+    endpoint = _AsyncEndpoint if mode == "async" else _SyncEndpoint
+    text_state = _RequestState(
+        response_ids=text_response_ids,
+        nested_prompt_ids=True,
+    )
+    chat_state = _RequestState(response_ids=chat_response_ids)
+    client = SimpleNamespace(
+        completions=endpoint(text_state),
+        chat=SimpleNamespace(completions=endpoint(chat_state)),
+    )
+    return client, text_state, chat_state
+
+
+def _generate(mode: str, client: Any, item: dict, **kwargs) -> str:
+    kwargs.setdefault("max_retries", 0)
+    if mode == "async":
+        return asyncio.run(
+            generate_hidden_states_async(client, "dummy-model", item, **kwargs)
+        )
+    return generate_hidden_states(client, "dummy-model", item, **kwargs)
+
+
+@pytest.mark.parametrize("mode", ["sync", "async"])
+def test_routes_text_and_multimodal_payloads(mode):
+    client, text_state, chat_state = _make_client(
+        mode,
+        chat_response_ids=[4, 5, 6],
+    )
+
+    assert (
+        _generate(mode, client, {"input_ids": [1, 2, 3]}, timeout=1)
+        == "/tmp/hs_0.safetensors"
+    )
+    assert text_state.calls[0]["prompt"] == [1, 2, 3]
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "describe_image",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": "https://example.com/cat.png"},
+                {"type": "text", "text": "describe"},
+            ],
+        },
+        {"role": "assistant", "content": "A cat."},
+    ]
+
+    assert (
+        _generate(
+            mode,
+            client,
+            {"input_ids": [4, 5, 6], "messages": messages, "tools": tools},
+            timeout=1,
+        )
+        == "/tmp/hs_0.safetensors"
+    )
+    chat_call = chat_state.calls[0]
+    assert chat_call["messages"][0]["content"] == [
+        {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/cat.png"},
+        },
+        {"type": "text", "text": "describe"},
+    ]
+    assert chat_call["tools"] == tools
+    assert chat_call["extra_body"] == {
+        "add_generation_prompt": False,
+        "continue_final_message": True,
+        "return_token_ids": True,
+    }
+
+    _generate(mode, client, {"input_ids": [4, 5, 6], "messages": messages})
+    assert "tools" not in chat_state.calls[1]
+
+
+def test_canonicalizes_local_paths_and_percent_encoded_file_uris(tmp_path):
+    client, _, chat_state = _make_client("sync", chat_response_ids=[1])
+    image_path = tmp_path / "test image#100%.png"
+    image_path.write_bytes(b"image")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "path": str(image_path)},
+                {"type": "image_url", "image_url": {"url": image_path.as_uri()}},
+            ],
+        }
+    ]
+
+    _generate("sync", client, {"input_ids": [1], "messages": messages}, timeout=1)
+
+    sent_content = chat_state.calls[0]["messages"][0]["content"]
+    assert [part["image_url"]["url"] for part in sent_content] == [
+        image_path.resolve().as_uri(),
+        image_path.resolve().as_uri(),
+    ]
+
+
+@pytest.mark.parametrize(
+    "image_ref",
+    [
+        "file://remote.example/tmp/cat.png",
+        "file:///tmp/cat.png?version=1",
+        "file:relative/cat.png",
+        "ftp://example.com/cat.png",
+        "//remote.example/tmp/cat.png",
+    ],
+)
+def test_rejects_ambiguous_or_unsupported_image_uri(image_ref):
+    client, _, chat_state = _make_client("sync", chat_response_ids=[1])
+    item = {
+        "input_ids": [1],
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "image", "image": image_ref}],
+            }
+        ],
+    }
+
+    with pytest.raises(ValueError, match="Unsupported|query/fragment|absolute"):
+        _generate("sync", client, item, timeout=1)
+    assert chat_state.calls == []
+
+
+@pytest.mark.parametrize(
+    ("mode", "multimodal", "response_ids", "accepted"),
+    [
+        ("sync", True, [1, 2, 3, 4], True),
+        ("async", True, [1, 2, 3, 4], True),
+        ("sync", True, [1, 9, 3, 4], True),
+        ("sync", False, [1, 2, 3, 4], False),
+    ],
+)
+def test_token_alignment_policy(mode, multimodal, response_ids, accepted):
+    client, text_state, chat_state = _make_client(
+        mode,
+        text_response_ids=response_ids,
+        chat_response_ids=response_ids,
+    )
+    item: dict[str, object] = {"input_ids": [1, 2, 3]}
+    if multimodal:
+        item["messages"] = [{"role": "user", "content": "describe"}]
+
+    if accepted:
+        assert _generate(mode, client, item, timeout=1) == "/tmp/hs_0.safetensors"
+    else:
+        with pytest.raises(InvalidResponseError, match="Prompt token IDs mismatch"):
+            _generate(mode, client, item, timeout=1)
+
+    state = chat_state if multimodal else text_state
+    assert len(state.calls) == 1

--- a/tests/unit/data_generation/test_vllm_client.py
+++ b/tests/unit/data_generation/test_vllm_client.py
@@ -6,6 +6,7 @@ import pytest
 
 from speculators.data_generation.vllm_client import (
     InvalidResponseError,
+    _continue_final_message_for,
     generate_hidden_states,
     generate_hidden_states_async,
 )
@@ -134,12 +135,18 @@ def test_routes_text_and_multimodal_payloads(mode):
     assert chat_call["tools"] == tools
     assert chat_call["extra_body"] == {
         "add_generation_prompt": False,
-        "continue_final_message": True,
+        "continue_final_message": False,
         "return_token_ids": True,
     }
 
     _generate(mode, client, {"input_ids": [4, 5, 6], "messages": messages})
     assert "tools" not in chat_state.calls[1]
+
+
+def test_continue_final_message_is_model_specific():
+    assert not _continue_final_message_for("dummy-model")
+    assert _continue_final_message_for("mistral-small")
+    assert _continue_final_message_for("mistralai/Mistral-7B-Instruct-v0.3")
 
 
 def test_canonicalizes_local_paths_and_percent_encoded_file_uris(tmp_path):

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -1,7 +1,9 @@
 """Unit tests for data processing in speculators.train.data."""
 
+import json
 from pathlib import Path
 
+import pytest
 import torch
 from datasets import Dataset
 from safetensors.torch import save_file
@@ -10,6 +12,8 @@ from speculators.models.eagle3.data import shift_batch
 from speculators.train.data import (
     ArrowDataset,
     CollateFn,
+    _align_loss_mask_to_token_ids,
+    build_client_item,
 )
 
 
@@ -49,6 +53,79 @@ def test_shift_batch():
 
     for key, value in shifted.items():
         assert torch.allclose(value, expected_output[key])
+
+
+def test_build_client_item_forwards_tools_only_for_multimodal_messages():
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "describe_image", "parameters": {"type": "object"}},
+        }
+    ]
+    multimodal_item = {
+        "input_ids": torch.tensor([1, 2, 3]),
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    {"type": "image_url", "image_url": {"url": "file:///tmp/cat.png"}},
+                ],
+            }
+        ],
+        "tools": json.dumps(tools),
+    }
+
+    assert build_client_item(multimodal_item) == {
+        "input_ids": [1, 2, 3],
+        "messages": multimodal_item["messages"],
+        "tools": tools,
+    }
+
+    text_only_item = {
+        "input_ids": torch.tensor([1, 2, 3]),
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        "tools": json.dumps(tools),
+    }
+    assert build_client_item(text_only_item) == {"input_ids": [1, 2, 3]}
+
+
+def test_align_loss_mask_to_vllm_multimodal_token_ids_with_image_block_delta():
+    source_ids = [10, 20, 30, 30, 30, 30, 30, 40, 50, 60, 70, 80]
+    source_mask = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0]
+    target_ids = [10, 20, 30, 30, 40, 50, 60, 70, 80]
+
+    aligned = _align_loss_mask_to_token_ids(source_ids, source_mask, target_ids)
+
+    assert aligned.tolist() == [0, 0, 0, 0, 0, 1, 1, 1, 0]
+
+
+def test_align_loss_mask_to_vllm_multimodal_token_ids_with_target_extra_and_suffix():
+    source_ids = [10, 20, 30, 40, 50, 60, 70, 80]
+    source_mask = [0, 0, 0, 0, 1, 1, 0, 0]
+    target_ids = [10, 20, 20, 20, 30, 40, 50, 60]
+
+    aligned = _align_loss_mask_to_token_ids(source_ids, source_mask, target_ids)
+
+    assert aligned.tolist() == [0, 0, 0, 0, 0, 0, 1, 1]
+
+
+def test_align_loss_mask_to_vllm_multimodal_token_ids_rejects_trainable_drop():
+    source_ids = [10, 20, 30, 40]
+    source_mask = [0, 1, 1, 0]
+    target_ids = [10, 40]
+
+    with pytest.raises(ValueError, match="trainable"):
+        _align_loss_mask_to_token_ids(source_ids, source_mask, target_ids)
+
+
+def test_align_loss_mask_to_vllm_multimodal_token_ids_rejects_trainable_insert():
+    source_ids = [10, 20, 30]
+    source_mask = [0, 1, 1]
+    target_ids = [10, 99, 20, 30]
+
+    with pytest.raises(ValueError, match="trainable"):
+        _align_loss_mask_to_token_ids(source_ids, source_mask, target_ids)
 
 
 def test_collate_fn_basic():


### PR DESCRIPTION
## Purpose

Add end-to-end Qwen3-VL image-text Eagle3 training support with vLLM chat-based hidden-state generation.

## Description

This PR adds a full multimodal image-text training path for Qwen3-VL speculators:

- prepares image-text datasets with `prepare_data.py --multimodal`
- expands image placeholders to the processor's actual visual-token length
- preserves normalized `messages` for vLLM chat-based hidden-state generation
- supports both offline datagen and online `--on-missing generate` training
- adds runnable Qwen3-VL LLaVA-CoT 5k and 48k training examples

Key implementation details:

- text-only samples stay on the existing token-id Completions path
- real multimodal samples use Chat Completions with OpenAI-compatible image content
- local images are sent as `file://` media URLs
- returned prompt token IDs are checked against preprocessed `input_ids`
- hidden-state files are consumed only after vLLM lock release and then aligned to the preprocessed sequence length

Validation-driven fixes:

- avoid routing text-only list content through chat retokenization
- reject truncation in the middle of expanded image token blocks
- keep checkpoint loading stable by avoiding target-layer mutation in `from_pretrained`
- avoid unnecessary offline safetensors reads when output validation is disabled

## Related Issue

https://github.com/vllm-project/speculators/issues/290

## Tests

Following `CONTRIBUTING.md`, validation was split by quality, unit, integration, e2e, and example-script checks.

Passed on current clean remote validation source:

- `make quality`
- `python -m pytest ...` targeted regression subset: `90 passed`
  - covers multimodal preprocessing, vLLM chat/message requests, hidden-state alignment, empty-batch dtype, target-layer handling, Pydantic config registration, and offline datagen no-load move regression
- `python -m pytest ...` prefix-cache launcher regression subset: `4 passed`
- `python -m pytest ...` multimodal offline e2e smoke: `1 passed`
- `python -m pytest ...` multimodal online `--on-missing generate` e2e smoke: `1 passed`
- `python -m pytest ...` resume regression e2e smoke: `1 passed`
Targeted coverage includes multimodal preprocessing, vLLM chat/message requests, hidden-state alignment, empty-batch dtype, target-layer handling, Pydantic config registration, and offline datagen no-load move regression.

Previously completed E2E validation:

- `bash examples/train/eagle3_qwen3_vl_4b_llava_cot_5k_online.sh`
- `bash examples/train/eagle3_qwen3_8b_sharegpt_online_5k.sh`

5k Qwen3-VL online run:

- 3x RTX 5090 32GB
- vLLM on GPUs 0,1; training on GPU 2
- total runtime: 4054 seconds
- `val/loss_epoch=7.803`
- `val/full_acc_0_epoch=64.2%`
- `val/full_acc_1_epoch=39.2%`
- `val/full_acc_2_epoch=23.9%`

48k Qwen3-VL online run, 1 epoch:

- `val/loss_epoch=6.894`
- `val/full_acc_0_epoch=65.5%`
- `val/full_acc_1_epoch=40.6%`
- `val/full_acc_2_epoch=25.3%`

Not counted as passed in the current clean remote validation:

- full unit suite: external HF test-resource failure; `nm-testing/testing-llama3.1.8b-2layer-eagle3` has config but no weights
- full integration suite: isolated HF network timeout while resolving `openai/gpt-oss-20b`
