### PR TITLE
refactor: move training hyperparameters from model configs to trainer kwargs

### DIFF
--- a/src/speculators/models/dflash/config.py
+++ b/src/speculators/models/dflash/config.py
@@ -48,14 +48,6 @@ class DFlashSpeculatorConfig(SpeculatorModelConfig):
         ),
     )
 
-    max_anchors: int = Field(
-        default=256,
-        description=(
-            "Maximum number of anchor positions to sample during training "
-            "(controls memory usage and training efficiency)"
-        ),
-    )
-
     target_hidden_size: int | None = Field(
         default=None,
         description="Hidden size of the target model (if different from draft model)",

--- a/src/speculators/models/dflash/config.py
+++ b/src/speculators/models/dflash/config.py
@@ -63,6 +63,13 @@ class DFlashSpeculatorConfig(SpeculatorModelConfig):
         description="Token ID used for masking",
     )
 
+    sliding_window_non_causal: bool = Field(
+        default=False,
+        description="Use non-causal (bidirectional) masking within draft blocks for "
+        "sliding window attention layers. Full attention layers are always "
+        "bidirectional.",
+    )
+
     @field_serializer("transformer_layer_config")
     def serialize_transformer_config(self, value: PretrainedConfig) -> dict:
         """Serialize transformer config to dict."""

--- a/src/speculators/models/dflash/config.py
+++ b/src/speculators/models/dflash/config.py
@@ -63,13 +63,6 @@ class DFlashSpeculatorConfig(SpeculatorModelConfig):
         description="Token ID used for masking",
     )
 
-    sliding_window_non_causal: bool = Field(
-        default=False,
-        description="Use non-causal (bidirectional) masking within draft blocks for "
-        "sliding window attention layers. Full attention layers are always "
-        "bidirectional.",
-    )
-
     @field_serializer("transformer_layer_config")
     def serialize_transformer_config(self, value: PretrainedConfig) -> dict:
         """Serialize transformer config to dict."""

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -79,7 +79,6 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         ]
         self.uses_sliding_window_attn = bool(self.sliding_window_indices)
         self.uses_full_attn = bool(num_draft_layers - len(self.sliding_window_indices))
