### PR TITLE
Add CLI option for DFlash decay gamma

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -144,6 +144,8 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 - **`--max-anchors`** (int, default: `256`) Maximum anchor positions for DFlash training.
 
+- **`--dflash-decay-gamma`** (float, default: `4.0`) Decay gamma for DFlash loss weighting.
+
 ### Dataloader Arguments
 
 - **`--num-workers`** (int, default: `12`) Number of dataloader worker processes.

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -752,6 +752,12 @@ def parse_args():
         help="Maximum anchor positions for DFlash training (default: 256)",
     )
     parser.add_argument(
+        "--dflash-decay-gamma",
+        type=float,
+        default=4.0,
+        help="Decay gamma for DFlash loss weighting (default: 4.0)",
+    )
+    parser.add_argument(
         "--draft-attn-impl",
         type=str,
         default="simple_flex_attention",

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -191,7 +191,11 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             Tuple of (train_call_kwargs, val_call_kwargs)
         """
         loss_fn = resolve_loss_fn(kwargs["loss_fn"])
-        return {"loss_fn": loss_fn}, {"loss_fn": loss_fn}
+        gamma = kwargs.get("dflash_decay_gamma", 4.0)
+        return {"loss_fn": loss_fn, "gamma": gamma}, {
+            "loss_fn": loss_fn,
+            "gamma": gamma,
+        }
 
     @property
     def mask_token_id(self) -> int:
@@ -271,6 +275,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         document_ids: torch.Tensor,  # shape: [1, total_seq_len]
         position_ids: torch.Tensor | None = None,  # shape: [1, total_seq_len]
         loss_fn=kl_div_loss,
+        gamma: float = 4.0,
         **kwargs,
     ):
         device = hidden_states.device
@@ -353,7 +358,12 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
 
         aligned_loss_mask[:, :: self.block_size] = 0
         loss, metrics = compute_metrics(
-            logits, targets, aligned_loss_mask, self.block_size, loss_fn=loss_fn
+            logits,
+            targets,
+            aligned_loss_mask,
+            self.block_size,
+            gamma=gamma,
+            loss_fn=loss_fn,
         )
         draft_tokens = torch.argmax(logits, dim=-1)
 

--- a/tests/unit/train/test_cli_args.py
+++ b/tests/unit/train/test_cli_args.py
@@ -24,6 +24,8 @@ def test_dflash_default_uses_kl(monkeypatch):
     train_kw, val_kw = DFlashDraftModel.get_trainer_kwargs(**vars(args))
     assert train_kw["loss_fn"] is kl_div_loss
     assert val_kw["loss_fn"] is kl_div_loss
+    assert train_kw["gamma"] == 4.0
+    assert val_kw["gamma"] == 4.0
 
 
 def test_dflash_explicit_ce(monkeypatch):
@@ -31,6 +33,21 @@ def test_dflash_explicit_ce(monkeypatch):
     train_kw, val_kw = DFlashDraftModel.get_trainer_kwargs(**vars(args))
     assert train_kw["loss_fn"] is ce_loss
     assert val_kw["loss_fn"] is ce_loss
+    assert train_kw["gamma"] == 4.0
+    assert val_kw["gamma"] == 4.0
+
+
+def test_dflash_explicit_decay_gamma(monkeypatch):
+    args = _parse(monkeypatch, ["--dflash-decay-gamma", "7.0"])
+    train_kw, val_kw = DFlashDraftModel.get_trainer_kwargs(**vars(args))
+    assert train_kw["gamma"] == 7.0
+    assert val_kw["gamma"] == 7.0
+
+
+def test_dflash_decay_gamma_falls_back_when_omitted():
+    train_kw, val_kw = DFlashDraftModel.get_trainer_kwargs(loss_fn="kl_div")
+    assert train_kw["gamma"] == 4.0
+    assert val_kw["gamma"] == 4.0
 
 
 def test_eagle3_default_uses_kl(monkeypatch):


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Add a DFlash training CLI option to configure the loss decay gamma.

DFlash loss weighting already supports a configurable `gamma` in `compute_metrics()`, but users could not set it from `scripts/train.py`. This PR exposes `--dflash-decay-gamma`, keeps the existing default value of `4.0`, and passes the parsed value through DFlash train/validation kwargs into the forward pass.

This also updates the CLI docs and adds unit coverage for the default value, explicit CLI value, and fallback behavior.

## Tests

```bash
python -m pytest tests/unit/train/test_cli_args.py
```

```text
======================== 8 passed, 16 warnings in 0.06s ========================
```

Also ran:

```bash
make quality
```

`ruff check`, `ruff format --check`, and `mdformat --check` passed. `mypy --check-untyped-defs` failed on an existing unrelated issue:

```text
src/speculators/models/attention.py:56: error: Incompatible types in assignment
```
