### PR TITLE
Add mistral training support

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -218,7 +218,8 @@ def create_transformer_layer_config(  # noqa: C901
                 )
                 rope_params.pop("type", None)
                 rope_params.pop("mrope_interleaved", None)
-                rope_params.pop("partial_rotary_factor", None)
+                if "mrope_section" not in rope_params:
+                    rope_params.pop("partial_rotary_factor", None)
             config.rope_parameters = rope_params
     else:
         if hasattr(verifier_config, "rope_scaling"):
@@ -229,7 +230,8 @@ def create_transformer_layer_config(  # noqa: C901
                 )
                 rope_scaling.pop("type", None)
                 rope_scaling.pop("mrope_interleaved", None)
-                rope_scaling.pop("partial_rotary_factor", None)
+                if "mrope_section" not in rope_scaling:
+                    rope_scaling.pop("partial_rotary_factor", None)
             config.rope_scaling = rope_scaling
         config.rope_theta = getattr(verifier_config, "rope_theta", 10000.0)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -216,11 +216,9 @@ def create_transformer_layer_config(  # noqa: C901
                 _maybe_apply_mrope_full_head_hack(
                     rope_params, resolved_head_dim, mrope_full_head_hack
                 )
-                # ``type`` is a legacy alias (only "mrope" on VL models) that
-                # transformers strips during validation and that breaks vLLM's
-                # config checks; drop it while keeping the real MRoPE fields.
                 rope_params.pop("type", None)
                 rope_params.pop("mrope_interleaved", None)
+                rope_params.pop("partial_rotary_factor", None)
             config.rope_parameters = rope_params
     else:
         if hasattr(verifier_config, "rope_scaling"):
@@ -229,9 +227,9 @@ def create_transformer_layer_config(  # noqa: C901
                 _maybe_apply_mrope_full_head_hack(
                     rope_scaling, resolved_head_dim, mrope_full_head_hack
                 )
-                # Strip legacy fields for consistency with rope_parameters path
                 rope_scaling.pop("type", None)
                 rope_scaling.pop("mrope_interleaved", None)
+                rope_scaling.pop("partial_rotary_factor", None)
             config.rope_scaling = rope_scaling
         config.rope_theta = getattr(verifier_config, "rope_theta", 10000.0)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -216,8 +216,14 @@ def create_transformer_layer_config(  # noqa: C901
                 _maybe_apply_mrope_full_head_hack(
                     rope_params, resolved_head_dim, mrope_full_head_hack
                 )
+                # ``type`` is a legacy alias (only "mrope" on VL models) that
+                # transformers strips during validation and that breaks vLLM's
+                # config checks; drop it while keeping the real MRoPE fields.
                 rope_params.pop("type", None)
                 rope_params.pop("mrope_interleaved", None)
+                # The verifier (e.g. Mistral) may use partial rotary embeddings,
+                # but the draft model doesn't support partial_rotary_factor.
+                # Only keep it for MRoPE configs that need it.
                 if "mrope_section" not in rope_params:
                     rope_params.pop("partial_rotary_factor", None)
             config.rope_parameters = rope_params
@@ -228,8 +234,10 @@ def create_transformer_layer_config(  # noqa: C901
                 _maybe_apply_mrope_full_head_hack(
                     rope_scaling, resolved_head_dim, mrope_full_head_hack
                 )
+                # Strip legacy fields for consistency with rope_parameters path
                 rope_scaling.pop("type", None)
                 rope_scaling.pop("mrope_interleaved", None)
+                # Same partial_rotary_factor guard as the rope_parameters path.
                 if "mrope_section" not in rope_scaling:
                     rope_scaling.pop("partial_rotary_factor", None)
             config.rope_scaling = rope_scaling

--- a/src/speculators/data_generation/vllm_client.py
+++ b/src/speculators/data_generation/vllm_client.py
@@ -200,7 +200,11 @@ async def generate_hidden_states_async(
             model=model,
             messages=messages,
             max_tokens=1,
-            extra_body={"add_generation_prompt": False, "return_token_ids": True},
+            extra_body={
+                "add_generation_prompt": False,
+                "continue_final_message": True,
+                "return_token_ids": True,
+            },
             timeout=timeout,
         )
 
@@ -242,7 +246,11 @@ def generate_hidden_states(
             model=model,
             messages=messages,
             max_tokens=1,
-            extra_body={"add_generation_prompt": False, "return_token_ids": True},
+            extra_body={
+                "add_generation_prompt": False,
+                "continue_final_message": True,
+                "return_token_ids": True,
+            },
             timeout=timeout,
         )
 

--- a/src/speculators/utils/loading.py
+++ b/src/speculators/utils/loading.py
@@ -8,6 +8,23 @@ from huggingface_hub.errors import EntryNotFoundError
 from loguru import logger
 from safetensors import safe_open
 
+_WEIGHT_ALIASES: dict[str, list[str]] = {
+    "embed_tokens.weight": ["tok_embeddings.weight"],
+    "lm_head.weight": ["output.weight"],
+    "model.norm.weight": ["norm.weight"],
+}
+
+
+def _resolve_key(name: str, weight_map: dict[str, str]) -> str | None:
+    """Try exact match, then suffix match, then known aliases."""
+    for candidate in [name, *_WEIGHT_ALIASES.get(name, [])]:
+        if candidate in weight_map:
+            return candidate
+        matched = next((k for k in weight_map if k.endswith(candidate)), None)
+        if matched:
+            return matched
+    return None
+
 
 def is_config_only_dir(path: str | Path) -> bool:
     """Return True if ``path`` is a local directory with a ``config.json`` but no
@@ -91,17 +108,14 @@ def load_model_layers(
         with safe_open(model_file, framework="pt", device="cpu") as f:
             weight_map = dict.fromkeys(f.keys(), "model.safetensors")
 
-    # Resolve names: try exact match first, then suffix match
+    # Resolve names: try exact match, then suffix match, then known aliases
     name_to_key = {}  # Maps input name to actual checkpoint key
     for name in layer_names:
-        if name in weight_map:
-            name_to_key[name] = name
+        key = _resolve_key(name, weight_map)
+        if key:
+            name_to_key[name] = key
         else:
-            matched = next((k for k in weight_map if k.endswith(name)), None)
-            if matched:
-                name_to_key[name] = matched
-            else:
-                logger.warning(f"Tensor '{name}' not found in weight_map.")
+            logger.warning(f"Tensor '{name}' not found in weight_map.")
 
     # group requested names by shard filename
     shard_to_names: dict[str, list[tuple[str, str]]] = {}

--- a/tests/unit/utils/test_loading.py
+++ b/tests/unit/utils/test_loading.py
@@ -8,6 +8,7 @@ from transformers import AutoModelForCausalLM
 
 from speculators.utils.loading import (
     _resolve_file,
+    _resolve_key,
     is_config_only_dir,
     load_model_layers,
 )
@@ -54,6 +55,67 @@ def test_is_config_only_dir_detects_sharded_index(tmp_path, index_file):
     (tmp_path / index_file).write_text("{}")
 
     assert is_config_only_dir(tmp_path) is False
+
+
+# _resolve_key Tests
+
+
+FAKE_WEIGHT_MAP = {
+    "model.embed_tokens.weight": "shard-0.safetensors",
+    "model.layers.0.self_attn.q_proj.weight": "shard-0.safetensors",
+    "tok_embeddings.weight": "shard-1.safetensors",
+    "output.weight": "shard-1.safetensors",
+    "norm.weight": "shard-1.safetensors",
+}
+
+
+@pytest.mark.smoke
+def test_resolve_key_exact_match():
+    assert _resolve_key("model.embed_tokens.weight", FAKE_WEIGHT_MAP) == (
+        "model.embed_tokens.weight"
+    )
+
+
+@pytest.mark.smoke
+def test_resolve_key_suffix_match():
+    assert _resolve_key("self_attn.q_proj.weight", FAKE_WEIGHT_MAP) == (
+        "model.layers.0.self_attn.q_proj.weight"
+    )
+
+
+@pytest.mark.smoke
+def test_resolve_key_alias_exact():
+    wm = {"tok_embeddings.weight": "shard.safetensors"}
+    assert _resolve_key("embed_tokens.weight", wm) == "tok_embeddings.weight"
+
+
+@pytest.mark.smoke
+def test_resolve_key_alias_suffix():
+    wm = {"model.tok_embeddings.weight": "shard.safetensors"}
+    assert _resolve_key("embed_tokens.weight", wm) == "model.tok_embeddings.weight"
+
+
+@pytest.mark.smoke
+def test_resolve_key_all_aliases():
+    wm_lm = {"output.weight": "s.safetensors"}
+    assert _resolve_key("lm_head.weight", wm_lm) == "output.weight"
+
+    wm_norm = {"norm.weight": "s.safetensors"}
+    assert _resolve_key("model.norm.weight", wm_norm) == "norm.weight"
+
+
+@pytest.mark.smoke
+def test_resolve_key_miss():
+    assert _resolve_key("nonexistent.weight", FAKE_WEIGHT_MAP) is None
+
+
+@pytest.mark.smoke
+def test_resolve_key_prefers_exact_over_alias():
+    wm = {
+        "embed_tokens.weight": "shard-0.safetensors",
+        "tok_embeddings.weight": "shard-1.safetensors",
+    }
+    assert _resolve_key("embed_tokens.weight", wm) == "embed_tokens.weight"
 
 
 # _resolve_file Tests


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
Added support for Mistral styled checkpoints. Three changes:
- mrope fix: Mistral uses partial rotary embeddings, and it's in the verifier's rope config. When creating the draft model's transformer layer config, we copy the verifier's rope parameters. But the draft model doesn't support partial_rotary_factor. Pop it so we get the correct rope config.
- hidden states generation: Adds continue_final_message: True to the chat completions path used for multimodal hidden state extraction. Without it, Mistral's chat template appends a spurious EOS token, causing a token ID mismatch with the preprocessed input_ids. This is now the default. Text-only models are unaffected, they go through the Completions API with pre-tokenized IDs and bypass chat templates entirely.
- weight loading: adds weight name aliases (tok_embeddings.weight → embed_tokens.weight, etc.) so Mistral's non-standard naming resolves correctly. If we end up supporting more models with non-traditional names we might need a model-free pathway like llm-compressor does.

## Tests
see trained model [evaluation](https://docs.google.com/spreadsheets/d/15NqjQrkOJxQbqKZZZRKli8A2sJHWU6QEmlrmOt6xnS8/edit?gid=0#gid=0)

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
