### PR TITLE
[Models] Add DSpark speculator (DFlash + Markov + confidence head)

### DIFF
--- a/examples/train/dspark_qwen3_0_6b_sharegpt_online.sh
+++ b/examples/train/dspark_qwen3_0_6b_sharegpt_online.sh
@@ -2,26 +2,22 @@
 # Online DSpark Training Script
 #
 # Runs the full online DSpark training pipeline: data preparation, vLLM server
-# launch, and training with hidden states generated on-the-fly from the live
-# server. DSpark extends DFlash with a sequential Markov head (intra-block token
-# dependency) and a confidence head (per-position acceptance prediction), so the
-# pipeline is identical to the DFlash one plus a few DSpark-specific flags.
-#
-# Unlike DeepSeek's DeepSpec reference (which precomputes a very large offline
-# target-hidden-state cache), this trains DSpark fully online.
+# launch, and training (with hidden states generated on-the-fly from the live
+# server). DSpark extends DFlash with a Markov head (intra-block token
+# dependency) and a confidence head (per-position acceptance prediction); the
+# pipeline is the DFlash one plus a few DSpark-specific flags.
 #
 # Usage: Copy this script, modify the configuration variables below, then run:
 #   bash examples/train/dspark_qwen3_0_6b_sharegpt_online.sh
 #
-# See the DFlash online tutorial for a detailed walkthrough of the shared steps:
+# For a detailed walkthrough, see
 # https://docs.vllm.ai/projects/speculators/en/latest/user_guide/tutorials/train_dflash_online/
 
 ### Example E2E run for DSpark Qwen3-0.6B on 5k samples from ShareGPT ###
 
-# Note: With just 5k samples the absolute acceptance length will be low; the run
-# is meant to verify the pipeline works and that DSpark is learning (in
-# particular that the Markov head lifts later-position accuracy over plain DFlash
-# and that the confidence head calibrates).
+# Note: With just 5k samples, performance will be low, but it is enough to verify
+# the pipeline works and DSpark is learning (the Markov head should lift
+# later-position accuracy over plain DFlash).
 
 set -euo pipefail
 
@@ -50,14 +46,13 @@ CE_LOSS_ALPHA=0.1
 L1_LOSS_ALPHA=0.9
 CONFIDENCE_HEAD_ALPHA=1.0
 
-# GPU assignments (online training needs separate GPUs for vLLM and training).
-# Pick currently-idle devices (check `nvidia-smi`).
+# GPU assignments (online training needs separate GPUs for vLLM and training)
 VLLM_GPUS="0"
 TRAIN_GPUS="1"
 NUM_TRAIN_GPUS=1
 # =======================================
 
-# Step 1: Prepare data (also writes token_freq.pt used to build the draft vocab)
+# Step 1: Prepare data
 echo "=== Step 1: Preparing data ==="
 python scripts/prepare_data.py \
     --model "$MODEL" \
@@ -66,7 +61,7 @@ python scripts/prepare_data.py \
     --max-samples "$MAX_SAMPLES" \
     --seq-length "$SEQ_LENGTH"
 
-# Step 2: Launch vLLM server in the background (exposes the aux hidden states)
+# Step 2: Launch vLLM server in the background
 echo "=== Step 2: Launching vLLM server ==="
 CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm.py "$MODEL" \
     --target-layer-ids $TARGET_LAYER_IDS \

