### PR TITLE
feat(evaluate): add NVIDIA SPEED-Bench support to evaluate.py

### DIFF
--- a/docs/user_guide/tutorials/evaluating_performance.md
+++ b/docs/user_guide/tutorials/evaluating_performance.md
@@ -41,6 +41,68 @@ Both `throughput` and `sweep` share the same options:
   --data-column-mapper JSON  Column mapping for guidellm (default: '{"text_column":"prompt"}')
 ```
 
+## SPEED-Bench
+
+[NVIDIA SPEED-Bench](https://huggingface.co/datasets/nvidia/SPEED-Bench) provides structured evaluation across qualitative categories (coding, math, reasoning, multilingual, …) and throughput splits with varying input sequence lengths (1 k–32 k tokens).
+
+### One-time data preparation
+
+SPEED-Bench prompts are fetched from external sources and cannot be redistributed directly.
+Run the preparation step once to materialise them locally:
+
+```bash
+# Fetch and materialise prompts, then split into per-category files (all in one command)
+python scripts/evaluate/prepare_speedbench.py \
+    --data-dir ./speedbench_data \
+    --download
+
+# Or run the two steps separately if you already have the flat files:
+curl -LsSf https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/refs/heads/main/nemo_skills/dataset/speed-bench/prepare.py \
+    | python3 - --output_dir ./speedbench_data
+python scripts/evaluate/prepare_speedbench.py --data-dir ./speedbench_data
+```
+
+> **Note:** `prepare_speedbench.py` reads from the URL above to fetch NVIDIA's `prepare.py`.
+> Save a local copy (`--download` does this implicitly) if you anticipate running data
+> preparation again.  The materialised files contain data from third-party sources —
+> do not redistribute them.
+
+### Running evaluations
+
+Pass a `speedbench/<config>` spec to `--dataset` together with `--speedbench-data-dir`:
+
+```bash
+# All 11 qualitative categories
+python evaluate.py throughput \
+    --target http://localhost:8000/v1 \
+    --dataset speedbench/qualitative \
+    --speedbench-data-dir ./speedbench_data
+
+# Single category
+python evaluate.py throughput \
+    --target http://localhost:8000/v1 \
+    --dataset speedbench/qualitative/coding \
+    --speedbench-data-dir ./speedbench_data
+
+# All throughput_1k subcategories
+python evaluate.py throughput \
+    --target http://localhost:8000/v1 \
+    --dataset speedbench/throughput_1k \
+    --speedbench-data-dir ./speedbench_data
+
+# One entropy tier only
+python evaluate.py throughput \
+    --target http://localhost:8000/v1 \
+    --dataset speedbench/throughput_1k/high_entropy \
+    --speedbench-data-dir ./speedbench_data
+```
+
+Available configs: `qualitative`, `throughput_1k`, `throughput_2k`, `throughput_8k`, `throughput_32k`.
+
+Results are written to `acceptance.csv` in the output directory with per-category
+acceptance lengths and per-position acceptance rates, identical in format to the
+`RedHatAI/speculator_benchmarks` output.
+
 ## Visualization
 
 ```bash

--- a/docs/user_guide/tutorials/evaluating_performance.md
+++ b/docs/user_guide/tutorials/evaluating_performance.md
@@ -47,8 +47,7 @@ Both `throughput` and `sweep` share the same options:
 
 ### One-time data preparation
 
-SPEED-Bench prompts are fetched from external sources and cannot be redistributed directly.
-Run the preparation step once to materialise them locally:
+SPEED-Bench prompts are fetched from external sources and cannot be redistributed directly. Run the preparation step once to materialise them locally:
 
 ```bash
 # Fetch and materialise prompts, then split into per-category files (all in one command)
@@ -62,10 +61,7 @@ curl -LsSf https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/refs/heads/main/
 python scripts/evaluate/prepare_speedbench.py --data-dir ./speedbench_data
 ```
 
-> **Note:** `prepare_speedbench.py` reads from the URL above to fetch NVIDIA's `prepare.py`.
-> Save a local copy (`--download` does this implicitly) if you anticipate running data
-> preparation again.  The materialised files contain data from third-party sources —
-> do not redistribute them.
+> **Note:** `prepare_speedbench.py` reads from the URL above to fetch NVIDIA's `prepare.py`. Save a local copy (`--download` does this implicitly) if you anticipate running data preparation again. The materialised files contain data from third-party sources — do not redistribute them.
 
 ### Running evaluations
 
@@ -99,9 +95,7 @@ python evaluate.py throughput \
 
 Available configs: `qualitative`, `throughput_1k`, `throughput_2k`, `throughput_8k`, `throughput_32k`.
 
