### PR TITLE
Add total variation (TV) loss for speculative decoding

### DIFF
--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -119,6 +119,33 @@ def ce_loss(
     return elementwise_loss  # noqa: RET504
 
 
+def tv_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position total variation (TV) distance from draft to target.
+
+    The rejection-sampling acceptance rate of speculative decoding equals the
+    distributional overlap between target and draft,
+    ``alpha = sum_v min(p_v, q_v) = 1 - d_TV(p, q)``. Minimizing this TV distance
+    therefore directly optimizes the acceptance rate, whereas cross-entropy and
+    KL only optimize it indirectly (KL is a loose upper bound on TV via Pinsker).
+
+    Args:
+        logits: Draft model logits (softmax applied internally to form q).
+        targets: Target model logits (softmax applied internally to form p).
+
+    Returns:
+        Per-position TV distance with shape [1, seq_len].
+    """
+    draft_p = torch.nn.functional.softmax(logits, dim=-1)
+    target_p = torch.nn.functional.softmax(targets, dim=-1)
+    overlap = torch.minimum(draft_p, target_p).sum(dim=-1)  # shape: [1, seq_len]
+    elementwise_loss = 1.0 - overlap
+
+    return elementwise_loss  # noqa: RET504
+
+
 def dflash_loss_decay(pos_idx: torch.Tensor, gamma: float):
     """Compute DFlash-style exponential decay weights per position.
 
@@ -159,7 +186,8 @@ def resolve_loss_fn(
     """Resolves a loss function given its abbreviated name.
 
     Args:
-        name: ``"kl_div"`` for KL-divergence or ``"ce"`` for cross-entropy.
+        name: ``"kl_div"`` for KL-divergence, ``"ce"`` for cross-entropy, or
+            ``"tv"`` for total variation.
 
     Returns:
         The corresponding loss function.
@@ -170,6 +198,7 @@ def resolve_loss_fn(
     loss_fn_map: dict[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = {
         "kl_div": kl_div_loss,
         "ce": ce_loss,
+        "tv": tv_loss,
     }
     if name not in loss_fn_map:
         raise ValueError(

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -11,6 +11,8 @@ from speculators.models.metrics import (
     exp_loss_decay,
     kl_div_loss,
     loss_function,
+    resolve_loss_fn,
+    tv_loss,
 )
 
 
@@ -86,6 +88,34 @@ class TestKLDivLoss:
         torch.manual_seed(0)
         loss_random = kl_div_loss(torch.randn(1, 4, 8), torch.randn(1, 4, 8))
         assert (loss_random >= -1e-6).all()
+
+
+class TestTVLoss:
+    def test_identical_is_zero(self):
+        """TV distance between identical distributions is ~0."""
+        x = torch.randn(1, 4, 50)
+        loss = tv_loss(x, x)
+        assert torch.allclose(loss, torch.zeros(1, 4), atol=1e-6)
+
+    def test_matches_l1_form_shape_and_range(self):
+        """Overlap form equals 0.5 * L1; output is [1, seq_len] within [0, 1]."""
+        torch.manual_seed(0)
+        logits = torch.randn(1, 4, 50)
+        targets = torch.randn(1, 4, 50)
+        out = tv_loss(logits, targets)
+
+        p = torch.softmax(targets, dim=-1)
+        q = torch.softmax(logits, dim=-1)
+        l1 = 0.5 * (p - q).abs().sum(dim=-1)
+
+        assert out.shape == (1, 4)
+        assert torch.allclose(out, l1, atol=1e-6)
+        assert (out >= 0).all()
+        assert (out <= 1).all()
+
+    def test_resolve_tv(self):
+        """resolve_loss_fn maps 'tv' to tv_loss."""
+        assert resolve_loss_fn("tv") is tv_loss
 
 
 class TestComputeAccuracySingleStep:


### PR DESCRIPTION
## Summary
Adds a total variation (TV) loss function to the speculators loss interface.

## Motivation
The speculative-decoding acceptance rate equals the target/draft distribution overlap,
alpha = sum_v min(p_v, q_v) = 1 - d_TV(p, q). TV loss therefore optimizes acceptance rate
directly, whereas the existing cross-entropy and KL losses do so only indirectly (KL is a
loose upper bound on TV via Pinsker). Source: arXiv 2606.12370, Eq. 10 (per-step TV loss).

## Changes
- `tv_loss(logits, targets) -> [1, seq_len]` in `src/speculators/models/metrics.py`,
  matching the existing `kl_div_loss` / `ce_loss` interface.
- Registered as "tv" in `resolve_loss_fn`.
- Unit tests covering correctness, shape/range, equivalence to the L1 form, and resolution.

## Scope / notes
- Implements the regular per-step TV loss only. 
- Target distribution is treated as the (detached) reference, consistent with the existing
  kl_div/ce losses which assume frozen-target logits.

## AI assistance
Implemented with assistance from Claude code