-        self.sliding_window_non_causal = config.sliding_window_non_causal
 
         self.norm = Qwen3RMSNorm(
             config.transformer_layer_config.hidden_size,
@@ -177,7 +176,6 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             "block_size": block_size,
             "aux_hidden_state_layer_ids": target_layer_ids,
             "mask_token_id": kwargs.get("mask_token_id"),
-            "sliding_window_non_causal": kwargs.get("sliding_window_non_causal", False),
             "speculators_config": SpeculatorsConfig(
                 algorithm=algorithm,
                 proposal_methods=[
@@ -204,10 +202,12 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         loss_config = resolve_loss_config(kwargs["loss_fn"])
         gamma = kwargs.get("dflash_decay_gamma", 4.0)
         max_anchors = kwargs.get("max_anchors", 3072)
+        sliding_window_non_causal = kwargs.get("sliding_window_non_causal", False)
         shared = {
             "loss_config": loss_config,
             "gamma": gamma,
             "max_anchors": max_anchors,
+            "sliding_window_non_causal": sliding_window_non_causal,
         }
         return dict(shared), dict(shared)
 
@@ -249,7 +249,9 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         )
 
     @torch.compiler.disable
-    def _build_attention_mask(self, loss_mask, max_anchors, document_ids, device):
+    def _build_attention_mask(
+        self, loss_mask, max_anchors, document_ids, device, sliding_window_non_causal
+    ):
         total_seq_len = loss_mask.shape[1]
 
         anchor_positions, anchor_valid = select_anchors(
@@ -274,7 +276,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
                 anchor_positions=anchor_positions,
                 device=device,
                 sliding_window=self.sliding_window,
-                sliding_window_non_causal=self.sliding_window_non_causal,
+                sliding_window_non_causal=sliding_window_non_causal,
             )
 
         return full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid
@@ -298,6 +300,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         device = hidden_states.device
         total_seq_len = hidden_states.shape[1]
         num_anchors = kwargs.pop("max_anchors", 3072)
+        sliding_window_non_causal = kwargs.pop("sliding_window_non_causal", False)
 
         if position_ids is None:
             position_ids = 1 + torch.arange(
@@ -305,7 +308,13 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             ).unsqueeze(0)
 
         full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid = (
-            self._build_attention_mask(loss_mask, num_anchors, document_ids, device)
+            self._build_attention_mask(
+                loss_mask,
+                num_anchors,
+                document_ids,
+                device,
+                sliding_window_non_causal,
+            )
         )
 
         mask_tokens_size = num_anchors * self.block_size
@@ -390,6 +399,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         loss_config: LossConfig | None = None,
         gamma: float = 4.0,
         max_anchors: int = 3072,
+        sliding_window_non_causal: bool = False,
         **kwargs,
     ):
         _, logits, targets, aligned_loss_mask, _ = self._backbone_forward(
@@ -400,6 +410,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             document_ids,
             position_ids,
             max_anchors=max_anchors,
+            sliding_window_non_causal=sliding_window_non_causal,
             **kwargs,
         )
         loss, metrics = compute_metrics(

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -128,7 +128,6 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             **kwargs: Training arguments with DFlash-specific params
                 - draft_vocab_size: Size of draft vocabulary
                 - block_size: Block size for draft predictions (default: 8)
-                - max_anchors: Max anchor positions during training (default: 256)
                 - verifier_name_or_path: Path to verifier model
 
         Returns:
@@ -176,9 +175,6 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             "transformer_layer_config": verifier_config,
             "draft_vocab_size": kwargs["draft_vocab_size"],
             "block_size": block_size,
-            "max_anchors": (
-                3072 if kwargs.get("max_anchors") is None else kwargs["max_anchors"]
-            ),
             "aux_hidden_state_layer_ids": target_layer_ids,
             "mask_token_id": kwargs.get("mask_token_id"),
             "sliding_window_non_causal": kwargs.get("sliding_window_non_causal", False),
@@ -207,7 +203,12 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         """
         loss_config = resolve_loss_config(kwargs["loss_fn"])
         gamma = kwargs.get("dflash_decay_gamma", 4.0)
-        shared = {"loss_config": loss_config, "gamma": gamma}
+        max_anchors = kwargs.get("max_anchors", 3072)
+        shared = {
+            "loss_config": loss_config,
+            "gamma": gamma,
+            "max_anchors": max_anchors,
+        }
         return dict(shared), dict(shared)
 
     @property
@@ -248,11 +249,11 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         )
 
     @torch.compiler.disable
-    def _build_attention_mask(self, loss_mask, document_ids, device):
+    def _build_attention_mask(self, loss_mask, max_anchors, document_ids, device):
         total_seq_len = loss_mask.shape[1]
 
         anchor_positions, anchor_valid = select_anchors(
-            loss_mask, self.config.max_anchors, self.block_size
+            loss_mask, max_anchors, self.block_size
         )
 
         full_attn_mask = None
@@ -296,7 +297,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         """
         device = hidden_states.device
         total_seq_len = hidden_states.shape[1]
-        num_anchors = self.config.max_anchors
+        num_anchors = kwargs.pop("max_anchors", 3072)
 
         if position_ids is None:
             position_ids = 1 + torch.arange(
@@ -304,7 +305,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             ).unsqueeze(0)
 
         full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid = (
-            self._build_attention_mask(loss_mask, document_ids, device)
+            self._build_attention_mask(loss_mask, num_anchors, document_ids, device)
         )
 
         mask_tokens_size = num_anchors * self.block_size
@@ -388,6 +389,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         position_ids: torch.Tensor | None = None,  # shape: [1, total_seq_len]
         loss_config: LossConfig | None = None,
         gamma: float = 4.0,
+        max_anchors: int = 3072,
         **kwargs,
     ):
         _, logits, targets, aligned_loss_mask, _ = self._backbone_forward(
@@ -397,6 +399,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             verifier_last_hidden_states,
             document_ids,
             position_ids,
+            max_anchors=max_anchors,
             **kwargs,
         )
         loss, metrics = compute_metrics(

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -79,6 +79,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         ]
         self.uses_sliding_window_attn = bool(self.sliding_window_indices)
         self.uses_full_attn = bool(num_draft_layers - len(self.sliding_window_indices))
+        self.sliding_window_non_causal = config.sliding_window_non_causal
 
         self.norm = Qwen3RMSNorm(
             config.transformer_layer_config.hidden_size,
@@ -176,6 +177,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             "block_size": block_size,
             "aux_hidden_state_layer_ids": target_layer_ids,
             "mask_token_id": kwargs.get("mask_token_id"),
+            "sliding_window_non_causal": kwargs.get("sliding_window_non_causal", False),
             "speculators_config": SpeculatorsConfig(
                 algorithm=algorithm,
                 proposal_methods=[
@@ -202,12 +204,10 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         loss_config = resolve_loss_config(kwargs["loss_fn"])
         gamma = kwargs.get("dflash_decay_gamma", 4.0)
         max_anchors = kwargs.get("max_anchors", 3072)
-        sliding_window_non_causal = kwargs.get("sliding_window_non_causal", False)
         shared = {
             "loss_config": loss_config,
             "gamma": gamma,
             "max_anchors": max_anchors,
-            "sliding_window_non_causal": sliding_window_non_causal,
         }
         return dict(shared), dict(shared)
 
@@ -249,9 +249,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         )
 
     @torch.compiler.disable
-    def _build_attention_mask(
-        self, loss_mask, max_anchors, document_ids, device, sliding_window_non_causal
-    ):
+    def _build_attention_mask(self, loss_mask, max_anchors, document_ids, device):
         total_seq_len = loss_mask.shape[1]
 
         anchor_positions, anchor_valid = select_anchors(
@@ -276,7 +274,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
                 anchor_positions=anchor_positions,
                 device=device,
                 sliding_window=self.sliding_window,
-                sliding_window_non_causal=sliding_window_non_causal,
+                sliding_window_non_causal=self.sliding_window_non_causal,
             )
 
         return full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid
@@ -300,7 +298,6 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         device = hidden_states.device
         total_seq_len = hidden_states.shape[1]
         num_anchors = kwargs.pop("max_anchors", 3072)
-        sliding_window_non_causal = kwargs.pop("sliding_window_non_causal", False)
 
         if position_ids is None:
             position_ids = 1 + torch.arange(
@@ -308,13 +305,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             ).unsqueeze(0)
 
         full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid = (
-            self._build_attention_mask(
-                loss_mask,
-                num_anchors,
-                document_ids,
-                device,
-                sliding_window_non_causal,
-            )
+            self._build_attention_mask(loss_mask, num_anchors, document_ids, device)
         )
 
         mask_tokens_size = num_anchors * self.block_size
@@ -399,7 +390,6 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         loss_config: LossConfig | None = None,
         gamma: float = 4.0,
         max_anchors: int = 3072,
-        sliding_window_non_causal: bool = False,
         **kwargs,
     ):
         _, logits, targets, aligned_loss_mask, _ = self._backbone_forward(
@@ -410,7 +400,6 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             document_ids,
             position_ids,
             max_anchors=max_anchors,
-            sliding_window_non_causal=sliding_window_non_causal,
             **kwargs,
         )
         loss, metrics = compute_metrics(

--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -83,13 +83,11 @@ class DSparkDraftModel(DFlashDraftModel):
         loss_config = resolve_loss_config(kwargs["loss_fn"])
         gamma = kwargs.get("dflash_decay_gamma", 4.0)
         max_anchors = kwargs.get("max_anchors", 3072)
-        sliding_window_non_causal = kwargs.get("sliding_window_non_causal", False)
         confidence_head_alpha = kwargs.get("confidence_head_alpha", 1.0)
         shared = {
             "loss_config": loss_config,
             "gamma": gamma,
             "max_anchors": max_anchors,
-            "sliding_window_non_causal": sliding_window_non_causal,
             "confidence_head_alpha": confidence_head_alpha,
         }
         return dict(shared), dict(shared)
@@ -106,7 +104,6 @@ class DSparkDraftModel(DFlashDraftModel):
         loss_config: LossConfig | None = None,
         gamma: float = 4.0,
         max_anchors: int = 3072,
-        sliding_window_non_causal: bool = False,
         confidence_head_alpha: float = 1.0,
         **kwargs,
     ):
@@ -119,7 +116,6 @@ class DSparkDraftModel(DFlashDraftModel):
                 document_ids,
                 position_ids,
                 max_anchors=max_anchors,
-                sliding_window_non_causal=sliding_window_non_causal,
                 **kwargs,
             )
         )

