### PR TITLE
Recommend on-policy (regenerated) data as training default

### DIFF
--- a/docs/user_guide/tutorials/response_regeneration.md
+++ b/docs/user_guide/tutorials/response_regeneration.md
@@ -143,7 +143,7 @@ python scripts/response_regeneration/script.py --dataset ultrachat
 
 After regenerating your dataset:
 
-1. **Train a speculator** - See [Train Eagle-3 Online](train_eagle3_online.md) or [Train Eagle-3 Offline](train_eagle3_offline.md). For Eagle-3, pass `--use-off-policy-tokens` to the trainer when using regenerated data (other architectures ignore this flag).
+1. **Train a speculator** - See [Train Eagle-3 Online](train_eagle3_online.md) or [Train Eagle-3 Offline](train_eagle3_offline.md).
 2. **Evaluate performance** - See [Evaluating Performance](evaluating_performance.md)
 3. **Deploy to production** - See [Serve in vLLM](serve_vllm.md)
 

--- a/docs/user_guide/tutorials/response_regeneration.md
+++ b/docs/user_guide/tutorials/response_regeneration.md
@@ -143,7 +143,7 @@ python scripts/response_regeneration/script.py --dataset ultrachat
 
 After regenerating your dataset:
 
-1. **Train a speculator** - See [Train Eagle-3 Online](train_eagle3_online.md) or [Train Eagle-3 Offline](train_eagle3_offline.md). Pass `--use-off-policy-tokens` to the trainer when using regenerated data.
+1. **Train a speculator** - See [Train Eagle-3 Online](train_eagle3_online.md) or [Train Eagle-3 Offline](train_eagle3_offline.md). For Eagle-3, pass `--use-off-policy-tokens` to the trainer when using regenerated data (other architectures ignore this flag).
 2. **Evaluate performance** - See [Evaluating Performance](evaluating_performance.md)
 3. **Deploy to production** - See [Serve in vLLM](serve_vllm.md)
 

--- a/docs/user_guide/tutorials/response_regeneration.md
+++ b/docs/user_guide/tutorials/response_regeneration.md
@@ -1,6 +1,6 @@
 # Response Regeneration
 
-This tutorial walks you through regenerating assistant responses in an existing dataset using a target model served by vLLM. The resulting dataset pairs the original user prompts with freshly generated responses, which can be used as training data for speculator models with improved alignment to your target model.
+This tutorial walks you through regenerating assistant responses in an existing dataset using a target model served by vLLM. The resulting dataset pairs the original user prompts with freshly generated responses (on-policy data), and is the recommended starting point for speculator training: the drafter learns to predict what the target model actually generates, not what the dataset's original authors wrote. Training directly on the dataset's original responses (off-policy) is a cheaper fallback, since it skips a full target-model pass over the data, but costs acceptance length at inference time.
 
 ## Overview
 
@@ -143,7 +143,7 @@ python scripts/response_regeneration/script.py --dataset ultrachat
 
 After regenerating your dataset:
 
-1. **Train a speculator** - See [Train Eagle-3 Online](train_eagle3_online.md) or [Train Eagle-3 Offline](train_eagle3_offline.md)
+1. **Train a speculator** - See [Train Eagle-3 Online](train_eagle3_online.md) or [Train Eagle-3 Offline](train_eagle3_offline.md). Pass `--use-off-policy-tokens` to the trainer when using regenerated data.
 2. **Evaluate performance** - See [Evaluating Performance](evaluating_performance.md)
 3. **Deploy to production** - See [Serve in vLLM](serve_vllm.md)
 

