### PR TITLE
Apply max_length truncation on HF assistant-mask path

### DIFF
--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -385,7 +385,14 @@ def _get_input_ids_loss_mask(
     hf_conv = _adapt_conv_for_hf(normalized_conv, processor)
 
     if assistant_pattern is None:
-        # HF assistant token mask
+        # HF assistant token mask. Multimodal input_ids are re-tokenized by vLLM
+        # from `messages`, so truncating them here would desync the two; only
+        # truncate text-only inputs, which are sent to vLLM as input_ids.
+        truncation_kwargs: dict = (
+            {}
+            if isinstance(processor, ProcessorMixin)
+            else {"max_length": max_length, "truncation": True}
+        )
         encoded_any = processor.apply_chat_template(
             hf_conv,
             tokenize=True,
@@ -393,6 +400,7 @@ def _get_input_ids_loss_mask(
             add_generation_prompt=False,
             return_assistant_tokens_mask=True,
             return_dict=True,
+            **truncation_kwargs,
         )
         encoded = cast("BatchEncoding | BatchFeature", encoded_any)
 

--- a/tests/integration/datagen/test_preprocessing.py
+++ b/tests/integration/datagen/test_preprocessing.py
@@ -674,6 +674,34 @@ def test_preprocess_batch_truncation():
 
 
 @pytest.mark.sanity
+def test_preprocess_batch_truncation_hf_mask_path():
+    """Test that the HF assistant-mask path also truncates to max_length."""
+    processor = load_processor(TEXT_MODEL_REPO, trust_remote_code=True)
+
+    if not hasattr(processor, "apply_chat_template") or processor.chat_template is None:
+        pytest.skip("Processor does not support chat templates")
+
+    examples = {
+        "conversations": [
+            [
+                {"role": "user", "content": "word " * 1000},
+                {"role": "assistant", "content": "Short reply"},
+            ]
+        ]
+    }
+
+    max_length = 100
+    # assistant_pattern=None selects the HF mask path
+    results = _preprocess_batch(
+        examples, processor, max_length=max_length, assistant_pattern=None
+    )
+
+    assert len(results["input_ids"]) == 1
+    assert len(results["input_ids"][0]) <= max_length
+    assert len(results["loss_mask"][0]) <= max_length
+
+
+@pytest.mark.sanity
 def test_preprocess_batch_uses_hf_assistant_mask():
     """Test that HF assistant token mask is used when supported."""
     processor = load_processor(TEXT_MODEL_REPO, trust_remote_code=True)


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Truncate text-only inputs on the HF assistant-mask path to max_length, which it previously ignored, making `--seq-length` a no-op for text models using HF masks. Multimodal inputs stay untruncated since vLLM re-tokenizes them from messages.

## Tests

`test_preprocess_batch_truncation_hf_mask_path` → passed. Fails before the fix, passes after; `test_preprocess_batch_multimodal` still passes.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