--- a/examples/train/dspark_qwen3_0_6b_sharegpt_online.sh
+++ b/examples/train/dspark_qwen3_0_6b_sharegpt_online.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Online DSpark Training Script
+#
+# Runs the full online DSpark training pipeline: data preparation, vLLM server
+# launch, and training with hidden states generated on-the-fly from the live
+# server. DSpark extends DFlash with a sequential Markov head (intra-block token
+# dependency) and a confidence head (per-position acceptance prediction), so the
+# pipeline is identical to the DFlash one plus a few DSpark-specific flags.
+#
+# Unlike DeepSeek's DeepSpec reference (which precomputes a very large offline
+# target-hidden-state cache), this trains DSpark fully online.
+#
+# Usage: Copy this script, modify the configuration variables below, then run:
+#   bash examples/train/dspark_qwen3_0_6b_sharegpt_online.sh
+#
+# See the DFlash online tutorial for a detailed walkthrough of the shared steps:
+# https://docs.vllm.ai/projects/speculators/en/latest/user_guide/tutorials/train_dflash_online/
+
+### Example E2E run for DSpark Qwen3-0.6B on 5k samples from ShareGPT ###
+
+# Note: With just 5k samples the absolute acceptance length will be low; the run
+# is meant to verify the pipeline works and that DSpark is learning (in
+# particular that the Markov head lifts later-position accuracy over plain DFlash
+# and that the confidence head calibrates).
+
+set -euo pipefail
+
+# ============ Configuration ============
+MODEL="Qwen/Qwen3-0.6B"
+DATASET="sharegpt"                # sharegpt, ultrachat, or path to custom data
+OUTPUT_DIR="./output/dspark_qwen3_0_6b_sharegpt"
+VLLM_PORT=8000
+MAX_SAMPLES=5000
+SEQ_LENGTH=4096
+EPOCHS=5
+LR=3e-4
+
+# DSpark-specific parameters
+SPECULATOR_TYPE="dspark"
+BLOCK_SIZE=8
+MAX_ANCHORS=3072
+NUM_LAYERS=3
+DRAFT_VOCAB_SIZE=32000
+TARGET_LAYER_IDS="2 14 25"  # Must match vLLM's eagle_aux_hidden_state_layer_ids
+
+# Markov + confidence head settings
+MARKOV_RANK=256
+MARKOV_HEAD_TYPE="vanilla"   # vanilla | gated | rnn
+CE_LOSS_ALPHA=0.1
+L1_LOSS_ALPHA=0.9
+CONFIDENCE_HEAD_ALPHA=1.0
+
+# GPU assignments (online training needs separate GPUs for vLLM and training).
+# Pick currently-idle devices (check `nvidia-smi`).
+VLLM_GPUS="0"
+TRAIN_GPUS="1"
+NUM_TRAIN_GPUS=1
+# =======================================
+
+# Step 1: Prepare data (also writes token_freq.pt used to build the draft vocab)
+echo "=== Step 1: Preparing data ==="
+python scripts/prepare_data.py \
+    --model "$MODEL" \
+    --data "$DATASET" \
+    --output "$OUTPUT_DIR" \
+    --max-samples "$MAX_SAMPLES" \
+    --seq-length "$SEQ_LENGTH"
+
+# Step 2: Launch vLLM server in the background (exposes the aux hidden states)
+echo "=== Step 2: Launching vLLM server ==="
+CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm.py "$MODEL" \
+    --target-layer-ids $TARGET_LAYER_IDS \
+    -- --port "$VLLM_PORT" &
+VLLM_PID=$!
+
+# Ensure vLLM is cleaned up on exit
+cleanup() {
+    echo "Stopping vLLM server..."
+    kill "$VLLM_PID" 2>/dev/null || true
+    wait "$VLLM_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Waiting for vLLM server to be ready..."
+until curl -sf "http://localhost:${VLLM_PORT}/health" > /dev/null 2>&1; do
+    sleep 2
+done
+echo "vLLM server ready."
+
+# Step 3: Train DSpark against the live vLLM server
+echo "=== Step 3: Training ==="
+CUDA_VISIBLE_DEVICES="$TRAIN_GPUS" torchrun \
+    --standalone --nproc_per_node "$NUM_TRAIN_GPUS" \
+    scripts/train.py \
+    --verifier-name-or-path "$MODEL" \
+    --data-path "$OUTPUT_DIR" \
+    --vllm-endpoint "http://localhost:${VLLM_PORT}/v1" \
+    --save-path "$OUTPUT_DIR/checkpoints" \
+    --draft-vocab-size "$DRAFT_VOCAB_SIZE" \
+    --epochs "$EPOCHS" \
+    --lr "$LR" \
+    --total-seq-len "$SEQ_LENGTH" \
+    --speculator-type "$SPECULATOR_TYPE" \
+    --block-size "$BLOCK_SIZE" \
+    --max-anchors "$MAX_ANCHORS" \
+    --num-layers "$NUM_LAYERS" \
+    --target-layer-ids $TARGET_LAYER_IDS \
+    --markov-rank "$MARKOV_RANK" \
+    --markov-head-type "$MARKOV_HEAD_TYPE" \
+    --enable-confidence-head \
+    --confidence-head-with-markov \
+    --ce-loss-alpha "$CE_LOSS_ALPHA" \
+    --l1-loss-alpha "$L1_LOSS_ALPHA" \
+    --confidence-head-alpha "$CONFIDENCE_HEAD_ALPHA" \
+    --on-missing generate \
+    --on-generate delete
+
+echo "Done. Checkpoints saved to $OUTPUT_DIR/checkpoints/"

--- a/examples/train/dspark_qwen3_0_6b_sharegpt_online.sh
+++ b/examples/train/dspark_qwen3_0_6b_sharegpt_online.sh
@@ -42,8 +42,7 @@ TARGET_LAYER_IDS="2 14 25"  # Must match vLLM's eagle_aux_hidden_state_layer_ids
 # Markov + confidence head settings
 MARKOV_RANK=256
 MARKOV_HEAD_TYPE="vanilla"   # vanilla | gated | rnn
-CE_LOSS_ALPHA=0.1
-L1_LOSS_ALPHA=0.9
+LOSS_FN='{"ce": 0.1, "tv": 0.9}'
 CONFIDENCE_HEAD_ALPHA=1.0
 
 # GPU assignments (online training needs separate GPUs for vLLM and training)
@@ -104,8 +103,7 @@ CUDA_VISIBLE_DEVICES="$TRAIN_GPUS" torchrun \
     --markov-head-type "$MARKOV_HEAD_TYPE" \
     --enable-confidence-head \
     --confidence-head-with-markov \
-    --ce-loss-alpha "$CE_LOSS_ALPHA" \
-    --l1-loss-alpha "$L1_LOSS_ALPHA" \
+    --loss-fn "$LOSS_FN" \
     --confidence-head-alpha "$CONFIDENCE_HEAD_ALPHA" \
     --on-missing generate \
     --on-generate delete

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -501,11 +501,14 @@ def main(args: argparse.Namespace):  # noqa: C901
     else:
         d2t, t2d, draft_vocab_size = parse_vocab_mappings(args)
 
-        if args.sliding_window_indices and args.speculator_type != "dflash":
+        if args.sliding_window_indices and args.speculator_type not in (
+            "dflash",
+            "dspark",
+        ):
             raise ValueError(
                 "Currently sliding window attention is only supported by dflash "
-                "draft models. Please open an issue/pr if you would like to use "
-                "sliding window attention with a different speculator type"
+                "and dspark draft models. Please open an issue/pr if you would like "
+                "to use sliding window attention with a different speculator type"
             )
 
     registry = SpeculatorModel.registry
@@ -759,7 +762,7 @@ def parse_args():
         "--speculator-type",
         type=str,
         default="eagle3",
-        help="Type of speculator model to train (eagle3, dflash, peagle, mtp)",
+        help="Type of speculator model to train (eagle3, dflash, dspark, peagle, mtp)",
     )
     parser.add_argument(
         "--from-pretrained",
@@ -1045,7 +1048,52 @@ def parse_args():
         "--dflash-decay-gamma",
         type=float,
         default=4.0,
-        help="Decay gamma for DFlash loss weighting (default: 4.0)",
+        help="Decay gamma for DFlash/DSpark loss weighting (default: 4.0)",
+    )
+    # DSpark-specific arguments (sequential Markov head + confidence head).
+    parser.add_argument(
+        "--markov-rank",
+        type=int,
+        default=256,
+        help="DSpark: low-rank dim of the Markov logit-bias head (0 disables it).",
+    )
+    parser.add_argument(
+        "--markov-head-type",
+        type=str,
+        default="vanilla",
+        choices=["vanilla", "gated", "rnn"],
+        help="DSpark: sequential head variant (default: vanilla).",
+    )
+    parser.add_argument(
+        "--enable-confidence-head",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="DSpark: attach the per-position acceptance confidence head.",
+    )
+    parser.add_argument(
+        "--confidence-head-with-markov",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="DSpark: feed the Markov previous-token embedding into the "
+        "confidence head alongside the backbone hidden state.",
+    )
+    parser.add_argument(
+        "--ce-loss-alpha",
+        type=float,
+        default=0.1,
+        help="DSpark: weight of the cross-entropy loss term (default: 0.1).",
+    )
+    parser.add_argument(
+        "--l1-loss-alpha",
+        type=float,
+        default=0.9,
+        help="DSpark: weight of the total-variation loss term (default: 0.9).",
+    )
+    parser.add_argument(
+        "--confidence-head-alpha",
+        type=float,
+        default=1.0,
+        help="DSpark: weight of the confidence-head BCE term (default: 1.0).",
     )
     parser.add_argument(
         "--draft-attn-impl",

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -21,7 +21,7 @@ from speculators.data_generation.vllm_client import (
 )
 from speculators.model import SpeculatorModel
 from speculators.models.eagle3.data import shift_batch
-from speculators.models.metrics import resolve_loss_fn
+from speculators.models.metrics import resolve_loss_config
 from speculators.models.mtp.data import shift_batch_mtp
 from speculators.models.utils import (
     get_verifier_config,
@@ -966,11 +966,10 @@ def parse_args():
         "--loss-fn",
         type=str,
         default="kl_div",
-        choices=["kl_div", "ce"],
         help=(
-            "Loss function used during draft model training. "
-            "'kl_div' = KL divergence (default). "
-            "'ce' = cross-entropy."
+            "Loss function specification. Pass a name for a single loss "
+            "(kl_div, ce, tv, nla) or a JSON dict for a weighted combination, "
+            'e.g. \'{"ce": 0.1, "tv": 0.9}\'.'
         ),
     )
     parser.add_argument(
@@ -1076,18 +1075,6 @@ def parse_args():
         default=True,
         help="DSpark: feed the Markov previous-token embedding into the "
         "confidence head alongside the backbone hidden state.",
-    )
-    parser.add_argument(
-        "--ce-loss-alpha",
-        type=float,
-        default=0.1,
-        help="DSpark: weight of the cross-entropy loss term (default: 0.1).",
-    )
-    parser.add_argument(
-        "--l1-loss-alpha",
-        type=float,
-        default=0.9,
-        help="DSpark: weight of the total-variation loss term (default: 0.9).",
     )
     parser.add_argument(
         "--confidence-head-alpha",
@@ -1220,7 +1207,7 @@ def parse_args():
     args = parser.parse_args()
     provided = explicitly_provided_dests(parser, DECODER_SHAPING_FLAGS)
     validate_draft_init_args(parser, args, provided)
-    resolve_loss_fn(args.loss_fn)
+    resolve_loss_config(args.loss_fn)
     return args
 
 

--- a/src/speculators/models/__init__.py
+++ b/src/speculators/models/__init__.py
@@ -1,6 +1,7 @@
 from speculators.models.attention import ALL_ATTENTION_FUNCTIONS  # noqa: F401
 
 from .dflash import DFlashDraftModel, DFlashSpeculatorConfig
+from .dspark import DSparkDraftModel, DSparkSpeculatorConfig
 from .eagle3 import Eagle3DraftModel, Eagle3SpeculatorConfig
 from .mtp import MTPDraftModel, MTPSpeculatorConfig
 from .peagle import PEagleDraftModel, PEagleSpeculatorConfig
@@ -8,6 +9,8 @@ from .peagle import PEagleDraftModel, PEagleSpeculatorConfig
 __all__ = [
     "DFlashDraftModel",
     "DFlashSpeculatorConfig",
+    "DSparkDraftModel",
+    "DSparkSpeculatorConfig",
     "Eagle3DraftModel",
     "Eagle3SpeculatorConfig",
     "MTPDraftModel",

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -138,6 +138,25 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             The number of draft layers is encoded in verifier_config.num_hidden_layers,
             following the same pattern as EAGLE3.
         """
+        config = DFlashSpeculatorConfig(
+            **cls._build_base_config_kwargs("dflash", verifier_config, **kwargs)
+        )
+
+        model = cls(config=config)
+        model.load_vocab_mappings(t2d, d2t)
+        model.load_verifier_weights()
+        return model
+
+    @staticmethod
+    def _build_base_config_kwargs(
+        algorithm: str,
+        verifier_config: "PretrainedConfig",
+        **kwargs,
+    ) -> dict:
+        """Shared DFlash-family config kwargs for ``from_training_args``.
+
+        DSpark reuses this and appends its Markov/confidence/loss fields.
+        """
         from speculators.config import (  # noqa: PLC0415
             SpeculatorsConfig,
             VerifierConfig,
@@ -146,42 +165,33 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             GreedyTokenProposalConfig,
         )
 
-        # Resolve target layer IDs if not provided
         target_layer_ids = resolve_target_layer_ids(
             kwargs.get("target_layer_ids"), kwargs["verifier_name_or_path"]
         )
-
         verifier_config._attn_implementation = kwargs.get(  # noqa: SLF001
             "draft_attn_impl", "simple_flex_attention"
         )
-
-        config = DFlashSpeculatorConfig(
-            transformer_layer_config=verifier_config,
-            draft_vocab_size=kwargs["draft_vocab_size"],
-            block_size=kwargs.get("block_size", 8),
-            max_anchors=kwargs.get("max_anchors", 3072),
-            aux_hidden_state_layer_ids=target_layer_ids,
-            mask_token_id=kwargs.get("mask_token_id"),
-            sliding_window_non_causal=kwargs.get("sliding_window_non_causal", False),
-            speculators_config=SpeculatorsConfig(
-                algorithm="dflash",
+        block_size = kwargs.get("block_size", 8)
+        return {
+            "transformer_layer_config": verifier_config,
+            "draft_vocab_size": kwargs["draft_vocab_size"],
+            "block_size": block_size,
+            "max_anchors": kwargs.get("max_anchors", 3072),
+            "aux_hidden_state_layer_ids": target_layer_ids,
+            "mask_token_id": kwargs.get("mask_token_id"),
+            "sliding_window_non_causal": kwargs.get("sliding_window_non_causal", False),
+            "speculators_config": SpeculatorsConfig(
+                algorithm=algorithm,
                 proposal_methods=[
-                    GreedyTokenProposalConfig(
-                        # DFlash first position is anchor position, not used during gen
-                        speculative_tokens=kwargs.get("block_size", 8) - 1,
-                    )
+                    # First block position is the anchor, not emitted during gen.
+                    GreedyTokenProposalConfig(speculative_tokens=block_size - 1)
                 ],
                 default_proposal_method="greedy",
                 verifier=VerifierConfig.from_pretrained(
                     kwargs["verifier_name_or_path"]
                 ),
             ),
-        )
-
-        model = cls(config=config)
-        model.load_vocab_mappings(t2d, d2t)
-        model.load_verifier_weights()
-        return model
+        }
 
     @staticmethod
     def get_trainer_kwargs(**kwargs) -> tuple[dict, dict]:
@@ -268,19 +278,22 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
 
         return full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid
 
-    @conditional_torch_compile
-    def forward(
+    def _backbone_forward(
         self,
-        hidden_states: torch.Tensor,  # shape: [1,total_seq_len,num_hidden*hidden_size]
-        input_ids: torch.Tensor,  # shape: [1, total_seq_len]
-        loss_mask: torch.Tensor,  # shape: [1, total_seq_len]
-        verifier_last_hidden_states: torch.Tensor,  # shape: [1, total_seq_len, hidden_size] # noqa: E501
-        document_ids: torch.Tensor,  # shape: [1, total_seq_len]
-        position_ids: torch.Tensor | None = None,  # shape: [1, total_seq_len]
-        loss_fn=kl_div_loss,
-        gamma: float = 4.0,
+        hidden_states: torch.Tensor,  # [1, total_seq_len, num_hidden*hidden_size]
+        input_ids: torch.Tensor,  # [1, total_seq_len]
+        loss_mask: torch.Tensor,  # [1, total_seq_len]
+        verifier_last_hidden_states: torch.Tensor,  # [1, total_seq_len, hidden_size]
+        document_ids: torch.Tensor,  # [1, total_seq_len]
+        position_ids: torch.Tensor | None = None,  # [1, total_seq_len]
         **kwargs,
     ):
+        """Run the anchored-block draft transformer up to the draft logits.
+
+        Returns ``(hidden, logits, targets, aligned_loss_mask,
+        anchored_block_indices)``. DSpark reuses this and adds its Markov and
+        confidence heads before computing its own loss.
+        """
         device = hidden_states.device
         total_seq_len = hidden_states.shape[1]
         num_anchors = self.config.max_anchors
@@ -346,7 +359,8 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
                 **kwargs,
             )
 
-        logits = self.lm_head(self.norm(noise_embedding))
+        hidden = self.norm(noise_embedding)
+        logits = self.lm_head(hidden)
         # shape: [1, num_anchors*block_size, vocab_size]
 
         aligned_loss_mask = loss_mask.clone()[:, anchored_block_indices]
@@ -360,6 +374,31 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         )  # shape: [1, num_anchors*block_size]
 
         aligned_loss_mask[:, :: self.block_size] = 0
+
+        return hidden, logits, targets, aligned_loss_mask, anchored_block_indices
+
+    @conditional_torch_compile
+    def forward(
+        self,
+        hidden_states: torch.Tensor,  # shape: [1,total_seq_len,num_hidden*hidden_size]
+        input_ids: torch.Tensor,  # shape: [1, total_seq_len]
+        loss_mask: torch.Tensor,  # shape: [1, total_seq_len]
+        verifier_last_hidden_states: torch.Tensor,  # shape: [1, total_seq_len, hidden_size] # noqa: E501
+        document_ids: torch.Tensor,  # shape: [1, total_seq_len]
+        position_ids: torch.Tensor | None = None,  # shape: [1, total_seq_len]
+        loss_fn=kl_div_loss,
+        gamma: float = 4.0,
+        **kwargs,
+    ):
+        _, logits, targets, aligned_loss_mask, _ = self._backbone_forward(
+            hidden_states,
+            input_ids,
+            loss_mask,
+            verifier_last_hidden_states,
+            document_ids,
+            position_ids,
+            **kwargs,
+        )
         loss, metrics = compute_metrics(
             logits,
             targets,

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -18,7 +18,7 @@ from speculators.models.dflash.utils import (
     get_base_indices_for_anchored_blocks,
     select_anchors,
 )
-from speculators.models.metrics import kl_div_loss, resolve_loss_fn
+from speculators.models.metrics import LossConfig, resolve_loss_config
 from speculators.models.utils import conditional_torch_compile, resolve_target_layer_ids
 
 
@@ -203,12 +203,10 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         Returns:
             Tuple of (train_call_kwargs, val_call_kwargs)
         """
-        loss_fn = resolve_loss_fn(kwargs["loss_fn"])
+        loss_config = resolve_loss_config(kwargs["loss_fn"])
         gamma = kwargs.get("dflash_decay_gamma", 4.0)
-        return {"loss_fn": loss_fn, "gamma": gamma}, {
-            "loss_fn": loss_fn,
-            "gamma": gamma,
-        }
+        shared = {"loss_config": loss_config, "gamma": gamma}
+        return dict(shared), dict(shared)
 
     @property
     def mask_token_id(self) -> int:
@@ -386,7 +384,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         verifier_last_hidden_states: torch.Tensor,  # shape: [1, total_seq_len, hidden_size] # noqa: E501
         document_ids: torch.Tensor,  # shape: [1, total_seq_len]
         position_ids: torch.Tensor | None = None,  # shape: [1, total_seq_len]
-        loss_fn=kl_div_loss,
+        loss_config: LossConfig | None = None,
         gamma: float = 4.0,
         **kwargs,
     ):
@@ -405,7 +403,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             aligned_loss_mask,
             self.block_size,
             gamma=gamma,
-            loss_fn=loss_fn,
+            loss_config=loss_config,
         )
         draft_tokens = torch.argmax(logits, dim=-1)
 

--- a/src/speculators/models/dflash/metrics.py
+++ b/src/speculators/models/dflash/metrics.py
@@ -1,17 +1,19 @@
 """Metrics and loss functions for DFlash draft model."""
 
-from collections.abc import Callable
 from functools import partial
 from typing import Any
 
 import torch
 
 from speculators.models.metrics import (
+    LossConfig,
+    compound_loss,
     compute_accuracy_multi_step,
     dflash_loss_decay,
     kl_div_loss,
-    loss_function,
 )
+
+_DEFAULT_LOSS_CONFIG: LossConfig = {"kl_div": (kl_div_loss, 1.0)}
 
 
 def compute_metrics(
@@ -20,7 +22,7 @@ def compute_metrics(
     loss_mask: torch.Tensor,  # shape: [1, num_anchors*block_size]
     block_size: int = 1,
     gamma: float = 4.0,
-    loss_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None = kl_div_loss,
+    loss_config: LossConfig | None = None,
 ) -> tuple[torch.Tensor, dict]:
     """Compute loss and accuracy metrics for draft model predictions.
 
@@ -30,7 +32,7 @@ def compute_metrics(
         loss_mask: Binary mask [1, T]
         block_size: Block size for per-position metrics
         gamma: Temperature for exponential decay in loss weighting
-        loss_fn: Loss function
+        loss_config: Mapping of ``{name: (loss_fn, weight)}``
 
     Returns:
         Tuple of (loss, metrics_dict) where metrics_dict contains:
@@ -38,18 +40,18 @@ def compute_metrics(
             - full_acc: Overall accuracy
             - position {i} acc: Accuracy at position i within blocks
     """
-    if loss_fn is None:
-        loss_fn = kl_div_loss
+    if loss_config is None:
+        loss_config = _DEFAULT_LOSS_CONFIG
     seq_len = logits.shape[1]
     pos_idx = torch.arange(seq_len, device=logits.device) % block_size
     pos_idx = pos_idx.unsqueeze(0)  # shape: [1, T]
 
-    loss = loss_function(
+    loss, term_losses = compound_loss(
         logits,
         targets,
         loss_mask,
         pos_idx,
-        loss_fn=loss_fn,
+        loss_config=loss_config,
         decay_fn=partial(dflash_loss_decay, gamma=gamma),
     )
 
@@ -60,9 +62,13 @@ def compute_metrics(
         pred_ids, target_ids, loss_mask, pos_idx, block_size
     )
 
+    ones = torch.tensor(1.0, device=logits.device)
     metrics: dict[str, Any] = {}
     metrics["loss_sum"] = loss.detach().clone()
-    metrics["loss_total"] = torch.tensor(1.0, device=logits.device)
+    metrics["loss_total"] = ones
+    for term_name, term_val in term_losses.items():
+        metrics[f"{term_name}_sum"] = term_val
+        metrics[f"{term_name}_total"] = ones
     # Position 0 is the anchor — intentionally excluded from accuracy
     metrics["full_acc_sum"] = correct_per_pos[1:].sum()
     metrics["full_acc_total"] = total_per_pos[1:].sum()

--- a/src/speculators/models/dspark/__init__.py
+++ b/src/speculators/models/dspark/__init__.py
@@ -1,0 +1,7 @@
+from speculators.models.dspark.config import DSparkSpeculatorConfig
+from speculators.models.dspark.core import DSparkDraftModel
+
+__all__ = [
+    "DSparkDraftModel",
+    "DSparkSpeculatorConfig",
+]

--- a/src/speculators/models/dspark/config.py
+++ b/src/speculators/models/dspark/config.py
@@ -54,17 +54,3 @@ class DSparkSpeculatorConfig(DFlashSpeculatorConfig):
         ),
     )
 
-    # DSpark loss weights.
-    ce_loss_alpha: float = Field(
-        default=0.1, description="Weight of the cross-entropy term."
-    )
-    l1_loss_alpha: float = Field(
-        default=0.9,
-        description=(
-            "Weight of the total-variation (distribution-matching) term, which "
-            "directly optimizes the acceptance rate."
-        ),
-    )
-    confidence_head_alpha: float = Field(
-        default=1.0, description="Weight of the confidence-head BCE term."
-    )

--- a/src/speculators/models/dspark/config.py
+++ b/src/speculators/models/dspark/config.py
@@ -1,0 +1,70 @@
+from typing import Literal
+
+from pydantic import Field
+
+from speculators import SpeculatorModelConfig
+from speculators.models.dflash.config import DFlashSpeculatorConfig
+
+__all__ = [
+    "DSparkSpeculatorConfig",
+]
+
+
+@SpeculatorModelConfig.register("dspark")
+class DSparkSpeculatorConfig(DFlashSpeculatorConfig):
+    """DFlash config plus a Markov logit-bias head and a confidence head.
+
+    The Markov head lets each draft position condition on previously sampled
+    tokens within the block; the confidence head predicts the per-position
+    acceptance probability. All DFlash fields are inherited unchanged.
+    """
+
+    speculators_model_type: Literal["dspark"] = "dspark"  # type: ignore[assignment]
+    architectures: list[str] = Field(
+        default_factory=lambda: ["DSparkSpeculator"],
+        description="Model architectures that can load these weights",
+    )
+
+    # Sequential (Markov) head.
+    markov_rank: int = Field(
+        default=256,
+        description=(
+            "Low-rank dimension of the Markov logit-bias factorization B = W1 @ W2. "
+            "Set to 0 to disable the sequential head (pure DFlash drafting)."
+        ),
+    )
+    markov_head_type: Literal["vanilla", "gated", "rnn"] = Field(
+        default="vanilla",
+        description=(
+            "Sequential head variant: 'vanilla' (first-order Markov bias), 'gated' "
+            "(hidden-gated bias), or 'rnn' (recurrent state over the block)."
+        ),
+    )
+
+    # Confidence head.
+    enable_confidence_head: bool = Field(
+        default=True,
+        description="Whether to attach the per-position acceptance-probability head.",
+    )
+    confidence_head_with_markov: bool = Field(
+        default=True,
+        description=(
+            "Concatenate the Markov previous-token embedding with the backbone "
+            "hidden state as the confidence-head input."
+        ),
+    )
+
+    # DSpark loss weights.
+    ce_loss_alpha: float = Field(
+        default=0.1, description="Weight of the cross-entropy term."
+    )
+    l1_loss_alpha: float = Field(
+        default=0.9,
+        description=(
+            "Weight of the total-variation (distribution-matching) term, which "
+            "directly optimizes the acceptance rate."
+        ),
+    )
+    confidence_head_alpha: float = Field(
+        default=1.0, description="Weight of the confidence-head BCE term."
+    )

--- a/src/speculators/models/dspark/config.py
+++ b/src/speculators/models/dspark/config.py
@@ -53,4 +53,3 @@ class DSparkSpeculatorConfig(DFlashSpeculatorConfig):
             "hidden state as the confidence-head input."
         ),
     )
