### PR TITLE
Fix discarded shuffle when combining preprocessed datasets

### DIFF
--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -790,7 +790,7 @@ def load_and_preprocess_dataset(
         processed_datasets.append(preprocessed_dataset)
 
     combined_dataset = concatenate_datasets(processed_datasets)
-    combined_dataset.shuffle(seed=seed)
+    combined_dataset = combined_dataset.shuffle(seed=seed)
     if max_samples is not None and len(combined_dataset) > max_samples:
         combined_dataset = combined_dataset.select(range(max_samples))
 

--- a/tests/integration/datagen/test_preprocessing.py
+++ b/tests/integration/datagen/test_preprocessing.py
@@ -21,6 +21,8 @@ from speculators.data_generation.preprocessing import (
     _preprocess_batch,
     _supports_assistant_mask,
     build_eagle3_dataset,
+    get_tokenizer,
+    load_and_preprocess_dataset,
     load_processor,
 )
 
@@ -1393,3 +1395,45 @@ def test_normalize_conversation_tool_calls_with_empty_content():
     assert assistant_tool_call_turn["role"] == "assistant"
     assert assistant_tool_call_turn["content"] == ""
     assert assistant_tool_call_turn["tool_calls"] == tool_calls
+
+
+# Tests for load_and_preprocess_dataset
+
+
+@pytest.mark.sanity
+def test_load_and_preprocess_dataset_shuffles_combined_datasets(tmp_path):
+    """Combined datasets must be shuffled before truncating to max_samples,
+    otherwise only samples from the first dataset are kept."""
+    paths = []
+    for marker in ("ALPHA", "BETA"):
+        path = tmp_path / f"{marker.lower()}.jsonl"
+        path.write_text(
+            "\n".join(
+                json.dumps(
+                    {
+                        "conversations": [
+                            {"role": "user", "content": f"Question {i}?"},
+                            {"role": "assistant", "content": f"{marker} answer {i}."},
+                        ]
+                    }
+                )
+                for i in range(12)
+            )
+        )
+        paths.append(str(path))
+
+    dataset, processor = load_and_preprocess_dataset(
+        TEXT_MODEL_REPO,
+        paths,
+        seq_length=128,
+        build_dataset_num_proc=1,
+        seed=0,
+        max_samples=12,
+        token_freq_path=tmp_path / "token_freq.pt",
+        trust_remote_code=True,
+    )
+
+    assert len(dataset) == 12
+    tokenizer = get_tokenizer(processor)
+    decoded = [tokenizer.decode(row["input_ids"]) for row in dataset]
+    assert any("BETA" in text for text in decoded)


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Assign the shuffle result back so the combined dataset is actually shuffled before truncating to max_samples. `Dataset.shuffle` returns a new dataset, so the discarded return left kept samples biased toward the first source dataset.

## Tests

python -m pytest "tests/integration/datagen/test_preprocessing.py::test_load_and_preprocess_dataset_shuffles_combined_datasets"

## Checklist

Added test fails before the fix (kept samples are all from the first dataset) and passes after.

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