--- a/docs/user_guide/tutorials/train_dflash_online.md
+++ b/docs/user_guide/tutorials/train_dflash_online.md
@@ -38,6 +38,8 @@ Note: if you are using an experiment tracker (e.g. trackio, wandb, tensorboard, 
 
 ## Step 1: Prepare Your Data
 
+**Recommended:** regenerate the dataset's responses with your target model first (see [Response Regeneration](response_regeneration.md)) and pass the resulting JSONL to `--data`. This on-policy data aligns the drafter with what the target actually generates. Using the dataset's original responses, as shown below, is a cheaper off-policy fallback that skips a full target-model pass over the data, at the cost of lower acceptance length.
+
 First, preprocess your training dataset:
 
 ```bash

--- a/docs/user_guide/tutorials/train_eagle3_offline.md
+++ b/docs/user_guide/tutorials/train_eagle3_offline.md
@@ -36,6 +36,8 @@ Note: if you are using an experiment tracker (e.g. trackio, wandb, tensorboard, 
 
 ## Step 1: Prepare Your Data
 
+**Recommended:** regenerate the dataset's responses with your target model first (see [Response Regeneration](response_regeneration.md)) and pass the resulting JSONL to `--data`, along with `--use-off-policy-tokens` during training. This on-policy data aligns the drafter with what the target actually generates. Using the dataset's original responses, as shown below, is a cheaper off-policy fallback that skips a full target-model pass over the data, at the cost of lower acceptance length.
+
 First, preprocess your training dataset:
 
 ```bash

--- a/docs/user_guide/tutorials/train_eagle3_offline.md
+++ b/docs/user_guide/tutorials/train_eagle3_offline.md
@@ -36,7 +36,7 @@ Note: if you are using an experiment tracker (e.g. trackio, wandb, tensorboard, 
 
 ## Step 1: Prepare Your Data
 
-**Recommended:** regenerate the dataset's responses with your target model first (see [Response Regeneration](response_regeneration.md)) and pass the resulting JSONL to `--data`, along with `--use-off-policy-tokens` during training. This on-policy data aligns the drafter with what the target actually generates. Using the dataset's original responses, as shown below, is a cheaper off-policy fallback that skips a full target-model pass over the data, at the cost of lower acceptance length.
+**Recommended:** regenerate the dataset's responses with your target model first (see [Response Regeneration](response_regeneration.md)) and pass the resulting JSONL to `--data`. This on-policy data aligns the drafter with what the target actually generates. Using the dataset's original responses, as shown below, is a cheaper off-policy fallback that skips a full target-model pass over the data, at the cost of lower acceptance length.
 
 First, preprocess your training dataset:
 

--- a/docs/user_guide/tutorials/train_eagle3_online.md
+++ b/docs/user_guide/tutorials/train_eagle3_online.md
@@ -35,7 +35,7 @@ Note: if you are using an experiment tracker (e.g. trackio, wandb, tensorboard, 
 
 ## Step 1: Prepare Your Data
 
-**Recommended:** regenerate the dataset's responses with your target model first (see [Response Regeneration](response_regeneration.md)) and pass the resulting JSONL to `--data`, along with `--use-off-policy-tokens` during training. This on-policy data aligns the drafter with what the target actually generates. Using the dataset's original responses, as shown below, is a cheaper off-policy fallback that skips a full target-model pass over the data, at the cost of lower acceptance length.
+**Recommended:** regenerate the dataset's responses with your target model first (see [Response Regeneration](response_regeneration.md)) and pass the resulting JSONL to `--data`. This on-policy data aligns the drafter with what the target actually generates. Using the dataset's original responses, as shown below, is a cheaper off-policy fallback that skips a full target-model pass over the data, at the cost of lower acceptance length.
 
 First, preprocess your training dataset:
 

--- a/docs/user_guide/tutorials/train_eagle3_online.md
+++ b/docs/user_guide/tutorials/train_eagle3_online.md
@@ -35,6 +35,8 @@ Note: if you are using an experiment tracker (e.g. trackio, wandb, tensorboard, 
 
 ## Step 1: Prepare Your Data
 
+**Recommended:** regenerate the dataset's responses with your target model first (see [Response Regeneration](response_regeneration.md)) and pass the resulting JSONL to `--data`, along with `--use-off-policy-tokens` during training. This on-policy data aligns the drafter with what the target actually generates. Using the dataset's original responses, as shown below, is a cheaper off-policy fallback that skips a full target-model pass over the data, at the cost of lower acceptance length.
+
 First, preprocess your training dataset:
 
 ```bash

--- a/docs/user_guide/tutorials/train_peagle_offline.md
+++ b/docs/user_guide/tutorials/train_peagle_offline.md
@@ -36,6 +36,8 @@ Note: if you are using an experiment tracker (e.g. trackio, wandb, tensorboard, 
 
 ## Step 1: Prepare Your Data
 
+**Recommended:** regenerate the dataset's responses with your target model first (see [Response Regeneration](response_regeneration.md)) and pass the resulting JSONL to `--data`. This on-policy data aligns the drafter with what the target actually generates. Using the dataset's original responses, as shown below, is a cheaper off-policy fallback that skips a full target-model pass over the data, at the cost of lower acceptance length.
+
 First, preprocess your training dataset:
 
 ```bash


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Make on-policy training data the documented default (part of #694). Eagle-3 tutorials now recommend regenerating responses with the target model first; off-policy stays as a cheaper fallback with its acceptance penalty called out.

## Tests

Docs-only. make quality passes.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
