### PR TITLE
Suppress uv and apt progress bars in logs

### DIFF
--- a/.buildkite/gpu-tests/scripts/run-tests.sh
+++ b/.buildkite/gpu-tests/scripts/run-tests.sh
@@ -7,7 +7,7 @@ cat /etc/issue
 
 git fetch --tags --unshallow 2>/dev/null || git fetch --tags
 
-apt-get update && apt-get install -y curl g++ gcc make python3-dev
+apt-get update -qq && apt-get install -y -qq curl g++ gcc make python3-dev
 
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
@@ -15,6 +15,7 @@ export LD_LIBRARY_PATH=/usr/local/nvidia/lib64
 export PATH="$HOME/.local/bin:/usr/local/nvidia/bin:$PATH"
 nvidia-smi
 
+export UV_NO_PROGRESS=1
 uv venv testvenv --python "${PYTHON_VERSION}"
 source testvenv/bin/activate
 

--- a/.buildkite/gpu-tests/scripts/run-tests.sh
+++ b/.buildkite/gpu-tests/scripts/run-tests.sh
@@ -16,6 +16,7 @@ export PATH="$HOME/.local/bin:/usr/local/nvidia/bin:$PATH"
 nvidia-smi
 
 export UV_NO_PROGRESS=1
+export UV_CACHE_DIR="$PWD/.uv-cache"
 uv venv testvenv --python "${PYTHON_VERSION}"
 source testvenv/bin/activate
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Currently all of the buildkite logs are getting truncated because they exceed 2MB. The reason for this is the uv (and to a lesser degree apt) installs print and then delete progress updates as they go. This looks nice locally but results in massive log files in non-terminal environments. 

Edit: It looks like we're also currently downloading uv packages to a default cache dir, which then get copied for use in the environment. This seems to be happening because the default cache dir isn't on the same volume as the workplace where the env is created. I added a commit to set a new local cache dir. 

## Tests

Will run buildkite ci and confirm changes improve logs.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