-

--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -8,6 +8,7 @@ from speculators.models.dflash.core import DFlashDraftModel
 from speculators.models.dspark.config import DSparkSpeculatorConfig
 from speculators.models.dspark.metrics import compute_metrics
 from speculators.models.dspark.model_definitions import ConfidenceHead, MarkovHead
+from speculators.models.metrics import LossConfig, resolve_loss_config
 from speculators.models.utils import conditional_torch_compile
 
 __all__ = [
@@ -67,9 +68,6 @@ class DSparkDraftModel(DFlashDraftModel):
             markov_head_type=kwargs.get("markov_head_type", "vanilla"),
             enable_confidence_head=kwargs.get("enable_confidence_head", True),
             confidence_head_with_markov=kwargs.get("confidence_head_with_markov", True),
-            ce_loss_alpha=kwargs.get("ce_loss_alpha", 0.1),
-            l1_loss_alpha=kwargs.get("l1_loss_alpha", 0.9),
-            confidence_head_alpha=kwargs.get("confidence_head_alpha", 1.0),
         )
 
         model = cls(config=config)
@@ -79,13 +77,16 @@ class DSparkDraftModel(DFlashDraftModel):
 
     @staticmethod
     def get_trainer_kwargs(**kwargs) -> tuple[dict, dict]:
-        """DSpark owns its multi-term loss; only the decay gamma flows through.
-
-        The ``ce``/``tv``/``confidence`` weights are read from the saved config, and
-        ``--loss-fn`` is intentionally ignored for DSpark.
-        """
+        """Resolve DSpark's compound loss from ``--loss-fn``."""
+        loss_config = resolve_loss_config(kwargs["loss_fn"])
         gamma = kwargs.get("dflash_decay_gamma", 4.0)
-        return {"gamma": gamma}, {"gamma": gamma}
+        confidence_head_alpha = kwargs.get("confidence_head_alpha", 1.0)
+        shared = {
+            "loss_config": loss_config,
+            "gamma": gamma,
+            "confidence_head_alpha": confidence_head_alpha,
+        }
+        return dict(shared), dict(shared)
 
     @conditional_torch_compile
     def forward(
@@ -96,11 +97,11 @@ class DSparkDraftModel(DFlashDraftModel):
         verifier_last_hidden_states: torch.Tensor,  # [1, total_seq_len, hidden_size]
         document_ids: torch.Tensor,  # [1, total_seq_len]
         position_ids: torch.Tensor | None = None,  # [1, total_seq_len]
-        loss_fn=None,  # accepted for trainer-kwarg compatibility; unused by DSpark
+        loss_config: LossConfig | None = None,
         gamma: float = 4.0,
+        confidence_head_alpha: float = 1.0,
         **kwargs,
     ):
-        del loss_fn
         hidden, logits, targets, aligned_loss_mask, anchored_block_indices = (
             self._backbone_forward(
                 hidden_states,
@@ -158,9 +159,8 @@ class DSparkDraftModel(DFlashDraftModel):
             aligned_loss_mask,
             self.block_size,
             gamma=gamma,
-            ce_loss_alpha=self.config.ce_loss_alpha,
-            l1_loss_alpha=self.config.l1_loss_alpha,
-            confidence_head_alpha=self.config.confidence_head_alpha,
+            loss_config=loss_config,
+            confidence_head_alpha=confidence_head_alpha,
         )
         draft_tokens = torch.argmax(logits, dim=-1)
         return draft_tokens, loss, metrics

--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -5,11 +5,10 @@ from transformers import PretrainedConfig
 
 from speculators.model import SpeculatorModel
 from speculators.models.dflash.core import DFlashDraftModel
-from speculators.models.dflash.utils import get_base_indices_for_anchored_blocks
 from speculators.models.dspark.config import DSparkSpeculatorConfig
 from speculators.models.dspark.metrics import compute_metrics
 from speculators.models.dspark.model_definitions import ConfidenceHead, MarkovHead
-from speculators.models.utils import conditional_torch_compile, resolve_target_layer_ids
+from speculators.models.utils import conditional_torch_compile
 
 __all__ = [
     "DSparkDraftModel",
@@ -62,30 +61,8 @@ class DSparkDraftModel(DFlashDraftModel):
         **kwargs,
     ) -> "DSparkDraftModel":
         """Create a DSpark model from training arguments (mirrors DFlash)."""
-        from speculators.config import (  # noqa: PLC0415
-            SpeculatorsConfig,
-            VerifierConfig,
-        )
-        from speculators.proposals.greedy import (  # noqa: PLC0415
-            GreedyTokenProposalConfig,
-        )
-
-        target_layer_ids = resolve_target_layer_ids(
-            kwargs.get("target_layer_ids"), kwargs["verifier_name_or_path"]
-        )
-        verifier_config._attn_implementation = kwargs.get(  # noqa: SLF001
-            "draft_attn_impl", "simple_flex_attention"
-        )
-
-        block_size = kwargs.get("block_size", 8)
         config = DSparkSpeculatorConfig(
-            transformer_layer_config=verifier_config,
-            draft_vocab_size=kwargs["draft_vocab_size"],
-            block_size=block_size,
-            max_anchors=kwargs.get("max_anchors", 3072),
-            aux_hidden_state_layer_ids=target_layer_ids,
-            mask_token_id=kwargs.get("mask_token_id"),
-            sliding_window_non_causal=kwargs.get("sliding_window_non_causal", False),
+            **cls._build_base_config_kwargs("dspark", verifier_config, **kwargs),
             markov_rank=kwargs.get("markov_rank", 256),
             markov_head_type=kwargs.get("markov_head_type", "vanilla"),
             enable_confidence_head=kwargs.get("enable_confidence_head", True),
@@ -93,19 +70,6 @@ class DSparkDraftModel(DFlashDraftModel):
             ce_loss_alpha=kwargs.get("ce_loss_alpha", 0.1),
             l1_loss_alpha=kwargs.get("l1_loss_alpha", 0.9),
             confidence_head_alpha=kwargs.get("confidence_head_alpha", 1.0),
-            speculators_config=SpeculatorsConfig(
-                algorithm="dspark",
-                proposal_methods=[
-                    GreedyTokenProposalConfig(
-                        # First block position is the anchor, not emitted during gen.
-                        speculative_tokens=block_size - 1,
-                    )
-                ],
-                default_proposal_method="greedy",
-                verifier=VerifierConfig.from_pretrained(
-                    kwargs["verifier_name_or_path"]
-                ),
-            ),
         )
 
         model = cls(config=config)
@@ -137,64 +101,22 @@ class DSparkDraftModel(DFlashDraftModel):
         **kwargs,
     ):
         del loss_fn
