### PR TITLE
fix(regen): stable --resume identity + request retries

### DIFF
--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -116,7 +116,12 @@ def parse_args():
             f"(default: {DEFAULT_RETRY_BACKOFF})"
         ),
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.max_retries < 0:
+        parser.error("--max-retries must be >= 0")
+    if args.retry_backoff < 0:
+        parser.error("--retry-backoff must be >= 0")
+    return args
 
 
 def sanitize_filename(name: str) -> str:
@@ -169,62 +174,32 @@ def _is_present(value: Any) -> bool:
 
 
 def _content_hash(row: dict[str, Any]) -> str:
-    """Deterministic hash of a row, used as a last-resort stable identifier."""
+    """Deterministic hash of a row, used when it has no explicit id."""
     payload = json.dumps(row, sort_keys=True, ensure_ascii=False, default=str)
     return "hash_" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-def _primary_identifier(row: dict[str, Any]) -> tuple[str, str]:
-    """Return a stable ``(id, source)`` for a dataset row.
+def _primary_identifier(row: dict[str, Any]) -> str:
+    """Return a stable primary id for a dataset row.
 
-    Prefers an explicit ``id``/``uuid``, then a nested ``metadata`` id, and
-    finally a content hash. Unlike a streaming enumeration index, this key does
-    not shift when ``--limit``/``--language-filter`` or the input order change,
-    so ``--resume`` stays correct across runs.
+    Prefers an explicit ``id``/``uuid``; otherwise a deterministic content hash.
+    Unlike a streaming enumeration index, this key does not shift when
+    ``--limit``/``--language-filter`` or the input order change, so ``--resume``
+    stays correct across runs.
     """
     for field in ("id", "uuid"):
         value = row.get(field)
         if _is_present(value):
-            return str(value), field
-
-    metadata = row.get("metadata")
-    if isinstance(metadata, dict):
-        for field in ("id", "uuid", "sample_id", "idx", "index"):
-            value = metadata.get(field)
-            if _is_present(value):
-                return str(value), f"metadata.{field}"
-
-    return _content_hash(row), "content_hash"
-
-
-def _output_seen_ids(obj: dict[str, Any]) -> set[str]:
-    """Extract resume keys from one previously written output row.
-
-    Prefers ``metadata.primary_id`` (written by this script); falls back to
-    legacy top-level ``id``/``uuid`` and nested metadata ids so output files
-    written before this change still resume for rows that carried a real id.
-    """
-    metadata = obj.get("metadata")
-    if isinstance(metadata, dict):
-        primary_id = metadata.get("primary_id")
-        if _is_present(primary_id):
-            return {str(primary_id)}
-
-    ids: set[str] = set()
-    for field in ("id", "uuid"):
-        value = obj.get(field)
-        if _is_present(value):
-            ids.add(str(value))
-    if isinstance(metadata, dict):
-        for field in ("id", "uuid", "sample_id", "idx", "index"):
-            value = metadata.get(field)
-            if _is_present(value):
-                ids.add(str(value))
-    return ids
+            return str(value)
+    return _content_hash(row)
 
 
 def load_seen(path: str) -> set[str]:
-    """Load previously processed primary IDs from output file."""
+    """Load previously written ``metadata.primary_id`` values from the output.
+
+    Resume is not back-compatible with pre-``primary_id`` outputs; since resume
+    never worked before this change, there are no such files to support.
+    """
     seen: set[str] = set()
     if not os.path.isfile(path):
         return seen
@@ -235,7 +210,9 @@ def load_seen(path: str) -> set[str]:
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            seen.update(_output_seen_ids(obj))
+            metadata = obj.get("metadata")
+            if isinstance(metadata, dict) and _is_present(metadata.get("primary_id")):
+                seen.add(str(metadata["primary_id"]))
     return seen
 
 
@@ -265,6 +242,21 @@ async def detect_model(endpoint: str) -> str:
         ) from e
 
 
+# Transient statuses worth retrying: request timeout, conflict, too-early, and
+# rate limiting, plus all 5xx. Other non-2xx replies (e.g. 400/401/404) are
+# permanent config/client errors and fail fast.
+SERVER_ERROR_STATUS = 500
+RETRYABLE_HTTP_STATUSES = {408, 409, 425, 429}
+
+
+class _NonRetryableChatError(RuntimeError):
+    """A non-2xx reply that should fail fast instead of being retried."""
+
+
+def _is_retryable_http_status(status: int) -> bool:
+    return status >= SERVER_ERROR_STATUS or status in RETRYABLE_HTTP_STATUSES
+
+
 async def _post_chat(
     session: aiohttp.ClientSession,
     endpoint: str,
@@ -277,10 +269,11 @@ async def _post_chat(
 
     A non-2xx reply has no ``choices`` array, so raise with the status and a
     short body; otherwise the caller records a bare ``KeyError('choices')`` and
-    the real cause is lost. Transient failures (network errors or non-2xx
-    replies) are retried up to ``max_retries`` times with exponential backoff;
-    the semaphore is released between attempts so a backing-off request does not
-    hold a concurrency slot.
+    the real cause is lost. Transient failures (network errors or transient
+    HTTP statuses) are retried up to ``max_retries`` times with exponential
+    backoff; a backing-off worker just sleeps without pulling new work, so it
+    does not block the other workers. Permanent non-2xx replies (e.g. 400/404)
+    fail fast without retrying.
     """
     total_attempts = max_retries + 1
     last_error: Exception | None = None
