### PR TITLE
[On Policy Training] Multi-Turn Response Regeneration

### DIFF
--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -216,8 +216,12 @@ async def worker(
         # are built in lockstep as we walk the turns.
         prefix: list[dict[str, Any]] = []
         out_convs: list[dict[str, Any]] = []
-        finish_reason = None
-        usage = None
+        # Finish reasons are collected per turn: recording only the last would
+        # hide an earlier turn truncated at max_tokens (finish_reason "length").
+        finish_reasons: list[str | None] = []
+        # Usage is summed across turns: each user turn is a separate API call, so
+        # the conversation's cost is the sum, not just the final call's counts.
+        usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
         start_time = time.time()
         try:
             for turn in turns:
@@ -235,6 +239,14 @@ async def worker(
                     "max_tokens": args.max_tokens,
                 }
                 async with sem, session.post(endpoint, json=payload) as response:
+                    # A non-2xx reply has no `choices` array; surface the status
+                    # and a short body so `.errors.jsonl` is diagnosable instead
+                    # of recording a bare KeyError('choices').
+                    if not response.ok:
+                        body = (await response.text())[:500]
+                        raise RuntimeError(
+                            f"HTTP {response.status} from {endpoint}: {body}"
+                        )
                     data = await response.json()
 
                 choice = data["choices"][0]
@@ -243,8 +255,10 @@ async def worker(
                 reasoning_content = message.get("reasoning_content")
                 if reasoning_content is None:
                     reasoning_content = message.get("reasoning")
-                finish_reason = choice.get("finish_reason")
-                usage = data.get("usage")
+                finish_reasons.append(choice.get("finish_reason"))
+                turn_usage = data.get("usage") or {}
+                for key in usage:
+                    usage[key] += turn_usage.get(key) or 0
 
                 # An empty/None content (e.g. a response truncated mid-reasoning)
                 # would corrupt the prefix of every following turn and emit a
@@ -262,7 +276,7 @@ async def worker(
 
             metadata = {
                 "idx": idx,
-                "finish_reason": finish_reason,
+                "finish_reasons": finish_reasons,
                 "latency_s": round(time.time() - start_time, 3),
                 "usage": usage,
                 "endpoint": endpoint,
@@ -398,7 +412,8 @@ async def main():
                     continue
 
                 turns = extract_turns(row, prompt_field)
-                if not any(turn["role"] == "user" for turn in turns):
+                # extract_turns returns [] when there is no usable user turn.
+                if not turns:
                     continue
 
                 uuid = row.get("uuid")

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -104,6 +104,43 @@ def sanitize_filename(name: str) -> str:
     return name.strip("._")
 
 
+def extract_turns(row, prompt_field):
+    """Extract ordered system/user turns from a dataset row.
+
+    Multi-turn conversations are read from a ``messages`` or ``conversations``
+    field (either the role/content or from/value schema), preserving any system
+    prompt and dropping the original assistant turns so they can be regenerated.
+    Rows without a usable conversation fall back to a single user turn taken
+    from ``prompt_field``.
+    """
+    convs = row.get("messages")
+    if not (isinstance(convs, list) and convs):
+        convs = row.get("conversations")
+
+    if isinstance(convs, list) and convs:
+        turns = []
+        for m in convs:
+            if not isinstance(m, dict):
+                continue
+            role = m.get("role") or m.get("from")
+            content = m.get("content") or m.get("value")
+            if not content:
+                continue
+            if role == "system":
+                turns.append({"role": "system", "content": content})
+            elif role in ("user", "human"):
+                turns.append({"role": "user", "content": content})
+            # original assistant/gpt turns are dropped and regenerated
+        if any(turn["role"] == "user" for turn in turns):
+            return turns
+        # no usable user turn: fall through to the prompt_field fallback
+
+    prompt = row.get(prompt_field)
+    if prompt:
+        return [{"role": "user", "content": prompt}]
+    return []
+
+
 def load_seen(path: str):
     """Load previously processed record IDs from output file."""
     seen = set()
@@ -154,11 +191,18 @@ async def worker(
     queue: "asyncio.Queue[dict[str, Any]]",
     args,
     out_fh,
+    err_fh,
     endpoint: str,
     progress,
     stats: dict[str, int],
 ):
-    """Worker that pulls items from queue and sends them to the vLLM endpoint."""
+    """Worker that pulls conversations from the queue and regenerates them.
+
+    Each user turn is sent to the endpoint with the freshly generated prefix
+    (system + regenerated history); the original assistant turns are discarded
+    and replaced by the model's responses. Single-turn rows are the degenerate
+    case of one user turn.
+    """
     while True:
         item = await queue.get()
         if item is None:
@@ -166,62 +210,88 @@ async def worker(
             return
 
         idx = item["idx"]
-        payload = {
-            "model": args.model,
-            "messages": [{"role": "user", "content": item["prompt"]}],
-            "max_tokens": args.max_tokens,
-        }
+        turns = item["turns"]
 
+        # The API prefix (role/content) and the output conversation (from/value)
+        # are built in lockstep as we walk the turns.
+        prefix: list[dict[str, Any]] = []
+        out_convs: list[dict[str, Any]] = []
+        finish_reason = None
+        usage = None
         start_time = time.time()
         try:
-            async with sem, session.post(endpoint, json=payload) as response:
-                data = await response.json()
+            for turn in turns:
+                if turn["role"] == "system":
+                    prefix.append({"role": "system", "content": turn["content"]})
+                    out_convs.append({"from": "system", "value": turn["content"]})
+                    continue
 
-            choice = data["choices"][0]
-            message = choice["message"]
-            generated_text = message["content"]
-            reasoning_content = message.get("reasoning_content")
-            if reasoning_content is None:
-                reasoning_content = message.get("reasoning")
-            finish_reason = choice.get("finish_reason")
-            latency = time.time() - start_time
+                prefix.append({"role": "user", "content": turn["content"]})
+                out_convs.append({"from": "human", "value": turn["content"]})
 
-            # Format output in conversations structure
+                payload = {
+                    "model": args.model,
+                    "messages": prefix,
+                    "max_tokens": args.max_tokens,
+                }
+                async with sem, session.post(endpoint, json=payload) as response:
+                    data = await response.json()
+
+                choice = data["choices"][0]
+                message = choice["message"]
+                generated_text = message.get("content")
+                reasoning_content = message.get("reasoning_content")
+                if reasoning_content is None:
+                    reasoning_content = message.get("reasoning")
+                finish_reason = choice.get("finish_reason")
+                usage = data.get("usage")
+
+                # An empty/None content (e.g. a response truncated mid-reasoning)
+                # would corrupt the prefix of every following turn and emit a
+                # null assistant target; treat it as a failed conversation.
+                if not generated_text:
+                    raise ValueError(f"empty assistant content (turn {len(out_convs)})")
+
+                prefix.append({"role": "assistant", "content": generated_text})
+                gpt_turn = {"from": "gpt", "value": generated_text}
+                # Reasoning is stored per assistant turn: data preparation reads
+                # it from the turn, whereas top-level metadata is dropped.
+                if reasoning_content is not None:
+                    gpt_turn["reasoning_content"] = reasoning_content
+                out_convs.append(gpt_turn)
+
             metadata = {
                 "idx": idx,
                 "finish_reason": finish_reason,
-                "latency_s": round(latency, 3),
-                "usage": data.get("usage"),
+                "latency_s": round(time.time() - start_time, 3),
+                "usage": usage,
                 "endpoint": endpoint,
             }
 
-            # Only include reasoning_content if it exists
-            if reasoning_content is not None:
-                metadata["reasoning_content"] = reasoning_content
-
             output = {
                 "id": item.get("uuid") or f"sample_{idx}",
-                "conversations": [
-                    {"from": "human", "value": item["prompt"]},
-                    {"from": "gpt", "value": generated_text},
-                ],
+                "conversations": out_convs,
                 "metadata": metadata,
             }
             out_fh.write(json.dumps(output, ensure_ascii=False) + "\n")
             out_fh.flush()
             stats["ok"] += 1
         except Exception as e:  # noqa: BLE001
+            # Failed / partial conversations go to a SEPARATE error file so the
+            # training output is never polluted with truncated records (the
+            # downstream pipeline drops metadata, so an in-band error marker
+            # would be invisible).
             error_output = {
                 "id": item.get("uuid") or f"sample_{idx}",
-                "conversations": [{"from": "human", "value": item["prompt"]}],
+                "conversations": out_convs,
                 "metadata": {
                     "idx": idx,
                     "error": repr(e),
                     "endpoint": endpoint,
                 },
             }
-            out_fh.write(json.dumps(error_output, ensure_ascii=False) + "\n")
-            out_fh.flush()
+            err_fh.write(json.dumps(error_output, ensure_ascii=False) + "\n")
+            err_fh.flush()
             stats["errors"] += 1
         finally:
             progress.set_postfix(
@@ -262,10 +332,15 @@ async def main():
         model_name = sanitize_filename(model_name)
         args.outfile = f"{args.dataset}_{model_name}.jsonl"
 
+    # Failed / partial conversations are written here instead of the training file.
+    base, ext = os.path.splitext(args.outfile)
+    error_outfile = f"{base}.errors{ext or '.jsonl'}"
+
     print(f"Using dataset: {dataset_id}")
     print(f"Split: {split}")
     print(f"Prompt field: {prompt_field}")
     print(f"Output file: {args.outfile}")
+    print(f"Error file: {error_outfile}")
     print()
 
     seen_ids = load_seen(args.outfile) if args.resume else set()
@@ -288,6 +363,7 @@ async def main():
     ) as session:
         with (
             open(args.outfile, "a", encoding="utf-8") as output_file,  # noqa: ASYNC230
+            open(error_outfile, "a", encoding="utf-8") as error_file,  # noqa: ASYNC230
             tqdm(
                 total=args.limit,
                 desc="Generating responses",
@@ -304,6 +380,7 @@ async def main():
                         queue,
                         args,
                         output_file,
+                        error_file,
                         endpoint,
                         progress,
                         stats,
@@ -320,8 +397,8 @@ async def main():
                 if args.language_filter and row.get("language") != args.language_filter:
                     continue
 
-                prompt = row.get(prompt_field)
-                if not prompt:
+                turns = extract_turns(row, prompt_field)
+                if not any(turn["role"] == "user" for turn in turns):
                     continue
 
                 uuid = row.get("uuid")
@@ -333,7 +410,7 @@ async def main():
                     {
                         "idx": index,
                         "uuid": uuid,
-                        "prompt": prompt,
+                        "turns": turns,
                     }
                 )
                 processed_count += 1

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -185,6 +185,25 @@ async def detect_model(endpoint: str) -> str:
         ) from e
 
 
+async def _post_chat(
+    sem: asyncio.Semaphore,
+    session: aiohttp.ClientSession,
+    endpoint: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """POST one chat-completion request and return the parsed response.
+
+    A non-2xx reply has no ``choices`` array, so raise with the status and a
+    short body; otherwise the caller records a bare ``KeyError('choices')`` and
+    the real cause is lost.
+    """
+    async with sem, session.post(endpoint, json=payload) as response:
+        if not response.ok:
+            body = (await response.text())[:500]
+            raise RuntimeError(f"HTTP {response.status} from {endpoint}: {body}")
+        return await response.json()
+
+
 async def worker(
     sem: asyncio.Semaphore,
     session: aiohttp.ClientSession,
@@ -216,11 +235,7 @@ async def worker(
         # are built in lockstep as we walk the turns.
         prefix: list[dict[str, Any]] = []
         out_convs: list[dict[str, Any]] = []
-        # Finish reasons are collected per turn: recording only the last would
-        # hide an earlier turn truncated at max_tokens (finish_reason "length").
         finish_reasons: list[str | None] = []
-        # Usage is summed across turns: each user turn is a separate API call, so
-        # the conversation's cost is the sum, not just the final call's counts.
         usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
         start_time = time.time()
         try:
@@ -238,16 +253,7 @@ async def worker(
                     "messages": prefix,
                     "max_tokens": args.max_tokens,
                 }
-                async with sem, session.post(endpoint, json=payload) as response:
-                    # A non-2xx reply has no `choices` array; surface the status
-                    # and a short body so `.errors.jsonl` is diagnosable instead
-                    # of recording a bare KeyError('choices').
-                    if not response.ok:
-                        body = (await response.text())[:500]
-                        raise RuntimeError(
-                            f"HTTP {response.status} from {endpoint}: {body}"
-                        )
-                    data = await response.json()
+                data = await _post_chat(sem, session, endpoint, payload)
 
                 choice = data["choices"][0]
                 message = choice["message"]
@@ -260,16 +266,14 @@ async def worker(
                 for key in usage:
                     usage[key] += turn_usage.get(key) or 0
 
-                # An empty/None content (e.g. a response truncated mid-reasoning)
-                # would corrupt the prefix of every following turn and emit a
-                # null assistant target; treat it as a failed conversation.
+                # Empty content (e.g. truncated mid-reasoning) would corrupt the
+                # next turn's prefix and emit a null target; fail the conversation.
                 if not generated_text:
                     raise ValueError(f"empty assistant content (turn {len(out_convs)})")
 
                 prefix.append({"role": "assistant", "content": generated_text})
                 gpt_turn = {"from": "gpt", "value": generated_text}
-                # Reasoning is stored per assistant turn: data preparation reads
-                # it from the turn, whereas top-level metadata is dropped.
+                # Stored per turn: data prep reads it here, not top-level metadata.
                 if reasoning_content is not None:
                     gpt_turn["reasoning_content"] = reasoning_content
                 out_convs.append(gpt_turn)
@@ -291,10 +295,8 @@ async def worker(
             out_fh.flush()
             stats["ok"] += 1
         except Exception as e:  # noqa: BLE001
-            # Failed / partial conversations go to a SEPARATE error file so the
-            # training output is never polluted with truncated records (the
-            # downstream pipeline drops metadata, so an in-band error marker
-            # would be invisible).
+            # Failures go to a separate error file, not the training output; an
+            # in-band marker would be invisible (the pipeline drops metadata).
             error_output = {
                 "id": item.get("uuid") or f"sample_{idx}",
                 "conversations": out_convs,

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -1,0 +1,236 @@
+"""Real, dependency-light tests for the response-regeneration script.
+
+Two seams are covered with no network and no mocked HTTP:
+
+1. ``extract_turns`` over the *actual* schemas of the supported datasets
+   (ultrachat ``messages`` role/content, magpie/open-perfectblend
+   ``conversations`` from/value, gsm8k single prompt), plus the robustness
+   fixes (empty conversation lists, non-dict elements, mixed schema).
+
+2. The conversation format the worker emits, consumed by the *real* downstream
+   ``_normalize_conversation``. This pins the train/infer contract the PR exists
+   to protect: the system turn and per-turn reasoning survive into training, and
+   the regenerated human/gpt turns map to user/assistant targets.
+
+The script is not a package, so it is imported by path.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from speculators.data_generation.preprocessing import _normalize_conversation
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "scripts"
+    / "response_regeneration"
+    / "script.py"
+)
+
+
+def _load_regen_module():
+    spec = importlib.util.spec_from_file_location("response_regen_script", _SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+regen = _load_regen_module()
+
+
+# ---------------------------------------------------------------------------
+# 1. extract_turns over the real dataset shapes
+# ---------------------------------------------------------------------------
+
+# HuggingFaceH4/ultrachat_200k: full conversation in `messages` (role/content).
+_ULTRACHAT_ROW = {
+    "prompt": "Tell me about photosynthesis.",
+    "messages": [
+        {"role": "user", "content": "Tell me about photosynthesis."},
+        {"role": "assistant", "content": "<original answer to drop>"},
+        {"role": "user", "content": "Now summarize it in one line."},
+        {"role": "assistant", "content": "<original answer to drop>"},
+    ],
+}
+
+# A conversation that carries a system prompt (sharegpt / open-perfectblend style).
+_SYSTEM_PROMPTED_ROW = {
+    "conversations": [
+        {"from": "system", "value": "You are a terse assistant."},
+        {"from": "human", "value": "Hi"},
+        {"from": "gpt", "value": "<original answer to drop>"},
+    ],
+}
+
+# Magpie-Pro carries BOTH a scalar `instruction` and a `conversations` list.
+_MAGPIE_ROW = {
+    "instruction": "Solve 2+2.",
+    "response": "4",
+    "conversations": [
+        {"from": "human", "value": "Solve 2+2."},
+        {"from": "gpt", "value": "4"},
+    ],
+}
+
+# mlabonne/open-perfectblend: `conversations` (from/value), genuinely multi-turn.
+_OPEN_PERFECTBLEND_ROW = {
+    "source": "blend",
+    "conversations": [
+        {"from": "human", "value": "h1"},
+        {"from": "gpt", "value": "g1"},
+        {"from": "human", "value": "h2"},
+        {"from": "gpt", "value": "g2"},
+    ],
+}
+
+# openai/gsm8k: no conversation field; only a scalar prompt column.
+_GSM8K_ROW = {"question": "What is 6*7?", "answer": "42"}
+
+
+_EXTRACT_CASES = [
+    pytest.param(
+        _ULTRACHAT_ROW,
+        "prompt",
+        [
+            {"role": "user", "content": "Tell me about photosynthesis."},
+            {"role": "user", "content": "Now summarize it in one line."},
+        ],
+        id="ultrachat_messages_multiturn_drops_assistant",
+    ),
+    pytest.param(
+        _SYSTEM_PROMPTED_ROW,
+        "prompt",
+        [
+            {"role": "system", "content": "You are a terse assistant."},
+            {"role": "user", "content": "Hi"},
+        ],
+        id="system_prompt_preserved",
+    ),
+    pytest.param(
+        _MAGPIE_ROW,
+        "instruction",
+        [{"role": "user", "content": "Solve 2+2."}],
+        id="magpie_uses_conversations_not_instruction",
+    ),
+    pytest.param(
+        _OPEN_PERFECTBLEND_ROW,
+        "missing_field",
+        [
+            {"role": "user", "content": "h1"},
+            {"role": "user", "content": "h2"},
+        ],
+        id="open_perfectblend_from_value_multiturn",
+    ),
+    pytest.param(
+        _GSM8K_ROW,
+        "question",
+        [{"role": "user", "content": "What is 6*7?"}],
+        id="gsm8k_single_prompt_fallback",
+    ),
+    pytest.param(
+        {"messages": [], "prompt": "fallback prompt"},
+        "prompt",
+        [{"role": "user", "content": "fallback prompt"}],
+        id="empty_messages_falls_back_to_prompt",
+    ),
+    pytest.param(
+        {"messages": ["not-a-dict", {"role": "user", "content": "ok"}]},
+        "prompt",
+        [{"role": "user", "content": "ok"}],
+        id="non_dict_turn_element_skipped",
+    ),
+    pytest.param(
+        {"conversations": [{"role": "user", "content": "c1"}]},
+        "prompt",
+        [{"role": "user", "content": "c1"}],
+        id="conversations_role_content_schema",
+    ),
+    pytest.param(
+        {"messages": [{"role": "system", "content": "S"}], "prompt": "P"},
+        "prompt",
+        [{"role": "user", "content": "P"}],
+        id="system_only_falls_back_to_prompt",
+    ),
+    pytest.param(
+        {
+            "messages": [
+                {"role": "user", "content": ""},
+                {"role": "user", "content": "u"},
+            ]
+        },
+        "prompt",
+        [{"role": "user", "content": "u"}],
+        id="empty_content_turn_skipped",
+    ),
+]
+
+
+@pytest.mark.parametrize(("row", "prompt_field", "expected"), _EXTRACT_CASES)
+def test_extract_turns(row, prompt_field, expected):
+    assert regen.extract_turns(row, prompt_field) == expected
+
+
+def test_extract_turns_no_usable_input_returns_empty():
+    # No conversation field and no prompt_field value -> nothing to regenerate.
+    assert regen.extract_turns({"answer": "orphan"}, "question") == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Emitted conversation is consumed correctly by the real downstream
+#    normaliser (the train/infer contract).
+# ---------------------------------------------------------------------------
+
+# Multi-turn conversation carrying a system prompt, used to prove the contract.
+_CONTRACT_ROW = {
+    "conversations": [
+        {"from": "system", "value": "You are a terse assistant."},
+        {"from": "human", "value": "Hi"},
+        {"from": "gpt", "value": "<original answer to drop>"},
+        {"from": "human", "value": "And goodbye"},
+        {"from": "gpt", "value": "<original answer to drop>"},
+    ],
+}
+
+
+def _to_worker_output(turns) -> list[dict]:
+    """Mirror worker(): map system->system and user->human, and append a
+    regenerated assistant turn (with per-turn reasoning) after each user turn,
+    exactly as the script writes the ``conversations`` field."""
+    out_convs: list[dict] = []
+    for turn in turns:
+        if turn["role"] == "system":
+            out_convs.append({"from": "system", "value": turn["content"]})
+            continue
+        out_convs.append({"from": "human", "value": turn["content"]})
+        out_convs.append(
+            {
+                "from": "gpt",
+                "value": f"answer:{turn['content']}",
+                "reasoning_content": f"reason:{turn['content']}",
+            }
+        )
+    return out_convs
+
+
+def test_emitted_conversation_survives_downstream_normalization():
+    turns = regen.extract_turns(_CONTRACT_ROW, "prompt")
+    out_convs = _to_worker_output(turns)
+
+    normalized = _normalize_conversation(out_convs)
+    roles = [m["role"] for m in normalized]
+
+    # System preserved; human/gpt mapped to user/assistant; order intact.
+    assert roles == ["system", "user", "assistant", "user", "assistant"]
+    assert normalized[0]["content"] == "You are a terse assistant."
+
+    # Per-turn reasoning survives into training (top-level metadata would not).
+    assistants = [m for m in normalized if m["role"] == "assistant"]
+    assert [m["content"] for m in assistants] == ["answer:Hi", "answer:And goodbye"]
+    assert [m["reasoning_content"] for m in assistants] == [
+        "reason:Hi",
+        "reason:And goodbye",
+    ]


### PR DESCRIPTION

## Purpose

Response regeneration should support multi-turn (currently single-turn only). The driver is exposure bias: off-policy multi-turn data conditions each turn on the dataset's responses rather than the target's, so every turn past the first is misaligned. Regenerating turn-by-turn against the on-policy prefix fixes this — and yields longer, more realistic context as a bonus.

## Summary

- Multi-turn output. For any dataset with a messages/conversations field (ultrachat, magpie, open-perfectblend…), every user turn is regenerated against the freshly generated prefix, so a conversations list can now be many turns long instead of always exactly [human, gpt].
- System prompt preserved. A source system turn now appears in the output ({"from":"system",…}) and is used as context during regeneration. Previously system was always dropped.
- Per-turn reasoning_content. Reasoning is now attached to each assistant turn inside conversations. Previously it was a single field in top-level metadata (which the training pipeline drops).

## New behavior

- New <outfile>.errors.jsonl → partial multi-turn records were otherwise indistinguishable from clean ones downstream. (align with SpecForge)
- Empty/None assistant content → treated as a failed turn

## Out-of-scope

* tool use
* multi-modal
* concurrency
* doc: This PR indeed expands the behavior a bit. But I plan to make a larger refactoring PR to the doc, to make response regeneration explicitly the default. 

## Tests

* new unit tests, with diverse dataset format preset
* verified end2end: Qwen2.5-0.5B + `--dataset ultrachat --limit 2`

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
