### PR TITLE
(feat) train: enable train data ratio choice

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -98,6 +98,8 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 - **`--lr`** (float, default: `1e-4`) Learning rate.
 
+- **`--train-data-ratio`** (float, default: `0.9`) Ratio of data to use for training, the rest of the provided data will be used for validation.
+
 - **`--no-resume-from-checkpoint`** (flag) Disable automatic checkpoint resumption. Without this flag, this script will automatically load the latest checkpoint in `{save-path}` if one exists.
 
 - **`--logger`** (str, default: `""`) Metric logging backend(s). Options: `trackio`, `wandb`, `tensorboard`, `mlflow` Can specify multiple comma-separated: `--logger tensorboard,wandb`. **Warning:** backend must be pip installed before using.

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -510,6 +510,7 @@ def main(args: argparse.Namespace):  # noqa: C901
 
     train_loader, val_loader = create_train_val_loaders(
         data_path=args.data_path,
+        train_data_ratio=args.train_data_ratio,
         total_seq_len=args.total_seq_len,
         hidden_states_dtype=hidden_states_dtype,
         noise_std=args.noise_std,
@@ -777,6 +778,7 @@ def parse_args():
     parser.add_argument("--save-path", type=str, default="./output/checkpoints")
     parser.add_argument("--epochs", type=int, default=20)
     parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--train-data-ratio", type=float, default=0.9)
     parser.add_argument("--no-resume-from-checkpoint", action="store_true")
     parser.add_argument(
         "--logger",

--- a/src/speculators/train/dataloader.py
+++ b/src/speculators/train/dataloader.py
@@ -91,6 +91,9 @@ def create_train_val_loaders(
     """
     noise_transform = AddUniformNoise(std=noise_std)
 
+    if not (0.0 < train_data_ratio < 1.0):
+        raise ValueError(f"train_data_ratio must be in (0, 1), got {train_data_ratio}")
+
     if legacy_data:
         warnings.warn(
             "Using '--legacy-data' is deprecated and will be removed soon.",

--- a/src/speculators/train/dataloader.py
+++ b/src/speculators/train/dataloader.py
@@ -64,6 +64,7 @@ def _setup_dataloader(
 def create_train_val_loaders(
     *,
     data_path: str,
+    train_data_ratio: float,
     total_seq_len: int,
     hidden_states_dtype: torch.dtype,
     noise_std: float,
@@ -96,7 +97,7 @@ def create_train_val_loaders(
             category=DeprecationWarning,
             stacklevel=2,
         )
-        train_files, val_files = split_files(data_path, ratio=0.9)
+        train_files, val_files = split_files(data_path, ratio=train_data_ratio)
         train_dataset: BaseDataset = SampleFileDataset(
             file_list=train_files,
             max_len=total_seq_len,
@@ -117,7 +118,7 @@ def create_train_val_loaders(
             on_missing=on_missing,
             on_generate=on_generate,
             transform=noise_transform,
-            split_ratio=0.9,
+            split_ratio=train_data_ratio,
             model=verifier_name_or_path,
             hidden_states_dtype=hidden_states_dtype,
             request_timeout=request_timeout,
@@ -130,7 +131,7 @@ def create_train_val_loaders(
             vllm_endpoint=vllm_endpoint,
             on_missing=on_missing,
             on_generate=on_generate,
-            split_ratio=-0.1,
+            split_ratio=train_data_ratio - 1.0,
             model=verifier_name_or_path,
             hidden_states_dtype=hidden_states_dtype,
             request_timeout=request_timeout,


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

The purpose of this PR is to provided users an opportunity to determine the ratio of the training data that will be used for training. Now the proportion of 90% and 10% between train and validation respectively is fixed. In my opinion it is necessary to let user determine this proportion, especially if they use large datasets for training.

## Tests

The suggested fixes are minor and could be checked with fairly any train command. The fact that it works correctly follows from the change in the train length.

## Checklist

I have filled in:

- [+] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [-] The test plan/results, such as providing test command and pasting the results.
- [+] (Optional) The necessary documentation update.
- [+] I (a human) have written or reviewed the code in this pr to the best of my ability.
