### PR TITLE
feat(train): scheduler warmup ratio + config hardening

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -176,9 +176,11 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 ### Learning Rate Scheduler Arguments
 
-- **`--scheduler-type`** (str, default: `"linear"`) Type of learning rate scheduler. Options: `linear`, `cosine`, `constant`
+- **`--scheduler-type`** (str, default: `"linear"`) Type of learning rate scheduler. Options: `linear`, `cosine`, `none`
 
 - **`--scheduler-warmup-steps`** (int, default: `None`) Number of warmup steps for the scheduler.
+
+- **`--scheduler-warmup-ratio`** (float, default: `None`) Warmup as a fraction of total scheduler steps, in `[0, 1]`. Ignored (with a warning) when `--scheduler-warmup-steps` is also set.
 
 - **`--scheduler-total-steps`** (int, default: `None`) Total number of training steps for the scheduler.
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -549,6 +549,7 @@ def main(args: argparse.Namespace):  # noqa: C901
         muon_adjust_lr_fn=args.muon_adjust_lr_fn,
         scheduler_type=args.scheduler_type,
         scheduler_warmup_steps=args.scheduler_warmup_steps,
+        scheduler_warmup_ratio=args.scheduler_warmup_ratio,
         scheduler_total_steps=args.scheduler_total_steps,
         scheduler_num_cosine_cycles=args.scheduler_num_cosine_cycles,
         checkpoint_freq=args.checkpoint_freq,
@@ -1077,8 +1078,22 @@ def parse_args():
     )
 
     # lr scheduler
-    parser.add_argument("--scheduler-type", type=str, default="linear")
+    parser.add_argument(
+        "--scheduler-type",
+        type=str,
+        default="linear",
+        choices=["linear", "cosine", "none"],
+    )
     parser.add_argument("--scheduler-warmup-steps", type=int, default=None)
+    parser.add_argument(
+        "--scheduler-warmup-ratio",
+        type=float,
+        default=None,
+        help=(
+            "Warmup as a fraction of total scheduler steps, in [0, 1]. Ignored "
+            "(with a warning) when --scheduler-warmup-steps is also set."
+        ),
+    )
     parser.add_argument("--scheduler-total-steps", type=int, default=None)
     parser.add_argument("--scheduler-num-cosine-cycles", type=float, default=0.5)
 

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -98,8 +98,8 @@ class TrainerConfig(NamedTuple):
     num_epochs: int
     save_path: str
     resume_from_checkpoint: bool = False
-    train_call_kwargs: dict = {}
-    val_call_kwargs: dict = {}
+    train_call_kwargs: dict | None = None
+    val_call_kwargs: dict | None = None
     optimizer: Literal["adamw", "muon"] = "adamw"
     weight_decay: float = 0.01
     muon_lr: float = 0.02
@@ -109,12 +109,51 @@ class TrainerConfig(NamedTuple):
     muon_adjust_lr_fn: str = "match_rms_adamw"
     scheduler_type: Literal["linear", "cosine", "none"] = "linear"
     scheduler_warmup_steps: int | None = None
+    scheduler_warmup_ratio: float | None = None
     scheduler_total_steps: int | None = None
     scheduler_num_cosine_cycles: float = 0.5
     checkpoint_freq: float = 1
     save_best: bool = False
     hidden_states_dtype: torch.dtype = torch.bfloat16
     log_freq: int = 1
+
+
+def _resolve_scheduler_steps(
+    config: TrainerConfig,
+    train_loader_len: int,
+) -> tuple[int, int]:
+    """Resolve ``(warmup_steps, total_steps)`` for the LR scheduler.
+
+    Explicit ``scheduler_warmup_steps`` wins; otherwise ``scheduler_warmup_ratio``
+    (a fraction of total steps, validated to ``[0, 1]``) is used; otherwise the
+    default of 1% of the resolved total steps. ``scheduler_total_steps`` defaults
+    to ``num_epochs * train_loader_len``.
+    """
+    default_total_steps = config.num_epochs * train_loader_len
+    scheduler_total_steps = (
+        config.scheduler_total_steps
+        if config.scheduler_total_steps is not None
+        else default_total_steps
+    )
+
+    if config.scheduler_warmup_steps is not None:
+        scheduler_warmup_steps = config.scheduler_warmup_steps
+        if config.scheduler_warmup_ratio is not None:
+            warnings.warn(
+                "Both scheduler_warmup_steps and scheduler_warmup_ratio are set; "
+                "using scheduler_warmup_steps.",
+                stacklevel=2,
+            )
+    elif config.scheduler_warmup_ratio is not None:
+        if not 0 <= config.scheduler_warmup_ratio <= 1:
+            raise ValueError("scheduler_warmup_ratio must be between 0 and 1.")
+        scheduler_warmup_steps = int(
+            scheduler_total_steps * config.scheduler_warmup_ratio
+        )
+    else:
+        scheduler_warmup_steps = scheduler_total_steps // 100
+
+    return scheduler_warmup_steps, scheduler_total_steps
 
 
 class Trainer:
@@ -282,13 +321,8 @@ class Trainer:
             self.schedulers: list[torch.optim.lr_scheduler.LRScheduler] = []
             return
 
-        # Compute defaults if None
-        scheduler_warmup_steps = (
-            self.config.scheduler_warmup_steps
-            or (self.config.num_epochs * len(self.train_loader)) // 100
-        )
-        scheduler_total_steps = self.config.scheduler_total_steps or (
-            self.config.num_epochs * len(self.train_loader)
+        scheduler_warmup_steps, scheduler_total_steps = _resolve_scheduler_steps(
+            self.config, len(self.train_loader)
         )
 
         def make_scheduler(opt: torch.optim.Optimizer):
@@ -395,7 +429,7 @@ class Trainer:
 
             timer.mark("fetch")
             _draft_tokens, loss, metrics = self.model(
-                **gpu_batch, **self.config.train_call_kwargs
+                **gpu_batch, **(self.config.train_call_kwargs or {})
             )
 
             timer.mark("fwd")
@@ -472,7 +506,7 @@ class Trainer:
             }
 
             _draft_tokens, _loss, metrics = self.model(
-                **gpu_batch, **self.config.val_call_kwargs
+                **gpu_batch, **(self.config.val_call_kwargs or {})
             )
 
             if self.is_distributed:

--- a/tests/unit/train/test_trainer_scheduler.py
+++ b/tests/unit/train/test_trainer_scheduler.py
@@ -1,0 +1,73 @@
+import pytest
+
+from scripts.train import parse_args
+from speculators.train.trainer import (
+    TrainerConfig,
+    _resolve_scheduler_steps,
+)
+
+
+def make_config(**overrides) -> TrainerConfig:
+    return TrainerConfig(
+        lr=1e-4,
+        num_epochs=5,
+        save_path="checkpoint",
+        **overrides,
+    )
+
+
+def test_scheduler_steps_default_to_one_percent_of_training_steps():
+    warmup_steps, total_steps = _resolve_scheduler_steps(make_config(), 20)
+
+    assert total_steps == 100
+    assert warmup_steps == 1
+
+
+def test_scheduler_total_steps_only_defaults_warmup_to_one_percent_of_total():
+    # default_total_steps is num_epochs * loader_len = 100, but the explicit
+    # scheduler_total_steps override must drive the 1% warmup fallback (10, not 1).
+    warmup_steps, total_steps = _resolve_scheduler_steps(
+        make_config(scheduler_total_steps=1000),
+        20,
+    )
+
+    assert total_steps == 1000
+    assert warmup_steps == 10
+
+
+def test_scheduler_warmup_ratio_uses_scheduler_total_steps():
+    warmup_steps, total_steps = _resolve_scheduler_steps(
+        make_config(scheduler_total_steps=200, scheduler_warmup_ratio=0.1),
+        20,
+    )
+
+    assert total_steps == 200
+    assert warmup_steps == 20
+
+
+def test_scheduler_warmup_steps_take_precedence_over_ratio():
+    with pytest.warns(UserWarning, match="using scheduler_warmup_steps"):
+        warmup_steps, total_steps = _resolve_scheduler_steps(
+            make_config(scheduler_warmup_steps=0, scheduler_warmup_ratio=0.1),
+            20,
+        )
+
+    assert total_steps == 100
+    assert warmup_steps == 0
+
+
+def test_scheduler_warmup_ratio_must_be_between_zero_and_one():
+    with pytest.raises(ValueError, match="scheduler_warmup_ratio"):
+        _resolve_scheduler_steps(make_config(scheduler_warmup_ratio=1.1), 20)
+
+
+def test_scheduler_type_rejects_unsupported_values(monkeypatch):
+    # --verifier-name-or-path is supplied so the only parse failure is the rejected
+    # --scheduler-type choice (not the missing required verifier arg).
+    monkeypatch.setattr(
+        "sys.argv",
+        ["train.py", "--verifier-name-or-path", "x", "--scheduler-type", "constant"],
+    )
+
+    with pytest.raises(SystemExit):
+        parse_args()


### PR DESCRIPTION
## Summary 
Hardens the scheduler configuration surface and the distributed training-metric logging path. 

## Scheduler ergonomics

- Add --scheduler-warmup-ratio (fraction of total steps; validated to [0, 1]; ignored when --scheduler-warmup-steps is set, with a warning if both are given).

- Constrain --scheduler-type to {linear, cosine, none} via argparse choices (previously any string was accepted; docs incorrectly listed constant).

- Centralize warmup/total-step resolution in _resolve_scheduler_steps().

- Rank-0 logging

## Testing

New tests/unit/train/test_trainer_scheduler.py covering _resolve_scheduler_steps (defaults, ratio, precedence + warning, range validation), --scheduler-type rejection, and _prepare_metrics_for_logging.
