### PR TITLE
Cleanup unused draft-token argmax from DFlash/DSpark forward

### DIFF
--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -423,6 +423,4 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             per_position_loss_weight=per_position_loss_weight,
             dpace_alpha=dpace_alpha,
         )
-        draft_tokens = torch.argmax(logits, dim=-1)
-
-        return draft_tokens, loss, metrics
+        return None, loss, metrics

--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -178,5 +178,4 @@ class DSparkDraftModel(DFlashDraftModel):
             per_position_loss_weight=per_position_loss_weight,
             dpace_alpha=dpace_alpha,
         )
-        draft_tokens = torch.argmax(logits, dim=-1)
-        return draft_tokens, loss, metrics
+        return None, loss, metrics


### PR DESCRIPTION


## Purpose

Cleanup unused draft-token argmax from DFlash/DSpark forward. Match P-Eagle. 

## Why this is safe

DFlash and DSpark are single-pass (block-parallel), so the top-level `torch.argmax(logits)` at the end of their training forward produces draft tokens that no caller uses: the trainer discards the first return value, the loss reads `logits` directly, and `compute_metrics` runs its own `argmax` for per-position accuracy. 

It also duplicated the argmax `compute_metrics` had just performed on the same tensor.

## Tests

Nothing broken

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
