### PR TITLE
Add Jensen-Shannon divergence (JSD) loss for speculative decoding

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -953,7 +953,7 @@ def parse_args():
         default="kl_div",
         help=(
             "Loss function specification. Pass a name for a single loss "
-            "(kl_div, rkl, ce, tv, nla, lk_hybrid) or a JSON dict for a weighted "
+            "(kl_div, rkl, jsd, ce, tv, nla, lk_hybrid) or a JSON dict for a weighted "
             'combination, e.g. \'{"ce": 0.1, "tv": 0.9}\'.'
         ),
     )

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -1,4 +1,5 @@
 import json
+import math
 from collections.abc import Callable
 
 import torch
@@ -116,6 +117,43 @@ def reverse_kl_div_loss(
     elementwise_loss = torch.nn.functional.kl_div(
         target_logp, draft_logq, reduction="none", log_target=True
     ).sum(dim=-1)  # shape: [1, seq_len]
+
+    return elementwise_loss  # noqa: RET504
+
+
+def js_div_loss(
+    logits: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+    targets: torch.Tensor,  # shape: [1, seq_len, draft_vocab_size]
+):
+    """Compute per-position Jensen-Shannon divergence between draft and target.
+
+    ``JSD(p, q) = 0.5 * KL(p || m) + 0.5 * KL(q || m)`` with ``m = (p + q) / 2``.
+    Symmetric and bounded by ``log 2`` (Lin 1991, "Divergence measures based on
+    the Shannon entropy"), it balances forward KL's mass-covering pull with
+    reverse KL's mode-seeking pull and keeps gradients finite where either
+    distribution assigns near-zero probability. Compared to plain KL, this
+    avoids unbounded penalties on tokens the target barely supports; compared
+    to TV, it provides smoother, better-conditioned gradients for draft
+    training.
+
+    Args:
+        logits: Draft model logits (log-softmax applied internally).
+        targets: Target model logits (log-softmax applied internally).
+
+    Returns:
+        Per-position JS divergence with shape [1, seq_len].
+    """
+    draft_logq = torch.nn.functional.log_softmax(logits, dim=-1)
+    target_logp = torch.nn.functional.log_softmax(targets, dim=-1)
+    # log m = log((p + q) / 2), computed in log space for stability
+    log_m = torch.logaddexp(draft_logq, target_logp) - math.log(2.0)
+    kl_target_to_mix = torch.nn.functional.kl_div(
+        log_m, target_logp, reduction="none", log_target=True
+    ).sum(dim=-1)
+    kl_draft_to_mix = torch.nn.functional.kl_div(
+        log_m, draft_logq, reduction="none", log_target=True
+    ).sum(dim=-1)
+    elementwise_loss = 0.5 * (kl_target_to_mix + kl_draft_to_mix)  # [1, seq_len]
 
     return elementwise_loss  # noqa: RET504
 
@@ -332,6 +370,7 @@ def dpace_loss_decay(
 _LOSS_FN_MAP: dict[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = {
     "kl_div": kl_div_loss,
     "rkl": reverse_kl_div_loss,
+    "jsd": js_div_loss,
     "ce": ce_loss,
     "tv": tv_loss,
     "nla": neg_log_acceptance_loss,
@@ -346,9 +385,9 @@ def resolve_loss_fn(
 
     Args:
         name: ``"kl_div"`` for KL-divergence, ``"rkl"`` for reverse KL-divergence,
-            ``"ce"`` for cross-entropy, ``"tv"`` for total variation, ``"nla"``
-            for negative log-acceptance, or ``"lk_hybrid"`` for the adaptive
-            KL/TV blend.
+            ``"jsd"`` for Jensen-Shannon divergence, ``"ce"`` for cross-entropy,
+            ``"tv"`` for total variation, ``"nla"`` for negative log-acceptance,
+            or ``"lk_hybrid"`` for the adaptive KL/TV blend.
 
     Returns:
         The corresponding loss function.

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -10,6 +10,7 @@ from speculators.models.metrics import (
     compute_accuracy_single_step,
     dflash_loss_decay,
     exp_loss_decay,
+    js_div_loss,
     kl_div_loss,
     lk_hybrid_loss,
     loss_function,
@@ -119,6 +120,57 @@ class TestReverseKLDivLoss:
     def test_resolve_rkl(self):
         """resolve_loss_fn maps 'rkl' to reverse_kl_div_loss."""
         assert resolve_loss_fn("rkl") is reverse_kl_div_loss
+
+
+class TestJSDivLoss:
+    def test_identical_zero_and_random_nonnegative(self):
+        """JSD of identical distributions is ~0; random inputs are >= 0."""
+        x = torch.randn(1, 4, 8)
+        loss_identical = js_div_loss(x, x)
+        assert loss_identical.sum().item() == pytest.approx(0.0, abs=1e-4)
+
+        torch.manual_seed(0)
+        loss_random = js_div_loss(torch.randn(1, 4, 8), torch.randn(1, 4, 8))
+        assert (loss_random >= -1e-6).all()
+
+    def test_symmetric_and_bounded_by_log2(self):
+        """JSD(p, q) == JSD(q, p) and is bounded by log 2."""
+        torch.manual_seed(0)
+        logits = torch.randn(1, 4, 8)
+        targets = torch.randn(1, 4, 8)
+        assert torch.allclose(
+            js_div_loss(logits, targets),
+            js_div_loss(targets, logits),
+            atol=1e-6,
+        )
+        # near-disjoint point masses approach the log 2 bound
+        disjoint_p = torch.full((1, 1, 4), -100.0)
+        disjoint_p[0, 0, 0] = 100.0
+        disjoint_q = torch.full((1, 1, 4), -100.0)
+        disjoint_q[0, 0, 1] = 100.0
+        loss = js_div_loss(disjoint_p, disjoint_q)
+        assert loss.max().item() == pytest.approx(0.6931, abs=1e-3)
+
+    def test_matches_manual_formula(self):
+        """js_div_loss matches an independent JSD reference implementation."""
+        torch.manual_seed(0)
+        logits = torch.randn(1, 4, 50)
+        targets = torch.randn(1, 4, 50)
+        out = js_div_loss(logits, targets)
+
+        p = torch.softmax(targets, dim=-1)
+        q = torch.softmax(logits, dim=-1)
+        m = 0.5 * (p + q)
+        kl_pm = (p * (p / m).log()).sum(dim=-1)
+        kl_qm = (q * (q / m).log()).sum(dim=-1)
+        expected = 0.5 * (kl_pm + kl_qm)
+
+        assert out.shape == (1, 4)
+        assert torch.allclose(out, expected, atol=1e-5)
+
+    def test_resolve_jsd(self):
+        """resolve_loss_fn maps 'jsd' to js_div_loss."""
+        assert resolve_loss_fn("jsd") is js_div_loss
 
 
 class TestTVLoss:


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Follow-up to #667: forward KL is mass-covering, reverse KL is mode-seeking; JSD is the symmetric, bounded (log 2) middle ground with finite gradients where either distribution assigns near-zero mass. Add it as a selectable loss (jsd).

## Tests

- Unit tests in test_metrics.py: identical dists -> ~0 and random -> non-negative, symmetry JSD(p,q) == JSD(q,p), disjoint point masses hit the log 2 bound, and resolve_loss_fn("jsd") wiring. 25 passed.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
