### PR TITLE
Fix --resume in response_regeneration (key by written id)

### DIFF
--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -87,7 +87,7 @@ def parse_args():
     parser.add_argument(
         "--resume",
         action="store_true",
-        help="Skip rows already in outfile (by uuid or idx)",
+        help="Skip successfully-processed rows in outfile; errored rows are retried",
     )
     parser.add_argument(
         "--language-filter",
@@ -116,7 +116,12 @@ def load_seen(path: str):
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            key = obj.get("uuid") or obj.get("idx")
+            # Only treat successful rows as seen so errored rows are retried.
+            if "error" in obj.get("metadata", {}):
+                continue
+            key = obj.get("id")
+            if key is None:
+                key = obj.get("metadata", {}).get("idx")
             if key is not None:
                 seen.add(str(key))
     return seen
@@ -325,7 +330,7 @@ async def main():
                     continue
 
                 uuid = row.get("uuid")
-                key = str(uuid or index)
+                key = str(uuid) if uuid else f"sample_{index}"
                 if key in seen_ids:
                     continue
 

--- a/tests/unit/test_response_regeneration.py
+++ b/tests/unit/test_response_regeneration.py
@@ -1,0 +1,51 @@
+"""Unit tests for scripts/response_regeneration/script.py resume handling."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+# The script imports optional, scripts-only deps at module load.
+pytest.importorskip("aiohttp")
+pytest.importorskip("datasets")
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "response_regeneration"
+    / "script.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("regen_script", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_load_seen_matches_written_ids(tmp_path):
+    """load_seen must key off the same ``id`` the script writes, and must not
+    mark errored rows as seen (so they are retried on resume)."""
+    mod = _load_module()
+    out = tmp_path / "out.jsonl"
+    records = [
+        # uuid-less dataset: written id is f"sample_{idx}"
+        {"id": "sample_5", "metadata": {"idx": 5, "finish_reason": "stop"}},
+        # uuid dataset: written id is the uuid
+        {"id": "abc-123", "metadata": {"idx": 9, "finish_reason": "stop"}},
+        # errored row: must NOT be seen -> retried
+        {"id": "sample_7", "metadata": {"idx": 7, "error": "boom"}},
+    ]
+    out.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+    seen = mod.load_seen(str(out))
+
+    assert seen == {"sample_5", "abc-123"}
+    assert "sample_7" not in seen
+
+
+def test_load_seen_missing_file(tmp_path):
+    mod = _load_module()
+    assert mod.load_seen(str(tmp_path / "does_not_exist.jsonl")) == set()


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

load_seen() read top-level `uuid`/`idx`, but rows are written with `id` (= uuid or `sample_{idx}`) and `metadata.idx`, so the seen-set was always empty and --resume reprocessed the whole dataset. Key off the written `id` (fallback `metadata.idx`) and exclude errored rows so they are retried; the main-loop dedup key now matches the written `id` for uuid-less datasets.

## Tests

## Checklist

I have filled in:

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [ ] I (a human) have written or reviewed the code in this pr to the best of my ability.
