### PR TITLE
fix(ci): move build artifacts to model-cache storage to reduce /var disk pressure

### DIFF
--- a/.buildkite/gpu-tests/scripts/run-tests.sh
+++ b/.buildkite/gpu-tests/scripts/run-tests.sh
@@ -18,10 +18,15 @@ echo "~~~ GPU info"
 nvidia-smi
 
 echo "--- Setting up Python environment"
+BUILD_DIR="/model-cache/.builds/${BUILDKITE_BUILD_ID}"
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+trap "rm -rf $BUILD_DIR" EXIT
+
 export UV_NO_PROGRESS=1
-export UV_CACHE_DIR="$PWD/.uv-cache"
-uv venv testvenv --python "${PYTHON_VERSION}"
-source testvenv/bin/activate
+export UV_CACHE_DIR="$BUILD_DIR/.uv-cache"
+uv venv "$BUILD_DIR/testvenv" --python "${PYTHON_VERSION}"
+source "$BUILD_DIR/testvenv/bin/activate"
 
 export UV_TORCH_BACKEND=cu130
 export HF_HOME=/model-cache

--- a/.buildkite/gpu-tests/scripts/run-tests.sh
+++ b/.buildkite/gpu-tests/scripts/run-tests.sh
@@ -18,10 +18,10 @@ echo "~~~ GPU info"
 nvidia-smi
 
 echo "--- Setting up Python environment"
-BUILD_DIR="/model-cache/.builds/${BUILDKITE_BUILD_ID}"
-rm -rf "$BUILD_DIR"
+find /model-cache/.builds -maxdepth 1 -type d -mmin +240 -exec rm -rf {} + 2>/dev/null || true
+BUILD_DIR="/model-cache/.builds/${BUILDKITE_JOB_ID}"
 mkdir -p "$BUILD_DIR"
-trap "rm -rf $BUILD_DIR" EXIT
+trap 'rm -rf "$BUILD_DIR" || true' EXIT
 
 export UV_NO_PROGRESS=1
 export UV_CACHE_DIR="$BUILD_DIR/.uv-cache"


### PR DESCRIPTION
## Summary
- Moves UV cache and Python venv from the workspace emptyDir to `/model-cache` 
- Each build gets an isolated directory under `/model-cache/.builds/<BUILDKITE_BUILD_ID>/`
- Automatic cleanup via `trap` on exit; stale directories also cleaned before each build

## Problem
Buildkite H100 GPU test builds are failing with `No space left on device` during `uv pip install`. 
The workspace emptyDir and container writable layer both live under `/var/lib/kubelet`.

## What changed
| Artifact | Before (on `/var`) | After (on `/model-cache`) |
|----------|-------------------|--------------------------|
| UV cache | `$PWD/.uv-cache` | `/model-cache/.builds/<id>/.uv-cache` |
| Venv | `$PWD/testvenv` | `/model-cache/.builds/<id>/testvenv` |

## Test plan
- [ ] Buildkite H100 build passes without "No space left on device" errors
- [ ] Build logs show venv and UV cache paths under `/model-cache/.builds/`
- [ ] No stale `.builds/` directories remain after build completes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vllm-project/codesmith/speculators/pr/660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785004355&installation_id=142609222&pr_number=660&repository=vllm-project%2Fspeculators&return_to=https%3A%2F%2Fgithub.com%2Fvllm-project%2Fspeculators%2Fpull%2F660&signature=75bef76df90ab9e3c1c4cba92dd7d2b5c86a0d4c12297c9f66e131cfb9379895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->