### PR TITLE
Remove stale vLLM compatibility warning for draft arch

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -135,14 +135,6 @@ def create_transformer_layer_config(  # noqa: C901
             f"Available: {list(DRAFT_ARCH_CONFIGS.keys())}"
         )
 
-    if draft_arch not in ("llama", "qwen3"):
-        warnings.warn(
-            f"Draft architecture '{draft_arch}' is not yet supported in vLLM. "
-            "The trained model may not be usable for inference in vLLM. "
-            "Consider using 'llama' or 'qwen3' for full vLLM compatibility.",
-            stacklevel=2,
-        )
-
     config_class = DRAFT_ARCH_CONFIGS[draft_arch]
     verifier_config = AutoConfig.from_pretrained(verifier_name_or_path)
 


### PR DESCRIPTION
## Summary
- Remove the stale vLLM compatibility warning in `create_transformer_layer_config` that was missed by #620
- Both llama and qwen3 are supported in vLLM, so the warning is no longer needed

## Test plan
- [ ] Run training with default args — no spurious warning emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)