--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -83,11 +83,13 @@ class DSparkDraftModel(DFlashDraftModel):
         loss_config = resolve_loss_config(kwargs["loss_fn"])
         gamma = kwargs.get("dflash_decay_gamma", 4.0)
         max_anchors = kwargs.get("max_anchors", 3072)
+        sliding_window_non_causal = kwargs.get("sliding_window_non_causal", False)
         confidence_head_alpha = kwargs.get("confidence_head_alpha", 1.0)
         shared = {
             "loss_config": loss_config,
             "gamma": gamma,
             "max_anchors": max_anchors,
+            "sliding_window_non_causal": sliding_window_non_causal,
             "confidence_head_alpha": confidence_head_alpha,
         }
         return dict(shared), dict(shared)
@@ -104,6 +106,7 @@ class DSparkDraftModel(DFlashDraftModel):
         loss_config: LossConfig | None = None,
         gamma: float = 4.0,
         max_anchors: int = 3072,
+        sliding_window_non_causal: bool = False,
         confidence_head_alpha: float = 1.0,
         **kwargs,
     ):
@@ -116,6 +119,7 @@ class DSparkDraftModel(DFlashDraftModel):
                 document_ids,
                 position_ids,
                 max_anchors=max_anchors,
+                sliding_window_non_causal=sliding_window_non_causal,
                 **kwargs,
             )
         )

