### PR TITLE
ci: revert default GPU runner back to H100

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ":gear: Speculators Unit and Integration Tests"
     command: |
-      RUNNER=$$(buildkite-agent meta-data get "test-runner" --default "L4")
+      RUNNER=$$(buildkite-agent meta-data get "test-runner" --default "H100")
       echo "╔══════════════════════════════════════════╗"
       echo "║          BUILD SUMMARY                   ║"
       echo "╠══════════════════════════════════════════╣"


### PR DESCRIPTION
H100 cluster driver issue is resolved. Switching default runner back to H100 from L4.