### PR TITLE
ci: skip link checks on draft PRs to avoid 429s

### DIFF
--- a/.github/workflows/link-checks.yml
+++ b/.github/workflows/link-checks.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -17,6 +17,7 @@ env:
 
 jobs:
   link-checks:
+    if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Skip the link-check CI job while a PR is in draft state to avoid hitting 429 rate limits from external sites (e.g. `docs.vllm.ai`)
- Add `ready_for_review` event type so the check runs automatically when the PR is marked ready
- Add `if: github.event.pull_request.draft != true` condition on the job

## Test plan
- [ ] Open a draft PR and verify link checks are skipped
- [ ] Mark the draft PR as ready and verify link checks run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated link checks to run when a pull request is marked ready for review.
  * Draft pull requests will now skip this check until they’re ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->