-        device = hidden_states.device
-        total_seq_len = hidden_states.shape[1]
-        num_anchors = self.config.max_anchors
-
-        if position_ids is None:
-            position_ids = 1 + torch.arange(
-                total_seq_len, dtype=torch.long, device=device
-            ).unsqueeze(0)
-
-        full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid = (
-            self._build_attention_mask(loss_mask, document_ids, device)
-        )
-
-        mask_tokens_size = num_anchors * self.block_size
-        mask_token_ids = torch.full(
-            (1, mask_tokens_size), self.mask_token_id, dtype=torch.long, device=device
-        )
-        mask_token_ids[:, :: self.block_size] = input_ids[:, anchor_positions]
-        noise_embedding = self.embed_tokens(mask_token_ids)
-
-        fc_output = self.hidden_norm(self.fc(hidden_states))
-
-        mask_position_ids = get_base_indices_for_anchored_blocks(
-            position_ids[0, anchor_positions], self.block_size
-        )
-        position_ids = torch.cat([position_ids, mask_position_ids.unsqueeze(0)], dim=1)
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
-
-        anchored_block_indices = get_base_indices_for_anchored_blocks(
-            anchor_positions, self.block_size
-        )  # [num_anchors*block_size]
-
-        with torch.no_grad():
-            verifier_logits = self.verifier_lm_head(
-                self.verifier_norm(verifier_last_hidden_states)
-            )
-            verifier_logits = torch.roll(verifier_logits, 1, dims=1)
-            targets = verifier_logits[:, anchored_block_indices]
-
-        for layer_idx, layer in enumerate(self.layers):
-            noise_embedding = layer(
-                hidden_states=noise_embedding,
-                target_hidden=fc_output,
-                attention_mask=sliding_window_attn_mask
-                if layer_idx in self.sliding_window_indices
-                else full_attn_mask,
-                position_ids=position_ids,
-                use_cache=False,
-                position_embeddings=position_embeddings,
+        hidden, logits, targets, aligned_loss_mask, anchored_block_indices = (
+            self._backbone_forward(
+                hidden_states,
+                input_ids,
+                loss_mask,
+                verifier_last_hidden_states,
+                document_ids,
+                position_ids,
                 **kwargs,
             )
-
-        hidden = self.norm(noise_embedding)  # [1, T, hidden_size]
-        logits = self.lm_head(hidden)  # [1, T, draft_vocab_size]
+        )
 
         # DSpark: add the Markov logit bias and predict per-position confidence.
-        num_blocks = num_anchors
+        num_blocks = self.config.max_anchors
         block = self.block_size
+        mask_tokens_size = num_blocks * block
         # Ground-truth block tokens (verifier vocab); position 0 is the anchor.
         block_tokens = input_ids[0, anchored_block_indices].view(num_blocks, block)
         # prev_token_ids[:, k] is the token preceding draft position k within the block.
@@ -228,14 +150,6 @@ class DSparkDraftModel(DFlashDraftModel):
             confidence_logits = self.confidence_head(conf_features).reshape(
                 1, mask_tokens_size
             )
-
-        aligned_loss_mask = loss_mask.clone()[:, anchored_block_indices]
-        aligned_loss_mask = aligned_loss_mask * (
-            anchor_valid.repeat_interleave(self.block_size)
-            .unsqueeze(0)
-            .to(aligned_loss_mask.dtype)
-        )
-        aligned_loss_mask[:, :: self.block_size] = 0
 
         loss, metrics = compute_metrics(
             logits,

--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -192,7 +192,7 @@ class DSparkDraftModel(DFlashDraftModel):
         hidden = self.norm(noise_embedding)  # [1, T, hidden_size]
         logits = self.lm_head(hidden)  # [1, T, draft_vocab_size]
 
-        # ---- DSpark: semi-autoregressive Markov bias + confidence head ----
+        # DSpark: add the Markov logit bias and predict per-position confidence.
         num_blocks = num_anchors
         block = self.block_size
         # Ground-truth block tokens (verifier vocab); position 0 is the anchor.
@@ -217,7 +217,9 @@ class DSparkDraftModel(DFlashDraftModel):
             )
 
         if self.confidence_head is not None:
-            if self.config.confidence_head_with_markov:
+            # confidence_head_with_markov requires markov_rank > 0 (enforced in
+            # __init__), so prev_emb is always set when the flag is on.
+            if self.config.confidence_head_with_markov and prev_emb is not None:
                 conf_features = torch.cat(
                     [hidden_blocks, prev_emb.to(hidden_blocks.dtype)], dim=-1
                 )

--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -1,0 +1,250 @@
+from typing import ClassVar
+
+import torch
+from transformers import PretrainedConfig
+
+from speculators.model import SpeculatorModel
+from speculators.models.dflash.core import DFlashDraftModel
+from speculators.models.dflash.utils import get_base_indices_for_anchored_blocks
+from speculators.models.dspark.config import DSparkSpeculatorConfig
+from speculators.models.dspark.metrics import compute_metrics
+from speculators.models.dspark.model_definitions import ConfidenceHead, MarkovHead
+from speculators.models.utils import conditional_torch_compile, resolve_target_layer_ids
+
+__all__ = [
+    "DSparkDraftModel",
+]
+
+
+@SpeculatorModel.register("dspark")
+class DSparkDraftModel(DFlashDraftModel):
+    """DFlash backbone plus a Markov logit-bias head and a confidence head.
+
+    After the base draft logits are produced, the Markov head biases position
+    ``k`` using the previous block token and the confidence head predicts each
+    position's acceptance probability. Everything else is inherited from DFlash.
+    """
+
+    config_class: ClassVar[type[DSparkSpeculatorConfig]] = DSparkSpeculatorConfig  # type: ignore[misc,assignment]
+
+    def __init__(self, config: DSparkSpeculatorConfig) -> None:
+        super().__init__(config=config)
+
+        hidden_size = config.transformer_layer_config.hidden_size
+
+        self.markov_head: MarkovHead | None = None
+        if config.markov_rank > 0:
+            self.markov_head = MarkovHead(
+                verifier_vocab_size=self.verifier_vocab_size,
+                draft_vocab_size=self.draft_vocab_size,
+                markov_rank=config.markov_rank,
+                hidden_size=hidden_size,
+                head_type=config.markov_head_type,
+            )
+
+        self.confidence_head: ConfidenceHead | None = None
+        if config.enable_confidence_head:
+            if config.confidence_head_with_markov and self.markov_head is None:
+                raise ValueError(
+                    "confidence_head_with_markov=True requires markov_rank > 0."
+                )
+            input_dim = hidden_size + (
+                config.markov_rank if config.confidence_head_with_markov else 0
+            )
+            self.confidence_head = ConfidenceHead(input_dim)
+
+    @classmethod
+    def from_training_args(
+        cls,
+        verifier_config: "PretrainedConfig",
+        t2d: torch.Tensor | None = None,
+        d2t: torch.Tensor | None = None,
+        **kwargs,
+    ) -> "DSparkDraftModel":
+        """Create a DSpark model from training arguments (mirrors DFlash)."""
+        from speculators.config import (  # noqa: PLC0415
+            SpeculatorsConfig,
+            VerifierConfig,
+        )
+        from speculators.proposals.greedy import (  # noqa: PLC0415
+            GreedyTokenProposalConfig,
+        )
+
+        target_layer_ids = resolve_target_layer_ids(
+            kwargs.get("target_layer_ids"), kwargs["verifier_name_or_path"]
+        )
+        verifier_config._attn_implementation = kwargs.get(  # noqa: SLF001
+            "draft_attn_impl", "simple_flex_attention"
+        )
+
+        block_size = kwargs.get("block_size", 8)
+        config = DSparkSpeculatorConfig(
+            transformer_layer_config=verifier_config,
+            draft_vocab_size=kwargs["draft_vocab_size"],
+            block_size=block_size,
+            max_anchors=kwargs.get("max_anchors", 3072),
+            aux_hidden_state_layer_ids=target_layer_ids,
+            mask_token_id=kwargs.get("mask_token_id"),
+            sliding_window_non_causal=kwargs.get("sliding_window_non_causal", False),
+            markov_rank=kwargs.get("markov_rank", 256),
+            markov_head_type=kwargs.get("markov_head_type", "vanilla"),
+            enable_confidence_head=kwargs.get("enable_confidence_head", True),
+            confidence_head_with_markov=kwargs.get("confidence_head_with_markov", True),
+            ce_loss_alpha=kwargs.get("ce_loss_alpha", 0.1),
+            l1_loss_alpha=kwargs.get("l1_loss_alpha", 0.9),
+            confidence_head_alpha=kwargs.get("confidence_head_alpha", 1.0),
+            speculators_config=SpeculatorsConfig(
+                algorithm="dspark",
+                proposal_methods=[
+                    GreedyTokenProposalConfig(
+                        # First block position is the anchor, not emitted during gen.
+                        speculative_tokens=block_size - 1,
+                    )
+                ],
+                default_proposal_method="greedy",
+                verifier=VerifierConfig.from_pretrained(
+                    kwargs["verifier_name_or_path"]
+                ),
+            ),
+        )
+
+        model = cls(config=config)
+        model.load_vocab_mappings(t2d, d2t)
+        model.load_verifier_weights()
+        return model
+
+    @staticmethod
+    def get_trainer_kwargs(**kwargs) -> tuple[dict, dict]:
+        """DSpark owns its multi-term loss; only the decay gamma flows through.
+
+        The ``ce``/``tv``/``confidence`` weights are read from the saved config, and
+        ``--loss-fn`` is intentionally ignored for DSpark.
+        """
+        gamma = kwargs.get("dflash_decay_gamma", 4.0)
+        return {"gamma": gamma}, {"gamma": gamma}
+
+    @conditional_torch_compile
+    def forward(
+        self,
+        hidden_states: torch.Tensor,  # [1, total_seq_len, num_hidden*hidden_size]
+        input_ids: torch.Tensor,  # [1, total_seq_len]
+        loss_mask: torch.Tensor,  # [1, total_seq_len]
+        verifier_last_hidden_states: torch.Tensor,  # [1, total_seq_len, hidden_size]
+        document_ids: torch.Tensor,  # [1, total_seq_len]
+        position_ids: torch.Tensor | None = None,  # [1, total_seq_len]
+        loss_fn=None,  # accepted for trainer-kwarg compatibility; unused by DSpark
+        gamma: float = 4.0,
+        **kwargs,
+    ):
+        del loss_fn
+        device = hidden_states.device
+        total_seq_len = hidden_states.shape[1]
+        num_anchors = self.config.max_anchors
+
+        if position_ids is None:
+            position_ids = 1 + torch.arange(
+                total_seq_len, dtype=torch.long, device=device
+            ).unsqueeze(0)
+
+        full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid = (
+            self._build_attention_mask(loss_mask, document_ids, device)
+        )
+
+        mask_tokens_size = num_anchors * self.block_size
+        mask_token_ids = torch.full(
+            (1, mask_tokens_size), self.mask_token_id, dtype=torch.long, device=device
+        )
+        mask_token_ids[:, :: self.block_size] = input_ids[:, anchor_positions]
+        noise_embedding = self.embed_tokens(mask_token_ids)
+
+        fc_output = self.hidden_norm(self.fc(hidden_states))
+
+        mask_position_ids = get_base_indices_for_anchored_blocks(
+            position_ids[0, anchor_positions], self.block_size
+        )
+        position_ids = torch.cat([position_ids, mask_position_ids.unsqueeze(0)], dim=1)
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        anchored_block_indices = get_base_indices_for_anchored_blocks(
+            anchor_positions, self.block_size
+        )  # [num_anchors*block_size]
+
+        with torch.no_grad():
+            verifier_logits = self.verifier_lm_head(
+                self.verifier_norm(verifier_last_hidden_states)
+            )
+            verifier_logits = torch.roll(verifier_logits, 1, dims=1)
+            targets = verifier_logits[:, anchored_block_indices]
+
+        for layer_idx, layer in enumerate(self.layers):
+            noise_embedding = layer(
+                hidden_states=noise_embedding,
+                target_hidden=fc_output,
+                attention_mask=sliding_window_attn_mask
+                if layer_idx in self.sliding_window_indices
+                else full_attn_mask,
+                position_ids=position_ids,
+                use_cache=False,
+                position_embeddings=position_embeddings,
+                **kwargs,
+            )
+
+        hidden = self.norm(noise_embedding)  # [1, T, hidden_size]
+        logits = self.lm_head(hidden)  # [1, T, draft_vocab_size]
+
+        # ---- DSpark: semi-autoregressive Markov bias + confidence head ----
+        num_blocks = num_anchors
+        block = self.block_size
+        # Ground-truth block tokens (verifier vocab); position 0 is the anchor.
+        block_tokens = input_ids[0, anchored_block_indices].view(num_blocks, block)
+        # prev_token_ids[:, k] is the token preceding draft position k within the block.
+        prev_token_ids = torch.cat(
+            [block_tokens[:, :1], block_tokens[:, :-1]], dim=1
+        )  # [num_blocks, block]
+        hidden_blocks = hidden.view(num_blocks, block, -1)
+
+        confidence_logits = None
+        prev_emb = None
+        if self.markov_head is not None:
+            prev_emb = self.markov_head.prev_embeddings(prev_token_ids)
+            markov_bias = self.markov_head.block_bias(
+                prev_token_ids=prev_token_ids,
+                hidden_states=hidden_blocks,
+                prev_emb=prev_emb,
+            )
+            logits = (logits.view(num_blocks, block, -1) + markov_bias).view(
+                1, mask_tokens_size, -1
+            )
+
+        if self.confidence_head is not None:
+            if self.config.confidence_head_with_markov:
+                conf_features = torch.cat(
+                    [hidden_blocks, prev_emb.to(hidden_blocks.dtype)], dim=-1
+                )
+            else:
+                conf_features = hidden_blocks
+            confidence_logits = self.confidence_head(conf_features).reshape(
+                1, mask_tokens_size
+            )
+
+        aligned_loss_mask = loss_mask.clone()[:, anchored_block_indices]
+        aligned_loss_mask = aligned_loss_mask * (
+            anchor_valid.repeat_interleave(self.block_size)
+            .unsqueeze(0)
+            .to(aligned_loss_mask.dtype)
+        )
+        aligned_loss_mask[:, :: self.block_size] = 0
+
+        loss, metrics = compute_metrics(
+            logits,
+            targets,
+            confidence_logits,
+            aligned_loss_mask,
+            self.block_size,
+            gamma=gamma,
+            ce_loss_alpha=self.config.ce_loss_alpha,
+            l1_loss_alpha=self.config.l1_loss_alpha,
+            confidence_head_alpha=self.config.confidence_head_alpha,
+        )
+        draft_tokens = torch.argmax(logits, dim=-1)
+        return draft_tokens, loss, metrics

--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -8,8 +8,10 @@ from speculators.models.dflash.core import DFlashDraftModel
 from speculators.models.dspark.config import DSparkSpeculatorConfig
 from speculators.models.dspark.metrics import compute_metrics
 from speculators.models.dspark.model_definitions import ConfidenceHead, MarkovHead
-from speculators.models.metrics import LossConfig, resolve_loss_config
+from speculators.models.metrics import LossConfig, kl_div_loss, resolve_loss_config
 from speculators.models.utils import conditional_torch_compile
+
+_DEFAULT_LOSS_CONFIG: LossConfig = {"kl_div": (kl_div_loss, 1.0)}
 
 __all__ = [
     "DSparkDraftModel",
@@ -158,8 +160,8 @@ class DSparkDraftModel(DFlashDraftModel):
             confidence_logits,
             aligned_loss_mask,
             self.block_size,
+            loss_config=loss_config or _DEFAULT_LOSS_CONFIG,
             gamma=gamma,
-            loss_config=loss_config,
             confidence_head_alpha=confidence_head_alpha,
         )
         draft_tokens = torch.argmax(logits, dim=-1)

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -1,0 +1,126 @@
+"""Loss and metrics for the DSpark draft model.
+
+    loss = ce_alpha * CE + l1_alpha * TV + conf_alpha * BCE(confidence, accept_rate)
+
+The confidence target ``accept_rate = sum_v min(q_v, p_v) = 1 - d_TV`` is the
+analytical acceptance rate (the overlap ``tv_loss`` already computes).
+"""
+
+from collections.abc import Callable
+from functools import partial
+from typing import Any
+
+import torch
+from torch.nn.functional import binary_cross_entropy_with_logits, softmax
+
+from speculators.models.metrics import (
+    ce_loss,
+    compute_accuracy_multi_step,
+    dflash_loss_decay,
+    loss_function,
+    tv_loss,
+)
+
+__all__ = [
+    "compute_metrics",
+]
+
+_EPS = 1e-8
+
+
+def _masked_decayed_mean(
+    elementwise: torch.Tensor,  # [1, T]
+    loss_mask: torch.Tensor,  # [1, T]
+    pos_idx: torch.Tensor,  # [1, T]
+    decay_fn: Callable[[torch.Tensor], torch.Tensor] | None,
+) -> torch.Tensor:
+    """Masked, optionally position-decayed mean of a precomputed per-position term."""
+    loss_mask = loss_mask.to(elementwise.dtype)
+    weighted = elementwise * loss_mask
+    if decay_fn is not None:
+        weighted = weighted * decay_fn(pos_idx.to(weighted.dtype))
+    denominator = loss_mask.sum(dim=1) + _EPS
+    return (weighted.sum(dim=1) / denominator).mean()
+
+
+def compute_metrics(
+    logits: torch.Tensor,  # [1, T, draft_vocab_size] (Markov-corrected)
+    targets: torch.Tensor,  # [1, T, draft_vocab_size]
+    confidence_logits: torch.Tensor | None,  # [1, T] or None
+    loss_mask: torch.Tensor,  # [1, T]
+    block_size: int = 8,
+    gamma: float = 4.0,
+    ce_loss_alpha: float = 0.1,
+    l1_loss_alpha: float = 0.9,
+    confidence_head_alpha: float = 1.0,
+) -> tuple[torch.Tensor, dict]:
+    """Compute the DSpark loss and a metrics dict (``*_sum``/``*_total`` pairs)."""
+    device = logits.device
+    seq_len = logits.shape[1]
+    pos_idx = (torch.arange(seq_len, device=device) % block_size).unsqueeze(0)
+    decay_fn = partial(dflash_loss_decay, gamma=gamma)
+
+    ce = loss_function(
+        logits, targets, loss_mask, pos_idx, loss_fn=ce_loss, decay_fn=decay_fn
+    )
+    tv = loss_function(
+        logits, targets, loss_mask, pos_idx, loss_fn=tv_loss, decay_fn=decay_fn
+    )
+    loss = ce_loss_alpha * ce + l1_loss_alpha * tv
+
+    # Analytical per-position acceptance rate = distributional overlap.
+    with torch.no_grad():
+        draft_p = softmax(logits.float(), dim=-1)
+        target_p = softmax(targets.float(), dim=-1)
+        accept_rate = torch.minimum(draft_p, target_p).sum(dim=-1)  # [1, T]
+
+    metrics: dict[str, Any] = {}
+    if confidence_logits is not None:
+        c_star = accept_rate.detach().to(confidence_logits.dtype)
+        bce = binary_cross_entropy_with_logits(
+            confidence_logits, c_star, reduction="none"
+        )  # [1, T]
+        conf_loss = _masked_decayed_mean(bce, loss_mask, pos_idx, decay_fn)
+        loss = loss + confidence_head_alpha * conf_loss
+
+        with torch.no_grad():
+            mask_f = loss_mask.to(accept_rate.dtype)
+            mask_total = mask_f.sum().clamp_min(1.0)
+            conf_prob = confidence_logits.float().sigmoid()
+            metrics["confidence_loss_sum"] = conf_loss.detach().clone()
+            metrics["confidence_loss_total"] = torch.ones((), device=device)
+            metrics["confidence_abs_error_sum"] = (
+                (conf_prob - accept_rate).abs() * mask_f
+            ).sum()
+            metrics["confidence_abs_error_total"] = mask_total
+            # Mean predicted vs. observed acceptance — a calibration sanity check.
+            metrics["confidence_pred_mean_sum"] = (conf_prob * mask_f).sum()
+            metrics["confidence_pred_mean_total"] = mask_total
+
+    # Component + total loss logging.
+    metrics["ce_loss_sum"] = ce.detach().clone()
+    metrics["ce_loss_total"] = torch.ones((), device=device)
+    metrics["tv_loss_sum"] = tv.detach().clone()
+    metrics["tv_loss_total"] = torch.ones((), device=device)
+    metrics["loss_sum"] = loss.detach().clone()
+    metrics["loss_total"] = torch.ones((), device=device)
+
+    # Mean acceptance rate of the (Markov-corrected) drafter.
+    with torch.no_grad():
+        mask_f = loss_mask.to(accept_rate.dtype)
+        metrics["accept_rate_sum"] = (accept_rate * mask_f).sum()
+        metrics["accept_rate_total"] = mask_f.sum().clamp_min(1.0)
+
+    # Per-position greedy accuracy (position 0 is the anchor — excluded).
+    pred_ids = torch.argmax(logits, dim=-1)
+    target_ids = torch.argmax(targets, dim=-1)
+    correct_per_pos, total_per_pos = compute_accuracy_multi_step(
+        pred_ids, target_ids, loss_mask, pos_idx, block_size
+    )
+    metrics["full_acc_sum"] = correct_per_pos[1:].sum()
+    metrics["full_acc_total"] = total_per_pos[1:].sum()
+    for pos in range(1, block_size):
+        metrics[f"position_{pos}_acc_sum"] = correct_per_pos[pos]
+        metrics[f"position_{pos}_acc_total"] = total_per_pos[pos]
+
+    return loss, metrics

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -73,6 +73,12 @@ def compute_metrics(
         draft_p = softmax(logits.float(), dim=-1)
         target_p = softmax(targets.float(), dim=-1)
         accept_rate = torch.minimum(draft_p, target_p).sum(dim=-1)  # [1, T]
+        # Per-block cumulative acceptance product over the draft slots (slot 0
+        # is the anchor), shared by the accept-length and calibration metrics.
+        num_blocks = seq_len // block_size
+        accept_blocks = accept_rate.view(num_blocks, block_size)
+        draft_mask = loss_mask.to(accept_rate.dtype).view(num_blocks, block_size)[:, 1:]
+        accept_prefix = (accept_blocks[:, 1:] * draft_mask).cumprod(dim=-1)
 
     metrics: dict[str, Any] = {}
     if confidence_logits is not None:
@@ -96,6 +102,15 @@ def compute_metrics(
             # Mean predicted vs. observed acceptance — a calibration sanity check.
             metrics["confidence_pred_mean_sum"] = (conf_prob * mask_f).sum()
             metrics["confidence_pred_mean_total"] = mask_total
+            # Calibration of the cumulative acceptance product, which is what
+            # dynamic draft-length thresholding consumes (signed pred - target).
+            conf_prefix = (
+                conf_prob.view(num_blocks, block_size)[:, 1:] * draft_mask
+            ).cumprod(dim=-1)
+            metrics["confidence_cumprod_bias_sum"] = (
+                (conf_prefix - accept_prefix) * draft_mask
+            ).sum()
+            metrics["confidence_cumprod_bias_total"] = draft_mask.sum().clamp_min(1.0)
 
     # Component + total loss logging.
     metrics["ce_loss_sum"] = ce.detach().clone()
@@ -110,6 +125,14 @@ def compute_metrics(
         mask_f = loss_mask.to(accept_rate.dtype)
         metrics["accept_rate_sum"] = (accept_rate * mask_f).sum()
         metrics["accept_rate_total"] = mask_f.sum().clamp_min(1.0)
+
+    # Expected accepted draft length per block (DSpark's tau): the cumulative
+    # acceptance product summed over draft slots, plus the always-emitted anchor.
+    with torch.no_grad():
+        per_block_len = accept_prefix.sum(dim=-1) + 1.0
+        block_valid = (draft_mask.sum(dim=-1) > 0).to(accept_rate.dtype)
+        metrics["accept_len_sum"] = (per_block_len * block_valid).sum()
+        metrics["accept_len_total"] = block_valid.sum().clamp_min(1.0)
 
     # Per-position greedy accuracy (position 0 is the anchor — excluded).
     pred_ids = torch.argmax(logits, dim=-1)

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -1,6 +1,6 @@
 """Loss and metrics for the DSpark draft model.
 
-loss = ce_alpha * CE + l1_alpha * TV + conf_alpha * BCE(confidence, accept_rate)
+loss = compound_loss(logits, targets) + conf_alpha * BCE(confidence, accept_rate)
 
 The confidence target ``accept_rate = sum_v min(q_v, p_v) = 1 - d_TV`` is the
 analytical acceptance rate (the overlap ``tv_loss`` already computes).
@@ -14,11 +14,10 @@ import torch
 from torch.nn.functional import binary_cross_entropy_with_logits, softmax
 
 from speculators.models.metrics import (
-    ce_loss,
+    LossConfig,
+    compound_loss,
     compute_accuracy_multi_step,
     dflash_loss_decay,
-    loss_function,
-    tv_loss,
 )
 
 __all__ = [
@@ -50,23 +49,23 @@ def compute_metrics(
     loss_mask: torch.Tensor,  # [1, T]
     block_size: int = 8,
     gamma: float = 4.0,
-    ce_loss_alpha: float = 0.1,
-    l1_loss_alpha: float = 0.9,
+    loss_config: LossConfig | None = None,
     confidence_head_alpha: float = 1.0,
 ) -> tuple[torch.Tensor, dict]:
     """Compute the DSpark loss and a metrics dict (``*_sum``/``*_total`` pairs)."""
+    if loss_config is None:
+        from speculators.models.metrics import ce_loss, tv_loss  # noqa: PLC0415
+
+        loss_config = {"ce": (ce_loss, 0.1), "tv": (tv_loss, 0.9)}
+
     device = logits.device
     seq_len = logits.shape[1]
     pos_idx = (torch.arange(seq_len, device=device) % block_size).unsqueeze(0)
     decay_fn = partial(dflash_loss_decay, gamma=gamma)
 
-    ce = loss_function(
-        logits, targets, loss_mask, pos_idx, loss_fn=ce_loss, decay_fn=decay_fn
+    loss, term_losses = compound_loss(
+        logits, targets, loss_mask, pos_idx, loss_config=loss_config, decay_fn=decay_fn
     )
-    tv = loss_function(
-        logits, targets, loss_mask, pos_idx, loss_fn=tv_loss, decay_fn=decay_fn
-    )
-    loss = ce_loss_alpha * ce + l1_loss_alpha * tv
 
     # Analytical per-position acceptance rate = distributional overlap.
     with torch.no_grad():
@@ -112,13 +111,12 @@ def compute_metrics(
             ).sum()
             metrics["confidence_cumprod_bias_total"] = draft_mask.sum().clamp_min(1.0)
 
-    # Component + total loss logging.
-    metrics["ce_loss_sum"] = ce.detach().clone()
-    metrics["ce_loss_total"] = torch.ones((), device=device)
-    metrics["tv_loss_sum"] = tv.detach().clone()
-    metrics["tv_loss_total"] = torch.ones((), device=device)
+    ones = torch.ones((), device=device)
     metrics["loss_sum"] = loss.detach().clone()
-    metrics["loss_total"] = torch.ones((), device=device)
+    metrics["loss_total"] = ones
+    for term_name, term_val in term_losses.items():
+        metrics[f"{term_name}_sum"] = term_val
+        metrics[f"{term_name}_total"] = ones
 
     # Mean acceptance rate of the (Markov-corrected) drafter.
     with torch.no_grad():

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -1,6 +1,6 @@
 """Loss and metrics for the DSpark draft model.
 
-    loss = ce_alpha * CE + l1_alpha * TV + conf_alpha * BCE(confidence, accept_rate)
+loss = ce_alpha * CE + l1_alpha * TV + conf_alpha * BCE(confidence, accept_rate)
 
 The confidence target ``accept_rate = sum_v min(q_v, p_v) = 1 - d_TV`` is the
 analytical acceptance rate (the overlap ``tv_loss`` already computes).

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -47,16 +47,12 @@ def compute_metrics(
     targets: torch.Tensor,  # [1, T, draft_vocab_size]
     confidence_logits: torch.Tensor | None,  # [1, T] or None
     loss_mask: torch.Tensor,  # [1, T]
-    block_size: int = 8,
+    block_size: int,
+    loss_config: LossConfig,
     gamma: float = 4.0,
-    loss_config: LossConfig | None = None,
     confidence_head_alpha: float = 1.0,
 ) -> tuple[torch.Tensor, dict]:
     """Compute the DSpark loss and a metrics dict (``*_sum``/``*_total`` pairs)."""
-    if loss_config is None:
-        from speculators.models.metrics import ce_loss, tv_loss  # noqa: PLC0415
-
-        loss_config = {"ce": (ce_loss, 0.1), "tv": (tv_loss, 0.9)}
 
     device = logits.device
     seq_len = logits.shape[1]

--- a/src/speculators/models/dspark/model_definitions.py
+++ b/src/speculators/models/dspark/model_definitions.py
@@ -1,0 +1,91 @@
+"""Sequential (Markov) and confidence heads for the DSpark draft model."""
+
+import torch
+from torch import nn
+
+__all__ = [
+    "ConfidenceHead",
+    "MarkovHead",
+]
+
+
+class MarkovHead(nn.Module):
+    """Low-rank sequential logit bias ``B = W1 @ W2``.
+
+    ``W1`` indexes the verifier vocabulary (the previous token id); ``W2`` projects
+    to the draft vocabulary so the bias adds onto the DFlash logits.
+    """
+
+    def __init__(
+        self,
+        *,
+        verifier_vocab_size: int,
+        draft_vocab_size: int,
+        markov_rank: int,
+        hidden_size: int,
+        head_type: str = "vanilla",
+    ) -> None:
+        super().__init__()
+        if markov_rank <= 0:
+            raise ValueError(f"markov_rank must be > 0, got {markov_rank}")
+        if head_type not in ("vanilla", "gated", "rnn"):
+            raise ValueError(f"Unsupported markov_head_type: {head_type!r}")
+        self.head_type = head_type
+        self.markov_rank = markov_rank
+        self.markov_w1 = nn.Embedding(verifier_vocab_size, markov_rank)
+        self.markov_w2 = nn.Linear(markov_rank, draft_vocab_size, bias=False)
+        if head_type == "gated":
+            self.gate_proj = nn.Linear(hidden_size + markov_rank, markov_rank)
+        elif head_type == "rnn":
+            # Joint [gate; candidate; output] projection over [state; prev_emb; hidden].
+            self.joint_proj = nn.Linear(2 * markov_rank + hidden_size, 3 * markov_rank)
+
+    def prev_embeddings(self, token_ids: torch.Tensor) -> torch.Tensor:
+        """Look up W1 embeddings for the given previous-token ids."""
+        return self.markov_w1(token_ids.long())
+
+    def block_bias(
+        self,
+        *,
+        prev_token_ids: torch.Tensor,  # [N, block_size]
+        hidden_states: torch.Tensor,  # [N, block_size, hidden]
+        prev_emb: torch.Tensor | None = None,  # [N, block_size, r]
+    ) -> torch.Tensor:
+        """Return the per-position logit bias, shape [N, block_size, draft_vocab]."""
+        if prev_emb is None:
+            prev_emb = self.prev_embeddings(prev_token_ids)
+        prev_emb = prev_emb.to(self.markov_w2.weight.dtype)
+
+        if self.head_type == "vanilla":
+            return self.markov_w2(prev_emb)
+
+        if self.head_type == "gated":
+            hidden_states = hidden_states.to(prev_emb.dtype)
+            gate = torch.sigmoid(
+                self.gate_proj(torch.cat([hidden_states, prev_emb], dim=-1))
+            )
+            return self.markov_w2(gate * prev_emb)
+
+        # rnn: maintain a recurrent state across block positions.
+        hidden_states = hidden_states.to(prev_emb.dtype)
+        num_blocks, block_size, _ = prev_emb.shape
+        state = prev_emb.new_zeros(num_blocks, self.markov_rank)
+        outputs = []
+        for k in range(block_size):
+            z = torch.cat([state, prev_emb[:, k], hidden_states[:, k]], dim=-1)
+            gate_raw, cand_raw, out_raw = self.joint_proj(z).chunk(3, dim=-1)
+            gate = torch.sigmoid(gate_raw)
+            state = gate * state + (1.0 - gate) * torch.tanh(cand_raw)
+            outputs.append(self.markov_w2(torch.tanh(out_raw)))
+        return torch.stack(outputs, dim=1)
+
+
+class ConfidenceHead(nn.Module):
+    """Per-position acceptance-probability predictor (linear -> scalar logit)."""
+
+    def __init__(self, input_dim: int) -> None:
+        super().__init__()
+        self.proj = nn.Linear(input_dim, 1)
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return self.proj(features).squeeze(-1)

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -15,7 +15,7 @@ from speculators.models.eagle3.attention import (
 )
 from speculators.models.eagle3.metrics import compute_metrics
 from speculators.models.eagle3.model_definitions import model_classes
-from speculators.models.metrics import kl_div_loss, resolve_loss_fn
+from speculators.models.metrics import LossConfig, resolve_loss_config
 from speculators.models.utils import conditional_torch_compile, resolve_target_layer_ids
 from speculators.proposals.greedy import GreedyTokenProposalConfig
 
@@ -149,10 +149,9 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
         ttt_steps: int = 3,
         ttt_step_loss_decay: float = 1.0,
         use_off_policy_tokens: bool = False,
-        loss_fn=kl_div_loss,
+        loss_config: LossConfig | None = None,
         **kwargs,
     ):
-        loss_fn = loss_fn or kl_div_loss
         device = hidden_states.device
         total_seq_len = hidden_states.shape[1]
 
@@ -247,7 +246,7 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
                     prev_correct,
                     ttt_step,
                     ttt_step_loss_decay,
-                    loss_fn=loss_fn,
+                    loss_config=loss_config,
                 )
                 loss += s_loss
                 metrics.update(s_metrics)
@@ -361,17 +360,17 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
         Returns:
             Tuple of (train_call_kwargs, val_call_kwargs)
         """
-        loss_fn = resolve_loss_fn(kwargs["loss_fn"])
+        loss_config = resolve_loss_config(kwargs["loss_fn"])
         train_kwargs = {
             "use_off_policy_tokens": kwargs["use_off_policy_tokens"],
             "ttt_steps": kwargs["ttt_steps"],
             "ttt_step_loss_decay": kwargs["ttt_step_loss_decay"],
-            "loss_fn": loss_fn,
+            "loss_config": loss_config,
         }
         val_kwargs = {
             "use_off_policy_tokens": False,
             "ttt_steps": kwargs["ttt_steps"],
             "ttt_step_loss_decay": kwargs["ttt_step_loss_decay"],
-            "loss_fn": loss_fn,
+            "loss_config": loss_config,
         }
         return train_kwargs, val_kwargs

--- a/src/speculators/models/eagle3/metrics.py
+++ b/src/speculators/models/eagle3/metrics.py
@@ -1,15 +1,15 @@
 """Metrics and loss functions for Eagle3 draft model."""
 
-from collections.abc import Callable
 from functools import partial
 
 import torch
 
 from speculators.models.metrics import (
+    LossConfig,
+    compound_loss,
     compute_accuracy_single_step,
     exp_loss_decay,
     kl_div_loss,
-    loss_function,
 )
 
 
@@ -55,7 +55,7 @@ def compute_metrics(
     prev_correct: torch.Tensor | None,
     ttt_step: int,
     ttt_step_loss_decay: float,
-    loss_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None = kl_div_loss,
+    loss_config: LossConfig | None = None,
 ) -> tuple[torch.Tensor, dict]:
     """Compute metrics for a given ttt_step.
 
@@ -66,7 +66,7 @@ def compute_metrics(
         prev_correct: The previous correct predictions for the current ttt_step.
         ttt_step: The current ttt_step.
         ttt_step_loss_decay: The loss decay for the current ttt_step.
-        loss_fn: Loss function.
+        loss_config: Mapping of ``{name: (loss_fn, weight)}``.
 
     Effects:
         Modifies prev_correct in place.
@@ -74,8 +74,8 @@ def compute_metrics(
     Returns:
         Loss value and metrics dictionary.
     """
-    if loss_fn is None:
-        loss_fn = kl_div_loss
+    if loss_config is None:
+        loss_config = {"kl_div": (kl_div_loss, 1.0)}
     s_logits, s_targets, s_loss_mask, s_prev_correct = align_for_step(
         logits, targets, loss_mask, prev_correct, ttt_step
     )
@@ -88,12 +88,12 @@ def compute_metrics(
         (1, seq_len), ttt_step, device=s_logits.device, dtype=torch.long
     )
 
-    s_loss = loss_function(
+    s_loss, term_losses = compound_loss(
         s_logits,
         s_targets,
         s_loss_mask,
         pos_idx,
-        loss_fn=loss_fn,
+        loss_config=loss_config,
         decay_fn=partial(exp_loss_decay, gamma=ttt_step_loss_decay),
     )
 
@@ -104,9 +104,13 @@ def compute_metrics(
         pred_ids, target_ids, s_loss_mask, s_prev_correct
     )
 
+    ones = torch.tensor(1.0, device=s_loss.device)
     s_metrics = {}
     s_metrics[f"loss_{ttt_step}_sum"] = s_loss.detach().clone()
-    s_metrics[f"loss_{ttt_step}_total"] = torch.tensor(1.0, device=s_loss.device)
+    s_metrics[f"loss_{ttt_step}_total"] = ones
+    for term_name, term_val in term_losses.items():
+        s_metrics[f"{term_name}_{ttt_step}_sum"] = term_val
+        s_metrics[f"{term_name}_{ttt_step}_total"] = ones
     s_metrics[f"full_acc_{ttt_step}_sum"] = full_correct
     s_metrics[f"full_acc_{ttt_step}_total"] = full_total
     s_metrics[f"cond_acc_{ttt_step}_sum"] = cond_correct

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -1,8 +1,13 @@
+import json
 from collections.abc import Callable
 
 import torch
 
 _EPS = 1e-5
+
+LossConfig = dict[
+    str, tuple[Callable[[torch.Tensor, torch.Tensor], torch.Tensor], float]
+]
 
 
 def compute_accuracy_single_step(
@@ -209,6 +214,14 @@ def exp_loss_decay(pos_idx: torch.Tensor, gamma: float):
     return gamma**pos_idx
 
 
+_LOSS_FN_MAP: dict[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = {
+    "kl_div": kl_div_loss,
+    "ce": ce_loss,
+    "tv": tv_loss,
+    "nla": neg_log_acceptance_loss,
+}
+
+
 def resolve_loss_fn(
     name: str,
 ) -> "Callable[[torch.Tensor, torch.Tensor], torch.Tensor]":
@@ -225,17 +238,84 @@ def resolve_loss_fn(
     Raises:
         ValueError: If *name* is not a recognised loss function.
     """
-    loss_fn_map: dict[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = {
-        "kl_div": kl_div_loss,
-        "ce": ce_loss,
-        "tv": tv_loss,
-        "nla": neg_log_acceptance_loss,
-    }
-    if name not in loss_fn_map:
+    if name not in _LOSS_FN_MAP:
         raise ValueError(
-            f"Unknown loss function '{name}'. Choose from: {sorted(loss_fn_map.keys())}"
+            f"Unknown loss function '{name}'. "
+            f"Choose from: {sorted(_LOSS_FN_MAP.keys())}"
         )
-    return loss_fn_map[name]
+    return _LOSS_FN_MAP[name]
+
+
+def resolve_loss_config(spec: str) -> LossConfig:
+    """Parse a loss spec into ``{name: (loss_fn, weight)}``.
+
+    Accepts either a plain loss name (``"kl_div"``) or a JSON dict mapping
+    loss names to weights (``'{"ce": 0.1, "tv": 0.9}'``).
+    """
+    if spec in _LOSS_FN_MAP:
+        return {spec: (_LOSS_FN_MAP[spec], 1.0)}
+
+    try:
+        parsed = json.loads(spec)
+    except json.JSONDecodeError:
+        raise ValueError(
+            f"Unknown loss function '{spec}'. Pass a known name "
+            f"({sorted(_LOSS_FN_MAP.keys())}) or a JSON dict, "
+            f'e.g. \'{{"ce": 0.1, "tv": 0.9}}\'.'
+        ) from None
+
+    if not isinstance(parsed, dict) or not parsed:
+        raise ValueError(
+            "Loss config must be a non-empty JSON dict mapping loss names to weights, "
+            f'e.g. \'{{"ce": 0.1, "tv": 0.9}}\'. Got: {spec}'
+        )
+
+    config: LossConfig = {}
+    for name, weight in parsed.items():
+        if name not in _LOSS_FN_MAP:
+            raise ValueError(
+                f"Unknown loss function '{name}' in loss config. "
+                f"Choose from: {sorted(_LOSS_FN_MAP.keys())}"
+            )
+        if not isinstance(weight, (int, float)):
+            raise ValueError(
+                f"Loss weight for '{name}' must be a number, "
+                f"got {type(weight).__name__}"
+            )
+        config[name] = (_LOSS_FN_MAP[name], float(weight))
+
+    return config
+
+
+def compound_loss(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    loss_mask: torch.Tensor,
+    pos_idx: torch.Tensor,
+    loss_config: LossConfig,
+    decay_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """Compute a weighted sum of loss terms.
+
+    Each entry in *loss_config* maps a name to ``(loss_fn, weight)``; the
+    result is ``sum(weight * loss_function(logits, targets, ..., loss_fn))``
+    over all entries.
+
+    Returns the total loss and a dict of per-term (unweighted) scalar losses
+    keyed as ``"{name}_loss"``.  When the config contains a single term the
+    dict is empty (the overall loss already captures it).
+    """
+    total = torch.tensor(0.0, device=logits.device, dtype=logits.dtype)
+    term_losses: dict[str, torch.Tensor] = {}
+    multi = len(loss_config) > 1
+    for name, (fn, weight) in loss_config.items():
+        term = loss_function(
+            logits, targets, loss_mask, pos_idx, loss_fn=fn, decay_fn=decay_fn
+        )
+        if multi:
+            term_losses[f"{name}_loss"] = term.detach()
+        total = total + weight * term
+    return total, term_losses
 
 
 def loss_function(

--- a/src/speculators/models/peagle/core.py
+++ b/src/speculators/models/peagle/core.py
@@ -8,7 +8,7 @@ from transformers import PretrainedConfig
 from speculators.config import SpeculatorsConfig, VerifierConfig
 from speculators.model import SpeculatorModel
 from speculators.models.eagle3.core import Eagle3DraftModel
-from speculators.models.metrics import kl_div_loss, resolve_loss_fn
+from speculators.models.metrics import LossConfig, resolve_loss_config
 from speculators.models.peagle.attention import create_peagle_mask_mod
 from speculators.models.peagle.config import PEagleSpeculatorConfig
 from speculators.models.peagle.data import generate_cod_sample_indices
@@ -55,7 +55,7 @@ class PEagleDraftModel(Eagle3DraftModel):
         position_ids: torch.Tensor | None = None,
         loss_mask: torch.Tensor | None = None,
         verifier_last_hidden_states: torch.Tensor | None = None,
-        loss_fn=kl_div_loss,
+        loss_config: LossConfig | None = None,
         **kwargs,
     ):
         """
@@ -170,7 +170,7 @@ class PEagleDraftModel(Eagle3DraftModel):
             anchor_pos=anchor_pos,
             depth=depth,
             num_depths=self.num_depths,
-            loss_fn=loss_fn,
+            loss_config=loss_config,
         )
 
         return None, loss, metrics
@@ -252,5 +252,5 @@ class PEagleDraftModel(Eagle3DraftModel):
         Returns:
             Tuple of (train_call_kwargs, val_call_kwargs)
         """
-        loss_fn = resolve_loss_fn(kwargs["loss_fn"])
-        return {"loss_fn": loss_fn}, {"loss_fn": loss_fn}
+        loss_config = resolve_loss_config(kwargs["loss_fn"])
+        return {"loss_config": loss_config}, {"loss_config": loss_config}

--- a/src/speculators/models/peagle/metrics.py
+++ b/src/speculators/models/peagle/metrics.py
@@ -1,15 +1,17 @@
 """Metrics and loss functions for P-EAGLE draft model."""
 
-from collections.abc import Callable
 from typing import Any
 
 import torch
 
 from speculators.models.metrics import (
+    LossConfig,
+    compound_loss,
     compute_accuracy_multi_step,
     kl_div_loss,
-    loss_function,
 )
+
+_DEFAULT_LOSS_CONFIG: LossConfig = {"kl_div": (kl_div_loss, 1.0)}
 
 
 def compute_metrics(
@@ -19,7 +21,7 @@ def compute_metrics(
     anchor_pos: torch.Tensor,
     depth: torch.Tensor,
     num_depths: int,
-    loss_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None = kl_div_loss,
+    loss_config: LossConfig | None = None,
 ) -> tuple[torch.Tensor, dict[str, Any]]:
     """Compute loss and accuracy metrics for P-EAGLE predictions.
 
@@ -31,13 +33,13 @@ def compute_metrics(
             sampling chain started from [total_sampled]
         depth: Which COD sampling round each element belongs to [total_sampled]
         num_depths: Number of parallel depths
-        loss_fn: Loss function.
+        loss_config: Mapping of ``{name: (loss_fn, weight)}``.
 
     Returns:
         Tuple of (loss, metrics_dict)
     """
-    if loss_fn is None:
-        loss_fn = kl_div_loss
+    if loss_config is None:
+        loss_config = _DEFAULT_LOSS_CONFIG
     device = logits.device
 
     # TODO: batch size is always 1 for P-EAGLE; unsqueeze is only to match the
@@ -45,8 +47,8 @@ def compute_metrics(
     orig_positions = anchor_pos + depth  # [total_sampled]
     sampled_loss_mask = loss_mask[:, orig_positions]  # [1, total_sampled]
 
-    loss = loss_function(
-        logits, targets, sampled_loss_mask, depth.unsqueeze(0), loss_fn=loss_fn
+    loss, term_losses = compound_loss(
+        logits, targets, sampled_loss_mask, depth.unsqueeze(0), loss_config=loss_config
     )
 
     with torch.no_grad():
@@ -58,12 +60,16 @@ def compute_metrics(
             pred_ids, target_ids, sampled_loss_mask, depth.unsqueeze(0), num_depths
         )
 
+    ones = torch.tensor(1.0, device=device)
     metrics: dict[str, Any] = {
         "loss_sum": loss.detach(),
-        "loss_total": torch.tensor(1.0, device=device),
+        "loss_total": ones,
         "full_acc_sum": correct_per_pos.sum(),
         "full_acc_total": total_per_pos.sum(),
     }
+    for term_name, term_val in term_losses.items():
+        metrics[f"{term_name}_sum"] = term_val
+        metrics[f"{term_name}_total"] = ones
     for d in range(num_depths):
         metrics[f"position_{d}_acc_sum"] = correct_per_pos[d]
         metrics[f"position_{d}_acc_total"] = total_per_pos[d]

--- a/tests/unit/models/test_dspark_metrics.py
+++ b/tests/unit/models/test_dspark_metrics.py
@@ -3,6 +3,7 @@
 import torch
 
 from speculators.models.dspark.metrics import compute_metrics
+from speculators.models.metrics import resolve_loss_config
 
 
 def _ids_to_logits(ids: torch.Tensor, vocab_size: int) -> torch.Tensor:
@@ -101,8 +102,7 @@ class TestComputeMetrics:
             None,
             loss_mask,
             block_size=2,
-            ce_loss_alpha=0.0,
-            l1_loss_alpha=0.1,
+            loss_config=resolve_loss_config('{"tv": 0.1}'),
         )
         loss_large, _ = compute_metrics(
             logits,
@@ -110,8 +110,7 @@ class TestComputeMetrics:
             None,
             loss_mask,
             block_size=2,
-            ce_loss_alpha=0.0,
-            l1_loss_alpha=1.0,
+            loss_config=resolve_loss_config('{"tv": 1.0}'),
         )
         assert float(loss_large) > float(loss_small)
 

--- a/tests/unit/models/test_dspark_metrics.py
+++ b/tests/unit/models/test_dspark_metrics.py
@@ -5,6 +5,8 @@ import torch
 from speculators.models.dspark.metrics import compute_metrics
 from speculators.models.metrics import resolve_loss_config
 
+_DEFAULT_LOSS = resolve_loss_config('{"ce": 0.1, "tv": 0.9}')
+
 
 def _ids_to_logits(ids: torch.Tensor, vocab_size: int) -> torch.Tensor:
     logits = torch.zeros(*ids.shape, vocab_size)
@@ -20,7 +22,13 @@ class TestComputeMetrics:
         targets = logits.clone()
         loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
         loss, metrics = compute_metrics(
-            logits, targets, None, loss_mask, block_size=2, gamma=4.0
+            logits,
+            targets,
+            None,
+            loss_mask,
+            2,
+            gamma=4.0,
+            loss_config=_DEFAULT_LOSS,
         )
         assert torch.isfinite(loss)
         # Matching distributions -> CE/TV ~ 0 and acceptance ~ 1.
@@ -46,6 +54,7 @@ class TestComputeMetrics:
             loss_mask,
             block_size=2,
             gamma=4.0,
+            loss_config=_DEFAULT_LOSS,
         )
         abs_err = (
             metrics["confidence_abs_error_sum"] / metrics["confidence_abs_error_total"]
@@ -59,7 +68,12 @@ class TestComputeMetrics:
         targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]]), 8)
         loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
         loss_no_conf, _ = compute_metrics(
-            logits, targets, None, loss_mask, block_size=2
+            logits,
+            targets,
+            None,
+            loss_mask,
+            block_size=2,
+            loss_config=_DEFAULT_LOSS,
         )
         # A badly-calibrated confidence head (predicts accept~1 when accept~0)
         # must add positive BCE on top of the base loss.
@@ -70,6 +84,7 @@ class TestComputeMetrics:
             confidence_logits,
             loss_mask,
             block_size=2,
+            loss_config=_DEFAULT_LOSS,
             confidence_head_alpha=1.0,
         )
         assert float(loss_conf) > float(loss_no_conf)
@@ -83,7 +98,12 @@ class TestComputeMetrics:
         loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
         confidence_logits = torch.full((1, 4), 20.0)  # sigmoid ~ 1.0
         _, metrics = compute_metrics(
-            logits, targets, confidence_logits, loss_mask, block_size=2
+            logits,
+            targets,
+            confidence_logits,
+            loss_mask,
+            block_size=2,
+            loss_config=_DEFAULT_LOSS,
         )
         bias = (
             metrics["confidence_cumprod_bias_sum"]
@@ -120,7 +140,12 @@ class TestComputeMetrics:
         targets = logits.clone()
         loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
         _, metrics = compute_metrics(
-            logits, targets, torch.zeros(1, 4), loss_mask, block_size=2
+            logits,
+            targets,
+            torch.zeros(1, 4),
+            loss_mask,
+            block_size=2,
+            loss_config=_DEFAULT_LOSS,
         )
         for key in (
             "loss_sum",

--- a/tests/unit/models/test_dspark_metrics.py
+++ b/tests/unit/models/test_dspark_metrics.py
@@ -26,6 +26,9 @@ class TestComputeMetrics:
         assert float(loss) < 1e-2
         accept = metrics["accept_rate_sum"] / metrics["accept_rate_total"]
         assert float(accept) > 0.99
+        # One draft slot per block accepted w.p. ~1, plus the anchor token -> ~2.
+        accept_len = metrics["accept_len_sum"] / metrics["accept_len_total"]
+        assert abs(float(accept_len) - 2.0) < 1e-2
 
     def test_confidence_target_is_overlap(self):
         # When draft == target, accept rate == 1, so a confidence logit that is
@@ -70,6 +73,23 @@ class TestComputeMetrics:
         )
         assert float(loss_conf) > float(loss_no_conf)
 
+    def test_confidence_cumprod_bias_sign(self):
+        # Draft != target so accept rate is ~0; an over-confident head (predicts
+        # accept ~1) must show a positive cumulative-product calibration bias.
+        ids = torch.tensor([[0, 1, 0, 2]])
+        logits = _ids_to_logits(ids, 8)
+        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]]), 8)
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
+        confidence_logits = torch.full((1, 4), 20.0)  # sigmoid ~ 1.0
+        _, metrics = compute_metrics(
+            logits, targets, confidence_logits, loss_mask, block_size=2
+        )
+        bias = (
+            metrics["confidence_cumprod_bias_sum"]
+            / metrics["confidence_cumprod_bias_total"]
+        )
+        assert float(bias) > 0.5
+
     def test_alpha_weighting(self):
         ids = torch.tensor([[0, 1, 0, 2]])
         logits = _ids_to_logits(ids, 8)
