### PR TITLE
feat: add --normalize-loss-by-decay for decay-weighted loss normalization

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -961,6 +961,14 @@ def parse_args():
         default=4.0,
         help="Decay gamma for DFlash/DSpark loss weighting (default: 4.0)",
     )
+    parser.add_argument(
+        "--normalize-loss-by-decay",
+        action="store_true",
+        default=False,
+        help="Normalize loss by sum of decay weights instead of token count. "
+        "Produces a proper weighted average, stabilizing loss magnitude "
+        "across different gamma values (default: False).",
+    )
     # DSpark-specific arguments (sequential Markov head + confidence head).
     parser.add_argument(
         "--markov-rank",

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -207,10 +207,12 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         loss_config = resolve_loss_config(kwargs["loss_fn"])
         gamma = kwargs.get("dflash_decay_gamma", 4.0)
         max_anchors = kwargs.get("max_anchors", 3072)
+        normalize_by_decay = kwargs.get("normalize_loss_by_decay", False)
         shared = {
             "loss_config": loss_config,
             "gamma": gamma,
             "max_anchors": max_anchors,
+            "normalize_by_decay": normalize_by_decay,
         }
         return dict(shared), dict(shared)
 
@@ -393,6 +395,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         loss_config: LossConfig | None = None,
         gamma: float = 4.0,
         max_anchors: int = 3072,
+        normalize_by_decay: bool = False,
         **kwargs,
     ):
         _, logits, targets, aligned_loss_mask, _ = self._backbone_forward(
@@ -412,6 +415,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             self.block_size,
             gamma=gamma,
             loss_config=loss_config,
+            normalize_by_decay=normalize_by_decay,
         )
         draft_tokens = torch.argmax(logits, dim=-1)
 

--- a/src/speculators/models/dflash/metrics.py
+++ b/src/speculators/models/dflash/metrics.py
@@ -23,6 +23,7 @@ def compute_metrics(
     block_size: int = 1,
     gamma: float = 4.0,
     loss_config: LossConfig | None = None,
+    normalize_by_decay: bool = False,
 ) -> tuple[torch.Tensor, dict]:
     """Compute loss and accuracy metrics for draft model predictions.
 
@@ -53,6 +54,7 @@ def compute_metrics(
         pos_idx,
         loss_config=loss_config,
         decay_fn=partial(dflash_loss_decay, gamma=gamma),
+        normalize_by_decay=normalize_by_decay,
     )
 
     pred_ids = torch.argmax(logits, dim=-1)

--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -84,11 +84,13 @@ class DSparkDraftModel(DFlashDraftModel):
         gamma = kwargs.get("dflash_decay_gamma", 4.0)
         max_anchors = kwargs.get("max_anchors", 3072)
         confidence_head_alpha = kwargs.get("confidence_head_alpha", 1.0)
+        normalize_by_decay = kwargs.get("normalize_loss_by_decay", False)
         shared = {
             "loss_config": loss_config,
             "gamma": gamma,
             "max_anchors": max_anchors,
             "confidence_head_alpha": confidence_head_alpha,
+            "normalize_by_decay": normalize_by_decay,
         }
         return dict(shared), dict(shared)
 
@@ -105,6 +107,7 @@ class DSparkDraftModel(DFlashDraftModel):
         gamma: float = 4.0,
         max_anchors: int = 3072,
         confidence_head_alpha: float = 1.0,
+        normalize_by_decay: bool = False,
         **kwargs,
     ):
         hidden, logits, targets, aligned_loss_mask, anchored_block_indices = (
@@ -167,6 +170,7 @@ class DSparkDraftModel(DFlashDraftModel):
             loss_config=loss_config or _DEFAULT_LOSS_CONFIG,
             gamma=gamma,
             confidence_head_alpha=confidence_head_alpha,
+            normalize_by_decay=normalize_by_decay,
         )
         draft_tokens = torch.argmax(logits, dim=-1)
         return draft_tokens, loss, metrics

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -32,13 +32,20 @@ def _masked_decayed_mean(
     loss_mask: torch.Tensor,  # [1, T]
     pos_idx: torch.Tensor,  # [1, T]
     decay_fn: Callable[[torch.Tensor], torch.Tensor] | None,
+    normalize_by_decay: bool = False,
 ) -> torch.Tensor:
     """Masked, optionally position-decayed mean of a precomputed per-position term."""
     loss_mask = loss_mask.to(elementwise.dtype)
     weighted = elementwise * loss_mask
     if decay_fn is not None:
-        weighted = weighted * decay_fn(pos_idx.to(weighted.dtype))
-    denominator = loss_mask.sum(dim=1) + _EPS
+        decay_mult = decay_fn(pos_idx.to(weighted.dtype))
+        weighted = weighted * decay_mult
+        if normalize_by_decay:
+            denominator = (loss_mask * decay_mult).sum(dim=1) + _EPS
+        else:
+            denominator = loss_mask.sum(dim=1) + _EPS
+    else:
+        denominator = loss_mask.sum(dim=1) + _EPS
     return (weighted.sum(dim=1) / denominator).mean()
 
 
@@ -51,6 +58,7 @@ def compute_metrics(
     loss_config: LossConfig,
     gamma: float = 4.0,
     confidence_head_alpha: float = 1.0,
+    normalize_by_decay: bool = False,
 ) -> tuple[torch.Tensor, dict]:
     """Compute the DSpark loss and a metrics dict (``*_sum``/``*_total`` pairs)."""
 
@@ -60,7 +68,13 @@ def compute_metrics(
     decay_fn = partial(dflash_loss_decay, gamma=gamma)
 
     loss, term_losses = compound_loss(
-        logits, targets, loss_mask, pos_idx, loss_config=loss_config, decay_fn=decay_fn
+        logits,
+        targets,
+        loss_mask,
+        pos_idx,
+        loss_config=loss_config,
+        decay_fn=decay_fn,
+        normalize_by_decay=normalize_by_decay,
     )
 
     # Analytical per-position acceptance rate = distributional overlap.
@@ -81,7 +95,9 @@ def compute_metrics(
         bce = binary_cross_entropy_with_logits(
             confidence_logits, c_star, reduction="none"
         )  # [1, T]
-        conf_loss = _masked_decayed_mean(bce, loss_mask, pos_idx, decay_fn)
+        conf_loss = _masked_decayed_mean(
+            bce, loss_mask, pos_idx, decay_fn, normalize_by_decay=normalize_by_decay
+        )
         loss = loss + confidence_head_alpha * conf_loss
 
         with torch.no_grad():

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -361,6 +361,7 @@ def compound_loss(
     pos_idx: torch.Tensor,
     loss_config: LossConfig,
     decay_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
+    normalize_by_decay: bool = False,
 ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
     """Compute a weighted sum of loss terms.
 
