### PR TITLE
Ignore ruff "too many branches"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ ignore = [
     "RET506", # allow `else` blocks
     "PD011", # ignore .values usage since ruff assumes it's a Pandas DataFrame
     "PLR0915", # too-many-statements
+    "PLR0912", # too-many-branches
 ]
 select = [
     # Rules reference: https://docs.astral.sh/ruff/rules/


### PR DESCRIPTION
Currently ruff blocks when there is more than 12 branches with:
```bash
PLR0912 Too many branches (13 > 12)
   --> scripts/train.py:123:5
    |
123 | def create_transformer_layer_config(  # noqa: C901
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
124 |     verifier_name_or_path: str,
125 |     num_layers: int,
    |

Found 1 error.
```

This PR ignores this rule.