@@ -111,6 +131,9 @@ class TestComputeMetrics:
             "full_acc_sum",
             "full_acc_total",
             "position_1_acc_sum",
+            "accept_len_sum",
+            "accept_len_total",
+            "confidence_cumprod_bias_sum",
         ):
             assert key in metrics
         # all metric values must be tensors (so dist.reduce works in the trainer)

--- a/tests/unit/models/test_dspark_metrics.py
+++ b/tests/unit/models/test_dspark_metrics.py
@@ -1,0 +1,117 @@
+"""Unit tests for the DSpark loss and metrics."""
+
+import torch
+
+from speculators.models.dspark.metrics import compute_metrics
+
+
+def _ids_to_logits(ids: torch.Tensor, vocab_size: int) -> torch.Tensor:
+    logits = torch.zeros(*ids.shape, vocab_size)
+    logits.scatter_(-1, ids.unsqueeze(-1), 100.0)
+    return logits
+
+
+class TestComputeMetrics:
+    def test_perfect_draft_low_loss_high_accept(self):
+        # block_size=2; position 0 is the anchor (masked), position 1 supervised.
+        ids = torch.tensor([[0, 1, 0, 2]])
+        logits = _ids_to_logits(ids, 8)
+        targets = logits.clone()
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
+        loss, metrics = compute_metrics(
+            logits, targets, None, loss_mask, block_size=2, gamma=4.0
+        )
+        assert torch.isfinite(loss)
+        # Matching distributions -> CE/TV ~ 0 and acceptance ~ 1.
+        assert float(loss) < 1e-2
+        accept = metrics["accept_rate_sum"] / metrics["accept_rate_total"]
+        assert float(accept) > 0.99
+
+    def test_confidence_target_is_overlap(self):
+        # When draft == target, accept rate == 1, so a confidence logit that is
+        # very positive (sigmoid -> 1) yields ~zero abs error.
+        ids = torch.tensor([[0, 1, 0, 2]])
+        logits = _ids_to_logits(ids, 8)
+        targets = logits.clone()
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
+        confidence_logits = torch.full((1, 4), 20.0)  # sigmoid ~ 1.0
+        _, metrics = compute_metrics(
+            logits,
+            targets,
+            confidence_logits,
+            loss_mask,
+            block_size=2,
+            gamma=4.0,
+        )
+        abs_err = (
+            metrics["confidence_abs_error_sum"] / metrics["confidence_abs_error_total"]
+        )
+        assert float(abs_err) < 1e-2
+        assert "confidence_loss_sum" in metrics
+
+    def test_confidence_term_changes_loss(self):
+        ids = torch.tensor([[0, 1, 0, 2]])
+        logits = _ids_to_logits(ids, 8)
+        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]]), 8)
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
+        loss_no_conf, _ = compute_metrics(
+            logits, targets, None, loss_mask, block_size=2
+        )
+        # A badly-calibrated confidence head (predicts accept~1 when accept~0)
+        # must add positive BCE on top of the base loss.
+        confidence_logits = torch.full((1, 4), 20.0)
+        loss_conf, _ = compute_metrics(
+            logits,
+            targets,
+            confidence_logits,
+            loss_mask,
+            block_size=2,
+            confidence_head_alpha=1.0,
+        )
+        assert float(loss_conf) > float(loss_no_conf)
+
+    def test_alpha_weighting(self):
+        ids = torch.tensor([[0, 1, 0, 2]])
+        logits = _ids_to_logits(ids, 8)
+        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]]), 8)
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
+        loss_small, _ = compute_metrics(
+            logits,
+            targets,
+            None,
+            loss_mask,
+            block_size=2,
+            ce_loss_alpha=0.0,
+            l1_loss_alpha=0.1,
+        )
+        loss_large, _ = compute_metrics(
+            logits,
+            targets,
+            None,
+            loss_mask,
+            block_size=2,
+            ce_loss_alpha=0.0,
+            l1_loss_alpha=1.0,
+        )
+        assert float(loss_large) > float(loss_small)
+
+    def test_metric_keys_present(self):
+        ids = torch.tensor([[0, 1, 0, 2]])
+        logits = _ids_to_logits(ids, 8)
+        targets = logits.clone()
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
+        _, metrics = compute_metrics(
+            logits, targets, torch.zeros(1, 4), loss_mask, block_size=2
+        )
+        for key in (
+            "loss_sum",
+            "loss_total",
+            "ce_loss_sum",
+            "tv_loss_sum",
+            "full_acc_sum",
+            "full_acc_total",
+            "position_1_acc_sum",
+        ):
+            assert key in metrics
+        # all metric values must be tensors (so dist.reduce works in the trainer)
+        assert all(torch.is_tensor(v) for v in metrics.values())

