### PR TITLE
fix(test): enforce eager mode in Eagle3 quantized E2E test

### DIFF
--- a/tests/e2e/regression/test_eagle3_conversion_acceptance.py
+++ b/tests/e2e/regression/test_eagle3_conversion_acceptance.py
@@ -101,5 +101,6 @@ class TestEagle3vLLM:
             tmp_path=tmp_path,
             prompts=prompts,
             acceptance_thresholds=acceptance_thresholds,
+            enforce_eager=True,
             ignore_eos=True,
         )


### PR DESCRIPTION
## Summary

- Add `enforce_eager=True` to `test_vllm_engine_eagle3` to work around a vLLM bug where CUDA graph capture crashes with an illegal memory access on quantized speculator models (H100-specific — passes on A100)

## Root Cause

From the [nightly CI run](https://github.com/neuralmagic/llm-compressor-testing/actions/runs/28632521105) (vLLM 0.24.0, Python 3.11):

**Failure 1** — `test_vllm_engine_eagle3[llama3-converted-quantized]`: vLLM's `EngineCore` crashes during speculator prefill CUDA graph capture (`cudagraph_utils.py` → `torch.cuda.graph()` → `torch.cuda.synchronize()` → `CUDA error: an illegal memory access`). Upstream issue: https://github.com/vllm-project/vllm/issues/47561

**Failure 2** — `test_offline_smoke[Qwen/Qwen3-0.6B-sharegpt-dflash]`: OOM during warmup. The CI log shows an unrelated process (pid 1528) holding 1.83 GiB on the GPU, leaving only 4.54 GiB free vs the 4.64 GiB needed for warmup with `gpu_memory_utilization=0.9`. It's unclear whether process 1528 is a remnant of the Eagle3 crash or an unrelated CI process — the Eagle3 EngineCore had a different pid (6832). Either way, this test is fragile at 0.9 utilization if any other process occupies GPU memory on the CI runner.

If the DFlash OOM persists after this fix, I'll follow up.

## Test plan

- [x] Reproduced Eagle3 CUDA graph crash on H100 with `enforce_eager=False` (return code 1)
- [x] Validated fix on H100 with `enforce_eager=True` (return code 0, all acceptance thresholds pass)
- [ ] Nightly CI passes both tests

Fixes: INFERENG-8164

🤖 Generated with [Claude Code](https://claude.com/claude-code)