### PR TITLE
SP Ulysses precursor: Refactor distributed and dataloader into separate modules

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -10,7 +10,6 @@ import numpy as np
 import torch
 import transformers
 from packaging import version
-from torch.utils.data import DataLoader
 from transformers import LlamaConfig, PretrainedConfig
 from transformers.models.auto.configuration_auto import AutoConfig
 from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
@@ -27,25 +26,15 @@ from speculators.models.utils import (
     get_verifier_config,
     resolve_draft_intermediate_size,
 )
-from speculators.train.data import (
-    ArrowDataset,
-    BaseDataset,
-    SampleFileDataset,
-    create_collate_fn,
-    split_files,
-)
-from speculators.train.distributed_batch_sampler import (
-    MultipackDistributedBatchSamplerV2,
-)
-from speculators.train.logger import setup_metric_logger, setup_root_logger
-from speculators.train.noise_transforms import AddUniformNoise
-from speculators.train.trainer import Trainer, TrainerConfig
-from speculators.train.utils import (
+from speculators.train.dataloader import create_train_val_loaders
+from speculators.train.distributed import (
+    get_rank,
     maybe_destroy_distributed,
     maybe_setup_distributed,
-    resolve_mask_token_id,
-    save_train_command,
 )
+from speculators.train.logger import setup_metric_logger, setup_root_logger
+from speculators.train.trainer import Trainer, TrainerConfig
+from speculators.train.utils import resolve_mask_token_id, save_train_command
 from speculators.train.vocab_mapping import (
     build_vocab_mappings_from_distribution,
     get_target_vocab_size,
@@ -72,53 +61,6 @@ def set_seed(seed: int, deterministic: bool = False):
         # For deterministic behavior (may impact performance)
         torch.backends.cudnn.deterministic = True
         torch.backends.cudnn.benchmark = False
-
-
-def setup_dataloader(
-    dataset: BaseDataset,
-    world_size: int,
-    rank: int,
-    hidden_size: int,
-    num_workers: int = 12,
-    num_target_layers: int = 3,
-    prefetch_factor: int = 4,
-    preprocess=None,
-) -> DataLoader:
-    """Setup dataloader for training.
-    Args:
-        file_list: List of file paths to load data from.
-        world_size: Number of processes in the distributed training.
-        rank: Global rank of the current process (shards data across nodes).
-        add_noise: Whether to add noise to the data.
-        noise_std: Standard deviation for noise augmentation.
-        num_workers: Number of dataloader workers.
-        prefetch_factor: Dataloader prefetch factor.
-        preprocess: Optional per-sample preprocessing function applied
-            before collation (e.g. shift_batch for Eagle3).
-    Returns:
-        DataLoader: Dataloader for training.
-    """
-    batch_sampler = MultipackDistributedBatchSamplerV2(
-        batch_max_length=args.total_seq_len,
-        lengths=dataset.approx_lengths,
-        num_replicas=world_size,
-        rank=rank,
-    )
-    return DataLoader(
-        dataset,
-        batch_sampler=batch_sampler,
-        num_workers=num_workers,
-        prefetch_factor=prefetch_factor,
-        pin_memory=True,
-        collate_fn=create_collate_fn(
-            args.total_seq_len,
-            hidden_size,
-            num_target_layers=num_target_layers,
-            dtype=dataset.hidden_states_dtype,
-            preprocess=preprocess,
-        ),
-        persistent_workers=True,
-    )
 
 
 def create_transformer_layer_config(  # noqa: C901
@@ -478,9 +420,9 @@ def main(args: argparse.Namespace):  # noqa: C901
     )
 
     # Setup distributed training
-    local_rank, world_size, rank, is_distributed = maybe_setup_distributed()
+    maybe_setup_distributed()
 
-    if rank == 0:
+    if get_rank() == 0:
         save_train_command(args.save_path)
 
     if not hasattr(torch, args.hidden_states_dtype):
@@ -538,7 +480,7 @@ def main(args: argparse.Namespace):  # noqa: C901
         # hidden_states_dtype, so save the dry-run checkpoint in that dtype too
         # rather than the float32 the model is built in.
         draft_model.to(hidden_states_dtype)
-        if local_rank == 0:
+        if get_rank() == 0:
             logger.info(
                 "[dry-run] Saving initialized checkpoint (%s) to '%s'",
                 hidden_states_dtype,
@@ -563,69 +505,20 @@ def main(args: argparse.Namespace):  # noqa: C901
     }
     preprocess = preprocess_fns.get(args.speculator_type)
 
-    noise_transform = AddUniformNoise(std=args.noise_std)
-    if args.legacy_data:
-        warnings.warn(
-            "Using '--legacy-data' is deprecated and will be removed soon.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        train_files, val_files = split_files(args.data_path, ratio=0.9)
-        train_dataset: BaseDataset = SampleFileDataset(
-            file_list=train_files,
-            max_len=args.total_seq_len,
-            transform=noise_transform,
-            hidden_states_dtype=hidden_states_dtype,
-        )
-        val_dataset: BaseDataset = SampleFileDataset(
-            file_list=val_files,
-            max_len=args.total_seq_len,
-            hidden_states_dtype=hidden_states_dtype,
-        )
-    else:
-        train_dataset = ArrowDataset(
-            datapath=args.data_path,
-            max_len=args.total_seq_len,
-            hidden_states_path=args.hidden_states_path,
-            vllm_endpoint=args.vllm_endpoint,
-            on_missing=args.on_missing,
-            on_generate=args.on_generate,
-            transform=noise_transform,
-            split_ratio=0.9,
-            model=args.verifier_name_or_path,
-            hidden_states_dtype=hidden_states_dtype,
-            request_timeout=args.request_timeout,
-            max_retries=args.max_retries,
-        )
-        val_dataset = ArrowDataset(
-            datapath=args.data_path,
-            max_len=args.total_seq_len,
-            hidden_states_path=args.hidden_states_path,
-            vllm_endpoint=args.vllm_endpoint,
-            on_missing=args.on_missing,
-            on_generate=args.on_generate,
-            split_ratio=-0.1,
-            model=args.verifier_name_or_path,
-            hidden_states_dtype=hidden_states_dtype,
-            request_timeout=args.request_timeout,
-            max_retries=args.max_retries,
-        )
-
-    train_loader = setup_dataloader(
-        train_dataset,
-        world_size,
-        rank,
-        hidden_size,
-        num_target_layers=num_target_layers,
-        num_workers=args.num_workers,
-        prefetch_factor=args.prefetch_factor,
-        preprocess=preprocess,
-    )
-    val_loader = setup_dataloader(
-        val_dataset,
-        world_size,
-        rank,
-        hidden_size,
+    train_loader, val_loader = create_train_val_loaders(
+        data_path=args.data_path,
+        total_seq_len=args.total_seq_len,
+        hidden_states_dtype=hidden_states_dtype,
+        noise_std=args.noise_std,
+        legacy_data=args.legacy_data,
+        hidden_states_path=args.hidden_states_path,
+        vllm_endpoint=args.vllm_endpoint,
+        on_missing=args.on_missing,
+        on_generate=args.on_generate,
+        verifier_name_or_path=args.verifier_name_or_path,
+        request_timeout=args.request_timeout,
+        max_retries=args.max_retries,
+        hidden_size=hidden_size,
         num_target_layers=num_target_layers,
         num_workers=args.num_workers,
         prefetch_factor=args.prefetch_factor,
@@ -640,9 +533,6 @@ def main(args: argparse.Namespace):  # noqa: C901
         save_path=args.save_path,
         lr=args.lr,
         resume_from_checkpoint=not args.no_resume_from_checkpoint,
-        is_distributed=is_distributed,
-        local_rank=local_rank,
-        rank=rank,
         train_call_kwargs=train_call_kwargs,
         val_call_kwargs=val_call_kwargs,
         optimizer=args.optimizer,

--- a/src/speculators/train/dataloader.py
+++ b/src/speculators/train/dataloader.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+import torch
+from torch.utils.data import DataLoader
+
+from speculators.train.data import (
+    ArrowDataset,
+    BaseDataset,
+    SampleFileDataset,
+    create_collate_fn,
+    split_files,
+)
+from speculators.train.distributed import get_dp_rank, get_dp_size
+from speculators.train.distributed_batch_sampler import (
+    MultipackDistributedBatchSamplerV2,
+)
+from speculators.train.noise_transforms import AddUniformNoise
+
+logger = logging.getLogger(__name__)
+
+BatchType = dict[str, Any]
+
+
+def _setup_dataloader(
+    dataset: BaseDataset,
+    total_seq_len: int,
+    hidden_size: int,
+    num_workers: int = 12,
+    num_target_layers: int = 3,
+    prefetch_factor: int | None = 4,
+    preprocess: Callable[[BatchType], BatchType] | None = None,
+) -> DataLoader:
+    batch_sampler = MultipackDistributedBatchSamplerV2(
+        batch_max_length=total_seq_len,
+        lengths=dataset.approx_lengths,
+        num_replicas=get_dp_size(),
+        rank=get_dp_rank(),
+    )
+    use_workers = num_workers > 0
+    return DataLoader(
+        dataset,
+        batch_sampler=batch_sampler,
+        num_workers=num_workers,
+        prefetch_factor=prefetch_factor if use_workers else None,
+        pin_memory=True,
+        collate_fn=create_collate_fn(
+            total_seq_len,
+            hidden_size,
+            num_target_layers=num_target_layers,
+            dtype=dataset.hidden_states_dtype,
+            preprocess=preprocess,
+        ),
+        persistent_workers=use_workers,
+    )
+
+
+def create_train_val_loaders(
+    *,
+    data_path: str,
+    total_seq_len: int,
+    hidden_states_dtype: torch.dtype,
+    noise_std: float,
+    legacy_data: bool,
+    hidden_states_path: str | None,
+    vllm_endpoint: str,
+    on_missing: Literal["generate", "skip", "warn", "raise"],
+    on_generate: Literal["cache", "delete"],
+    verifier_name_or_path: str,
+    request_timeout: float | None,
+    max_retries: int,
+    hidden_size: int,
+    num_target_layers: int,
+    num_workers: int,
+    prefetch_factor: int,
+    preprocess: Callable[[BatchType], BatchType] | None,
+) -> tuple[DataLoader, DataLoader]:
+    """Create training and validation DataLoaders.
+
+    Handles dataset construction (legacy vs Arrow) and dataloader wiring.
+    Non-data SP ranks get lightweight loaders with no workers (they receive
+    batches via scatter).  Reads DP/SP topology from
+    :mod:`speculators.train.distributed`.
+    """
+    noise_transform = AddUniformNoise(std=noise_std)
+
+    if legacy_data:
+        warnings.warn(
+            "Using '--legacy-data' is deprecated and will be removed soon.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        train_files, val_files = split_files(data_path, ratio=0.9)
+        train_dataset: BaseDataset = SampleFileDataset(
+            file_list=train_files,
+            max_len=total_seq_len,
+            transform=noise_transform,
+            hidden_states_dtype=hidden_states_dtype,
+        )
+        val_dataset: BaseDataset = SampleFileDataset(
+            file_list=val_files,
+            max_len=total_seq_len,
+            hidden_states_dtype=hidden_states_dtype,
+        )
+    else:
+        train_dataset = ArrowDataset(
+            datapath=data_path,
+            max_len=total_seq_len,
+            hidden_states_path=hidden_states_path,
+            vllm_endpoint=vllm_endpoint,
+            on_missing=on_missing,
+            on_generate=on_generate,
+            transform=noise_transform,
+            split_ratio=0.9,
+            model=verifier_name_or_path,
+            hidden_states_dtype=hidden_states_dtype,
+            request_timeout=request_timeout,
+            max_retries=max_retries,
+        )
+        val_dataset = ArrowDataset(
+            datapath=data_path,
+            max_len=total_seq_len,
+            hidden_states_path=hidden_states_path,
+            vllm_endpoint=vllm_endpoint,
+            on_missing=on_missing,
+            on_generate=on_generate,
+            split_ratio=-0.1,
+            model=verifier_name_or_path,
+            hidden_states_dtype=hidden_states_dtype,
+            request_timeout=request_timeout,
+            max_retries=max_retries,
+        )
+
+    train_loader = _setup_dataloader(
+        train_dataset,
+        total_seq_len,
+        hidden_size,
+        num_target_layers=num_target_layers,
+        num_workers=num_workers,
+        prefetch_factor=prefetch_factor,
+        preprocess=preprocess,
+    )
+    val_loader = _setup_dataloader(
+        val_dataset,
+        total_seq_len,
+        hidden_size,
+        num_target_layers=num_target_layers,
+        num_workers=num_workers,
+        prefetch_factor=prefetch_factor,
+        preprocess=preprocess,
+    )
+
+    return train_loader, val_loader

--- a/src/speculators/train/distributed.py
+++ b/src/speculators/train/distributed.py
@@ -1,0 +1,196 @@
+"""Single source of truth for distributed training topology.
+
+Stores local_rank, SP/DP sizes and ranks, and process groups.
+All other modules should import getters from here rather than
+maintaining their own distributed state.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
+
+logger = logging.getLogger("speculators")
+
+# ---------------------------------------------------------------------------
+# Module-level state
+# ---------------------------------------------------------------------------
+
+_local_rank: int = 0
+_rank: int = 0
+_world_size = 1
+_is_distributed: bool = False
+
+_sp_size: int = 1
+_sp_rank: int = 0
+_dp_size: int = 1
+_dp_rank: int = 0
+
+_sp_group: ProcessGroup | None = None
+_dp_group: ProcessGroup | None = None
+
+
+# ---------------------------------------------------------------------------
+# Getters
+# ---------------------------------------------------------------------------
+
+
+def get_local_rank() -> int:
+    return _local_rank
+
+
+def get_rank() -> int:
+    return _rank
+
+
+def get_world_size() -> int:
+    return _world_size
+
+
+def is_distributed() -> bool:
+    return _is_distributed
+
+
+def get_sp_group() -> ProcessGroup | None:
+    return _sp_group
+
+
+def get_dp_group() -> ProcessGroup | None:
+    return _dp_group
+
+
+def get_sp_size() -> int:
+    return _sp_size
+
+
+def get_sp_rank() -> int:
+    return _sp_rank
+
+
+def get_dp_size() -> int:
+    return _dp_size
+
+
+def get_dp_rank() -> int:
+    return _dp_rank
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+def _init_sp_process_groups(rank: int, world_size: int, sp_size: int) -> None:
+    """Initialize sequence-parallel and data-parallel process groups.
+
+    SP groups use contiguous ranks (e.g. sp_size=2, world_size=4: {0,1}, {2,3}).
+    DP groups use strided ranks (e.g. sp_size=2, world_size=4: {0,2}, {1,3}).
+    """
+    global _sp_group, _dp_group, _sp_size, _sp_rank, _dp_size, _dp_rank  # noqa: PLW0603
+
+    if world_size % sp_size != 0:
+        raise ValueError(
+            f"world_size ({world_size}) must be divisible by sp_size ({sp_size})"
+        )
+
+    dp_size = world_size // sp_size
+
+    sp_group = None
+    for i in range(dp_size):
+        sp_ranks = list(range(i * sp_size, (i + 1) * sp_size))
+        pg = dist.new_group(sp_ranks)
+        if rank in sp_ranks:
+            sp_group = pg
+
+    dp_group = None
+    for i in range(sp_size):
+        dp_ranks = list(range(i, world_size, sp_size))
+        pg = dist.new_group(dp_ranks)
+        if rank in dp_ranks:
+            dp_group = pg
+
+    assert sp_group is not None  # noqa: S101
+    assert dp_group is not None  # noqa: S101
+
+    _sp_group = sp_group
+    _dp_group = dp_group
+    _sp_size = sp_size
+    _sp_rank = rank % sp_size
+    _dp_size = dp_size
+    _dp_rank = rank // sp_size
+
+
+def maybe_setup_distributed(sp_size: int = 1) -> None:
+    """Set up distributed training if launched with ``torchrun``.
+
+    Always populates the module-level topology state so that callers
+    can use the getter functions regardless of whether SP is enabled.
+    Process groups are always created when distributed — with
+    ``sp_size == 1`` the DP group spans all ranks and each SP group
+    contains a single rank.
+    """
+    global _local_rank, _rank, _is_distributed, _world_size  # noqa: PLW0603
+
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "LOCAL_RANK" in os.environ
+
+    _local_rank = local_rank
+    _is_distributed = distributed
+
+    if not distributed:
+        return
+
+    torch.accelerator.set_device_index(local_rank)
+    acc = torch.accelerator.current_accelerator()
+    if acc is None:
+        raise ValueError("No accelerator found")
+    backend = torch.distributed.get_default_backend_for_device(acc)
+    dist.init_process_group(backend, device_id=local_rank)
+
+    _rank = dist.get_rank()
+    _world_size = dist.get_world_size()
+
+    _init_sp_process_groups(_rank, _world_size, sp_size)
+
+    logger.info(
+        f"Started distributed with local_rank={local_rank}, "
+        f"dp_size={_dp_size}, sp_size={_sp_size}",
+        extra={"override_rank0_filter": True},
+    )
+
+
+def maybe_destroy_distributed() -> None:
+    """Destroy the distributed process group if using distributed training."""
+    if not _is_distributed:
+        return
+
+    dist.destroy_process_group()
+    logger.info(
+        "Destroyed distributed process group",
+        extra={"override_rank0_filter": True},
+    )
+
+
+def apply_fully_sharded(model: torch.nn.Module):
+    """Applies torch FSDP fully_shard to the model, wrapping layers in FSDPModule.
+
+    Assumes the model has a `layers` attribute containing the decoder layers.
+    Model should be validated with SpeculatorModel.verify_training_compatible()
+    before calling this function.
+    """
+    mp_policy = MixedPrecisionPolicy(
+        param_dtype=torch.bfloat16,
+        reduce_dtype=torch.float32,
+    )
+
+    for layer in model.layers:  # type: ignore[union-attr]
+        fully_shard(layer, mp_policy=mp_policy)
+
+    fully_shard(model)
+
+    return model

--- a/src/speculators/train/distributed.py
+++ b/src/speculators/train/distributed.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("speculators")
 
 _local_rank: int = 0
 _rank: int = 0
-_world_size = 1
+_world_size: int = 1
 _is_distributed: bool = False
 
 _sp_size: int = 1

--- a/src/speculators/train/distributed.py
+++ b/src/speculators/train/distributed.py
@@ -169,6 +169,10 @@ def maybe_setup_distributed(sp_size: int = 1) -> None:
 
 def maybe_destroy_distributed() -> None:
     """Destroy the distributed process group if using distributed training."""
+    global _is_distributed, _local_rank, _rank, _world_size  # noqa: PLW0603
+    global _sp_size, _sp_rank, _dp_size, _dp_rank  # noqa: PLW0603
+    global _sp_group, _dp_group  # noqa: PLW0603
+
     if not _is_distributed:
         return
 
@@ -177,6 +181,17 @@ def maybe_destroy_distributed() -> None:
         "Destroyed distributed process group",
         extra={"override_rank0_filter": True},
     )
+
+    _is_distributed = False
+    _local_rank = 0
+    _rank = 0
+    _world_size = 1
+    _sp_size = 1
+    _sp_rank = 0
+    _dp_size = 1
+    _dp_rank = 0
+    _sp_group = None
+    _dp_group = None
 
 
 def apply_fully_sharded(model: torch.nn.Module):

--- a/src/speculators/train/distributed.py
+++ b/src/speculators/train/distributed.py
@@ -93,6 +93,9 @@ def _init_sp_process_groups(rank: int, world_size: int, sp_size: int) -> None:
     """
     global _sp_group, _dp_group, _sp_size, _sp_rank, _dp_size, _dp_rank  # noqa: PLW0603
 
+    if sp_size <= 0:
+        raise ValueError(f"sp_size must be positive, got {sp_size}")
+
     if world_size % sp_size != 0:
         raise ValueError(
             f"world_size ({world_size}) must be divisible by sp_size ({sp_size})"
@@ -114,8 +117,8 @@ def _init_sp_process_groups(rank: int, world_size: int, sp_size: int) -> None:
         if rank in dp_ranks:
             dp_group = pg
 
-    assert sp_group is not None  # noqa: S101
-    assert dp_group is not None  # noqa: S101
+    if sp_group is None or dp_group is None:
+        raise RuntimeError("Failed to initialize SP/DP process groups")
 
     _sp_group = sp_group
     _dp_group = dp_group

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -24,9 +24,15 @@ from speculators.train.checkpointer import (
     DistributedCheckpointer,
     SingleGPUCheckpointer,
 )
+from speculators.train.distributed import (
+    apply_fully_sharded,
+    get_local_rank,
+    get_rank,
+    is_distributed,
+)
 from speculators.train.graceful_shutdown import with_graceful_shutdown
 from speculators.train.optimizers import build_optimizers
-from speculators.train.utils import apply_fully_sharded, normalize_counted_metrics
+from speculators.train.utils import normalize_counted_metrics
 
 root_logger = logging.getLogger("speculators")
 metric_logger = logging.getLogger("speculators.metrics")
@@ -40,9 +46,6 @@ class TrainerConfig(NamedTuple):
     num_epochs: int
     save_path: str
     resume_from_checkpoint: bool = False
-    is_distributed: bool = False
-    local_rank: int = 0
-    rank: int = 0
     train_call_kwargs: dict = {}
     val_call_kwargs: dict = {}
     optimizer: Literal["adamw", "muon"] = "adamw"
@@ -72,11 +75,11 @@ class Trainer:
     ):
         self.model = model
         self.config = config
-        self.local_rank = config.local_rank
-        self.rank = config.rank
+        self.local_rank = get_local_rank()
+        self.rank = get_rank()
         self.train_loader = train_loader
         self.val_loader = val_loader
-        self.is_distributed = config.is_distributed
+        self.is_distributed = is_distributed()
         self.resume_from_checkpoint = config.resume_from_checkpoint
         checkpointer_class = (
             DistributedCheckpointer if self.is_distributed else SingleGPUCheckpointer

--- a/src/speculators/train/utils.py
+++ b/src/speculators/train/utils.py
@@ -9,60 +9,9 @@ import tempfile
 import warnings
 from pathlib import Path
 
-import torch
-import torch.distributed as dist
-from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
-
 from speculators.data_generation.preprocessing import get_tokenizer, load_processor
 
-local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-world_size = int(os.environ.get("WORLD_SIZE", "1"))
-is_distributed = "LOCAL_RANK" in os.environ
-
 logger = logging.getLogger("speculators")
-
-
-def maybe_setup_distributed() -> tuple[int, int, int, bool]:
-    """Sets up distributed training if the process was launched with `torchrun`.
-    If not, returns single process training.
-
-    Based on of https://docs.pytorch.org/tutorials/intermediate/ddp_tutorial.html#initialize-ddp-with-torch-distributed-run-torchrun
-
-    Returns:
-        tuple[int, int, int, bool]: Local rank, world size, rank, and is_distributed.
-    """
-    if not is_distributed:
-        # No distributed training
-        return 0, 1, 0, False
-
-    torch.accelerator.set_device_index(local_rank)
-    acc = torch.accelerator.current_accelerator()
-    if acc is None:
-        raise ValueError("No accelerator found")
-    backend = torch.distributed.get_default_backend_for_device(acc)
-    dist.init_process_group(backend, device_id=local_rank)
-
-    rank = dist.get_rank()
-
-    logger.info(
-        f"Started distributed with local_rank={local_rank},"
-        f" world_size={world_size}, rank={rank}",
-        extra={"override_rank0_filter": True},
-    )
-    return local_rank, world_size, rank, True
-
-
-def maybe_destroy_distributed():
-    """Destroys the distributed process group if using distributed training."""
-    if not is_distributed:
-        # No distributed training
-        return
-
-    dist.destroy_process_group()
-    logger.info(
-        f"Destroyed distributed with local_rank={local_rank}, world_size={world_size}",
-        extra={"override_rank0_filter": True},
-    )
 
 
 def resolve_mask_token_id(
@@ -194,23 +143,3 @@ def save_train_command(save_path: str) -> None:
     finally:
         if tmp_path.exists():
             tmp_path.unlink()
-
-
-def apply_fully_sharded(model: torch.nn.Module):
-    """Applies torch FSDP fully_shard to the model, wrapping layers in FSDPModule.
-
-    Assumes the model has a `layers` attribute containing the decoder layers.
-    Model should be validated with SpeculatorModel.verify_training_compatible()
-    before calling this function.
-    """
-    mp_policy = MixedPrecisionPolicy(
-        param_dtype=torch.bfloat16,
-        reduce_dtype=torch.float32,
-    )
-
-    for layer in model.layers:  # type: ignore[union-attr]
-        fully_shard(layer, mp_policy=mp_policy)
-
-    fully_shard(model)
-
-    return model

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -19,9 +19,6 @@ def _make_minimal_trainer(tmp_path: Path, checkpoint_freq: int, save_best: bool)
         num_epochs=0,
         save_path=str(tmp_path),
         resume_from_checkpoint=False,
-        is_distributed=False,
-        rank=0,
-        local_rank=0,
         checkpoint_freq=checkpoint_freq,
         save_best=save_best,
     )

--- a/tests/unit/train/test_mid_epoch_resume.py
+++ b/tests/unit/train/test_mid_epoch_resume.py
@@ -127,14 +127,11 @@ def _make_trainer(
     trained_steps: list[tuple[int, int, int]],
     resume: bool = False,
     epochs: int = 1,
-    is_distributed: bool = False,
 ) -> _MockTrainer:
     cfg = TrainerConfig(
         save_path=save_path,
         num_epochs=epochs,
         lr=1e-4,
-        local_rank=0,
-        is_distributed=is_distributed,
         resume_from_checkpoint=resume,
         checkpoint_freq=0.3,
         log_freq=1,
@@ -280,7 +277,6 @@ def test_distributed_mid_epoch_checkpoint_rank_gate(
         rank0 = _make_trainer(
             tmpdir,
             trained_steps=trained_steps,
-            is_distributed=True,
         )
         monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
         rank0.maybe_save_checkpoint(0, local_step=step_interval)
@@ -295,7 +291,6 @@ def test_distributed_mid_epoch_checkpoint_rank_gate(
         rank1 = _make_trainer(
             tmpdir,
             trained_steps=rank1_steps,
-            is_distributed=True,
         )
         monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
         rank1.maybe_save_checkpoint(0, local_step=step_interval)
@@ -392,8 +387,6 @@ def test_fast_skip_sampler_slice_avoids_skipped_getitem(
             save_path=tmpdir,
             num_epochs=1,
             lr=1e-4,
-            local_rank=0,
-            is_distributed=False,
             resume_from_checkpoint=False,
             checkpoint_freq=0.3,
             log_freq=1,

--- a/tests/unit/train/test_mid_epoch_resume.py
+++ b/tests/unit/train/test_mid_epoch_resume.py
@@ -278,6 +278,7 @@ def test_distributed_mid_epoch_checkpoint_rank_gate(
             tmpdir,
             trained_steps=trained_steps,
         )
+        rank0.is_distributed = True
         monkeypatch.setattr(torch.distributed, "get_rank", lambda: 0)
         rank0.maybe_save_checkpoint(0, local_step=step_interval)
 
@@ -292,6 +293,7 @@ def test_distributed_mid_epoch_checkpoint_rank_gate(
             tmpdir,
             trained_steps=rank1_steps,
         )
+        rank1.is_distributed = True
         monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
         rank1.maybe_save_checkpoint(0, local_step=step_interval)
 

--- a/tests/unit/train/test_setup_model.py
+++ b/tests/unit/train/test_setup_model.py
@@ -133,42 +133,18 @@ def _make_trainer_no_init(
         num_epochs=1,
         save_path=save_path,
         resume_from_checkpoint=resume_from_checkpoint,
-        is_distributed=is_distributed,
-        local_rank=local_rank,
-        rank=rank,
         hidden_states_dtype=hidden_states_dtype,
     )
     trainer = Trainer.__new__(Trainer)
     trainer.model = model
     trainer.config = config
-    trainer.local_rank = config.local_rank
-    trainer.rank = config.rank
-    trainer.is_distributed = config.is_distributed
+    trainer.local_rank = local_rank
+    trainer.rank = rank
+    trainer.is_distributed = is_distributed
     trainer.resume_from_checkpoint = config.resume_from_checkpoint
     trainer.train_loader = MagicMock(__len__=MagicMock(return_value=1))
     trainer.val_loader = None
     return trainer
-
-
-def test_trainer_uses_rank_from_config(monkeypatch: pytest.MonkeyPatch, tmp_path):
-    monkeypatch.setattr(Trainer, "setup_trainer", lambda self: None)
-    monkeypatch.setattr(Trainer, "setup_model", lambda self: None)
-    monkeypatch.setattr(Trainer, "setup_optimizer", lambda self: None)
-
-    trainer = Trainer(
-        MagicMock(),
-        TrainerConfig(
-            lr=1e-4,
-            num_epochs=1,
-            save_path=str(tmp_path),
-            rank=3,
-            local_rank=1,
-        ),
-        MagicMock(),
-    )
-
-    assert trainer.rank == 3
-    assert trainer.local_rank == 1
 
 
 def _param_checksums(state_dict: dict[str, torch.Tensor]) -> dict[str, float]:


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

To split up the SP Ulysses diff, this pr refactors some of the distributed / data loading logic into separate modules.

Distributed in particular now has a single source of truth for all distributed ranks/world size/group metadata which SP Ulysses will use.

## Tests

Run CI and verify nothing breaks. Should be a pure refactor with no behaviour changes. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
