### PR TITLE
Refactor(regen): emit generation boundary as loss mask for on-policy data, eliminate redundant re-tokenize roundtrip

### DIFF
--- a/docs/cli/response_regeneration.md
+++ b/docs/cli/response_regeneration.md
@@ -93,7 +93,7 @@ python scripts/response_regeneration/script.py --dataset magpie
 
 - **`--outfile`** (str, default: auto-generated) Output JSONL path. If not specified, auto-generated as `{dataset}_{model}.jsonl`.
 
-- **`--resume`** (flag) Skip rows already present in the output file (matched by uuid or index).
+- **`--resume`** (flag) Skip conversations already present in the output file (matched by `primary_id`: the row's `id`/`uuid` if it has one, otherwise a content hash).
 
 ### Full Example
 
@@ -117,40 +117,41 @@ python scripts/response_regeneration/script.py \
 
 ## Output Format
 
-Each line of the output JSONL file pairs the original user prompt with the newly generated response, in a conversations format compatible with fine-tuning:
+Rows are pre-tokenized and ready for training: one row per assistant turn, holding the prompt the target conditioned on followed by the tokens it generated. The endpoint must support `return_token_ids`, which the script uses to read the generation boundary directly instead of re-tokenizing the text and recovering the boundary with a regex.
 
 ```json
 {
-  "id": "sample_0",
+  "id": "conv-abc_turn0",
+  "primary_id": "conv-abc",
+  "input_ids": [151644, 872, ...],
+  "loss_mask": [0, 0, ..., 1, 1],
   "conversations": [
-    {"from": "human", "value": "What is the capital of France?"},
-    {"from": "gpt", "value": "The capital of France is Paris."}
+    {"role": "user", "content": "What is the capital of France?"},
+    {"role": "assistant", "content": "The capital of France is Paris."}
   ],
   "metadata": {
     "idx": 0,
     "finish_reason": "stop",
-    "latency_s": 1.234,
     "usage": {...},
-    "endpoint": "http://127.0.0.1:8000/v1/chat/completions",
-    "reasoning_content": "..."
+    "endpoint": "http://127.0.0.1:8000/v1/chat/completions"
   }
 }
 ```
 
-- The `id` field uses the dataset's UUID if available, otherwise falls back to `sample_{idx}`.
-- The `reasoning_content` field in metadata is only included when the model provides reasoning content (e.g., with reasoning models).
+- `loss_mask` is `0` over the prompt and `1` over the generated tokens. This *is* the generation boundary, so training applies no further masking.
+- A conversation with N assistant turns yields N rows, each carrying the history before it. Turn `k`'s row is `{primary_id}_turn{k}`.
+- `primary_id` is the conversation's stable id, used by `--resume`. The row `id` is turn-suffixed and never matches it.
+- `conversations` is a human-readable twin of `input_ids` for review only. Training drops it.
 
-On error, the response conversation turn is omitted and an `error` field is included in metadata:
+Rows are written only after every turn of a conversation succeeds. A conversation that fails partway writes nothing to the output file and one row to a sibling error file instead (`--outfile out.jsonl` gives `out.errors.jsonl`), so `--resume` retries it whole:
 
 ```json
 {
-  "id": "sample_0",
-  "conversations": [
-    {"from": "human", "value": "What is the capital of France?"}
-  ],
+  "id": "conv-abc",
   "metadata": {
     "idx": 0,
     "error": "ConnectionError(...)",
+    "turns_completed": 1,
     "endpoint": "http://127.0.0.1:8000/v1/chat/completions"
   }
 }

--- a/docs/user_guide/tutorials/response_regeneration.md
+++ b/docs/user_guide/tutorials/response_regeneration.md
@@ -50,24 +50,28 @@ For larger models, use data parallelism and/or tensor parallelism:
 
 ## Step 2: Verify the Output
 
-The output is a JSONL file where each line contains the original prompt and the generated response in a conversations format compatible with fine-tuning:
+The output is a JSONL file with one pre-tokenized row per assistant turn. `loss_mask` is `0` over the prompt the target conditioned on and `1` over the tokens it generated, so training needs no further masking:
 
 ```json
 {
-  "id": "sample_0",
+  "id": "conv-abc_turn0",
+  "primary_id": "conv-abc",
+  "input_ids": [151644, 872, ...],
+  "loss_mask": [0, 0, ..., 1, 1],
   "conversations": [
-    {"from": "human", "value": "What is the capital of France?"},
-    {"from": "gpt", "value": "The capital of France is Paris."}
+    {"role": "user", "content": "What is the capital of France?"},
+    {"role": "assistant", "content": "The capital of France is Paris."}
   ],
   "metadata": {
     "idx": 0,
     "finish_reason": "stop",
-    "latency_s": 1.234,
     "usage": {...},
     "endpoint": "http://127.0.0.1:8000/v1/chat/completions"
   }
 }
 ```
+
+A conversation with N assistant turns produces N rows, so expect more lines than input conversations. `conversations` is a review-only twin of `input_ids`; training drops it.
 
 Check that the output looks correct:
 

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -6,7 +6,6 @@ import json
 import os
 import re
 import sys
-import time
 from typing import Any
 
 import aiohttp
@@ -187,11 +186,16 @@ def _primary_identifier(row: dict[str, Any]) -> str:
 
 
 def load_seen(path: str) -> set[str]:
-    """Load previously written output ids from the output file.
+    """Load previously completed conversation ids from the output file.
 
-    Each record stores its stable id under the top-level ``id`` (equal to the
-    row's :func:`_primary_identifier`), so a resumed run skips a row when its
-    recomputed id is already present.
+    A conversation fans out to one row per assistant turn, whose ``id`` carries a
+    ``_turn<N>`` suffix; the conversation's own :func:`_primary_identifier` is
+    kept alongside it as ``primary_id``. Resume keys on that, since the suffixed
+    ids never match a recomputed one. Rows are written only after every turn
+    succeeds, so one row is enough to mark the conversation done.
+
+    ``id`` is the fallback for output files written before the fan-out, where the
+    top-level ``id`` *was* the primary identifier.
     """
     seen: set[str] = set()
     if not os.path.isfile(path):
@@ -203,8 +207,11 @@ def load_seen(path: str) -> set[str]:
                 obj = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            if _is_present(obj.get("id")):
-                seen.add(str(obj["id"]))
+            key = obj.get("primary_id")
+            if not _is_present(key):
+                key = obj.get("id")
+            if _is_present(key):
+                seen.add(str(key))
     return seen
 
 
@@ -270,6 +277,19 @@ async def _post_chat(
         return await response.json()
 
 
+def build_boundary_sample(
+    prompt_token_ids: list[int],
+    completion_token_ids: list[int],
+) -> tuple[list[int], list[int]]:
+    """Build one training sample: prompt (loss_mask 0) + generated tokens (1).
+
+    The generation boundary is the mask -- no ``{% generation %}`` markers, no regex.
+    """
+    input_ids = [*prompt_token_ids, *completion_token_ids]
+    loss_mask = [0] * len(prompt_token_ids) + [1] * len(completion_token_ids)
+    return input_ids, loss_mask
+
+
 async def worker(
     session: aiohttp.ClientSession,
     queue: "asyncio.Queue[dict[str, Any]]",
@@ -280,12 +300,10 @@ async def worker(
     progress,
     stats: dict[str, int],
 ):
-    """Worker that pulls conversations from the queue and regenerates them.
+    """Regenerate each queued conversation into pre-tokenized training samples.
 
-    Each user turn is sent to the endpoint with the freshly generated prefix
-    (system + regenerated history); the original assistant turns are discarded
-    and replaced by the model's responses. Single-turn rows are the degenerate
-    case of one user turn.
+    One sample per assistant turn: the prompt the target conditioned on
+    (loss_mask 0) followed by the tokens it generated (1).
     """
     while True:
         item = await queue.get()
@@ -295,28 +313,23 @@ async def worker(
 
         idx = item["idx"]
         turns = item["turns"]
+        conv_id = item["primary_id"]
 
-        # The API prefix (role/content) and the output conversation (from/value)
-        # are built in lockstep as we walk the turns.
         prefix: list[dict[str, Any]] = []
-        out_convs: list[dict[str, Any]] = []
-        finish_reasons: list[str | None] = []
-        usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
-        start_time = time.time()
+        samples: list[dict[str, Any]] = []
         try:
             for turn in turns:
                 if turn["role"] == "system":
                     prefix.append({"role": "system", "content": turn["content"]})
-                    out_convs.append({"from": "system", "value": turn["content"]})
                     continue
 
                 prefix.append({"role": "user", "content": turn["content"]})
-                out_convs.append({"from": "human", "value": turn["content"]})
 
                 payload = {
                     "model": args.model,
                     "messages": prefix,
                     "max_tokens": args.max_tokens,
+                    "return_token_ids": True,  # prompt_token_ids + completion token_ids
                 }
                 data = await _post_chat(
                     session,
@@ -326,53 +339,60 @@ async def worker(
                 )
 
                 choice = data["choices"][0]
-                message = choice["message"]
-                generated_text = message.get("content")
-                reasoning_content = message.get("reasoning_content")
-                if reasoning_content is None:
-                    reasoning_content = message.get("reasoning")
-                finish_reasons.append(choice.get("finish_reason"))
-                turn_usage = data.get("usage") or {}
-                for key in usage:
-                    usage[key] += turn_usage.get(key) or 0
+                generated_text = choice["message"].get("content")
 
-                # Empty content (e.g. truncated mid-reasoning) would corrupt the
-                # next turn's prefix and emit a null target; fail the conversation.
+                # Empty content corrupts the next turn's prefix; fail the conversation.
                 if not generated_text:
-                    raise ValueError(f"empty assistant content (turn {len(out_convs)})")
+                    raise ValueError(f"empty assistant content (turn {len(samples)})")
 
-                prefix.append({"role": "assistant", "content": generated_text})
-                gpt_turn = {"from": "gpt", "value": generated_text}
-                # Stored per turn: data prep reads it here, not top-level metadata.
-                if reasoning_content is not None:
-                    gpt_turn["reasoning_content"] = reasoning_content
-                out_convs.append(gpt_turn)
+                prompt_token_ids = data.get("prompt_token_ids")
+                completion_token_ids = choice.get("token_ids")
+                if not prompt_token_ids or not completion_token_ids:
+                    raise ValueError(
+                        "endpoint returned no token ids; it must support "
+                        "return_token_ids"
+                    )
 
-            metadata = {
-                "idx": idx,
-                "finish_reasons": finish_reasons,
-                "latency_s": round(time.time() - start_time, 3),
-                "usage": usage,
-                "endpoint": endpoint,
-            }
+                input_ids, loss_mask = build_boundary_sample(
+                    prompt_token_ids, completion_token_ids
+                )
+                # History keeps parsed content; the generated <think> is supervised
+                # in this turn's completion tokens above.
+                assistant_msg = {"role": "assistant", "content": generated_text}
+                samples.append(
+                    {
+                        "id": f"{conv_id}_turn{len(samples)}",
+                        # Conversation-level key for --resume; the row `id` is
+                        # turn-suffixed and would never match a recomputed one.
+                        "primary_id": conv_id,
+                        "input_ids": input_ids,
+                        "loss_mask": loss_mask,
+                        # Review-only twin of input_ids; ignored by training.
+                        "conversations": [*prefix, assistant_msg],
+                        "metadata": {
+                            "idx": idx,
+                            "finish_reason": choice.get("finish_reason"),
+                            "usage": data.get("usage") or {},
+                            "endpoint": endpoint,
+                        },
+                    }
+                )
+                prefix.append(assistant_msg)
 
-            output = {
-                "id": item["primary_id"],
-                "conversations": out_convs,
-                "metadata": metadata,
-            }
-            out_fh.write(json.dumps(output, ensure_ascii=False) + "\n")
+            # Written only after every turn succeeds, so any row in the output
+            # file means the whole conversation is done (see load_seen).
+            for sample in samples:
+                out_fh.write(json.dumps(sample, ensure_ascii=False) + "\n")
             out_fh.flush()
             stats["ok"] += 1
         except Exception as e:  # noqa: BLE001
-            # Failures go to a separate error file, not the training output; an
-            # in-band marker would be invisible (the pipeline drops metadata).
+            # Failures go to a separate error file, not the training output.
             error_output = {
-                "id": item["primary_id"],
-                "conversations": out_convs,
+                "id": conv_id,
                 "metadata": {
                     "idx": idx,
                     "error": repr(e),
+                    "turns_completed": len(samples),
                     "endpoint": endpoint,
                 },
             }

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -527,7 +527,10 @@ def _passthrough_pretokenized(
             )
         trimmed_ids = ids[:max_length]
         trimmed_mask = mask[:max_length]
-        if minimum_valid_tokens and sum(trimmed_mask) < minimum_valid_tokens:
+        if (
+            minimum_valid_tokens is not None
+            and sum(trimmed_mask) < minimum_valid_tokens
+        ):
             continue
         results["input_ids"].append(torch.tensor(trimmed_ids, dtype=torch.long))
         results["loss_mask"].append(torch.tensor(trimmed_mask, dtype=torch.long))
@@ -650,8 +653,21 @@ def build_eagle3_dataset(
                      conversation
         minimum_valid_tokens: Number of tokens to consider for a valid sample
     """
+    original_cols = dataset.column_names
+    # These rows carry the generation boundary as their mask, so _preprocess_batch
+    # passes them through: no chat template, no span detection, no turn dropout.
+    pretokenized = {"input_ids", "loss_mask"} <= set(original_cols)
+
+    if pretokenized:
+        log.info("Pre-tokenized rows: using their loss mask, skipping chat template")
+        if turn_dropout:
+            log.warning("turn_dropout does not apply to pre-tokenized rows; ignoring")
+        if assistant_pattern is not None:
+            log.warning(
+                "assistant_pattern does not apply to pre-tokenized rows; ignoring"
+            )
     # Detect and use provided assistant message pattern
-    if assistant_pattern is not None:
+    elif assistant_pattern is not None:
         log.info(f"Using custom assistant pattern: {str(assistant_pattern)[:80]}...")
     elif _supports_assistant_mask(processor):
         assistant_pattern = None  # Signal to use HF mask in _preprocess_batch
@@ -659,8 +675,6 @@ def build_eagle3_dataset(
     else:
         assistant_pattern = _detect_assistant_pattern(processor)
         log.info(f"Detected assistant pattern: {str(assistant_pattern)[:80]}...")
-
-    original_cols = dataset.column_names
 
     # Avoid CPU contention for MM processing:
     # https://github.com/vllm-project/vllm/pull/31879

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -507,6 +507,21 @@ def _parse_conv_tools(conv_tools: object, idx: int) -> list | None:
         return None
 
 
+def _passthrough_pretokenized(examples: dict, max_length: int) -> dict[str, list]:
+    """Carry pre-tokenized ``(input_ids, loss_mask)`` rows through, truncated only.
+
+    On-policy regeneration already applied the boundary as the mask, so these rows
+    need no chat-template rendering or regex span detection.
+    """
+    results: dict[str, list] = {"input_ids": [], "loss_mask": [], "seq_len": []}
+    for ids, mask in zip(examples["input_ids"], examples["loss_mask"], strict=True):
+        trimmed_ids = ids[:max_length]
+        results["input_ids"].append(torch.tensor(trimmed_ids, dtype=torch.long))
+        results["loss_mask"].append(torch.tensor(mask[:max_length], dtype=torch.long))
+        results["seq_len"].append(len(trimmed_ids))
+    return results
+
+
 def _preprocess_batch(
     examples: dict,
     processor: ProcessorLike,
@@ -516,6 +531,11 @@ def _preprocess_batch(
     minimum_valid_tokens: int | None = None,
 ) -> dict[str, list]:
     """Process a batch of conversations into tokenized format with loss masks."""
+
+    # On-policy regeneration rows are already masked (boundary); pass them through
+    # instead of re-tokenizing and re-masking.
+    if "input_ids" in examples and "loss_mask" in examples:
+        return _passthrough_pretokenized(examples, max_length)
 
     results: dict[str, list] = {"input_ids": [], "loss_mask": [], "seq_len": []}
     conversations: list[dict] = examples.get("conversations", [])

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -517,6 +517,14 @@ def _passthrough_pretokenized(
     """
     results: dict[str, list] = {"input_ids": [], "loss_mask": [], "seq_len": []}
     for ids, mask in zip(examples["input_ids"], examples["loss_mask"], strict=True):
+        # `strict=True` only pairs the columns; a per-row skew would survive it and
+        # the collator packs each key independently, silently shifting the mask
+        # against the ids for every sample packed after this one.
+        if len(ids) != len(mask):
+            raise ValueError(
+                f"Pre-tokenized row shape mismatch: "
+                f"input_ids={len(ids)}, loss_mask={len(mask)}"
+            )
         trimmed_ids = ids[:max_length]
         trimmed_mask = mask[:max_length]
         if minimum_valid_tokens and sum(trimmed_mask) < minimum_valid_tokens:

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -507,7 +507,9 @@ def _parse_conv_tools(conv_tools: object, idx: int) -> list | None:
         return None
 
 
-def _passthrough_pretokenized(examples: dict, max_length: int) -> dict[str, list]:
+def _passthrough_pretokenized(
+    examples: dict, max_length: int, minimum_valid_tokens: int | None = None
+) -> dict[str, list]:
     """Carry pre-tokenized ``(input_ids, loss_mask)`` rows through, truncated only.
 
     On-policy regeneration already applied the boundary as the mask, so these rows
@@ -516,8 +518,11 @@ def _passthrough_pretokenized(examples: dict, max_length: int) -> dict[str, list
     results: dict[str, list] = {"input_ids": [], "loss_mask": [], "seq_len": []}
     for ids, mask in zip(examples["input_ids"], examples["loss_mask"], strict=True):
         trimmed_ids = ids[:max_length]
+        trimmed_mask = mask[:max_length]
+        if minimum_valid_tokens and sum(trimmed_mask) < minimum_valid_tokens:
+            continue
         results["input_ids"].append(torch.tensor(trimmed_ids, dtype=torch.long))
-        results["loss_mask"].append(torch.tensor(mask[:max_length], dtype=torch.long))
+        results["loss_mask"].append(torch.tensor(trimmed_mask, dtype=torch.long))
         results["seq_len"].append(len(trimmed_ids))
     return results
 
@@ -535,7 +540,7 @@ def _preprocess_batch(
     # On-policy regeneration rows are already masked (boundary); pass them through
     # instead of re-tokenizing and re-masking.
     if "input_ids" in examples and "loss_mask" in examples:
-        return _passthrough_pretokenized(examples, max_length)
+        return _passthrough_pretokenized(examples, max_length, minimum_valid_tokens)
 
     results: dict[str, list] = {"input_ids": [], "loss_mask": [], "seq_len": []}
     conversations: list[dict] = examples.get("conversations", [])

--- a/tests/integration/datagen/fixtures/preprocess/gsm8k_singleturn.jsonl
+++ b/tests/integration/datagen/fixtures/preprocess/gsm8k_singleturn.jsonl
@@ -1,1 +1,0 @@
-{"question": "Natalia sold clips to 48 of her friends in April, and then she sold half as many clips in May. How many clips did Natalia sell altogether in April and May?", "answer": "Natalia sold 48/2 = <<48/2=24>>24 clips in May.\nNatalia sold 48+24 = <<48+24=72>>72 clips altogether in April and May.\n#### 72"}

--- a/tests/integration/datagen/fixtures/preprocess/gsm8k_singleturn.jsonl
+++ b/tests/integration/datagen/fixtures/preprocess/gsm8k_singleturn.jsonl
@@ -1,0 +1,1 @@
+{"question": "Natalia sold clips to 48 of her friends in April, and then she sold half as many clips in May. How many clips did Natalia sell altogether in April and May?", "answer": "Natalia sold 48/2 = <<48/2=24>>24 clips in May.\nNatalia sold 48+24 = <<48+24=72>>72 clips altogether in April and May.\n#### 72"}

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -1,16 +1,21 @@
 """Real, dependency-light tests for the response-regeneration script.
 
-Two seams are covered with no network and no mocked HTTP:
+The seams covered, with no network and no mocked HTTP:
 
 1. ``extract_turns`` over the *actual* schemas of the supported datasets
    (ultrachat ``messages`` role/content, magpie/open-perfectblend
    ``conversations`` from/value, gsm8k single prompt), plus the robustness
    fixes (empty conversation lists, non-dict elements, mixed schema).
 
-2. The conversation format the worker emits, consumed by the *real* downstream
-   ``_normalize_conversation``. This pins the train/infer contract the PR exists
-   to protect: the system turn and per-turn reasoning survive into training, and
-   the regenerated human/gpt turns map to user/assistant targets.
+2. ``build_boundary_sample`` (the boundary *is* the loss mask) and the pre-tokenized
+   rows it produces passing untouched through the real ``_preprocess_batch``.
+
+3. Resume identity: ``_primary_identifier`` / ``load_seen`` across the one-row-per-
+   assistant-turn fan-out.
+
+4. Retry/backoff around a single request.
+
+5. ``worker`` end to end over a fake endpoint, tying 2-4 together.
 
 The script is not a package, so it is imported by path.
 """
@@ -23,7 +28,7 @@ from pathlib import Path
 import pytest
 
 from speculators.data_generation import vllm_client
-from speculators.data_generation.preprocessing import _normalize_conversation
+from speculators.data_generation.preprocessing import _preprocess_batch
 from speculators.data_generation.vllm_client import InvalidResponseError
 
 
@@ -192,60 +197,33 @@ def test_extract_turns_no_usable_input_returns_empty():
 
 
 # ---------------------------------------------------------------------------
-# 2. Emitted conversation is consumed correctly by the real downstream
-#    normaliser (the train/infer contract).
+# 2. The generation boundary is the loss mask; pre-tokenized rows pass through.
 # ---------------------------------------------------------------------------
 
-# Multi-turn conversation carrying a system prompt, used to prove the contract.
-_CONTRACT_ROW = {
-    "conversations": [
-        {"from": "system", "value": "You are a terse assistant."},
-        {"from": "human", "value": "Hi"},
-        {"from": "gpt", "value": "<original answer to drop>"},
-        {"from": "human", "value": "And goodbye"},
-        {"from": "gpt", "value": "<original answer to drop>"},
-    ],
-}
+
+def test_build_boundary_sample_is_the_mask():
+    input_ids, loss_mask = regen.build_boundary_sample([10, 11, 12, 13], [20, 21, 22])
+    assert input_ids == [10, 11, 12, 13, 20, 21, 22]
+    assert loss_mask == [0, 0, 0, 0, 1, 1, 1]
 
 
-def _to_worker_output(turns) -> list[dict]:
-    """Mirror worker(): map system->system and user->human, and append a
-    regenerated assistant turn (with per-turn reasoning) after each user turn,
-    exactly as the script writes the ``conversations`` field."""
-    out_convs: list[dict] = []
-    for turn in turns:
-        if turn["role"] == "system":
-            out_convs.append({"from": "system", "value": turn["content"]})
-            continue
-        out_convs.append({"from": "human", "value": turn["content"]})
-        out_convs.append(
-            {
-                "from": "gpt",
-                "value": f"answer:{turn['content']}",
-                "reasoning_content": f"reason:{turn['content']}",
-            }
-        )
-    return out_convs
-
-
-def test_emitted_conversation_survives_downstream_normalization():
-    turns = regen.extract_turns(_CONTRACT_ROW, "prompt")
-    out_convs = _to_worker_output(turns)
-
-    normalized = _normalize_conversation(out_convs)
-    roles = [m["role"] for m in normalized]
-
-    # System preserved; human/gpt mapped to user/assistant; order intact.
-    assert roles == ["system", "user", "assistant", "user", "assistant"]
-    assert normalized[0]["content"] == "You are a terse assistant."
-
-    # Per-turn reasoning survives into training (top-level metadata would not).
-    assistants = [m for m in normalized if m["role"] == "assistant"]
-    assert [m["content"] for m in assistants] == ["answer:Hi", "answer:And goodbye"]
-    assert [m["reasoning_content"] for m in assistants] == [
-        "reason:Hi",
-        "reason:And goodbye",
-    ]
+def test_pretokenized_rows_pass_through_preprocessing():
+    # A regen row reaches training already masked: no processor, no re-masking,
+    # and the review-only `conversations` field is dropped.
+    input_ids, loss_mask = regen.build_boundary_sample([10, 11, 12], [20, 21])
+    out = _preprocess_batch(
+        {
+            "input_ids": [input_ids],
+            "loss_mask": [loss_mask],
+            "conversations": [[{"role": "user", "content": "2+2?"}]],
+        },
+        processor=None,
+        max_length=2048,
+        assistant_pattern=None,
+    )
+    assert out["input_ids"][0].tolist() == input_ids
+    assert out["loss_mask"][0].tolist() == loss_mask
+    assert "conversations" not in out
 
 
 # ---------------------------------------------------------------------------
@@ -253,9 +231,9 @@ def test_emitted_conversation_survives_downstream_normalization():
 #
 # The prior resume keyed rows on ``uuid or idx`` (idx = streaming enumeration
 # index), which is unstable across --limit/--language-filter/order changes and
-# never matched the emitted output (which stored ``id`` + ``metadata.idx``, not
-# top-level ``uuid``/``idx``). Resume now reads a single stable
-# ``metadata.primary_id`` written by the script.
+# never matched the emitted output. A conversation now fans out to one row per
+# assistant turn, so the row ``id`` is turn-suffixed and cannot itself be the
+# resume key; each row carries the conversation's ``primary_id`` for that.
 # ---------------------------------------------------------------------------
 
 
@@ -309,6 +287,20 @@ def test_load_seen_ignores_rows_without_id(tmp_path):
         encoding="utf-8",
     )
     assert regen.load_seen(str(out)) == set()
+
+
+def test_load_seen_prefers_primary_id_over_turn_suffixed_id(tmp_path):
+    # The turn-suffixed row `id` never equals a recomputed primary_id, so keying
+    # resume on it would reprocess every conversation and append duplicate rows.
+    out = tmp_path / "out.jsonl"
+    out.write_text(
+        json.dumps({"id": "P_turn0", "primary_id": "P"})
+        + "\n"
+        + json.dumps({"id": "P_turn1", "primary_id": "P"})
+        + "\n",
+        encoding="utf-8",
+    )
+    assert regen.load_seen(str(out)) == {"P"}
 
 
 def test_resume_roundtrip_hash_only_row(tmp_path):
@@ -429,3 +421,138 @@ def test_post_chat_fails_fast_on_permanent_status():
 
     asyncio.run(scenario())
     assert session.calls == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. worker() end to end over a fake endpoint: the queue item's ``primary_id``
+#    reaches every emitted row, and load_seen() recovers it from the turn-
+#    suffixed row ids so a resumed run skips the conversation.
+# ---------------------------------------------------------------------------
+
+
+class _Args:
+    model = "m"
+    max_tokens = 16
+    max_retries = 0
+
+
+class _NullProgress:
+    def set_postfix(self, **kwargs): ...
+    def update(self, n): ...
+
+
+def _chat_response(prompt_token_ids, completion_token_ids, text):
+    return {
+        "choices": [
+            {
+                "message": {"content": text},
+                "token_ids": completion_token_ids,
+                "finish_reason": "stop",
+            }
+        ],
+        "prompt_token_ids": prompt_token_ids,
+    }
+
+
+def _run_worker(session, item, out_path, err_path):
+    async def scenario():
+        queue: asyncio.Queue = asyncio.Queue()
+        await queue.put(item)
+        await queue.put(None)
+        stats = {"ok": 0, "errors": 0}
+        with (
+            open(out_path, "w", encoding="utf-8") as out_fh,
+            open(err_path, "w", encoding="utf-8") as err_fh,
+        ):
+            await regen.worker(
+                session,
+                queue,
+                _Args(),
+                out_fh,
+                err_fh,
+                "http://x/v1/chat/completions",
+                _NullProgress(),
+                stats,
+            )
+        return stats
+
+    return asyncio.run(scenario())
+
+
+def test_worker_stamps_primary_id_and_resume_recovers_it(tmp_path):
+    # Two assistant turns -> two rows. `primary_id` is the queue item's stable id
+    # (never the streaming `idx`), and `id` is that id plus a turn suffix.
+    session = _FakeSession(
+        [
+            _FakeResponse(
+                ok=True,
+                status=200,
+                text="",
+                payload=_chat_response([1, 2], [3, 4], "four"),
+            ),
+            _FakeResponse(
+                ok=True,
+                status=200,
+                text="",
+                payload=_chat_response([1, 2, 3, 4, 5], [6], "six"),
+            ),
+        ]
+    )
+    out_path = tmp_path / "out.jsonl"
+    err_path = tmp_path / "out.errors.jsonl"
+    item = {
+        "idx": 41,
+        "primary_id": "conv-abc",
+        "turns": [
+            {"role": "user", "content": "2+2?"},
+            {"role": "user", "content": "3+3?"},
+        ],
+    }
+
+    stats = _run_worker(session, item, out_path, err_path)
+
+    assert stats == {"ok": 1, "errors": 0}
+    rows = [json.loads(line) for line in out_path.read_text().splitlines()]
+    assert [r["id"] for r in rows] == ["conv-abc_turn0", "conv-abc_turn1"]
+    assert {r["primary_id"] for r in rows} == {"conv-abc"}
+    # The boundary is the mask: prompt 0s then completion 1s.
+    assert rows[0]["input_ids"] == [1, 2, 3, 4]
+    assert rows[0]["loss_mask"] == [0, 0, 1, 1]
+
+    # The resume key a re-run recomputes is the bare primary_id, not the row id.
+    assert regen.load_seen(str(out_path)) == {"conv-abc"}
+
+
+def test_worker_failure_writes_no_output_rows(tmp_path):
+    # Turn 2 fails; turn 1's sample is discarded so the conversation is retried
+    # whole on resume rather than resuming half-written.
+    session = _FakeSession(
+        [
+            _FakeResponse(
+                ok=True,
+                status=200,
+                text="",
+                payload=_chat_response([1, 2], [3, 4], "four"),
+            ),
+            _FakeResponse(ok=False, status=404, text="nope", payload={}),
+        ]
+    )
+    out_path = tmp_path / "out.jsonl"
+    err_path = tmp_path / "out.errors.jsonl"
+    item = {
+        "idx": 41,
+        "primary_id": "conv-abc",
+        "turns": [
+            {"role": "user", "content": "2+2?"},
+            {"role": "user", "content": "3+3?"},
+        ],
+    }
+
+    stats = _run_worker(session, item, out_path, err_path)
+
+    assert stats == {"ok": 0, "errors": 1}
+    assert out_path.read_text() == ""
+    assert regen.load_seen(str(out_path)) == set()
+    error = json.loads(err_path.read_text())
+    assert error["id"] == "conv-abc"
+    assert error["metadata"]["turns_completed"] == 1

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -226,6 +226,22 @@ def test_pretokenized_rows_pass_through_preprocessing():
     assert "conversations" not in out
 
 
+def test_pretokenized_passthrough_truncates_and_filters():
+    # Truncation can cut the completion span away (all-zero mask); such a row must
+    # be dropped by minimum_valid_tokens, like the tokenized path.
+    kept = regen.build_boundary_sample([1, 2], [3, 4])  # fits max_length=4
+    cut = regen.build_boundary_sample([1, 2, 3, 4], [5, 6])  # completion truncated off
+    out = _preprocess_batch(
+        {"input_ids": [kept[0], cut[0]], "loss_mask": [kept[1], cut[1]]},
+        processor=None,
+        max_length=4,
+        assistant_pattern=None,
+        minimum_valid_tokens=1,
+    )
+    assert [t.tolist() for t in out["input_ids"]] == [[1, 2, 3, 4]]
+    assert [m.tolist() for m in out["loss_mask"]] == [[0, 0, 1, 1]]
+
+
 # ---------------------------------------------------------------------------
 # 3. Stable resume identity.
 #
@@ -455,28 +471,28 @@ def _chat_response(prompt_token_ids, completion_token_ids, text):
 
 
 def _run_worker(session, item, out_path, err_path):
-    async def scenario():
+    async def scenario(out_fh, err_fh):
         queue: asyncio.Queue = asyncio.Queue()
         await queue.put(item)
         await queue.put(None)
         stats = {"ok": 0, "errors": 0}
-        with (
-            open(out_path, "w", encoding="utf-8") as out_fh,
-            open(err_path, "w", encoding="utf-8") as err_fh,
-        ):
-            await regen.worker(
-                session,
-                queue,
-                _Args(),
-                out_fh,
-                err_fh,
-                "http://x/v1/chat/completions",
-                _NullProgress(),
-                stats,
-            )
+        await regen.worker(
+            session,
+            queue,
+            _Args(),
+            out_fh,
+            err_fh,
+            "http://x/v1/chat/completions",
+            _NullProgress(),
+            stats,
+        )
         return stats
 
-    return asyncio.run(scenario())
+    with (
+        out_path.open("w", encoding="utf-8") as out_fh,
+        err_path.open("w", encoding="utf-8") as err_fh,
+    ):
+        return asyncio.run(scenario(out_fh, err_fh))
 
 
 def test_worker_stamps_primary_id_and_resume_recovers_it(tmp_path):

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -1,21 +1,8 @@
 """Real, dependency-light tests for the response-regeneration script.
 
-The seams covered, with no network and no mocked HTTP:
-
-1. ``extract_turns`` over the *actual* schemas of the supported datasets
-   (ultrachat ``messages`` role/content, magpie/open-perfectblend
-   ``conversations`` from/value, gsm8k single prompt), plus the robustness
-   fixes (empty conversation lists, non-dict elements, mixed schema).
-
-2. ``build_boundary_sample`` (the boundary *is* the loss mask) and the pre-tokenized
-   rows it produces passing untouched through the real ``_preprocess_batch``.
-
-3. Resume identity: ``_primary_identifier`` / ``load_seen`` across the one-row-per-
-   assistant-turn fan-out.
-
-4. Retry/backoff around a single request.
-
-5. ``worker`` end to end over a fake endpoint, tying 2-4 together.
+No network and no mocked HTTP: the script's seams are exercised directly against
+the real downstream ``_preprocess_batch``, and ``worker`` is driven end to end
+over a fake endpoint.
 
 The script is not a package, so it is imported by path.
 """
@@ -242,6 +229,19 @@ def test_pretokenized_passthrough_truncates_and_filters():
     assert [m.tolist() for m in out["loss_mask"]] == [[0, 0, 1, 1]]
 
 
+def test_pretokenized_passthrough_rejects_length_mismatch():
+    # The passthrough accepts rows from any dataset carrying both columns. A row
+    # whose mask is shorter than its ids must fail loudly here: the collator packs
+    # each key independently, so it would otherwise shift the mask silently.
+    with pytest.raises(ValueError, match="shape mismatch"):
+        _preprocess_batch(
+            {"input_ids": [[1, 2, 3, 4, 5]], "loss_mask": [[0, 0, 1]]},
+            processor=None,
+            max_length=2048,
+            assistant_pattern=None,
+        )
+
+
 # ---------------------------------------------------------------------------
 # 3. Stable resume identity.
 #
@@ -303,20 +303,6 @@ def test_load_seen_ignores_rows_without_id(tmp_path):
         encoding="utf-8",
     )
     assert regen.load_seen(str(out)) == set()
-
-
-def test_load_seen_prefers_primary_id_over_turn_suffixed_id(tmp_path):
-    # The turn-suffixed row `id` never equals a recomputed primary_id, so keying
-    # resume on it would reprocess every conversation and append duplicate rows.
-    out = tmp_path / "out.jsonl"
-    out.write_text(
-        json.dumps({"id": "P_turn0", "primary_id": "P"})
-        + "\n"
-        + json.dumps({"id": "P_turn1", "primary_id": "P"})
-        + "\n",
-        encoding="utf-8",
-    )
-    assert regen.load_seen(str(out)) == {"P"}
 
 
 def test_resume_roundtrip_hash_only_row(tmp_path):
@@ -440,9 +426,7 @@ def test_post_chat_fails_fast_on_permanent_status():
 
 
 # ---------------------------------------------------------------------------
-# 5. worker() end to end over a fake endpoint: the queue item's ``primary_id``
-#    reaches every emitted row, and load_seen() recovers it from the turn-
-#    suffixed row ids so a resumed run skips the conversation.
+# 5. worker() end to end over a fake endpoint.
 # ---------------------------------------------------------------------------
 
 
@@ -457,8 +441,18 @@ class _NullProgress:
     def update(self, n): ...
 
 
-def _chat_response(prompt_token_ids, completion_token_ids, text):
-    return {
+_TWO_TURN_ITEM = {
+    "idx": 41,
+    "primary_id": "conv-abc",
+    "turns": [
+        {"role": "user", "content": "2+2?"},
+        {"role": "user", "content": "3+3?"},
+    ],
+}
+
+
+def _ok(prompt_token_ids, completion_token_ids, text):
+    payload = {
         "choices": [
             {
                 "message": {"content": text},
@@ -468,16 +462,19 @@ def _chat_response(prompt_token_ids, completion_token_ids, text):
         ],
         "prompt_token_ids": prompt_token_ids,
     }
+    return _FakeResponse(ok=True, status=200, text="", payload=payload)
 
 
-def _run_worker(session, item, out_path, err_path):
+def _run_worker(responses, tmp_path, stem):
+    out_path, err_path = tmp_path / f"{stem}.jsonl", tmp_path / f"{stem}.errors.jsonl"
+
     async def scenario(out_fh, err_fh):
         queue: asyncio.Queue = asyncio.Queue()
-        await queue.put(item)
+        await queue.put(_TWO_TURN_ITEM)
         await queue.put(None)
         stats = {"ok": 0, "errors": 0}
         await regen.worker(
-            session,
+            _FakeSession(responses),
             queue,
             _Args(),
             out_fh,
@@ -492,41 +489,19 @@ def _run_worker(session, item, out_path, err_path):
         out_path.open("w", encoding="utf-8") as out_fh,
         err_path.open("w", encoding="utf-8") as err_fh,
     ):
-        return asyncio.run(scenario(out_fh, err_fh))
+        stats = asyncio.run(scenario(out_fh, err_fh))
+    return stats, out_path, err_path
 
 
-def test_worker_stamps_primary_id_and_resume_recovers_it(tmp_path):
+def test_worker_row_identity_and_all_or_nothing_writes(tmp_path):
     # Two assistant turns -> two rows. `primary_id` is the queue item's stable id
-    # (never the streaming `idx`), and `id` is that id plus a turn suffix.
-    session = _FakeSession(
-        [
-            _FakeResponse(
-                ok=True,
-                status=200,
-                text="",
-                payload=_chat_response([1, 2], [3, 4], "four"),
-            ),
-            _FakeResponse(
-                ok=True,
-                status=200,
-                text="",
-                payload=_chat_response([1, 2, 3, 4, 5], [6], "six"),
-            ),
-        ]
+    # (never the streaming `idx`); `id` is that id plus a turn suffix; and resume
+    # keys on the former, so a re-run of this conversation is skipped.
+    stats, out_path, _ = _run_worker(
+        [_ok([1, 2], [3, 4], "four"), _ok([1, 2, 3, 4, 5], [6], "six")],
+        tmp_path,
+        "ok",
     )
-    out_path = tmp_path / "out.jsonl"
-    err_path = tmp_path / "out.errors.jsonl"
-    item = {
-        "idx": 41,
-        "primary_id": "conv-abc",
-        "turns": [
-            {"role": "user", "content": "2+2?"},
-            {"role": "user", "content": "3+3?"},
-        ],
-    }
-
-    stats = _run_worker(session, item, out_path, err_path)
-
     assert stats == {"ok": 1, "errors": 0}
     rows = [json.loads(line) for line in out_path.read_text().splitlines()]
     assert [r["id"] for r in rows] == ["conv-abc_turn0", "conv-abc_turn1"]
@@ -534,38 +509,18 @@ def test_worker_stamps_primary_id_and_resume_recovers_it(tmp_path):
     # The boundary is the mask: prompt 0s then completion 1s.
     assert rows[0]["input_ids"] == [1, 2, 3, 4]
     assert rows[0]["loss_mask"] == [0, 0, 1, 1]
-
-    # The resume key a re-run recomputes is the bare primary_id, not the row id.
     assert regen.load_seen(str(out_path)) == {"conv-abc"}
 
-
-def test_worker_failure_writes_no_output_rows(tmp_path):
-    # Turn 2 fails; turn 1's sample is discarded so the conversation is retried
-    # whole on resume rather than resuming half-written.
-    session = _FakeSession(
+    # Turn 2 fails: turn 1's sample is discarded rather than half-written, which
+    # is what lets load_seen treat one row as a finished conversation.
+    stats, out_path, err_path = _run_worker(
         [
-            _FakeResponse(
-                ok=True,
-                status=200,
-                text="",
-                payload=_chat_response([1, 2], [3, 4], "four"),
-            ),
+            _ok([1, 2], [3, 4], "four"),
             _FakeResponse(ok=False, status=404, text="nope", payload={}),
-        ]
-    )
-    out_path = tmp_path / "out.jsonl"
-    err_path = tmp_path / "out.errors.jsonl"
-    item = {
-        "idx": 41,
-        "primary_id": "conv-abc",
-        "turns": [
-            {"role": "user", "content": "2+2?"},
-            {"role": "user", "content": "3+3?"},
         ],
-    }
-
-    stats = _run_worker(session, item, out_path, err_path)
-
+        tmp_path,
+        "fail",
+    )
     assert stats == {"ok": 0, "errors": 1}
     assert out_path.read_text() == ""
     assert regen.load_seen(str(out_path)) == set()

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -204,7 +204,7 @@ def test_pretokenized_rows_pass_through_preprocessing():
             "loss_mask": [loss_mask],
             "conversations": [[{"role": "user", "content": "2+2?"}]],
         },
-        processor=None,
+        processor=None,  # type: ignore[arg-type]  # passthrough never touches it
         max_length=2048,
         assistant_pattern=None,
     )
@@ -220,7 +220,7 @@ def test_pretokenized_passthrough_truncates_and_filters():
     cut = regen.build_boundary_sample([1, 2, 3, 4], [5, 6])  # completion truncated off
     out = _preprocess_batch(
         {"input_ids": [kept[0], cut[0]], "loss_mask": [kept[1], cut[1]]},
-        processor=None,
+        processor=None,  # type: ignore[arg-type]  # passthrough never touches it
         max_length=4,
         assistant_pattern=None,
         minimum_valid_tokens=1,
@@ -236,7 +236,7 @@ def test_pretokenized_passthrough_rejects_length_mismatch():
     with pytest.raises(ValueError, match="shape mismatch"):
         _preprocess_batch(
             {"input_ids": [[1, 2, 3, 4, 5]], "loss_mask": [[0, 0, 1]]},
-            processor=None,
+            processor=None,  # type: ignore[arg-type]  # passthrough never touches it
             max_length=2048,
             assistant_pattern=None,
         )


### PR DESCRIPTION
# Purpose

The current on-policy response regeneration has re-tokenization roundtrip redundancy. This PR helps eliminate the roundtrip:



```
BEFORE                               AFTER
regen -> text                        regen -> return_token_ids
write conversations                  write input_ids + loss_mask (boundary)
re-tokenize + REGEX/HF mask          _preprocess_batch passthrough (no masking)
vLLM -> hidden states                vLLM -> hidden states
```

The masking machinery still exists (off-policy needs it until PR2); it is just no longer on the on-policy path.

## Concrete example — a 2-turn conversation

Before (one row of text, masked later by regex over the whole rendering):

```json
{"id": "sample_7", "conversations": [{"from":"human","value":"2+2?"}, {"from":"gpt","value":"4"}, {"from":"human","value":"3+3?"}, {"from":"gpt","value":"6"}]}
```

After (one row per assistant turn, mask already applied):

```json
{"id":"sample_7_turn0", "input_ids":[<prompt>,<"4">], "loss_mask":[0,0,0,1,1], "conversations":[...]}
{"id":"sample_7_turn1", "input_ids":[<prompt+history>,<"6">], "loss_mask":[0,...,0,1,1], "conversations":[...]}
```

`loss_mask` 0 is the prompt the target conditioned on; 1 is what it generated. No `{% generation %}` markers, no regex — just the boundary the serving engine reports.



## Why

On-policy data never needed regex masking: we generated the response, so we already know where the assistant tokens are, and capturing that boundary is exact.

It is also correct for multi-turn reasoning models, where each turn supervises the `<think>` it actually generated while history keeps only parsed content — matching inference. The regex path cannot reproduce this, because the same turn tokenizes differently as "generated" vs as "history".

## What changes (observable)

| | Before | After |
|---|---|---|
| Output schema | `conversations` (text) | `input_ids` + `loss_mask` (+ `conversations`, review-only) |
| Rows per conversation | 1 | 1 per assistant turn |
| Mask made | downstream regex / HF | generation boundary |
| Endpoint | text out | must support `return_token_ids` |

`conversations` is retained as an inert human-review twin of `input_ids`: `_preprocess_batch` routes on `input_ids`/`loss_mask` (checked first) and drops `conversations` before training, so it is never re-masked.

## Tests

`build_boundary_sample` produces the boundary mask; pre-tokenized rows pass through `_preprocess_batch` without a processor, and a review `conversations` field is ignored. Off-policy suite unchanged (56 passed / 2 skipped).

## Scope — step 1 of 5 ("renderer is the single source of truth")

1. (this PR) on-policy → generation boundary; stop feeding the regex path. (Please note that this PR is a concrete standalone PR. No speculative scaffolding. )
2. To unify the chat template generation tag. we should vendor generation-tagged template from trl https://github.com/huggingface/trl/issues/4879. 
3. on-policy → we have to diverge a bit from pure on-policy regen: real inference has a thinking compression mechanism - newer models, e.g., GLM5.2, Qwen3.6 only keep the latest turn's thinking, and drop 0:n-1  thinking. But we need all thinking because that's where speculative decoding can helps. PR1 is correct (completely on policy, no divergence) but inefficient because it fan out multiturn to multi-row jsonl. PR3 can linearize them back to single-row, with some tradeoff. This is also the same solution with trl, llama-factory for multi-turn SFT. We can discuss further on the tradeoff when I have a draft PR. 
4. off-policy → vLLM `/render` this path can be decoupled from the regex & hf path
5. delete the regex/HF masking once both producers are redirected.

small followup PRs:

`--turn-dropout` not compatible with this PR. need to run some tests on real data to see if we should improve it or remove it. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