--- a/tests/unit/models/test_dspark_model_definitions.py
+++ b/tests/unit/models/test_dspark_model_definitions.py
@@ -1,0 +1,75 @@
+"""Unit tests for DSpark Markov and confidence heads."""
+
+import pytest
+import torch
+
+from speculators.models.dspark.model_definitions import ConfidenceHead, MarkovHead
+
+
+class TestMarkovHead:
+    def _head(self, head_type="vanilla", r=8, vv=50, dv=20, h=16):
+        torch.manual_seed(0)
+        return MarkovHead(
+            verifier_vocab_size=vv,
+            draft_vocab_size=dv,
+            markov_rank=r,
+            hidden_size=h,
+            head_type=head_type,
+        )
+
+    @pytest.mark.parametrize("head_type", ["vanilla", "gated", "rnn"])
+    def test_block_bias_shape(self, head_type):
+        head = self._head(head_type)
+        n, b, h = 3, 4, 16
+        prev = torch.randint(0, 50, (n, b))
+        hidden = torch.randn(n, b, h)
+        bias = head.block_bias(prev_token_ids=prev, hidden_states=hidden)
+        assert bias.shape == (n, b, 20)
+        assert torch.isfinite(bias).all()
+
+    def test_vanilla_is_low_rank_factorization(self):
+        head = self._head("vanilla")
+        prev = torch.randint(0, 50, (2, 4))
+        hidden = torch.zeros(2, 4, 16)
+        bias = head.block_bias(prev_token_ids=prev, hidden_states=hidden)
+        expected = head.markov_w2(head.markov_w1(prev))
+        assert torch.allclose(bias, expected, atol=1e-5)
+
+    def test_bias_depends_on_prev_token(self):
+        head = self._head("vanilla")
+        hidden = torch.zeros(1, 1, 16)
+        bias_a = head.block_bias(
+            prev_token_ids=torch.tensor([[1]]), hidden_states=hidden
+        )
+        bias_b = head.block_bias(
+            prev_token_ids=torch.tensor([[2]]), hidden_states=hidden
+        )
+        assert not torch.allclose(bias_a, bias_b)
+
+    def test_invalid_rank_raises(self):
+        with pytest.raises(ValueError):
+            MarkovHead(
+                verifier_vocab_size=50,
+                draft_vocab_size=20,
+                markov_rank=0,
+                hidden_size=16,
+            )
+
+    def test_invalid_head_type_raises(self):
+        with pytest.raises(ValueError):
+            MarkovHead(
+                verifier_vocab_size=50,
+                draft_vocab_size=20,
+                markov_rank=8,
+                hidden_size=16,
+                head_type="bogus",
+            )
+
+
+class TestConfidenceHead:
+    def test_output_shape(self):
+        head = ConfidenceHead(input_dim=24)
+        features = torch.randn(3, 4, 24)
+        out = head(features)
+        assert out.shape == (3, 4)
+        assert torch.isfinite(out).all()