@@ -289,10 +282,15 @@ async def _post_chat(
             async with session.post(endpoint, json=payload) as response:
                 if not response.ok:
                     body = (await response.text())[:500]
-                    raise RuntimeError(
-                        f"HTTP {response.status} from {endpoint}: {body}"
+                    error_cls = (
+                        RuntimeError
+                        if _is_retryable_http_status(response.status)
+                        else _NonRetryableChatError
                     )
+                    raise error_cls(f"HTTP {response.status} from {endpoint}: {body}")
                 return await response.json()
+        except _NonRetryableChatError:
+            raise
         except Exception as e:  # noqa: BLE001
             last_error = e
             if attempt >= total_attempts:
@@ -385,7 +383,6 @@ async def worker(
 
             metadata = {
                 "primary_id": item["primary_id"],
-                "primary_id_source": item["primary_id_source"],
                 "idx": idx,
                 "finish_reasons": finish_reasons,
                 "latency_s": round(time.time() - start_time, 3),
@@ -409,7 +406,6 @@ async def worker(
                 "conversations": out_convs,
                 "metadata": {
                     "primary_id": item["primary_id"],
-                    "primary_id_source": item["primary_id_source"],
                     "idx": idx,
                     "error": repr(e),
                     "endpoint": endpoint,
@@ -526,7 +522,7 @@ async def main():
                     continue
 
                 uuid = row.get("uuid")
-                primary_id, primary_id_source = _primary_identifier(row)
+                primary_id = _primary_identifier(row)
                 if primary_id in seen_ids:
                     continue
 
@@ -535,7 +531,6 @@ async def main():
                         "idx": index,
                         "uuid": uuid,
                         "primary_id": primary_id,
-                        "primary_id_source": primary_id_source,
                         "turns": turns,
                     }
                 )

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import asyncio
+import hashlib
 import json
 import os
 import re
@@ -30,6 +31,9 @@ DATASET_CONFIGS = {
         "subset": "main",
     },
 }
+
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_RETRY_BACKOFF = 2.0
 
 
 def parse_args():
@@ -87,12 +91,30 @@ def parse_args():
     parser.add_argument(
         "--resume",
         action="store_true",
-        help="Skip rows already in outfile (by uuid or idx)",
+        help="Skip rows already in outfile (by stable primary id)",
     )
     parser.add_argument(
         "--language-filter",
         default=None,
         help="Only process rows where language==this (e.g., EN)",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=DEFAULT_MAX_RETRIES,
+        help=(
+            "Max retry attempts per request on transient failure "
+            f"(default: {DEFAULT_MAX_RETRIES})"
+        ),
+    )
+    parser.add_argument(
+        "--retry-backoff",
+        type=float,
+        default=DEFAULT_RETRY_BACKOFF,
+        help=(
+            "Initial retry backoff in seconds; doubles after each failed attempt "
+            f"(default: {DEFAULT_RETRY_BACKOFF})"
+        ),
     )
     return parser.parse_args()
 
@@ -141,9 +163,69 @@ def extract_turns(row, prompt_field):
     return []
 
 
-def load_seen(path: str):
-    """Load previously processed record IDs from output file."""
-    seen = set()
+def _is_present(value: Any) -> bool:
+    """Return True for a usable identifier (not None / not empty string)."""
+    return value is not None and str(value) != ""
+
+
+def _content_hash(row: dict[str, Any]) -> str:
+    """Deterministic hash of a row, used as a last-resort stable identifier."""
+    payload = json.dumps(row, sort_keys=True, ensure_ascii=False, default=str)
+    return "hash_" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _primary_identifier(row: dict[str, Any]) -> tuple[str, str]:
+    """Return a stable ``(id, source)`` for a dataset row.
+
+    Prefers an explicit ``id``/``uuid``, then a nested ``metadata`` id, and
+    finally a content hash. Unlike a streaming enumeration index, this key does
+    not shift when ``--limit``/``--language-filter`` or the input order change,
+    so ``--resume`` stays correct across runs.
+    """
+    for field in ("id", "uuid"):
+        value = row.get(field)
+        if _is_present(value):
+            return str(value), field
+
+    metadata = row.get("metadata")
+    if isinstance(metadata, dict):
+        for field in ("id", "uuid", "sample_id", "idx", "index"):
+            value = metadata.get(field)
+            if _is_present(value):
+                return str(value), f"metadata.{field}"
+
+    return _content_hash(row), "content_hash"
+
+
+def _output_seen_ids(obj: dict[str, Any]) -> set[str]:
+    """Extract resume keys from one previously written output row.
+
+    Prefers ``metadata.primary_id`` (written by this script); falls back to
+    legacy top-level ``id``/``uuid`` and nested metadata ids so output files
+    written before this change still resume for rows that carried a real id.
+    """
+    metadata = obj.get("metadata")
+    if isinstance(metadata, dict):
+        primary_id = metadata.get("primary_id")
+        if _is_present(primary_id):
+            return {str(primary_id)}
+
+    ids: set[str] = set()
+    for field in ("id", "uuid"):
+        value = obj.get(field)
+        if _is_present(value):
+            ids.add(str(value))
+    if isinstance(metadata, dict):
+        for field in ("id", "uuid", "sample_id", "idx", "index"):
+            value = metadata.get(field)
+            if _is_present(value):
+                ids.add(str(value))
+    return ids
+
+
+def load_seen(path: str) -> set[str]:
+    """Load previously processed primary IDs from output file."""
+    seen: set[str] = set()
     if not os.path.isfile(path):
         return seen
 
@@ -153,9 +235,7 @@ def load_seen(path: str):
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            key = obj.get("uuid") or obj.get("idx")
-            if key is not None:
-                seen.add(str(key))
+            seen.update(_output_seen_ids(obj))
     return seen
 
 
@@ -189,18 +269,39 @@ async def _post_chat(
     session: aiohttp.ClientSession,
     endpoint: str,
     payload: dict[str, Any],
+    *,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    retry_backoff: float = DEFAULT_RETRY_BACKOFF,
 ) -> dict[str, Any]:
     """POST one chat-completion request and return the parsed response.
 
     A non-2xx reply has no ``choices`` array, so raise with the status and a
     short body; otherwise the caller records a bare ``KeyError('choices')`` and
-    the real cause is lost.
+    the real cause is lost. Transient failures (network errors or non-2xx
+    replies) are retried up to ``max_retries`` times with exponential backoff;
+    the semaphore is released between attempts so a backing-off request does not
+    hold a concurrency slot.
     """
-    async with session.post(endpoint, json=payload) as response:
-        if not response.ok:
-            body = (await response.text())[:500]
-            raise RuntimeError(f"HTTP {response.status} from {endpoint}: {body}")
-        return await response.json()
+    total_attempts = max_retries + 1
+    last_error: Exception | None = None
+    for attempt in range(1, total_attempts + 1):
+        try:
+            async with session.post(endpoint, json=payload) as response:
+                if not response.ok:
+                    body = (await response.text())[:500]
+                    raise RuntimeError(
+                        f"HTTP {response.status} from {endpoint}: {body}"
+                    )
+                return await response.json()
+        except Exception as e:  # noqa: BLE001
+            last_error = e
+            if attempt >= total_attempts:
+                break
+            await asyncio.sleep(retry_backoff * (2 ** (attempt - 1)))
+
+    raise RuntimeError(
+        f"chat request failed after {total_attempts} attempt(s)"
+    ) from last_error
 
 
 async def worker(
@@ -251,7 +352,13 @@ async def worker(
                     "messages": prefix,
                     "max_tokens": args.max_tokens,
                 }
-                data = await _post_chat(session, endpoint, payload)
+                data = await _post_chat(
+                    session,
+                    endpoint,
+                    payload,
+                    max_retries=args.max_retries,
+                    retry_backoff=args.retry_backoff,
+                )
 
                 choice = data["choices"][0]
                 message = choice["message"]
@@ -277,6 +384,8 @@ async def worker(
                 out_convs.append(gpt_turn)
 
             metadata = {
+                "primary_id": item["primary_id"],
+                "primary_id_source": item["primary_id_source"],
                 "idx": idx,
                 "finish_reasons": finish_reasons,
                 "latency_s": round(time.time() - start_time, 3),
@@ -299,6 +408,8 @@ async def worker(
                 "id": item.get("uuid") or f"sample_{idx}",
                 "conversations": out_convs,
                 "metadata": {
+                    "primary_id": item["primary_id"],
+                    "primary_id_source": item["primary_id_source"],
                     "idx": idx,
                     "error": repr(e),
                     "endpoint": endpoint,
@@ -415,14 +526,16 @@ async def main():
                     continue
 
                 uuid = row.get("uuid")
-                key = str(uuid or index)
-                if key in seen_ids:
+                primary_id, primary_id_source = _primary_identifier(row)
+                if primary_id in seen_ids:
                     continue
 
                 await queue.put(
                     {
                         "idx": index,
                         "uuid": uuid,
+                        "primary_id": primary_id,
+                        "primary_id_source": primary_id_source,
                         "turns": turns,
                     }
                 )

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -13,6 +13,12 @@ import aiohttp
 from datasets import load_dataset
 from tqdm import tqdm
 
+from speculators.data_generation.vllm_client import (
+    DEFAULT_MAX_RETRIES,
+    InvalidResponseError,
+    with_retries,
+)
+
 DATASET_CONFIGS = {
     "magpie": {
         "id": "Magpie-Align/Magpie-Llama-3.1-Pro-300K-Filtered",
@@ -31,9 +37,6 @@ DATASET_CONFIGS = {
         "subset": "main",
     },
 }
-
-DEFAULT_MAX_RETRIES = 3
-DEFAULT_RETRY_BACKOFF = 2.0
 
 
 def parse_args():
@@ -107,20 +110,9 @@ def parse_args():
             f"(default: {DEFAULT_MAX_RETRIES})"
         ),
     )
-    parser.add_argument(
-        "--retry-backoff",
-        type=float,
-        default=DEFAULT_RETRY_BACKOFF,
-        help=(
-            "Initial retry backoff in seconds; doubles after each failed attempt "
-            f"(default: {DEFAULT_RETRY_BACKOFF})"
-        ),
-    )
     args = parser.parse_args()
     if args.max_retries < 0:
         parser.error("--max-retries must be >= 0")
-    if args.retry_backoff < 0:
-        parser.error("--retry-backoff must be >= 0")
     return args
 
 
@@ -249,57 +241,33 @@ SERVER_ERROR_STATUS = 500
 RETRYABLE_HTTP_STATUSES = {408, 409, 425, 429}
 
 
-class _NonRetryableChatError(RuntimeError):
-    """A non-2xx reply that should fail fast instead of being retried."""
-
-
 def _is_retryable_http_status(status: int) -> bool:
     return status >= SERVER_ERROR_STATUS or status in RETRYABLE_HTTP_STATUSES
 
 
+@with_retries
 async def _post_chat(
     session: aiohttp.ClientSession,
     endpoint: str,
     payload: dict[str, Any],
-    *,
-    max_retries: int = DEFAULT_MAX_RETRIES,
-    retry_backoff: float = DEFAULT_RETRY_BACKOFF,
 ) -> dict[str, Any]:
     """POST one chat-completion request and return the parsed response.
 
-    A non-2xx reply has no ``choices`` array, so raise with the status and a
-    short body; otherwise the caller records a bare ``KeyError('choices')`` and
-    the real cause is lost. Transient failures (network errors or transient
-    HTTP statuses) are retried up to ``max_retries`` times with exponential
-    backoff; a backing-off worker just sleeps without pulling new work, so it
-    does not block the other workers. Permanent non-2xx replies (e.g. 400/404)
-    fail fast without retrying.
+    Wrapped by ``with_retries`` (adds a ``max_retries`` kwarg): transient
+    failures — network errors and transient HTTP statuses (408/409/425/429/5xx)
+    — are retried with exponential backoff. Permanent non-2xx replies (e.g.
+    400/404) raise ``InvalidResponseError``, which ``with_retries`` never
+    retries, so they fail fast. A non-2xx reply is surfaced with its status and
+    a short body so the caller does not record a bare ``KeyError('choices')``.
     """
-    total_attempts = max_retries + 1
-    last_error: Exception | None = None
-    for attempt in range(1, total_attempts + 1):
-        try:
-            async with session.post(endpoint, json=payload) as response:
-                if not response.ok:
-                    body = (await response.text())[:500]
-                    error_cls = (
-                        RuntimeError
-                        if _is_retryable_http_status(response.status)
-                        else _NonRetryableChatError
-                    )
-                    raise error_cls(f"HTTP {response.status} from {endpoint}: {body}")
-                return await response.json()
-        except _NonRetryableChatError:
-            raise
-        except Exception as e:  # noqa: BLE001
-            last_error = e
-            if attempt >= total_attempts:
-                break
-            await asyncio.sleep(retry_backoff * (2 ** (attempt - 1)))
-
-    raise RuntimeError(
-        f"chat request failed after {total_attempts} attempt(s)"
-    ) from last_error
+    async with session.post(endpoint, json=payload) as response:
+        if not response.ok:
+            body = (await response.text())[:500]
+            message = f"HTTP {response.status} from {endpoint}: {body}"
+            if _is_retryable_http_status(response.status):
+                raise RuntimeError(message)
+            raise InvalidResponseError(message)
+        return await response.json()
 
 
 async def worker(
@@ -355,7 +323,6 @@ async def worker(
                     endpoint,
                     payload,
                     max_retries=args.max_retries,
-                    retry_backoff=args.retry_backoff,
                 )
 
                 choice = data["choices"][0]
@@ -391,7 +358,7 @@ async def worker(
             }
 
             output = {
-                "id": item.get("uuid") or f"sample_{idx}",
+                "id": item["primary_id"],
                 "conversations": out_convs,
                 "metadata": metadata,
             }
@@ -402,7 +369,7 @@ async def worker(
             # Failures go to a separate error file, not the training output; an
             # in-band marker would be invisible (the pipeline drops metadata).
             error_output = {
-                "id": item.get("uuid") or f"sample_{idx}",
+                "id": item["primary_id"],
                 "conversations": out_convs,
                 "metadata": {
                     "primary_id": item["primary_id"],
@@ -521,7 +488,6 @@ async def main():
                 if not turns:
                     continue
 
-                uuid = row.get("uuid")
                 primary_id = _primary_identifier(row)
                 if primary_id in seen_ids:
                     continue
@@ -529,7 +495,6 @@ async def main():
                 await queue.put(
                     {
                         "idx": index,
-                        "uuid": uuid,
                         "primary_id": primary_id,
                         "turns": turns,
                     }

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -162,7 +162,7 @@ def extract_turns(row, prompt_field):
 
 def _is_present(value: Any) -> bool:
     """Return True for a usable identifier (not None / not empty string)."""
-    return value is not None and str(value) != ""
+    return value not in (None, "")
 
 
 def _content_hash(row: dict[str, Any]) -> str:
@@ -187,10 +187,11 @@ def _primary_identifier(row: dict[str, Any]) -> str:
 
 
 def load_seen(path: str) -> set[str]:
-    """Load previously written ``metadata.primary_id`` values from the output.
+    """Load previously written output ids from the output file.
 
-    Resume is not back-compatible with pre-``primary_id`` outputs; since resume
-    never worked before this change, there are no such files to support.
+    Each record stores its stable id under the top-level ``id`` (equal to the
+    row's :func:`_primary_identifier`), so a resumed run skips a row when its
+    recomputed id is already present.
     """
     seen: set[str] = set()
     if not os.path.isfile(path):
@@ -202,9 +203,8 @@ def load_seen(path: str) -> set[str]:
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            metadata = obj.get("metadata")
-            if isinstance(metadata, dict) and _is_present(metadata.get("primary_id")):
-                seen.add(str(metadata["primary_id"]))
+            if _is_present(obj.get("id")):
+                seen.add(str(obj["id"]))
     return seen
 
 
@@ -241,10 +241,6 @@ SERVER_ERROR_STATUS = 500
 RETRYABLE_HTTP_STATUSES = {408, 409, 425, 429}
 
 
-def _is_retryable_http_status(status: int) -> bool:
-    return status >= SERVER_ERROR_STATUS or status in RETRYABLE_HTTP_STATUSES
-
-
 @with_retries
 async def _post_chat(
     session: aiohttp.ClientSession,
@@ -264,7 +260,11 @@ async def _post_chat(
         if not response.ok:
             body = (await response.text())[:500]
             message = f"HTTP {response.status} from {endpoint}: {body}"
-            if _is_retryable_http_status(response.status):
+            # Retry transient statuses (408/409/425/429/5xx); fail fast otherwise.
+            if (
+                response.status >= SERVER_ERROR_STATUS
+                or response.status in RETRYABLE_HTTP_STATUSES
+            ):
                 raise RuntimeError(message)
             raise InvalidResponseError(message)
         return await response.json()
@@ -349,7 +349,6 @@ async def worker(
                 out_convs.append(gpt_turn)
 
             metadata = {
-                "primary_id": item["primary_id"],
                 "idx": idx,
                 "finish_reasons": finish_reasons,
                 "latency_s": round(time.time() - start_time, 3),
@@ -372,7 +371,6 @@ async def worker(
                 "id": item["primary_id"],
                 "conversations": out_convs,
                 "metadata": {
-                    "primary_id": item["primary_id"],
                     "idx": idx,
                     "error": repr(e),
                     "endpoint": endpoint,

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -22,7 +22,17 @@ from pathlib import Path
 
 import pytest
 
+from speculators.data_generation import vllm_client
 from speculators.data_generation.preprocessing import _normalize_conversation
+from speculators.data_generation.vllm_client import InvalidResponseError
+
+
+@pytest.fixture(autouse=True)
+def _no_retry_backoff(monkeypatch):
+    # with_retries sleeps RETRY_BACKOFF_BASE ** attempt between retries; zero it
+    # so the retry tests don't actually sleep.
+    monkeypatch.setattr(vllm_client, "RETRY_BACKOFF_BASE", 0)
+
 
 _SCRIPT_PATH = (
     Path(__file__).resolve().parents[3]
@@ -378,7 +388,6 @@ def test_post_chat_retries_transient_failure_then_succeeds():
             "http://x/v1/chat/completions",
             {"model": "m"},
             max_retries=3,
-            retry_backoff=0,
         )
 
     assert asyncio.run(scenario()) == ok_payload
@@ -391,13 +400,12 @@ def test_post_chat_raises_after_exhausting_retries():
     )
 
     async def scenario():
-        with pytest.raises(RuntimeError, match="failed after 3 attempt"):
+        with pytest.raises(RuntimeError, match="HTTP 500"):
             await regen._post_chat(
                 session,
                 "http://x/v1/chat/completions",
                 {"model": "m"},
                 max_retries=2,
-                retry_backoff=0,
             )
 
     asyncio.run(scenario())
@@ -429,7 +437,6 @@ def test_post_chat_retries_on_network_error_then_succeeds():
             "http://x/v1/chat/completions",
             {"model": "m"},
             max_retries=1,
-            retry_backoff=0,
         )
 
     assert asyncio.run(scenario()) == ok_payload
@@ -437,19 +444,19 @@ def test_post_chat_retries_on_network_error_then_succeeds():
 
 
 def test_post_chat_fails_fast_on_permanent_status():
-    # A permanent (non-transient) status must not be retried: one attempt only.
+    # A permanent (non-transient) status raises InvalidResponseError, which
+    # with_retries never retries: one attempt only.
     session = _FakeSession(
         [_FakeResponse(ok=False, status=404, text="nope", payload={})]
     )
 
     async def scenario():
-        with pytest.raises(RuntimeError, match="HTTP 404"):
+        with pytest.raises(InvalidResponseError, match="HTTP 404"):
             await regen._post_chat(
                 session,
                 "http://x/v1/chat/completions",
                 {"model": "m"},
                 max_retries=3,
-                retry_backoff=0,
             )
 
     asyncio.run(scenario())

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -243,57 +243,46 @@ def test_emitted_conversation_survives_downstream_normalization():
 #
 # The prior resume keyed rows on ``uuid or idx`` (idx = streaming enumeration
 # index), which is unstable across --limit/--language-filter/order changes and
-# never matched the emitted output (which stores ``id`` + ``metadata.idx``, not
-# top-level ``uuid``/``idx``). These tests pin the stable key and the
-# input->output->resume round-trip.
+# never matched the emitted output (which stored ``id`` + ``metadata.idx``, not
+# top-level ``uuid``/``idx``). Resume now reads a single stable
+# ``metadata.primary_id`` written by the script.
 # ---------------------------------------------------------------------------
 
 
 def test_primary_identifier_prefers_explicit_id_over_uuid():
-    assert regen._primary_identifier({"id": "abc", "uuid": "zzz"}) == ("abc", "id")
+    assert regen._primary_identifier({"id": "abc", "uuid": "zzz"}) == "abc"
 
 
-def test_primary_identifier_uuid_then_nested_metadata():
-    assert regen._primary_identifier({"uuid": "u1"}) == ("u1", "uuid")
-    assert regen._primary_identifier({"metadata": {"sample_id": 7}}) == (
-        "7",
-        "metadata.sample_id",
-    )
+def test_primary_identifier_uuid_when_no_id():
+    assert regen._primary_identifier({"uuid": "u1"}) == "u1"
 
 
 def test_primary_identifier_ignores_empty_values():
     # An empty-string id is not "present"; resolution falls through to uuid.
-    assert regen._primary_identifier({"id": "", "uuid": "u"}) == ("u", "uuid")
+    assert regen._primary_identifier({"id": "", "uuid": "u"}) == "u"
 
 
-def test_primary_identifier_content_hash_is_stable_and_order_independent():
+def test_primary_identifier_falls_back_to_content_hash():
+    # No explicit id/uuid -> deterministic content hash. Nested metadata ids are
+    # intentionally not consulted (the inputs that need this have no id at all).
     row = {"question": "What is 6*7?", "answer": "42"}
     reordered = {"answer": "42", "question": "What is 6*7?"}
-    pid, source = regen._primary_identifier(row)
+    pid = regen._primary_identifier(row)
 
-    assert source == "content_hash"
     assert pid.startswith("hash_")
     # Same content, different key order -> same key (JSON is sorted).
-    assert regen._primary_identifier(reordered)[0] == pid
+    assert regen._primary_identifier(reordered) == pid
     # Different content -> different key.
-    assert regen._primary_identifier({"question": "other"})[0] != pid
-
-
-def test_output_seen_ids_prefers_primary_id():
-    obj = {"id": "legacy", "metadata": {"primary_id": "P", "idx": 5}}
-    assert regen._output_seen_ids(obj) == {"P"}
-
-
-def test_output_seen_ids_legacy_fallback_without_primary_id():
-    obj = {"id": "L", "metadata": {"idx": 5, "sample_id": "S"}}
-    assert regen._output_seen_ids(obj) == {"L", "5", "S"}
+    assert regen._primary_identifier({"question": "other"}) != pid
+    # A nested metadata id is not used as a source.
+    assert regen._primary_identifier({"metadata": {"sample_id": 7}}).startswith("hash_")
 
 
 def test_load_seen_missing_file_returns_empty(tmp_path):
     assert regen.load_seen(str(tmp_path / "nope.jsonl")) == set()
 
 
-def test_load_seen_skips_malformed_lines(tmp_path):
+def test_load_seen_reads_primary_id_and_skips_malformed_lines(tmp_path):
     out = tmp_path / "out.jsonl"
     out.write_text(
         "not json\n" + json.dumps({"metadata": {"primary_id": "P"}}) + "\n",
@@ -302,12 +291,23 @@ def test_load_seen_skips_malformed_lines(tmp_path):
     assert regen.load_seen(str(out)) == {"P"}
 
 
+def test_load_seen_ignores_rows_without_primary_id(tmp_path):
+    # Resume is not back-compatible with pre-primary_id outputs (it never worked
+    # before), so a row lacking metadata.primary_id contributes no resume key.
+    out = tmp_path / "out.jsonl"
+    out.write_text(
+        json.dumps({"id": "legacy", "metadata": {"idx": 3}}) + "\n",
+        encoding="utf-8",
+    )
+    assert regen.load_seen(str(out)) == set()
+
+
 def test_resume_roundtrip_hash_only_row(tmp_path):
     # A row with no explicit id resolves to a content hash; the written output
     # stores that hash as metadata.primary_id, and load_seen must recover it so
     # a re-run skips the row. This is the exact case the old resume missed.
     row = {"question": "What is 6*7?", "answer": "42"}
-    primary_id, primary_id_source = regen._primary_identifier(row)
+    primary_id = regen._primary_identifier(row)
 
     out = tmp_path / "out.jsonl"
     out.write_text(
@@ -315,11 +315,7 @@ def test_resume_roundtrip_hash_only_row(tmp_path):
             {
                 "id": "sample_0",
                 "conversations": [],
-                "metadata": {
-                    "primary_id": primary_id,
-                    "primary_id_source": primary_id_source,
-                    "idx": 0,
-                },
+                "metadata": {"primary_id": primary_id, "idx": 0},
             }
         )
         + "\n",
@@ -378,7 +374,6 @@ def test_post_chat_retries_transient_failure_then_succeeds():
 
     async def scenario():
         return await regen._post_chat(
-            asyncio.Semaphore(1),
             session,
             "http://x/v1/chat/completions",
             {"model": "m"},
@@ -398,7 +393,6 @@ def test_post_chat_raises_after_exhausting_retries():
     async def scenario():
         with pytest.raises(RuntimeError, match="failed after 3 attempt"):
             await regen._post_chat(
-                asyncio.Semaphore(1),
                 session,
                 "http://x/v1/chat/completions",
                 {"model": "m"},
@@ -408,3 +402,55 @@ def test_post_chat_raises_after_exhausting_retries():
 
     asyncio.run(scenario())
     assert session.calls == 3
+
+
+class _RaisingFakeResponse:
+    """A response whose context-manager entry raises (network-error path)."""
+
+    async def __aenter__(self):
+        raise ConnectionError("boom")
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def test_post_chat_retries_on_network_error_then_succeeds():
+    ok_payload = {"choices": [{"message": {"content": "hi"}}]}
+    session = _FakeSession(
+        [
+            _RaisingFakeResponse(),
+            _FakeResponse(ok=True, status=200, text="", payload=ok_payload),
+        ]
+    )
+
+    async def scenario():
+        return await regen._post_chat(
+            session,
+            "http://x/v1/chat/completions",
+            {"model": "m"},
+            max_retries=1,
+            retry_backoff=0,
+        )
+
+    assert asyncio.run(scenario()) == ok_payload
+    assert session.calls == 2
+
+
+def test_post_chat_fails_fast_on_permanent_status():
+    # A permanent (non-transient) status must not be retried: one attempt only.
+    session = _FakeSession(
+        [_FakeResponse(ok=False, status=404, text="nope", payload={})]
+    )
+
+    async def scenario():
+        with pytest.raises(RuntimeError, match="HTTP 404"):
+            await regen._post_chat(
+                session,
+                "http://x/v1/chat/completions",
+                {"model": "m"},
+                max_retries=3,
+                retry_backoff=0,
+            )
+
+    asyncio.run(scenario())
+    assert session.calls == 1

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -15,7 +15,9 @@ Two seams are covered with no network and no mocked HTTP:
 The script is not a package, so it is imported by path.
 """
 
+import asyncio
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -234,3 +236,175 @@ def test_emitted_conversation_survives_downstream_normalization():
         "reason:Hi",
         "reason:And goodbye",
     ]
+
+
+# ---------------------------------------------------------------------------
+# 3. Stable resume identity.
+#
+# The prior resume keyed rows on ``uuid or idx`` (idx = streaming enumeration
+# index), which is unstable across --limit/--language-filter/order changes and
+# never matched the emitted output (which stores ``id`` + ``metadata.idx``, not
+# top-level ``uuid``/``idx``). These tests pin the stable key and the
+# input->output->resume round-trip.
+# ---------------------------------------------------------------------------
+
+
+def test_primary_identifier_prefers_explicit_id_over_uuid():
+    assert regen._primary_identifier({"id": "abc", "uuid": "zzz"}) == ("abc", "id")
+
+
+def test_primary_identifier_uuid_then_nested_metadata():
+    assert regen._primary_identifier({"uuid": "u1"}) == ("u1", "uuid")
+    assert regen._primary_identifier({"metadata": {"sample_id": 7}}) == (
+        "7",
+        "metadata.sample_id",
+    )
+
+
+def test_primary_identifier_ignores_empty_values():
+    # An empty-string id is not "present"; resolution falls through to uuid.
+    assert regen._primary_identifier({"id": "", "uuid": "u"}) == ("u", "uuid")
+
+
+def test_primary_identifier_content_hash_is_stable_and_order_independent():
+    row = {"question": "What is 6*7?", "answer": "42"}
+    reordered = {"answer": "42", "question": "What is 6*7?"}
+    pid, source = regen._primary_identifier(row)
+
+    assert source == "content_hash"
+    assert pid.startswith("hash_")
+    # Same content, different key order -> same key (JSON is sorted).
+    assert regen._primary_identifier(reordered)[0] == pid
+    # Different content -> different key.
+    assert regen._primary_identifier({"question": "other"})[0] != pid
+
+
+def test_output_seen_ids_prefers_primary_id():
+    obj = {"id": "legacy", "metadata": {"primary_id": "P", "idx": 5}}
+    assert regen._output_seen_ids(obj) == {"P"}
+
+
+def test_output_seen_ids_legacy_fallback_without_primary_id():
+    obj = {"id": "L", "metadata": {"idx": 5, "sample_id": "S"}}
+    assert regen._output_seen_ids(obj) == {"L", "5", "S"}
+
+
+def test_load_seen_missing_file_returns_empty(tmp_path):
+    assert regen.load_seen(str(tmp_path / "nope.jsonl")) == set()
+
+
+def test_load_seen_skips_malformed_lines(tmp_path):
+    out = tmp_path / "out.jsonl"
+    out.write_text(
+        "not json\n" + json.dumps({"metadata": {"primary_id": "P"}}) + "\n",
+        encoding="utf-8",
+    )
+    assert regen.load_seen(str(out)) == {"P"}
+
+
+def test_resume_roundtrip_hash_only_row(tmp_path):
+    # A row with no explicit id resolves to a content hash; the written output
+    # stores that hash as metadata.primary_id, and load_seen must recover it so
+    # a re-run skips the row. This is the exact case the old resume missed.
+    row = {"question": "What is 6*7?", "answer": "42"}
+    primary_id, primary_id_source = regen._primary_identifier(row)
+
+    out = tmp_path / "out.jsonl"
+    out.write_text(
+        json.dumps(
+            {
+                "id": "sample_0",
+                "conversations": [],
+                "metadata": {
+                    "primary_id": primary_id,
+                    "primary_id_source": primary_id_source,
+                    "idx": 0,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert primary_id in regen.load_seen(str(out))
+
+
+# ---------------------------------------------------------------------------
+# 4. Retry / backoff around a single request.
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, *, ok, status, text, payload):
+        self.ok = ok
+        self.status = status
+        self._text = text
+        self._payload = payload
+
+    async def text(self):
+        return self._text
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    """Minimal aiohttp.ClientSession stand-in: hands out queued responses."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def post(self, endpoint, json):
+        self.calls += 1
+        return self._responses.pop(0)
+
+
+def test_post_chat_retries_transient_failure_then_succeeds():
+    ok_payload = {"choices": [{"message": {"content": "hi"}}]}
+    session = _FakeSession(
+        [
+            _FakeResponse(ok=False, status=503, text="busy", payload={}),
+            _FakeResponse(ok=False, status=503, text="busy", payload={}),
+            _FakeResponse(ok=True, status=200, text="", payload=ok_payload),
+        ]
+    )
+
+    async def scenario():
+        return await regen._post_chat(
+            asyncio.Semaphore(1),
+            session,
+            "http://x/v1/chat/completions",
+            {"model": "m"},
+            max_retries=3,
+            retry_backoff=0,
+        )
+
+    assert asyncio.run(scenario()) == ok_payload
+    assert session.calls == 3
+
+
+def test_post_chat_raises_after_exhausting_retries():
+    session = _FakeSession(
+        [_FakeResponse(ok=False, status=500, text="err", payload={}) for _ in range(3)]
+    )
+
+    async def scenario():
+        with pytest.raises(RuntimeError, match="failed after 3 attempt"):
+            await regen._post_chat(
+                asyncio.Semaphore(1),
+                session,
+                "http://x/v1/chat/completions",
+                {"model": "m"},
+                max_retries=2,
+                retry_backoff=0,
+            )
+
+    asyncio.run(scenario())
+    assert session.calls == 3

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -292,21 +292,20 @@ def test_load_seen_missing_file_returns_empty(tmp_path):
     assert regen.load_seen(str(tmp_path / "nope.jsonl")) == set()
 
 
-def test_load_seen_reads_primary_id_and_skips_malformed_lines(tmp_path):
+def test_load_seen_reads_id_and_skips_malformed_lines(tmp_path):
     out = tmp_path / "out.jsonl"
     out.write_text(
-        "not json\n" + json.dumps({"metadata": {"primary_id": "P"}}) + "\n",
+        "not json\n" + json.dumps({"id": "P"}) + "\n",
         encoding="utf-8",
     )
     assert regen.load_seen(str(out)) == {"P"}
 
 
-def test_load_seen_ignores_rows_without_primary_id(tmp_path):
-    # Resume is not back-compatible with pre-primary_id outputs (it never worked
-    # before), so a row lacking metadata.primary_id contributes no resume key.
+def test_load_seen_ignores_rows_without_id(tmp_path):
+    # A record without a top-level id contributes no resume key.
     out = tmp_path / "out.jsonl"
     out.write_text(
-        json.dumps({"id": "legacy", "metadata": {"idx": 3}}) + "\n",
+        json.dumps({"conversations": [], "metadata": {"idx": 3}}) + "\n",
         encoding="utf-8",
     )
     assert regen.load_seen(str(out)) == set()
@@ -314,8 +313,8 @@ def test_load_seen_ignores_rows_without_primary_id(tmp_path):
 
 def test_resume_roundtrip_hash_only_row(tmp_path):
     # A row with no explicit id resolves to a content hash; the written output
-    # stores that hash as metadata.primary_id, and load_seen must recover it so
-    # a re-run skips the row. This is the exact case the old resume missed.
+    # stores that hash as the top-level id, and load_seen must recover it so a
+    # re-run skips the row. This is the exact case the old resume missed.
     row = {"question": "What is 6*7?", "answer": "42"}
     primary_id = regen._primary_identifier(row)
 
@@ -323,9 +322,9 @@ def test_resume_roundtrip_hash_only_row(tmp_path):
     out.write_text(
         json.dumps(
             {
-                "id": "sample_0",
+                "id": primary_id,
                 "conversations": [],
-                "metadata": {"primary_id": primary_id, "idx": 0},
+                "metadata": {"idx": 0},
             }
         )
         + "\n",
@@ -410,37 +409,6 @@ def test_post_chat_raises_after_exhausting_retries():
 
     asyncio.run(scenario())
     assert session.calls == 3
-
-
-class _RaisingFakeResponse:
-    """A response whose context-manager entry raises (network-error path)."""
-
-    async def __aenter__(self):
-        raise ConnectionError("boom")
-
-    async def __aexit__(self, *exc):
-        return False
-
-
-def test_post_chat_retries_on_network_error_then_succeeds():
-    ok_payload = {"choices": [{"message": {"content": "hi"}}]}
-    session = _FakeSession(
-        [
-            _RaisingFakeResponse(),
-            _FakeResponse(ok=True, status=200, text="", payload=ok_payload),
-        ]
-    )
-
-    async def scenario():
-        return await regen._post_chat(
-            session,
-            "http://x/v1/chat/completions",
-            {"model": "m"},
-            max_retries=1,
-        )
-
-    assert asyncio.run(scenario()) == ok_payload
-    assert session.calls == 2
 
 
 def test_post_chat_fails_fast_on_permanent_status():


### PR DESCRIPTION
Follow-up to #693 (multi-turn response regeneration). This is the resume/robustness
hardening from the RFC #584 discussion.

cc @shanjiaz — flagging you here since this is the follow-up you signed off on.

## Why

`--resume` currently never skips anything. `load_seen` keys on top-level `uuid`/`idx`,
but the writer emits `id` + `metadata.idx` (no top-level `uuid`/`idx`), so `seen_ids`
is always empty and a resumed run reprocesses every row. Even a corrected index-based
key would be unstable: the streaming enumeration index shifts whenever
`--limit`, `--language-filter`, or the input order changes, so it can't safely
identify a row across runs.

Separately, a single transient HTTP/network hiccup sends the whole conversation to
the error file, which is costly on long runs against a busy vLLM server.

## What

- **Stable resume identity.** Resolve a per-row primary id (`id`/`uuid` →
  nested `metadata` id → deterministic content hash), persist it as
  `metadata.primary_id`, and resume against it. Legacy output files still resume
  for rows that carried a real id.
- **Request retries.** Retry transient failures with exponential backoff
  (`--max-retries`, default 3; `--retry-backoff`, default 2.0s), releasing the
  concurrency slot while backing off, instead of failing the conversation on the
  first error.

Both changes preserve #693's behavior.

