### PR TITLE
fix: prevent cross-document attention in MTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Big updates have landed in Speculators! To get a more in-depth look, check out t
 Some of the exciting new features include:
 
 - **P-EAGLE Training Support**: Added support for the [P-EAGLE training algorithm](https://docs.vllm.ai/projects/speculators/en/latest/user_guide/algorithms/peagle), which extends EAGLE-3's architecture with parallel multi-token prediction via Conditional-On-Distribution (COD) sampling. Rather than generating draft tokens sequentially, P-EAGLE predicts multiple tokens in a single forward pass, reducing drafting latency. The Red Hat team published a [P-EAGLE speculator for Qwen3-8B](https://huggingface.co/RedHatAI/Qwen3-8B-speculator.peagle).
-- **MTP Finetuning Support**: Added support for finetuning the native Multi-Token Prediction (MTP) heads of models like Qwen3-Next on domain-specific data, following the [FastMTP](https://arxiv.org/abs/2509.18362) approach. Because the MTP head is small (~100M–400M params), it can be trained on pre-extracted hidden states without loading the full verifier
+- **MTP Finetuning Support**: Added support for finetuning the native Multi-Token Prediction (MTP) heads of models like Qwen3-Next on domain-specific data, following the [FastMTP](https://arxiv.org/abs/2509.18362) approach. Because the MTP head is small (~100M–400M params), it can be trained on pre-extracted hidden states without loading the full verifier.
 - **Sliding Window Attention for DFlash**: Added sliding window attention support to DFlash speculators via `--sliding-window` and `--swa-causal` training flags. Sliding window attention reduces KV cache allocation for long-context sequences and can improve per-position acceptance rates compared to full attention.
 - **Qwen3-8B DFlash Speculator**: The RedHat team published a [DFlash speculator for Qwen3-8B](https://huggingface.co/RedHatAI/Qwen3-8B-speculator.dflash), achieving average speculative token acceptance lengths of up to 3.74 on `math_reasoning`.
 - **Gemma 4 Speculators**: The RedHat team published speculators for Gemma 4 31B-it, including both [DFlash](https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.dflash) and [EAGLE-3](https://huggingface.co/RedHatAI/gemma-4-31B-it-speculator.eagle3) checkpoints, enabling production-grade speculative decoding for Gemma 4 models.
@@ -141,6 +141,7 @@ The following table summarizes the models that have been trained end-to-end by o
     </a> ✅</td>
   <td>✅</td>
 </tr>
+<tr>
 <td>Qwen3-VL</td>
 <td>235B-A22B</td>
 <td><a href="https://huggingface.co/RedHatAI/Qwen3-VL-235B-A22B-Instruct-speculator.eagle3">

--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -183,6 +183,16 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
             position_ids=step_pos_ids,
         )
 
+        document_ids = kwargs.get("document_ids")
+        if document_ids is not None:
+            doc_ids_step = document_ids[:, :valid_len]
+            same_doc_mask = (doc_ids_step.unsqueeze(-1) == doc_ids_step.unsqueeze(-2)) & (
+                doc_ids_step.unsqueeze(-1) != -1
+            )
+            same_doc_mask = same_doc_mask.unsqueeze(1)
+            min_dtype = torch.finfo(causal_mask.dtype).min
+            causal_mask = causal_mask.masked_fill(~same_doc_mask, min_dtype)
+
         current_hidden = hidden_states
         for step in range(effective_steps):
             step_hidden = current_hidden[:, :valid_len]


### PR DESCRIPTION
Fixes #621. MTP's causal_mask did not account for document boundaries, allowing later sequences in the batch to attend to previous unrelated sequences. This PR adds masking based on `document_ids` passed in kwargs to block cross-document attention.