### PR TITLE
ci: switch default GPU runner from H100 to L4

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ":gear: Speculators Unit and Integration Tests"
     command: |
-      RUNNER=$$(buildkite-agent meta-data get "test-runner" --default "H100")
+      RUNNER=$$(buildkite-agent meta-data get "test-runner" --default "L4")
       echo "╔══════════════════════════════════════════╗"
       echo "║          BUILD SUMMARY                   ║"
       echo "╠══════════════════════════════════════════╣"


### PR DESCRIPTION
## Summary
- Temporarily switch default GPU runner from H100 (WDC) to L4 (GCP) due to H100 cluster issue

## Reason
H100 nodes on WDC cluster have NVIDIA driver failures.
## What changed
- `.buildkite/pipeline.yml` — changed default runner from `H100` to `L4`

## Revert
Once the H100 cluster issue is resolved, revert this change by switching the default back to `H100`.