--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -82,10 +82,12 @@ class DSparkDraftModel(DFlashDraftModel):
         """Resolve DSpark's compound loss from ``--loss-fn``."""
         loss_config = resolve_loss_config(kwargs["loss_fn"])
         gamma = kwargs.get("dflash_decay_gamma", 4.0)
+        max_anchors = kwargs.get("max_anchors", 3072)
         confidence_head_alpha = kwargs.get("confidence_head_alpha", 1.0)
         shared = {
             "loss_config": loss_config,
             "gamma": gamma,
+            "max_anchors": max_anchors,
             "confidence_head_alpha": confidence_head_alpha,
         }
         return dict(shared), dict(shared)
@@ -101,6 +103,7 @@ class DSparkDraftModel(DFlashDraftModel):
         position_ids: torch.Tensor | None = None,  # [1, total_seq_len]
         loss_config: LossConfig | None = None,
         gamma: float = 4.0,
+        max_anchors: int = 3072,
         confidence_head_alpha: float = 1.0,
         **kwargs,
     ):
@@ -112,12 +115,13 @@ class DSparkDraftModel(DFlashDraftModel):
                 verifier_last_hidden_states,
                 document_ids,
                 position_ids,
+                max_anchors=max_anchors,
                 **kwargs,
             )
         )
 
         # DSpark: add the Markov logit bias and predict per-position confidence.
-        num_blocks = self.config.max_anchors
+        num_blocks = max_anchors
         block = self.block_size
         mask_tokens_size = num_blocks * block
         # Ground-truth block tokens (verifier vocab); position 0 is the anchor.

--- a/src/speculators/models/peagle/config.py
+++ b/src/speculators/models/peagle/config.py
@@ -18,9 +18,6 @@ class PEagleSpeculatorConfig(Eagle3SpeculatorConfig):
     P-EAGLE extends EAGLE-3 with parallel multi-token prediction using
     Conditional Drop Token (COD) sampling for memory-efficient training.
 
-    :param num_depths: Number of parallel prediction groups (typically 8)
-    :param down_sample_ratio: Geometric decay ratio for COD sampling (r in [0,1])
-    :param down_sample_ratio_min: Minimum retention ratio floor
     :param mask_token_id: Token ID used for masking
     """
 
@@ -28,27 +25,6 @@ class PEagleSpeculatorConfig(Eagle3SpeculatorConfig):
     architectures: list[str] = Field(
         default_factory=lambda: ["PEagleSpeculator"],
         description="Model architectures that can load these weights",
-    )
-
-    num_depths: int = Field(
-        default=8,
-        description="Number of parallel prediction groups (num_depths)",
-        ge=1,
-        le=16,
-    )
-
-    down_sample_ratio: float = Field(
-        default=0.7,
-        description="Geometric decay ratio for COD sampling (retention rate r)",
-        gt=0.0,
-        le=1.0,
-    )
-
-    down_sample_ratio_min: float = Field(
-        default=0.2,
-        description="Minimum retention ratio floor to prevent over-sampling",
-        gt=0.0,
-        le=1.0,
     )
 
     mask_token_id: int | None = Field(

--- a/src/speculators/models/peagle/core.py
+++ b/src/speculators/models/peagle/core.py
@@ -38,9 +38,6 @@ class PEagleDraftModel(Eagle3DraftModel):
     ):
         super().__init__(config=config)
 
-        self.num_depths = config.num_depths
-        self.down_sample_ratio = config.down_sample_ratio
-        self.down_sample_ratio_min = config.down_sample_ratio_min
         self.mask_token_id = config.mask_token_id
 
         # Learnable mask_hidden parameter for padding unsampled positions
@@ -64,6 +61,9 @@ class PEagleDraftModel(Eagle3DraftModel):
         verifier_last_hidden_states: torch.Tensor | None = None,
         loss_config: LossConfig | None = None,
         max_anchors: int | None = None,
+        num_depths: int = 8,
+        down_sample_ratio: float = 0.7,
+        down_sample_ratio_min: float = 0.2,
         **kwargs,
     ):
         """