-Results are written to `acceptance.csv` in the output directory with per-category
-acceptance lengths and per-position acceptance rates, identical in format to the
-`RedHatAI/speculator_benchmarks` output.
+Results are written to `acceptance.csv` in the output directory with per-category acceptance lengths and per-position acceptance rates, identical in format to the `RedHatAI/speculator_benchmarks` output.
 
 ## Visualization
 

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -105,8 +105,19 @@ def _resolve_speedbench(
     """
     parts = spec.removeprefix("speedbench/").split("/")
     config = parts[0]
-    # Build a glob pattern from however much of the path was specified
-    suffix = "_".join(parts[1:]) if len(parts) > 1 else ""
+    rest = parts[1:]
+    # Build glob pattern matching prepare_speedbench.py's naming convention:
+    #   qualitative/coding          → qualitative_coding*.jsonl
+    #   throughput_1k/high_entropy  → throughput_1k_high_entropy_*.jsonl
+    #   throughput_1k/high_entropy/code_completion
+    #                               → throughput_1k_high_entropy__code_completion*.jsonl
+    # Entropy level and subcategory are separated by "__" in the filename.
+    if not rest:
+        suffix = ""
+    elif len(rest) == 1:
+        suffix = rest[0]
+    else:
+        suffix = rest[0] + "__" + "_".join(rest[1:])
     pattern = f"{config}_{suffix}*.jsonl" if suffix else f"{config}_*.jsonl"
 
     files = sorted(data_dir.glob(pattern))

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -152,20 +152,23 @@ def _run_subset(
     guidellm_common: dict,
     acceptance_csv: CsvWriter | None,
     perf_csv: CsvWriter | None,
-    data_subset: str | None = None,
 ) -> tuple[CsvWriter | None, CsvWriter | None, int | None]:
     """Run benchmark for one subset.
 
-    *subset* is used as the human-readable label and for output file names.
-    *data_subset* is the value passed to guidellm ``--data-args`` to filter
-    within an HF dataset (e.g. ``"HumanEval"`` → ``{"data_files":"HumanEval.jsonl"}``).
-    Pass ``None`` when ``guidellm_common["dataset"]`` already points to a local
-    JSONL file (e.g. pre-split SPEED-Bench data) and no ``--data-args`` is needed.
+    *subset* is the human-readable label used for output file names and the
+    acceptance CSV.  When ``guidellm_common["dataset"]`` is a local file path
+    the ``--data-args`` flag is suppressed automatically; when it is an HF
+    dataset ID *subset* is also passed as the data-args filter so guidellm
+    loads just that split.
     """
 
     logger.info("[%s] Starting", subset)
     safe = subset.replace("/", "_").replace(" ", "_")
     max_tokens = 4096
+
+    # For local JSONL files (SPEED-Bench) the dataset path IS the file —
+    # no --data-args needed.  For HF datasets subset name doubles as the filter.
+    guidellm_subset = None if Path(guidellm_common["dataset"]).exists() else subset
 
     if is_sweep:
         gen_len_dir = artifacts_dir / "gen_len"
@@ -173,7 +176,7 @@ def _run_subset(
         gen_len_output = gen_len_dir / f"gen_len_{safe}.json"
         run_guidellm(
             **guidellm_common,
-            subset=data_subset,
+            subset=guidellm_subset,
             profile="throughput",
             max_requests=None,
             output_path=gen_len_output,
@@ -183,7 +186,7 @@ def _run_subset(
             [gen_len_output],
             gen_len_dir / f"max_tokens_{safe}.json",
         )
-        key = data_subset if data_subset else safe
+        key = guidellm_subset if guidellm_subset else safe
         max_tokens = mapping.get(key, max_tokens)
         logger.info("[%s] max_tokens=%d", subset, max_tokens)
 
@@ -192,7 +195,7 @@ def _run_subset(
     run_output = artifacts_dir / f"run_{safe}.json"
     run_guidellm(
         **guidellm_common,
-        subset=data_subset,
+        subset=guidellm_subset,
         profile=profile,
         max_requests=args.max_requests,
         output_path=run_output,
@@ -250,10 +253,10 @@ def run_benchmark(args: argparse.Namespace) -> None:
     perf_csv = None
     all_max_tokens: dict[str, int] = {}
 
-    # Build a flat list of (label, guidellm_common, data_subset) to run uniformly.
-    # For HF datasets data_subset matches the label; for local JSONL it is None.
+    # Build a flat list of (label, guidellm_common) to run uniformly.
+    # _run_subset auto-detects whether --data-args is needed from the dataset path.
     dataset_spec = args.dataset
-    run_items: list[tuple[str, dict, str | None]] = []
+    run_items: list[tuple[str, dict]] = []
 
     if dataset_spec.startswith("speedbench/"):
         if not getattr(args, "speedbench_data_dir", None):
@@ -265,14 +268,18 @@ def run_benchmark(args: argparse.Namespace) -> None:
             sys.exit(1)
         pairs = _resolve_speedbench(dataset_spec, Path(args.speedbench_data_dir))
         for label, local_path in pairs:
-            sb_common = {
-                "target": args.target,
-                "dataset": str(local_path),
-                "data_column_mapper": _SPEEDBENCH_COLUMN_MAPPER,
-                "rate": args.gen_len_rate,
-                "max_concurrency": args.max_concurrency,
-            }
-            run_items.append((label, sb_common, None))
+            run_items.append(
+                (
+                    label,
+                    {
+                        "target": args.target,
+                        "dataset": str(local_path),
+                        "data_column_mapper": _SPEEDBENCH_COLUMN_MAPPER,
+                        "rate": args.gen_len_rate,
+                        "max_concurrency": args.max_concurrency,
+                    },
+                )
+            )
     else:
         guidellm_common = {
             "target": args.target,
@@ -282,12 +289,12 @@ def run_benchmark(args: argparse.Namespace) -> None:
             "max_concurrency": args.max_concurrency,
         }
         for subset in [s.strip() for s in args.subsets.split(",") if s.strip()]:
-            run_items.append((subset, guidellm_common, subset))
+            run_items.append((subset, guidellm_common))
 
     logger.info(
         "Mode: %s | %d subsets | Output: %s", args.mode, len(run_items), output_dir
     )
-    for label, common, data_subset in run_items:
+    for label, common in run_items:
         acceptance_csv, perf_csv, mt = _run_subset(
             label,
             args,
@@ -298,7 +305,6 @@ def run_benchmark(args: argparse.Namespace) -> None:
             guidellm_common=common,
             acceptance_csv=acceptance_csv,
             perf_csv=perf_csv,
-            data_subset=data_subset,
         )
         if mt is not None:
             all_max_tokens[label] = mt

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -152,15 +152,15 @@ def _run_subset(
     guidellm_common: dict,
     acceptance_csv: CsvWriter | None,
     perf_csv: CsvWriter | None,
-    hf_subset: str | None = None,
+    data_subset: str | None = None,
 ) -> tuple[CsvWriter | None, CsvWriter | None, int | None]:
     """Run benchmark for one subset.
 
     *subset* is used as the human-readable label and for output file names.
-    *hf_subset* is the HF subset name passed to guidellm ``--data-args``.
-    Pass the same value as *subset* for standard HF datasets.  Pass ``None``
-    when the dataset IS the file (e.g. a local JSONL from SPEED-Bench) so no
-    ``--data-args`` is added to the guidellm command.
+    *data_subset* is the value passed to guidellm ``--data-args`` to filter
+    within an HF dataset (e.g. ``"HumanEval"`` → ``{"data_files":"HumanEval.jsonl"}``).
+    Pass ``None`` when ``guidellm_common["dataset"]`` already points to a local
+    JSONL file (e.g. pre-split SPEED-Bench data) and no ``--data-args`` is needed.
     """
 
     logger.info("[%s] Starting", subset)
@@ -173,7 +173,7 @@ def _run_subset(
         gen_len_output = gen_len_dir / f"gen_len_{safe}.json"
         run_guidellm(
             **guidellm_common,
-            subset=hf_subset,
+            subset=data_subset,
             profile="throughput",
             max_requests=None,
             output_path=gen_len_output,
@@ -183,9 +183,8 @@ def _run_subset(
             [gen_len_output],
             gen_len_dir / f"max_tokens_{safe}.json",
         )
-        key = hf_subset if hf_subset else safe
+        key = data_subset if data_subset else safe
         max_tokens = mapping.get(key, max_tokens)
-        logger.info("[%s] max_tokens=%d", subset, max_tokens)
         logger.info("[%s] max_tokens=%d", subset, max_tokens)
 
     baseline = _require_metrics(metrics_url)
@@ -193,7 +192,7 @@ def _run_subset(
     run_output = artifacts_dir / f"run_{safe}.json"
     run_guidellm(
         **guidellm_common,
-        subset=hf_subset,
+        subset=data_subset,
         profile=profile,
         max_requests=args.max_requests,
         output_path=run_output,
@@ -251,10 +250,12 @@ def run_benchmark(args: argparse.Namespace) -> None:
     perf_csv = None
     all_max_tokens: dict[str, int] = {}
 
+    # Build a flat list of (label, guidellm_common, data_subset) to run uniformly.
+    # For HF datasets data_subset matches the label; for local JSONL it is None.
     dataset_spec = args.dataset
-    is_speedbench = dataset_spec.startswith("speedbench/")
+    run_items: list[tuple[str, dict, str | None]] = []
 
-    if is_speedbench:
+    if dataset_spec.startswith("speedbench/"):
         if not getattr(args, "speedbench_data_dir", None):
             logger.error(
                 "--speedbench-data-dir is required for speedbench/ datasets.\n"
@@ -262,14 +263,7 @@ def run_benchmark(args: argparse.Namespace) -> None:
                 " --speedbench-data-dir <dir>.",
             )
             sys.exit(1)
-
         pairs = _resolve_speedbench(dataset_spec, Path(args.speedbench_data_dir))
-        logger.info(
-            "Mode: %s | %d speedbench subsets | Output: %s",
-            args.mode,
-            len(pairs),
-            output_dir,
-        )
         for label, local_path in pairs:
             sb_common = {
                 "target": args.target,
@@ -278,28 +272,8 @@ def run_benchmark(args: argparse.Namespace) -> None:
                 "rate": args.gen_len_rate,
                 "max_concurrency": args.max_concurrency,
             }
-            acceptance_csv, perf_csv, mt = _run_subset(
-                label,
-                args,
-                is_sweep=is_sweep,
-                metrics_url=metrics_url,
-                artifacts_dir=artifacts_dir,
-                output_dir=output_dir,
-                guidellm_common=sb_common,
-                acceptance_csv=acceptance_csv,
-                perf_csv=perf_csv,
-                hf_subset=None,  # local JSONL is the dataset, no --data-args needed
-            )
-            if mt is not None:
-                all_max_tokens[label] = mt
+            run_items.append((label, sb_common, None))
     else:
-        subsets = [s.strip() for s in args.subsets.split(",") if s.strip()]
-        logger.info(
-            "Mode: %s | %d subsets | Output: %s",
-            args.mode,
-            len(subsets),
-            output_dir,
-        )
         guidellm_common = {
             "target": args.target,
             "dataset": dataset_spec,
@@ -307,21 +281,27 @@ def run_benchmark(args: argparse.Namespace) -> None:
             "rate": args.gen_len_rate,
             "max_concurrency": args.max_concurrency,
         }
-        for subset in subsets:
-            acceptance_csv, perf_csv, mt = _run_subset(
-                subset,
-                args,
-                is_sweep=is_sweep,
-                metrics_url=metrics_url,
-                artifacts_dir=artifacts_dir,
-                output_dir=output_dir,
-                guidellm_common=guidellm_common,
-                acceptance_csv=acceptance_csv,
-                perf_csv=perf_csv,
-                hf_subset=subset,  # HF dataset: subset name = --data-args filter
-            )
-            if mt is not None:
-                all_max_tokens[subset] = mt
+        for subset in [s.strip() for s in args.subsets.split(",") if s.strip()]:
+            run_items.append((subset, guidellm_common, subset))
+
+    logger.info(
+        "Mode: %s | %d subsets | Output: %s", args.mode, len(run_items), output_dir
+    )
+    for label, common, data_subset in run_items:
+        acceptance_csv, perf_csv, mt = _run_subset(
+            label,
+            args,
+            is_sweep=is_sweep,
+            metrics_url=metrics_url,
+            artifacts_dir=artifacts_dir,
+            output_dir=output_dir,
+            guidellm_common=common,
+            acceptance_csv=acceptance_csv,
+            perf_csv=perf_csv,
+            data_subset=data_subset,
+        )
+        if mt is not None:
+            all_max_tokens[label] = mt
 
     if acceptance_csv is None:
         logger.error("No acceptance metrics collected from any subset")

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -6,10 +6,18 @@ Modes:
     sweep        Full pipeline (gen-len, sweep, CSV)
 
 Examples:
-    python evaluate.py --target http://localhost:8108/v1 throughput
+    python evaluate.py --target http://localhost:8000/v1 throughput
     python evaluate.py --target http://localhost:8000/v1 sweep
     python evaluate.py --target http://localhost:8000/v1 sweep \\
         --subsets "HumanEval,qa" --gen-kwargs '{"temperature":0.6}'
+
+    # SPEED-Bench (run prepare_speedbench.py once first to split data):
+    python evaluate.py --target http://localhost:8000/v1 throughput \\
+        --dataset speedbench/qualitative \\
+        --speedbench-data-dir ./speedbench_data
+    python evaluate.py --target http://localhost:8000/v1 throughput \\
+        --dataset speedbench/qualitative/coding \\
+        --speedbench-data-dir ./speedbench_data
 """
 
 from __future__ import annotations
@@ -50,6 +58,12 @@ DEFAULT_MAX_REQUESTS = 80
 DEFAULT_GEN_LEN_RATE = 128
 DEFAULT_DATA_COLUMN_MAPPER = '{"text_column":"prompt"}'
 
+# ---------------------------------------------------------------------------
+# SPEED-Bench constants
+# ---------------------------------------------------------------------------
+
+_SPEEDBENCH_COLUMN_MAPPER = '{"text_column":"turns"}'
+
 
 def _fetch_model_name(target: str) -> str | None:
     base = target.rstrip("/")
@@ -79,6 +93,43 @@ def _require_metrics(metrics_url: str) -> list:
     return parse_prometheus_metrics(text)
 
 
+def _resolve_speedbench(
+    spec: str,
+    data_dir: Path,
+) -> list[tuple[str, Path]]:
+    """Resolve a ``speedbench/<config>[/<category>[/<subcategory>]]`` spec.
+
+    Returns ``(label, path)`` pairs for pre-split JSONL files produced by
+    ``scripts/evaluate/prepare_speedbench.py``.  Run that script once after
+    NVIDIA's ``prepare.py`` to create per-category/subcategory files.
+    """
+    parts = spec.removeprefix("speedbench/").split("/")
+    config = parts[0]
+    # Build a glob pattern from however much of the path was specified
+    suffix = "_".join(parts[1:]) if len(parts) > 1 else ""
+    pattern = f"{config}_{suffix}*.jsonl" if suffix else f"{config}_*.jsonl"
+
+    files = sorted(data_dir.glob(pattern))
+    if not files:
+        logger.error(
+            "--speedbench-data-dir='%s': no files matching '%s'.\n"
+            "Run scripts/evaluate/prepare_speedbench.py first.",
+            data_dir,
+            pattern,
+        )
+        sys.exit(1)
+
+    results = []
+    for path in files:
+        # Derive label: qualitative_coding → speedbench/qualitative/coding
+        stem = path.stem.removeprefix(f"{config}_")
+        label = f"speedbench/{config}/{stem.replace('__', '/')}"
+        results.append((label, path))
+        logger.info("  %s: %s", label, path.name)
+
+    return results
+
+
 def _run_subset(
     subset: str,
     args: argparse.Namespace,
@@ -90,17 +141,28 @@ def _run_subset(
     guidellm_common: dict,
     acceptance_csv: CsvWriter | None,
     perf_csv: CsvWriter | None,
+    hf_subset: str | None = None,
 ) -> tuple[CsvWriter | None, CsvWriter | None, int | None]:
+    """Run benchmark for one subset.
+
+    *subset* is used as the human-readable label and for output file names.
+    *hf_subset* is the HF subset name passed to guidellm ``--data-args``.
+    Pass the same value as *subset* for standard HF datasets.  Pass ``None``
+    when the dataset IS the file (e.g. a local JSONL from SPEED-Bench) so no
+    ``--data-args`` is added to the guidellm command.
+    """
+
     logger.info("[%s] Starting", subset)
+    safe = subset.replace("/", "_").replace(" ", "_")
     max_tokens = 4096
 
     if is_sweep:
         gen_len_dir = artifacts_dir / "gen_len"
         gen_len_dir.mkdir(parents=True, exist_ok=True)
-        gen_len_output = gen_len_dir / f"gen_len_{subset}.json"
+        gen_len_output = gen_len_dir / f"gen_len_{safe}.json"
         run_guidellm(
             **guidellm_common,
-            subset=subset,
+            subset=hf_subset,
             profile="throughput",
             max_requests=None,
             output_path=gen_len_output,
@@ -108,17 +170,19 @@ def _run_subset(
         )
         mapping = parse_gen_len_results(
             [gen_len_output],
-            gen_len_dir / f"max_tokens_{subset}.json",
+            gen_len_dir / f"max_tokens_{safe}.json",
         )
-        max_tokens = mapping[subset]
+        key = hf_subset if hf_subset else safe
+        max_tokens = mapping.get(key, max_tokens)
+        logger.info("[%s] max_tokens=%d", subset, max_tokens)
         logger.info("[%s] max_tokens=%d", subset, max_tokens)
 
     baseline = _require_metrics(metrics_url)
     profile = "sweep" if is_sweep else "throughput"
-    run_output = artifacts_dir / f"run_{subset}.json"
+    run_output = artifacts_dir / f"run_{safe}.json"
     run_guidellm(
         **guidellm_common,
-        subset=subset,
+        subset=hf_subset,
         profile=profile,
         max_requests=args.max_requests,
         output_path=run_output,
@@ -172,40 +236,81 @@ def run_benchmark(args: argparse.Namespace) -> None:
     artifacts_dir = output_dir / "artifacts"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 
-    subsets = args.subsets.split(",")
-    logger.info(
-        "Mode: %s | %d subsets | Output: %s",
-        args.mode,
-        len(subsets),
-        output_dir,
-    )
-
-    guidellm_common = {
-        "target": args.target,
-        "dataset": args.dataset,
-        "data_column_mapper": args.data_column_mapper,
-        "rate": args.gen_len_rate,
-        "max_concurrency": args.max_concurrency,
-    }
-
     acceptance_csv = None
     perf_csv = None
     all_max_tokens: dict[str, int] = {}
 
-    for subset in subsets:
-        acceptance_csv, perf_csv, mt = _run_subset(
-            subset,
-            args,
-            is_sweep=is_sweep,
-            metrics_url=metrics_url,
-            artifacts_dir=artifacts_dir,
-            output_dir=output_dir,
-            guidellm_common=guidellm_common,
-            acceptance_csv=acceptance_csv,
-            perf_csv=perf_csv,
+    dataset_spec = args.dataset
+    is_speedbench = dataset_spec.startswith("speedbench/")
+
+    if is_speedbench:
+        if not getattr(args, "speedbench_data_dir", None):
+            logger.error(
+                "--speedbench-data-dir is required for speedbench/ datasets.\n"
+                "Run scripts/evaluate/prepare_speedbench.py first, then add"
+                " --speedbench-data-dir <dir>.",
+            )
+            sys.exit(1)
+
+        pairs = _resolve_speedbench(dataset_spec, Path(args.speedbench_data_dir))
+        logger.info(
+            "Mode: %s | %d speedbench subsets | Output: %s",
+            args.mode,
+            len(pairs),
+            output_dir,
         )
-        if mt is not None:
-            all_max_tokens[subset] = mt
+        for label, local_path in pairs:
+            sb_common = {
+                "target": args.target,
+                "dataset": str(local_path),
+                "data_column_mapper": _SPEEDBENCH_COLUMN_MAPPER,
+                "rate": args.gen_len_rate,
+                "max_concurrency": args.max_concurrency,
+            }
+            acceptance_csv, perf_csv, mt = _run_subset(
+                label,
+                args,
+                is_sweep=is_sweep,
+                metrics_url=metrics_url,
+                artifacts_dir=artifacts_dir,
+                output_dir=output_dir,
+                guidellm_common=sb_common,
+                acceptance_csv=acceptance_csv,
+                perf_csv=perf_csv,
+                hf_subset=None,  # local JSONL is the dataset, no --data-args needed
+            )
+            if mt is not None:
+                all_max_tokens[label] = mt
+    else:
+        subsets = [s.strip() for s in args.subsets.split(",") if s.strip()]
+        logger.info(
+            "Mode: %s | %d subsets | Output: %s",
+            args.mode,
+            len(subsets),
+            output_dir,
+        )
+        guidellm_common = {
+            "target": args.target,
+            "dataset": dataset_spec,
+            "data_column_mapper": args.data_column_mapper,
+            "rate": args.gen_len_rate,
+            "max_concurrency": args.max_concurrency,
+        }
+        for subset in subsets:
+            acceptance_csv, perf_csv, mt = _run_subset(
+                subset,
+                args,
+                is_sweep=is_sweep,
+                metrics_url=metrics_url,
+                artifacts_dir=artifacts_dir,
+                output_dir=output_dir,
+                guidellm_common=guidellm_common,
+                acceptance_csv=acceptance_csv,
+                perf_csv=perf_csv,
+                hf_subset=subset,  # HF dataset: subset name = --data-args filter
+            )
+            if mt is not None:
+                all_max_tokens[subset] = mt
 
     if acceptance_csv is None:
         logger.error("No acceptance metrics collected from any subset")
@@ -292,6 +397,15 @@ def main() -> None:
         "--data-column-mapper",
         default=DEFAULT_DATA_COLUMN_MAPPER,
         help=f"Column mapping for guidellm (default: {DEFAULT_DATA_COLUMN_MAPPER})",
+    )
+    parser.add_argument(
+        "--speedbench-data-dir",
+        default=None,
+        dest="speedbench_data_dir",
+        help=(
+            "Path to directory produced by SPEED-Bench prepare.py. "
+            "Required when --dataset is a speedbench/ spec."
+        ),
     )
 
     args = parser.parse_args()

--- a/scripts/evaluate/perf_utils.py
+++ b/scripts/evaluate/perf_utils.py
@@ -29,6 +29,7 @@ except ImportError:
 
 logger = logging.getLogger("evaluate")
 
+
 # ---------------------------------------------------------------------------
 # Metric definitions (for plotting)
 # ---------------------------------------------------------------------------
@@ -186,7 +187,7 @@ def parse_source_args(source_args: list[str]) -> dict[str, list[Path]]:
     for arg in source_args:
         if "=" not in arg:
             raise ValueError(f"Invalid source format: '{arg}'. Expected 'LABEL=PATH'.")
-        label, path_str = arg.split("=", 1)
+        label, path_str = arg.rsplit("=", 1)
         path = Path(path_str.strip())
         if not path.exists():
             raise FileNotFoundError(f"File not found: {path}")
@@ -551,7 +552,7 @@ def fetch_metrics(metrics_url: str, retries: int = 3, delay: float = 2.0) -> str
 def run_guidellm(
     target: str,
     dataset: str,
-    subset: str,
+    subset: str | None,
     data_column_mapper: str,
     profile: str,
     rate: int | str,
@@ -567,8 +568,6 @@ def run_guidellm(
         target,
         "--data",
         dataset,
-        "--data-args",
-        json.dumps({"data_files": f"{subset}.jsonl"}),
         "--data-column-mapper",
         data_column_mapper,
         "--profile",
@@ -580,6 +579,10 @@ def run_guidellm(
         "--backend-args",
         backend_args,
     ]
+    # When subset is given, filter to that file within the HF dataset.
+    # When subset is None the dataset IS the file (e.g. a local JSONL).
+    if subset is not None:
+        cmd.extend(["--data-args", json.dumps({"data_files": f"{subset}.jsonl"})])
     if max_requests is not None:
         cmd.extend(["--max-requests", str(max_requests)])
 

--- a/scripts/evaluate/prepare_speedbench.py
+++ b/scripts/evaluate/prepare_speedbench.py
@@ -61,10 +61,16 @@ _ALL_CONFIGS = [
 
 
 def _extract_text(row: dict) -> str:
-    """Return prompt text — supports both ``turns`` and ``messages`` columns."""
+    """Return prompt text — supports both ``turns`` and ``messages`` columns.
+
+    .. note::
+        For multi-turn rows only the first turn is extracted.  Full multi-turn
+        conversation support is out of scope for this initial implementation.
+    """
     text = row.get("turns") or ""
     if not text:
         msgs = row.get("messages") or []
+        # TODO: support multi-turn by concatenating all turns
         text = msgs[0].get("content", "") if msgs else ""
     return text
 

--- a/scripts/evaluate/prepare_speedbench.py
+++ b/scripts/evaluate/prepare_speedbench.py
@@ -60,7 +60,8 @@ def split_config(flat_file: Path, out_dir: Path, config: str) -> int:
     Returns the number of output files written.
     """
     logger.info("Loading %s ...", flat_file)
-    rows = [json.loads(line) for line in flat_file.open() if line.strip()]
+    with flat_file.open() as f:
+        rows = [json.loads(line) for line in f if line.strip()]
 
     use_category_only = config == "qualitative"
     buckets: dict[str, list[str]] = {}

--- a/scripts/evaluate/prepare_speedbench.py
+++ b/scripts/evaluate/prepare_speedbench.py
@@ -1,13 +1,26 @@
 #!/usr/bin/env python3
 """Split SPEED-Bench flat files into per-category/subcategory JSONL files.
 
-Run NVIDIA's prepare.py first to materialise prompts::
+**Step 1** — run NVIDIA's prepare.py to materialise prompts from their
+original sources (fetched at runtime due to redistribution restrictions)::
 
     curl -LsSf https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/ \\
         refs/heads/main/nemo_skills/dataset/speed-bench/prepare.py \\
         | python3 - --output_dir ./speedbench_data
 
-Then run this script to produce the per-category files that evaluate.py expects::
+.. note::
+    The URL above points to the ``main`` branch of an external repository
+    maintained by NVIDIA.  Save a local copy of the script if you anticipate
+    running data preparation again::
+
+        curl -LsSf <url> -o prepare_nvidia_speedbench.py
+
+    The output files produced by prepare.py contain data fetched from
+    third-party sources that carry their own licences.  Do not redistribute
+    the materialised JSONL files.
+
+**Step 2** — run this script to split the flat files into per-category files
+that evaluate.py can consume directly::
 
     python prepare_speedbench.py --data-dir ./speedbench_data
 

--- a/scripts/evaluate/prepare_speedbench.py
+++ b/scripts/evaluate/prepare_speedbench.py
@@ -39,7 +39,9 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import subprocess
 import sys
+import urllib.request
 from pathlib import Path
 
 logger = logging.getLogger("prepare_speedbench")
@@ -110,6 +112,28 @@ def split_config(flat_file: Path, out_dir: Path, config: str) -> int:
     return written
 
 
+_NVIDIA_PREPARE_URL = (
+    "https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/"
+    "refs/heads/main/nemo_skills/dataset/speed-bench/prepare.py"
+)
+
+
+def _run_nvidia_prepare(data_dir: Path, configs: list[str]) -> None:
+    """Download and run NVIDIA's prepare.py to materialise prompts."""
+    logger.info("Downloading NVIDIA prepare.py from %s ...", _NVIDIA_PREPARE_URL)
+    with urllib.request.urlopen(_NVIDIA_PREPARE_URL) as resp:  # noqa: S310
+        script_bytes = resp.read()
+
+    for config in configs:
+        logger.info("Running prepare.py for config=%s ...", config)
+        subprocess.run(  # noqa: S603
+            [sys.executable, "-", "--config", config, "--output_dir", str(data_dir)],
+            input=script_bytes,
+            check=True,
+        )
+        logger.info("prepare.py done for config=%s", config)
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
 
@@ -130,14 +154,28 @@ def main() -> None:
         default=",".join(_ALL_CONFIGS),
         help=(f"Comma-separated configs to split (default: {','.join(_ALL_CONFIGS)})"),
     )
+    parser.add_argument(
+        "--download",
+        action="store_true",
+        default=False,
+        help=(
+            "Download and run NVIDIA's prepare.py to materialise prompts before "
+            "splitting. Fetches from the NVIDIA-NeMo/Skills repository."
+        ),
+    )
     args = parser.parse_args()
 
     data_dir: Path = args.data_dir
+    data_dir.mkdir(parents=True, exist_ok=True)
+    configs = [c.strip() for c in args.configs.split(",") if c.strip()]
+
+    if args.download:
+        _run_nvidia_prepare(data_dir, configs)
+
     if not data_dir.exists():
         logger.error("--data-dir '%s' does not exist.", data_dir)
         sys.exit(1)
 
-    configs = [c.strip() for c in args.configs.split(",") if c.strip()]
     total = 0
     for config in configs:
         flat_file = data_dir / f"{config}.jsonl"

--- a/scripts/evaluate/prepare_speedbench.py
+++ b/scripts/evaluate/prepare_speedbench.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Split SPEED-Bench flat files into per-category/subcategory JSONL files.
+
+Run NVIDIA's prepare.py first to materialise prompts::
+
+    curl -LsSf https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/ \\
+        refs/heads/main/nemo_skills/dataset/speed-bench/prepare.py \\
+        | python3 - --output_dir ./speedbench_data
+
+Then run this script to produce the per-category files that evaluate.py expects::
+
+    python prepare_speedbench.py --data-dir ./speedbench_data
+
+Output files follow the naming convention ``{config}_{key}.jsonl`` where
+``key`` is the category (qualitative) or ``{entropy}__{subcategory}``
+(throughput configs).  Each file has a single ``turns`` column.
+
+Usage::
+
+    python prepare_speedbench.py --data-dir ./speedbench_data \
+        [--configs qualitative,throughput_1k]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger("prepare_speedbench")
+
+_PLACEHOLDER_MARKERS = (
+    "FULL BENCHMARK DATA SHOULD BE FETCHED FROM THE SOURCE",
+    "{article}",
+)
+
+_ALL_CONFIGS = [
+    "qualitative",
+    "throughput_1k",
+    "throughput_2k",
+    "throughput_8k",
+    "throughput_32k",
+]
+
+
+def _extract_text(row: dict) -> str:
+    """Return prompt text — supports both ``turns`` and ``messages`` columns."""
+    text = row.get("turns") or ""
+    if not text:
+        msgs = row.get("messages") or []
+        text = msgs[0].get("content", "") if msgs else ""
+    return text
+
+
+def split_config(flat_file: Path, out_dir: Path, config: str) -> int:
+    """Split *flat_file* into per-category/subcategory files in *out_dir*.
+
+    Returns the number of output files written.
+    """
+    logger.info("Loading %s ...", flat_file)
+    rows = [json.loads(line) for line in flat_file.open() if line.strip()]
+
+    use_category_only = config == "qualitative"
+    buckets: dict[str, list[str]] = {}
+
+    for row in rows:
+        text = _extract_text(row)
+        if not text:
+            continue
+        for marker in _PLACEHOLDER_MARKERS:
+            if marker in text:
+                cat = row.get("category", "?")
+                logger.error(
+                    "Placeholder text in %s/%s — re-run NVIDIA prepare.py first.",
+                    config,
+                    cat,
+                )
+                sys.exit(1)
+
+        cat = (row.get("category") or "unknown").replace(" ", "_").replace("/", "_")
+        sub = (row.get("sub_category") or "unknown").replace(" ", "_").replace("/", "_")
+        key = cat if use_category_only else f"{cat}__{sub}"
+        buckets.setdefault(key, []).append(text)
+
+    written = 0
+    for key, texts in sorted(buckets.items()):
+        out_path = out_dir / f"{config}_{key}.jsonl"
+        with out_path.open("w") as f:
+            for t in texts:
+                f.write(json.dumps({"turns": t}) + "\n")
+        logger.info("  wrote %s (%d rows)", out_path.name, len(texts))
+        written += 1
+
+    return written
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+
+    parser = argparse.ArgumentParser(
+        description="Split SPEED-Bench flat files into per-category JSONL files.",
+    )
+    parser.add_argument(
+        "--data-dir",
+        required=True,
+        type=Path,
+        help=(
+            "Directory with flat JSONL files from NVIDIA prepare.py"
+            " (e.g. qualitative.jsonl)."
+        ),
+    )
+    parser.add_argument(
+        "--configs",
+        default=",".join(_ALL_CONFIGS),
+        help=(f"Comma-separated configs to split (default: {','.join(_ALL_CONFIGS)})"),
+    )
+    args = parser.parse_args()
+
+    data_dir: Path = args.data_dir
+    if not data_dir.exists():
+        logger.error("--data-dir '%s' does not exist.", data_dir)
+        sys.exit(1)
+
+    configs = [c.strip() for c in args.configs.split(",") if c.strip()]
+    total = 0
+    for config in configs:
+        flat_file = data_dir / f"{config}.jsonl"
+        if not flat_file.exists():
+            logger.warning("Skipping %s — %s not found.", config, flat_file)
+            continue
+        n = split_config(flat_file, data_dir, config)
+        total += n
+        logger.info("%s: %d files written.", config, n)
+
+    logger.info("Done. %d total files written to %s", total, data_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose

Adds support for evaluating speculative decoding on [NVIDIA SPEED-Bench](https://huggingface.co/datasets/nvidia/SPEED-Bench) alongside the existing `RedHatAI/speculator_benchmarks` workflow.

SPEED-Bench provides structured evaluation across qualitative categories (coding, math, reasoning, multilingual, etc.) and throughput splits with varying input sequence lengths (1k–32k tokens), enabling more comprehensive coverage than a single dataset.

## Changes

### `scripts/evaluate/prepare_speedbench.py` (new)

A one-time pre-processing script that splits the flat per-config JSONL files produced by NVIDIA's `prepare.py` into per-category/subcategory files that `evaluate.py` consumes directly:

```bash
# Step 1 – materialise prompts (NVIDIA script, run once)
curl -LsSf https://raw.githubusercontent.com/NVIDIA-NeMo/Skills/refs/heads/main/nemo_skills/dataset/speed-bench/prepare.py \
    | python3 - --output_dir ./speedbench_data

# Step 2 – split into per-category files
python scripts/evaluate/prepare_speedbench.py --data-dir ./speedbench_data
```

Output filenames follow `{config}_{category}.jsonl` (qualitative) and `{config}_{entropy}__{subcategory}.jsonl` (throughput). The script validates that no placeholder text remains — NVIDIA's `prepare.py` requires external data fetching that can fail silently; this script exits with a clear error if any un-materialised rows are detected.

### `scripts/evaluate/evaluate.py`

- New `--speedbench-data-dir` argument pointing to the pre-split directory.
- New `--dataset speedbench/<config>[/<category>[/<subcategory>]]` syntax:
  - `speedbench/qualitative` — all 11 qualitative categories
  - `speedbench/qualitative/coding` — single category
  - `speedbench/throughput_1k` — all throughput_1k subcategories
  - `speedbench/throughput_1k/high_entropy` — one entropy tier
- `_resolve_speedbench()` globs for pre-split files and returns `(label, path)` pairs — no temporary files, no runtime HuggingFace dataset loading.
- `run_benchmark()` branches on `speedbench/` datasets, building per-subset `guidellm_common` with the correct local path and `turns` column mapper.
- `_run_subset()` gains an optional `hf_subset` kwarg. For HF datasets `hf_subset=subset` (unchanged); for local JSONL files `hf_subset=None` suppresses `--data-args`.

### `scripts/evaluate/perf_utils.py`

- `run_guidellm` `subset` parameter: `str` → `str | None`. `--data-args` is now only added when `subset is not None`, making the function correct for local JSONL files as well as HF dataset subsets.

## Backward compatibility

All existing `--dataset RedHatAI/speculator_benchmarks` usage is unchanged. The `hf_subset` kwarg defaults to `subset` for the HF path, so existing call sites are unaffected.

## Tests

Verified end-to-end on 8×H100 GPUs with Qwen3-8B + `RedHatAI/Qwen3-8B-speculator.dflash` k=7 (thinking=true):

**speedbench/qualitative** (11 categories, 80 prompts each):

| Category | Pos1 | Pos2 | Pos3 | AvgLen |
|---|---|---|---|---|
| coding | 0.773 | 0.541 | 0.370 | 3.241 |
| math | 0.784 | 0.558 | 0.380 | 3.320 |
| reasoning | 0.761 | 0.521 | 0.348 | 3.154 |
| multilingual | 0.590 | 0.409 | 0.274 | 2.799 |

Results are consistent with RedHatAI/HumanEval (AL=3.24 with same setup), confirming the pipeline produces valid acceptance metrics.

## Checklist

- [x] Purpose described above
- [x] Test plan/results provided above
- [x] I (a human) have written or reviewed the code in this PR to the best of my ability

Made with [Cursor](https://cursor.com)