--- a/tests/unit/train/test_cli_args.py
+++ b/tests/unit/train/test_cli_args.py
@@ -22,8 +22,9 @@ def _parse(monkeypatch, extra: list[str]):
 def test_dflash_default_uses_kl(monkeypatch):
     args = _parse(monkeypatch, [])
     train_kw, val_kw = DFlashDraftModel.get_trainer_kwargs(**vars(args))
-    assert train_kw["loss_fn"] is kl_div_loss
-    assert val_kw["loss_fn"] is kl_div_loss
+    assert "kl_div" in train_kw["loss_config"]
+    assert train_kw["loss_config"]["kl_div"][0] is kl_div_loss
+    assert "kl_div" in val_kw["loss_config"]
     assert train_kw["gamma"] == 4.0
     assert val_kw["gamma"] == 4.0
 
@@ -31,8 +32,9 @@ def test_dflash_default_uses_kl(monkeypatch):
 def test_dflash_explicit_ce(monkeypatch):
     args = _parse(monkeypatch, ["--loss-fn", "ce"])
     train_kw, val_kw = DFlashDraftModel.get_trainer_kwargs(**vars(args))
-    assert train_kw["loss_fn"] is ce_loss
-    assert val_kw["loss_fn"] is ce_loss
+    assert "ce" in train_kw["loss_config"]
+    assert train_kw["loss_config"]["ce"][0] is ce_loss
+    assert "ce" in val_kw["loss_config"]
     assert train_kw["gamma"] == 4.0
     assert val_kw["gamma"] == 4.0
 