@@ -95,9 +95,9 @@ class PEagleDraftModel(Eagle3DraftModel):
         anchor_pos, depth = generate_cod_sample_indices(
             seq_length=seq_length,
             loss_mask=loss_mask,
-            num_depths=self.num_depths,
-            down_sample_ratio=self.down_sample_ratio,
-            down_sample_ratio_min=self.down_sample_ratio_min,
+            num_depths=num_depths,
+            down_sample_ratio=down_sample_ratio,
+            down_sample_ratio_min=down_sample_ratio_min,
             max_anchors=max_anchors,
         )
         total_sampled = anchor_pos.shape[0]
@@ -184,7 +184,7 @@ class PEagleDraftModel(Eagle3DraftModel):
             loss_mask=loss_mask,
             anchor_pos=anchor_pos,
             depth=depth,
-            num_depths=self.num_depths,
+            num_depths=num_depths,
             loss_config=loss_config,
         )
 
@@ -206,9 +206,6 @@ class PEagleDraftModel(Eagle3DraftModel):
             **kwargs: Training arguments with P-EAGLE-specific params
                 - draft_vocab_size: Size of draft vocabulary
                 - norm_before_residual: Whether to normalize before residual
-                - num_depths: Number of parallel groups (default 8)
-                - down_sample_ratio: COD sampling ratio (default 0.7)
-                - down_sample_ratio_min: Minimum sampling ratio (default 0.2)
                 - mask_token_id: Mask token ID
                 - t2d: Target-to-draft vocabulary mapping
                 - d2t: Draft-to-target vocabulary mapping
@@ -234,9 +231,6 @@ class PEagleDraftModel(Eagle3DraftModel):
             fc_norm=kwargs.get("fc_norm", False),
             norm_output=kwargs.get("norm_output", False),
             eagle_aux_hidden_state_layer_ids=target_layer_ids,
