### PR TITLE
Handle nested rope in transformers v5

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -205,7 +205,23 @@ def create_transformer_layer_config(  # noqa: C901
     # New rope parameters definition introduced in transformers 5.0
     if version.parse(transformers.__version__) >= version.parse("5.0.0"):
         if hasattr(verifier_config, "rope_parameters"):
-            config.rope_parameters = deepcopy(verifier_config.rope_parameters)
+            rope_params = deepcopy(verifier_config.rope_parameters)
+            # Some verifiers (e.g. Laguna) use the nested per-layer-type rope format
+            # {"full_attention": {...}, "sliding_attention": {...}} with no top-level
+            # "rope_theta". The llama-style draft uses a single rope, so collapse it to
+            # a flat default rope (preferring the sliding-attention theta).
+            if isinstance(rope_params, dict) and "rope_theta" not in rope_params:
+                sub = (
+                        rope_params.get("sliding_attention")
+                        or rope_params.get("full_attention")
+                        or {}
+                )
+                rope_params = {
+                        "rope_type": "default",
+                        "rope_theta": sub.get("rope_theta", 10000.0),
+                }
+            config.rope_parameters = rope_params
+
             _MROPE_KEYS = ("mrope_section", "mrope_interleaved", "type")  # noqa: N806
             for key in _MROPE_KEYS:
                 config.rope_parameters.pop(key, None)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -212,13 +212,13 @@ def create_transformer_layer_config(  # noqa: C901
             # a flat default rope (preferring the sliding-attention theta).
             if isinstance(rope_params, dict) and "rope_theta" not in rope_params:
                 sub = (
-                        rope_params.get("sliding_attention")
-                        or rope_params.get("full_attention")
-                        or {}
+                    rope_params.get("sliding_attention")
+                    or rope_params.get("full_attention")
+                    or {}
                 )
                 rope_params = {
-                        "rope_type": "default",
-                        "rope_theta": sub.get("rope_theta", 10000.0),
+                    "rope_type": "default",
+                    "rope_theta": sub.get("rope_theta", 10000.0),
                 }
             config.rope_parameters = rope_params
 


### PR DESCRIPTION
Models like Laguna have nested rope like:
```json
"rope_parameters": {
  "full_attention": {
    "rope_theta": 500000.0,
    "rope_type": "yarn",
    "factor": 64.0,
    "original_max_position_embeddings": 4096,
    "beta_slow": 1.0,
    "beta_fast": 64.0,
    "attention_factor": 1.0,
    "partial_rotary_factor": 0.5
  },
  "sliding_attention": {
    "rope_type": "default",
    "rope_theta": 10000.0,
    "partial_rotary_factor": 1.0
},
```
This PR enables inferring the correct `rope_theta` for such configurations. When both attns are present (full and sliding), we prefer theta from the sliding one.