### PR TITLE
[Dataset] Add open-perfectblend dataset

### DIFF
--- a/src/speculators/data_generation/configs.py
+++ b/src/speculators/data_generation/configs.py
@@ -119,4 +119,9 @@ DATASET_CONFIGS: dict[str, DatasetConfig] = {
         filter_fn=_filter_sharegpt4v_coco,
         normalize_fn=_normalize_sharegpt4v_coco,
     ),
+    "open-perfectblend": DatasetConfig(
+        name="open-perfectblend",
+        hf_path="mlabonne/open-perfectblend",
+        split="train",
+    ),
 }


### PR DESCRIPTION

## Purpose
Add open-perfectblend dataset. 

why: 

* DSpark is trained on open-perfectblend 
* Currently we don't have a predefined long context training data. open-perfectblend close this gap.
* #613 and Long context support in the roadmap

## Tests

Verified: the dataset is trainable, and the loss is decreasing. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `open-perfectblend` dataset configuration, making it available for data generation using the training split.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->