@@ -50,29 +52,44 @@ def test_dflash_decay_gamma_falls_back_when_omitted():
     assert val_kw["gamma"] == 4.0
 
 
+def test_dflash_compound_loss(monkeypatch):
+    args = _parse(monkeypatch, ["--loss-fn", '{"ce": 0.1, "tv": 0.9}'])
+    train_kw, val_kw = DFlashDraftModel.get_trainer_kwargs(**vars(args))
+    assert "ce" in train_kw["loss_config"]
+    assert "tv" in train_kw["loss_config"]
+    assert train_kw["loss_config"]["ce"][1] == 0.1
+    assert train_kw["loss_config"]["tv"][1] == 0.9
+    assert "ce" in val_kw["loss_config"]
+    assert "tv" in val_kw["loss_config"]
+
+
 def test_eagle3_default_uses_kl(monkeypatch):
     args = _parse(monkeypatch, [])
     train_kw, val_kw = Eagle3DraftModel.get_trainer_kwargs(**vars(args))
-    assert train_kw["loss_fn"] is kl_div_loss
-    assert val_kw["loss_fn"] is kl_div_loss
+    assert "kl_div" in train_kw["loss_config"]
+    assert train_kw["loss_config"]["kl_div"][0] is kl_div_loss
+    assert "kl_div" in val_kw["loss_config"]
 
 
 def test_eagle3_explicit_ce(monkeypatch):
     args = _parse(monkeypatch, ["--loss-fn", "ce"])
     train_kw, val_kw = Eagle3DraftModel.get_trainer_kwargs(**vars(args))
-    assert train_kw["loss_fn"] is ce_loss
-    assert val_kw["loss_fn"] is ce_loss
+    assert "ce" in train_kw["loss_config"]
+    assert train_kw["loss_config"]["ce"][0] is ce_loss
+    assert "ce" in val_kw["loss_config"]
 
 
 def test_peagle_default_uses_kl(monkeypatch):
     args = _parse(monkeypatch, [])
     train_kw, val_kw = PEagleDraftModel.get_trainer_kwargs(**vars(args))
-    assert train_kw["loss_fn"] is kl_div_loss
-    assert val_kw["loss_fn"] is kl_div_loss
+    assert "kl_div" in train_kw["loss_config"]
+    assert train_kw["loss_config"]["kl_div"][0] is kl_div_loss
+    assert "kl_div" in val_kw["loss_config"]
 
 
 def test_peagle_explicit_ce(monkeypatch):
     args = _parse(monkeypatch, ["--loss-fn", "ce"])
     train_kw, val_kw = PEagleDraftModel.get_trainer_kwargs(**vars(args))
-    assert train_kw["loss_fn"] is ce_loss
-    assert val_kw["loss_fn"] is ce_loss
+    assert "ce" in train_kw["loss_config"]
+    assert train_kw["loss_config"]["ce"][0] is ce_loss
+    assert "ce" in val_kw["loss_config"]

--- a/tests/unit/train/test_cli_args.py
+++ b/tests/unit/train/test_cli_args.py
@@ -2,8 +2,9 @@
 
 from scripts.train import parse_args
 from speculators.models.dflash.core import DFlashDraftModel
+from speculators.models.dspark.core import DSparkDraftModel
 from speculators.models.eagle3.core import Eagle3DraftModel
-from speculators.models.metrics import ce_loss, kl_div_loss
+from speculators.models.metrics import ce_loss, kl_div_loss, tv_loss
 from speculators.models.peagle.core import PEagleDraftModel
 
 
@@ -93,3 +94,33 @@ def test_peagle_explicit_ce(monkeypatch):
     assert "ce" in train_kw["loss_config"]
     assert train_kw["loss_config"]["ce"][0] is ce_loss
     assert "ce" in val_kw["loss_config"]
+
+
+def test_dspark_default_uses_kl(monkeypatch):
+    args = _parse(monkeypatch, [])
+    train_kw, val_kw = DSparkDraftModel.get_trainer_kwargs(**vars(args))
+    assert "kl_div" in train_kw["loss_config"]
+    assert train_kw["loss_config"]["kl_div"][0] is kl_div_loss
+    assert "kl_div" in val_kw["loss_config"]
+    assert train_kw["confidence_head_alpha"] == 1.0
+    assert val_kw["confidence_head_alpha"] == 1.0
+
+
+def test_dspark_compound_loss(monkeypatch):
+    args = _parse(monkeypatch, ["--loss-fn", '{"ce": 0.1, "tv": 0.9}'])
+    train_kw, val_kw = DSparkDraftModel.get_trainer_kwargs(**vars(args))
+    assert "ce" in train_kw["loss_config"]
+    assert train_kw["loss_config"]["ce"][0] is ce_loss
+    assert train_kw["loss_config"]["ce"][1] == 0.1
+    assert "tv" in train_kw["loss_config"]
+    assert train_kw["loss_config"]["tv"][0] is tv_loss
+    assert train_kw["loss_config"]["tv"][1] == 0.9
+    assert "ce" in val_kw["loss_config"]
+    assert "tv" in val_kw["loss_config"]
+
+
+def test_dspark_confidence_head_alpha(monkeypatch):
+    args = _parse(monkeypatch, ["--confidence-head-alpha", "0.5"])
+    train_kw, val_kw = DSparkDraftModel.get_trainer_kwargs(**vars(args))
+    assert train_kw["confidence_head_alpha"] == 0.5
+    assert val_kw["confidence_head_alpha"] == 0.5


### PR DESCRIPTION
## Summary
Adds **DSpark** (based on the new method in [DeepSpec](https://github.com/deepseek-ai/DeepSpec)), which extends DFlash with a low-rank Markov logit-bias head (intra-block token dependency) and a per-position confidence head, trained with a TV-dominant loss. DFlash with the heads disabled (`--markov-rank 0`) reproduces plain DFlash.

- `src/speculators/models/dspark/` — config, model, Markov/confidence heads, loss
- `scripts/train.py` — `--speculator-type dspark` + markov/confidence/loss-weight flags
- unit tests + an online training example

## Results
Qwen3-8B, matched 20k-ShareGPT online runs (3 epochs, seq 2048), validation per-position acceptance:

| run | full_acc | pos1 | pos4 | pos7 |
|---|---|---|---|---|
| DFlash (kl_div) | 0.309 | 0.665 | 0.243 | 0.115 |
| + TV loss (markov off) | 0.341 | 0.690 | 0.282 | 0.136 |
| + Markov head (DSpark) | 0.415 | 0.689 | 0.369 | 0.255 |

The Markov head contributes most of the gain and grows with position (the suffix-decay fix); the TV loss adds a smaller, roughly uniform lift.

## Testing
`pytest tests/unit/models/test_dspark_*` → 13 passed; `ruff` clean. Trained DSpark/DFlash drafts for Qwen3-0.6B/4B/8B online via the example script.

AI assistance (Claude) was used; the submitter reviewed every line. No existing PR covers DSpark.