### PR TITLE
feat(data): prepare-data safety & correctness (RFC #583)

### DIFF
--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -57,11 +57,12 @@ def assert_safe_to_overwrite(output: Path, token_freq_path: Path) -> None:
     metadata, and the token frequency file) may be deleted.
     """
     unexpected_paths = []
+    resolved_token_freq_path = token_freq_path.resolve()
     for path in output.iterdir():
         if path.is_file() and (
             path.suffix == ".arrow"
             or path.name in PREPARE_DATA_OVERWRITE_ALLOWED_FILES
-            or path == token_freq_path
+            or path.resolve() == resolved_token_freq_path
         ):
             continue
         unexpected_paths.append(path)

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -40,6 +40,41 @@ logging.basicConfig(
 log = PipelineLogger(__name__)
 
 
+# Files prepare_data.py itself writes into --output; only these may be removed by
+# --overwrite.
+PREPARE_DATA_OVERWRITE_ALLOWED_FILES = {
+    "dataset_info.json",
+    "state.json",
+    "token_freq.pt",
+}
+
+
+def assert_safe_to_overwrite(output: Path, token_freq_path: Path) -> None:
+    """Refuse to ``--overwrite`` a directory holding non-artifact files.
+
+    Guards against pointing ``--output`` at a directory with unrelated user files
+    and wiping it: only prepare_data.py's own outputs (``.arrow`` shards, dataset
+    metadata, and the token frequency file) may be deleted.
+    """
+    unexpected_paths = []
+    for path in output.iterdir():
+        if path.is_file() and (
+            path.suffix == ".arrow"
+            or path.name in PREPARE_DATA_OVERWRITE_ALLOWED_FILES
+            or path == token_freq_path
+        ):
+            continue
+        unexpected_paths.append(path)
+
+    if unexpected_paths:
+        formatted_paths = ", ".join(str(path) for path in unexpected_paths)
+        raise ValueError(
+            "--overwrite would delete files that do not look like prepare_data.py "
+            f"artifacts: {formatted_paths}. Remove them manually or choose a "
+            "different --output directory."
+        )
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Prepare data for speculator training")
 
@@ -117,7 +152,7 @@ def parse_args():
         "--overwrite",
         action="store_true",
         help=(
-            "Forcibly rerun `prepare_data.py`.Deletes existing content in output dir"
+            "Forcibly rerun `prepare_data.py`. Deletes existing content in output dir"
         ),
     )
 
@@ -143,6 +178,14 @@ def parse_args():
             "trainable tokens."
         ),
     )
+    parser.add_argument(
+        "--allow-empty-output",
+        action="store_true",
+        help=(
+            "Allow writing an empty preprocessed dataset. By default prepare_data.py "
+            "raises when normalization or filtering removes every sample."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -159,6 +202,12 @@ def main():
     )
 
     output = Path(args.output)
+    token_freq_path = (
+        output / "token_freq.pt"
+        if args.token_freq_path is None
+        else Path(args.token_freq_path)
+    )
+
     if output.exists():
         if not args.overwrite and glob.glob(str(output / "*.arrow")):
             log.warning(
@@ -167,16 +216,12 @@ def main():
             )
             sys.exit(0)
         if args.overwrite:
+            assert_safe_to_overwrite(output, token_freq_path)
+            log.warning(f"Removing existing output directory: {output}")
             shutil.rmtree(output)
             output.mkdir(parents=True)
     else:
         output.mkdir(parents=True)
-
-    token_freq_path = (
-        output / "token_freq.pt"
-        if args.token_freq_path is None
-        else Path(args.token_freq_path)
-    )
 
     dataset, _ = load_and_preprocess_dataset(
         target_model_path=args.model,
@@ -189,6 +234,7 @@ def main():
         assistant_pattern=args.assistant_pattern,
         turn_dropout=args.turn_dropout,
         minimum_valid_tokens=args.minimum_valid_tokens,
+        allow_empty_output=args.allow_empty_output,
         trust_remote_code=args.trust_remote_code,
     )
 

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -570,6 +570,11 @@ def _preprocess_batch(
             f"Shape mismatch: input_ids={len(input_ids)}, loss_mask={len(loss_mask)}"
         )
 
+        # Bound both to max_length: a turn running past the window keeps only its
+        # in-window tokens, and input_ids/loss_mask stay aligned and bounded.
+        input_ids = input_ids[:max_length]
+        loss_mask = loss_mask[:max_length]
+
         # Filtering samples out with too few valid tokens
         if minimum_valid_tokens is not None:
             num_valid_tokens = int(loss_mask.sum().item())
@@ -708,6 +713,7 @@ def load_and_preprocess_dataset(
     assistant_pattern: str | None = None,
     turn_dropout: bool = False,
     minimum_valid_tokens: int | None = None,
+    allow_empty_output: bool = False,
     trust_remote_code: bool = False,
 ) -> tuple[HFDataset, ProcessorLike]:
     """Load, tokenize, and preprocess a dataset for EAGLE3 training.