-            num_depths=kwargs.get("num_depths", 8),
-            down_sample_ratio=kwargs.get("down_sample_ratio", 0.7),
-            down_sample_ratio_min=kwargs.get("down_sample_ratio_min", 0.2),
             mask_token_id=kwargs.get("mask_token_id"),
             speculators_config=SpeculatorsConfig(
                 algorithm="peagle",
@@ -270,5 +264,14 @@ class PEagleDraftModel(Eagle3DraftModel):
         """
         loss_config = resolve_loss_config(kwargs["loss_fn"])
         max_anchors = kwargs.get("max_anchors")
-        shared = {"loss_config": loss_config, "max_anchors": max_anchors}
+        num_depths = kwargs.get("num_depths", 8)
+        down_sample_ratio = kwargs.get("down_sample_ratio", 0.7)
+        down_sample_ratio_min = kwargs.get("down_sample_ratio_min", 0.2)
+        shared = {
+            "loss_config": loss_config,
+            "max_anchors": max_anchors,
+            "num_depths": num_depths,
+            "down_sample_ratio": down_sample_ratio,
+            "down_sample_ratio_min": down_sample_ratio_min,
+        }
         return dict(shared), dict(shared)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -134,7 +134,6 @@ def make_dflash_model(
     *,
     draft_vocab_size: int = 64,
     block_size: int = 4,
-    max_anchors: int = 8,
     draft_attn_impl: str | None = None,
     device: str = "cuda:0",
     dtype: torch.dtype = torch.bfloat16,
@@ -147,7 +146,6 @@ def make_dflash_model(
         transformer_layer_config=transformer_config,
         draft_vocab_size=draft_vocab_size,
         block_size=block_size,
-        max_anchors=max_anchors,
         aux_hidden_state_layer_ids=[0, 1, 2],
         mask_token_id=0,
         speculators_config=SpeculatorsConfig(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -169,7 +169,6 @@ def make_peagle_model(
     *,
     draft_vocab_size: int = 64,
     num_depths: int = 4,
-    down_sample_ratio: float = 0.7,
     norm_before_fc: bool = False,
     fc_norm: bool = False,
     norm_output: bool = False,
@@ -188,9 +187,6 @@ def make_peagle_model(
         fc_norm=fc_norm,
         norm_output=norm_output,
         embed_requires_grad=True,
-        num_depths=num_depths,
-        down_sample_ratio=down_sample_ratio,
-        down_sample_ratio_min=0.2,
         mask_token_id=0,
         speculators_config=SpeculatorsConfig(
             algorithm="peagle",

--- a/tests/integration/models/test_dflash_vllm_parity.py
+++ b/tests/integration/models/test_dflash_vllm_parity.py
@@ -67,10 +67,10 @@ class TestDFlashAttentionParity:
 
     def _run_backend(self, backend, batch, state):
         torch.manual_seed(42)
-        m = make_dflash_model(block_size=4, max_anchors=4, draft_attn_impl=backend)
+        m = make_dflash_model(block_size=4, draft_attn_impl=backend)
         m.load_state_dict(state)
         with torch.no_grad():
-            _, loss, _ = m(**batch)
+            _, loss, _ = m(**batch, max_anchors=4)
         result = loss.item()
         del m
         torch.cuda.empty_cache()
@@ -78,7 +78,7 @@ class TestDFlashAttentionParity:
 
     def _make_shared_inputs(self):
         torch.manual_seed(42)
-        ref = make_dflash_model(block_size=4, max_anchors=4, draft_attn_impl="eager")
+        ref = make_dflash_model(block_size=4, draft_attn_impl="eager")
         samples = [
             make_sample(
                 seq_len=64,

--- a/tests/integration/models/test_model_forward.py
+++ b/tests/integration/models/test_model_forward.py
@@ -66,7 +66,9 @@ class ModelSpec:
     batch_factory: Callable[..., Any] = make_batch
 
 
-DFLASH_SPEC = ModelSpec(name="dflash", factory=make_dflash_model)
+DFLASH_SPEC = ModelSpec(
+    name="dflash", factory=make_dflash_model, forward_kwargs={"max_anchors": 8}
+)
 EAGLE3_SPEC = ModelSpec(
     name="eagle3", factory=make_eagle3_model, forward_kwargs={"ttt_steps": 2}
 )
@@ -240,20 +242,20 @@ class TestVocabBoundary:
 class TestDFlashParams:
     @pytest.mark.parametrize("block_size", [2, 4, 8])
     def test_varying_block_size(self, block_size):
-        model = make_dflash_model(block_size=block_size, max_anchors=4)
+        model = make_dflash_model(block_size=block_size)
         samples = _make_samples([128])
         batch = make_batch(max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE)
-        draft_tokens, loss, metrics = model(**batch)
+        draft_tokens, loss, metrics = model(**batch, max_anchors=4)
 
         assert loss.isfinite()
         loss.backward()
 
     @pytest.mark.parametrize("max_anchors", [2, 8, 16])
     def test_varying_max_anchors(self, max_anchors):
-        model = make_dflash_model(max_anchors=max_anchors)
+        model = make_dflash_model()
         samples = _make_samples([128])
         batch = make_batch(max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE)
-        draft_tokens, loss, metrics = model(**batch)
+        draft_tokens, loss, metrics = model(**batch, max_anchors=max_anchors)
 
         assert loss.isfinite()
         loss.backward()
@@ -264,7 +266,7 @@ class TestDFlashParams:
         model = make_dflash_model(draft_attn_impl=draft_attn_impl)
         samples = _make_samples(seq_lengths)
         batch = make_batch(max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE)
-        draft_tokens, loss, metrics = model(**batch)
+        draft_tokens, loss, metrics = model(**batch, max_anchors=8)
 
         assert loss.isfinite()
         loss.backward()
@@ -283,7 +285,7 @@ class TestDFlashParams:
             batch = make_batch(
                 max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE
             )
-            _, loss, _ = model(**batch)
+            _, loss, _ = model(**batch, max_anchors=8)
             results[backend] = loss.detach().cpu()
             del model
             torch.cuda.empty_cache()

--- a/tests/integration/models/test_model_forward.py
+++ b/tests/integration/models/test_model_forward.py
@@ -72,7 +72,15 @@ DFLASH_SPEC = ModelSpec(
 EAGLE3_SPEC = ModelSpec(
     name="eagle3", factory=make_eagle3_model, forward_kwargs={"ttt_steps": 2}
 )
-PEAGLE_SPEC = ModelSpec(name="peagle", factory=make_peagle_model)
+PEAGLE_SPEC = ModelSpec(
+    name="peagle",
+    factory=make_peagle_model,
+    forward_kwargs={
+        "num_depths": 4,
+        "down_sample_ratio": 0.7,
+        "down_sample_ratio_min": 0.2,
+    },
+)
 MTP_SPEC = ModelSpec(
     name="mtp",
     factory=make_mtp_model,
@@ -403,7 +411,7 @@ class TestNormOutputParams:
         assert len(model.fc_norm) == 3
         samples = _make_samples([128])
         batch = make_batch(max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE)
-        _draft_tokens, loss, _metrics = model(**batch)
+        _draft_tokens, loss, _metrics = model(**batch, num_depths=4)
 
         assert loss.isfinite()
         loss.backward()
@@ -416,7 +424,7 @@ class TestNormOutputParams:
         assert model.input_norm is not None
         samples = _make_samples([128])
         batch = make_batch(max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE)
-        _draft_tokens, loss, _metrics = model(**batch)
+        _draft_tokens, loss, _metrics = model(**batch, num_depths=4)
 
         assert loss.isfinite()
         loss.backward()
@@ -429,17 +437,19 @@ class TestPEagleParams:
         model = make_peagle_model(num_depths=num_depths)
         samples = _make_samples([128])
         batch = make_batch(max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE)
-        draft_tokens, loss, metrics = model(**batch)
+        draft_tokens, loss, metrics = model(**batch, num_depths=num_depths)
 
         assert loss.isfinite()
         loss.backward()
 
     @pytest.mark.parametrize("down_sample_ratio", [0.3, 0.7, 1.0])
     def test_varying_down_sample_ratio(self, down_sample_ratio):
-        model = make_peagle_model(down_sample_ratio=down_sample_ratio)
+        model = make_peagle_model()
         samples = _make_samples([128])
         batch = make_batch(max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE)
-        draft_tokens, loss, metrics = model(**batch)
+        draft_tokens, loss, metrics = model(
+            **batch, num_depths=4, down_sample_ratio=down_sample_ratio
+        )
 
         assert loss.isfinite()
         loss.backward()
@@ -450,7 +460,7 @@ class TestPEagleParams:
         model = make_peagle_model(draft_attn_impl=draft_attn_impl)
         samples = _make_samples(seq_lengths)
         batch = make_batch(max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE)
-        draft_tokens, loss, metrics = model(**batch)
+        draft_tokens, loss, metrics = model(**batch, num_depths=4)
 
         assert loss.isfinite()
         loss.backward()
@@ -469,7 +479,7 @@ class TestPEagleParams:
             batch = make_batch(
                 max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE
             )
-            _, loss, _ = model(**batch)
+            _, loss, _ = model(**batch, num_depths=4)
             results[backend] = loss.detach().cpu()
             del model
             torch.cuda.empty_cache()


### PR DESCRIPTION
## Summary

Follow-up to #687 as discussed in [review comments](https://github.com/vllm-project/speculators/pull/687#discussion_r3500559679):

Move training-only hyperparameters out of model configs into `get_trainer_kwargs` → `forward()`. These fields don't affect model architecture or inference behavior and shouldn't be persisted in `config.json`.

**DFlash/DSpark:**
- `max_anchors` — anchor sampling count, training-only
- `sliding_window_non_causal` — training attention mask flag (vLLM uses its own attention path)

**PEagle:**
- `num_depths`, `down_sample_ratio`, `down_sample_ratio_min` — COD sampling params, training-only
- Inference-time speculation count remains in `SpeculatorsConfig.proposal_methods[0].speculative_tokens`

Not breaking: `SpeculatorModelConfig` uses `extra="allow"`, so old checkpoints with these fields load fine.

## Test plan

- [ ] `pytest tests/integration/models/test_model_forward.py -k dflash` — DFlash param tests
- [ ] `pytest tests/integration/models/test_model_forward.py -k peagle` — PEagle param tests
- [ ] `pytest tests/integration/models/test_model_forward.py` — all model forward tests (no regressions)
- [ ] Existing checkpoints load without error (removed fields silently accepted by `extra="allow"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)