@@ -377,7 +378,13 @@ def compound_loss(
     multi = len(loss_config) > 1
     for name, (fn, weight) in loss_config.items():
         term = loss_function(
-            logits, targets, loss_mask, pos_idx, loss_fn=fn, decay_fn=decay_fn
+            logits,
+            targets,
+            loss_mask,
+            pos_idx,
+            loss_fn=fn,
+            decay_fn=decay_fn,
+            normalize_by_decay=normalize_by_decay,
         )
         if multi:
             term_losses[f"{name}_loss"] = term.detach()
@@ -392,6 +399,7 @@ def loss_function(
     pos_idx: torch.Tensor,  # shape: [1, seq_len]
     loss_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] = kl_div_loss,
     decay_fn: Callable[[torch.Tensor], torch.Tensor] | None = None,
+    normalize_by_decay: bool = False,
 ):
     """Compute masked, optionally position-decayed training loss.
 
@@ -402,6 +410,8 @@ def loss_function(
         pos_idx: Position indices within each speculative block.
         loss_fn: Per-position loss function (default: kl_div_loss).
         decay_fn: Optional position-dependent decay weighting function.
+        normalize_by_decay: When True and decay_fn is provided, divide by the
+            sum of decay weights instead of the token count.
 
     Returns:
         Scalar mean loss across the batch.
@@ -414,8 +424,12 @@ def loss_function(
     if decay_fn is not None:
         decay_mult = decay_fn(pos_idx.to(elementwise_loss.dtype))
         elementwise_loss = elementwise_loss * decay_mult
-
-    denominator = loss_mask.sum(dim=1) + _EPS
+        if normalize_by_decay:
+            denominator = (loss_mask * decay_mult).sum(dim=1) + _EPS
+        else:
+            denominator = loss_mask.sum(dim=1) + _EPS
+    else:
+        denominator = loss_mask.sum(dim=1) + _EPS
 
     batch_loss = torch.sum(elementwise_loss, dim=1) / denominator  # shape: [1]
     return batch_loss.mean()  # shape: []

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -81,6 +81,66 @@ class TestLossFunction:
         expected = (elementwise * loss_mask).sum() / (loss_mask.sum() + 1e-5)
         assert torch.isclose(result, expected)
 
+    def test_normalize_by_decay_changes_denominator(self):
+        """With non-uniform decay, normalize_by_decay must produce different loss."""
+        torch.manual_seed(42)
+        B, T, V = 1, 8, 4
+        logits = torch.randn(B, T, V)
+        targets = torch.randn(B, T, V)
+        loss_mask = torch.ones(B, T)
+        pos_idx = torch.arange(T).unsqueeze(0) % 4
+
+        decay_fn = partial(dflash_loss_decay, gamma=4.0)
+
+        loss_default = loss_function(
+            logits, targets, loss_mask, pos_idx,
+            decay_fn=decay_fn, normalize_by_decay=False,
+        )
+        loss_normalized = loss_function(
+            logits, targets, loss_mask, pos_idx,
+            decay_fn=decay_fn, normalize_by_decay=True,
+        )
+        assert not torch.isclose(loss_default, loss_normalized)
+
+    def test_normalize_by_decay_no_decay_fn_ignored(self):
+        """When decay_fn is None, normalize_by_decay has no effect."""
+        torch.manual_seed(42)
+        logits = torch.randn(1, 8, 4)
+        targets = torch.randn(1, 8, 4)
+        loss_mask = torch.ones(1, 8)
+        pos_idx = torch.zeros(1, 8, dtype=torch.long)
+
+        loss_off = loss_function(
+            logits, targets, loss_mask, pos_idx,
+            decay_fn=None, normalize_by_decay=False,
+        )
+        loss_on = loss_function(
+            logits, targets, loss_mask, pos_idx,
+            decay_fn=None, normalize_by_decay=True,
+        )
+        assert torch.isclose(loss_off, loss_on)
+
+    def test_normalize_by_decay_matches_manual_computation(self):
+        """Verify normalize_by_decay produces sum(loss*decay) / sum(decay)."""
+        torch.manual_seed(7)
+        logits = torch.randn(1, 4, 6)
+        targets = torch.randn(1, 4, 6)
+        loss_mask = torch.tensor([[1, 1, 1, 1]], dtype=torch.float)
+        pos_idx = torch.tensor([[0, 1, 2, 3]])
+
+        decay_fn = partial(exp_loss_decay, gamma=0.5)
+        result = loss_function(
+            logits, targets, loss_mask, pos_idx,
+            loss_fn=kl_div_loss, decay_fn=decay_fn, normalize_by_decay=True,
+        )
+
+        elementwise = kl_div_loss(logits, targets)
+        decay_mult = exp_loss_decay(pos_idx.float(), gamma=0.5)
+        expected = (elementwise * loss_mask * decay_mult).sum() / (
+            (loss_mask * decay_mult).sum() + 1e-5
+        )
+        assert torch.isclose(result, expected, rtol=1e-4)
+
 
 class TestKLDivLoss:
     def test_identical_zero_and_random_nonnegative(self):


### PR DESCRIPTION
## Summary

- Adds `--normalize-loss-by-decay` flag to normalize the training loss by the sum of decay weights instead of the token count
- Produces a proper weighted average, stabilizing loss magnitude across different gamma values
- Matches SGLang's DFlash loss normalization approach
- Threaded through DFlash and DSpark `compound_loss`/`loss_function` primitives
- Default is `False` — no behavior change for existing training runs

## Details

Currently the loss denominator divides by `loss_mask.sum()` (token count). With `--normalize-loss-by-decay`, it divides by `(loss_mask * decay_mult).sum()` (sum of decay weights). This makes the loss a proper weighted average rather than a scaled-then-averaged quantity, which stabilizes the effective learning rate when tuning gamma.

## Test plan

- [x] Unit tests for `loss_function` with `normalize_by_decay=True/False`
- [x] Verify `normalize_by_decay=True` changes the denominator with non-uniform decay
- [x] Verify no effect when `decay_fn=None`
- [x] Verify manual computation matches implementation
- [x] Existing DFlash and DSpark metrics tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)