@@ -730,6 +736,8 @@ def load_and_preprocess_dataset(
         turn_dropout: If True, randomly keeps first N consecutive turns per
                      conversation
         minimum_valid_tokens: Number of tokens to consider for a valid sample
+        allow_empty_output: If True, allow returning an empty dataset instead of
+                          raising when no samples survive preprocessing.
         trust_remote_code: If True, allows executing code from HF Hub.
 
     Returns:
@@ -794,14 +802,24 @@ def load_and_preprocess_dataset(
     if max_samples is not None and len(combined_dataset) > max_samples:
         combined_dataset = combined_dataset.select(range(max_samples))
 
+    if len(combined_dataset) == 0 and not allow_empty_output:
+        raise ValueError(
+            "No samples remain after preprocessing. Check the dataset schema, "
+            "assistant masking, and --minimum-valid-tokens. Pass "
+            "--allow-empty-output if an empty dataset is intentional."
+        )
+
     log.subsection("Computing token frequency distribution")
     save_token_frequency_distribution(
         dataset=combined_dataset,
         output_path=token_freq_path,
     )
 
-    log.subsection("Visualizing sample")
-    _visualize_sample(combined_dataset, processor, idx=0)
+    if len(combined_dataset) == 0:
+        log.warning("No samples remain after preprocessing; skipping visualization")
+    else:
+        log.subsection("Visualizing sample")
+        _visualize_sample(combined_dataset, processor, idx=0)
 
     log.section("Dataset preprocessing complete")
 

--- a/tests/unit/train/test_prepare_data.py
+++ b/tests/unit/train/test_prepare_data.py
@@ -1,8 +1,11 @@
 from pathlib import Path
 
 import pytest
+from datasets import Dataset as HFDataset
 
 from scripts.prepare_data import assert_safe_to_overwrite, parse_args
+from speculators.data_generation import preprocessing as preprocessing_module
+from speculators.data_generation.preprocessing import load_and_preprocess_dataset
 
 
 def test_assert_safe_to_overwrite_allows_prepare_data_artifacts(tmp_path: Path):
@@ -64,3 +67,60 @@ def test_parse_args_allow_empty_output_defaults_false(monkeypatch: pytest.Monkey
     args = parse_args()
 
     assert args.allow_empty_output is False
+
+
+class _FakeProcessor:
+    """Minimal processor stub that passes the chat-template precondition."""
+
+    chat_template = "{{ messages }}"
+
+    def apply_chat_template(self, *args, **kwargs):
+        return ""
+
+
+def _patch_empty_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make load_and_preprocess_dataset produce an empty dataset without GPU/network."""
+    empty = HFDataset.from_dict({"input_ids": [], "loss_mask": [], "seq_len": []})
+    monkeypatch.setattr(
+        preprocessing_module, "load_processor", lambda *a, **k: _FakeProcessor()
+    )
+    monkeypatch.setattr(
+        preprocessing_module,
+        "load_raw_dataset",
+        lambda _path: (HFDataset.from_dict({"conversations": []}), None),
+    )
+    monkeypatch.setattr(
+        preprocessing_module, "build_eagle3_dataset", lambda *a, **k: empty
+    )
+    monkeypatch.setattr(
+        preprocessing_module, "save_token_frequency_distribution", lambda **k: None
+    )
+
+
+def test_load_and_preprocess_raises_on_empty_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    _patch_empty_pipeline(monkeypatch)
+    with pytest.raises(ValueError, match="No samples remain"):
+        load_and_preprocess_dataset(
+            "target-model",
+            ["sharegpt"],
+            seq_length=8,
+            token_freq_path=tmp_path / "token_freq.pt",
+        )
+
+
+def test_load_and_preprocess_allows_empty_output_with_flag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    _patch_empty_pipeline(monkeypatch)
+    dataset, processor = load_and_preprocess_dataset(
+        "target-model",
+        ["sharegpt"],
+        seq_length=8,
+        token_freq_path=tmp_path / "token_freq.pt",
+        allow_empty_output=True,
+    )
+
+    assert len(dataset) == 0
+    assert isinstance(processor, _FakeProcessor)

--- a/tests/unit/train/test_prepare_data.py
+++ b/tests/unit/train/test_prepare_data.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import pytest
+
+from scripts.prepare_data import assert_safe_to_overwrite, parse_args
+
+
+def test_assert_safe_to_overwrite_allows_prepare_data_artifacts(tmp_path: Path):
+    output = tmp_path / "data"
+    output.mkdir()
+    (output / "data-00000-of-00001.arrow").touch()
+    (output / "dataset_info.json").touch()
+    token_freq_path = output / "token_freq.pt"
+    token_freq_path.touch()
+
+    assert_safe_to_overwrite(output, token_freq_path)
+
+
+def test_assert_safe_to_overwrite_rejects_unknown_files(tmp_path: Path):
+    output = tmp_path / "data"
+    output.mkdir()
+    (output / "data-00000-of-00001.arrow").touch()
+    (output / "checkpoints").mkdir()
+
+    with pytest.raises(ValueError, match="would delete files"):
+        assert_safe_to_overwrite(output, output / "token_freq.pt")
+
+
+def test_assert_safe_to_overwrite_honors_custom_token_freq_path(tmp_path: Path):
+    output = tmp_path / "data"
+    output.mkdir()
+    token_freq_path = output / "custom_freq.pt"
+    token_freq_path.touch()
+
+    assert_safe_to_overwrite(output, token_freq_path)
+
+
+def test_parse_args_forwards_allow_empty_output(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "prepare_data.py",
+            "--model",
+            "target",
+            "--data",
+            "sharegpt",
+            "--output",
+            "out",
+            "--allow-empty-output",
+        ],
+    )
+
+    args = parse_args()
+
+    assert args.allow_empty_output is True
+
+
+def test_parse_args_allow_empty_output_defaults_false(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "sys.argv",
+        ["prepare_data.py", "--model", "target", "--data", "sharegpt", "--output", "o"],
+    )
+
+    args = parse_args()
+
+    assert args.allow_empty_output is False


### PR DESCRIPTION
Hardens prepare_data.py reruns and preprocessing output (part of RFC #583).

## Changes

- **Safe --overwrite**. assert_safe_to_overwrite refuses to delete an output directory that contains files which aren't prepare_data.py artifacts (.arrow shards, dataset_info.json/state.json, and the token-frequency file). Previously --overwrite unconditionally rmtree'd the directory, so pointing --output at the wrong path could wipe unrelated files. token_freq_path is now resolved before the overwrite check so a custom path is recognized as an artifact.

- **Truncate to max_length**. _preprocess_batch now bounds input_ids/loss_mask to max_length, so a turn that runs past the sequence window keeps only its in-window tokens and the two stay aligned.

- **Fail loud on empty output**. load_and_preprocess_dataset raises when preprocessing yields zero samples (a common silent-failure mode from schema/mask/--minimum-valid-tokens issues). A new --allow-empty-output / allow_empty_output opts out, and sample visualization is skipped on an empty result.

## Testing

- tests/unit/train/test_prepare_data.py — assert_safe_to_overwrite accepts artifact-only directories (including a custom token-freq path) and rejects unexpected files/subdirectories; --allow-empty-output parsing (default False, set True).
