### PR TITLE
fix(docs): correct shape annotations from [batch, ...] to [1, ...]

### DIFF
--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -130,12 +130,12 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
         separate label tensor is needed. Use loss_mask to exclude positions
         (e.g. prompt tokens) from the loss.
 
-        :param input_ids: Token IDs [batch, seq_len]. Serves as both the
+        :param input_ids: Token IDs [1, seq_len]. Serves as both the
             embedding source and the prediction target (offset by step+2).
-        :param hidden_states: Hidden states from verifier [batch, seq_len, hidden_size]
-        :param attention_mask: Optional attention mask [batch, seq_len]
-        :param position_ids: Optional position IDs [batch, seq_len]
-        :param loss_mask: Optional binary mask [batch, seq_len]; 1=compute loss,
+        :param hidden_states: Hidden states from verifier [1, seq_len, hidden_size]
+        :param attention_mask: Optional attention mask [1, seq_len]
+        :param position_ids: Optional position IDs [1, seq_len]
+        :param loss_mask: Optional binary mask [1, seq_len]; 1=compute loss,
             0=ignore.
         :param step_weights: Per-step loss weights (None = uniform). Training only.
         :param return_dict: Unused, kept for interface compatibility.

--- a/src/speculators/models/peagle/core.py
+++ b/src/speculators/models/peagle/core.py
@@ -62,14 +62,14 @@ class PEagleDraftModel(Eagle3DraftModel):
         Forward pass for P-EAGLE model training with parallel group prediction.
 
         Args:
-            hidden_states: Verifier hidden states [batch, seq_len, 3*hidden_size]
-            input_ids: Input token IDs [batch, seq_len]
+            hidden_states: Verifier hidden states [1, seq_len, 3*hidden_size]
+            input_ids: Input token IDs [1, seq_len]
             document_ids: Document IDs [1, seq_len], maps positions to doc index, pad -1
-            position_ids: Position IDs [batch, seq_len] (optional)
+            position_ids: Position IDs [1, seq_len] (optional)
             loss_mask: Loss mask for which tokens to compute loss on
-                [batch, seq_len]
+                [1, seq_len]
             verifier_last_hidden_states: Verifier final hidden states for
-                targets [batch, seq_len, hidden_size]
+                targets [1, seq_len, hidden_size]
 
         Returns:
             Tuple of (draft_tokens, loss, metrics)


### PR DESCRIPTION
## Summary

- Fix misleading `[batch, seq_len, ...]` shape annotations in `peagle/core.py` and `mtp/core.py` docstrings to `[1, seq_len, ...]`
- The batch dimension is always 1 due to sequence packing — multiple documents are concatenated along the sequence dimension, not batched
- Aligns with the existing `[1, ...]` annotations used in `eagle3`, `dflash`, and `dspark` models, and with `document_ids` which already used `[1, seq_len]`

## Test plan

- [ ] Docstring-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)