### PR TITLE
fix(train): crash-safe checkpoints — completeness marker gating resume

### DIFF
--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -183,6 +183,14 @@ class BaseCheckpointer:
         finally:
             os.close(dir_fd)
 
+    def clear_checkpoint_complete(self, epoch: int | str) -> None:
+        """Durably remove a stale marker before rewriting an epoch dir."""
+        epoch_dir = self.path / str(epoch)
+        marker = self.complete_marker_path(epoch)
+        if marker.exists():
+            marker.unlink()
+            self._fsync_directory(epoch_dir)
+
     def mark_checkpoint_complete(self, epoch: int | str) -> None:
         """Sync checkpoint files, then atomically publish the marker."""
         epoch_dir = self.path / str(epoch)

--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import logging
+import os
 import shutil
 from abc import abstractmethod
 from pathlib import Path
@@ -135,9 +136,19 @@ class BaseCheckpointer:
                     )
                     continue
                 try:
-                    last_checkpoint_num = max(last_checkpoint_num, int(d.name))
+                    epoch_num = int(d.name)
                 except ValueError:
                     continue
+                if not (d / self.COMPLETE_MARKER_FILENAME).exists():
+                    logger.warning(
+                        f"Skipping checkpoint at {d}: missing "
+                        f"'{self.COMPLETE_MARKER_FILENAME}' marker (save was "
+                        "interrupted, or the checkpoint predates this version). "
+                        "To resume from it anyway, create the marker: "
+                        f"'touch {d / self.COMPLETE_MARKER_FILENAME}'."
+                    )
+                    continue
+                last_checkpoint_num = max(last_checkpoint_num, epoch_num)
         return last_checkpoint_num
 
     def model_path(self, epoch: int | str):
@@ -159,6 +170,37 @@ class BaseCheckpointer:
         return self.path / str(epoch) / "val_metrics.json"
 
     TRAIN_COMMAND_FILENAME = "train_command.txt"
+    COMPLETE_MARKER_FILENAME = "checkpoint_complete"
+
+    def complete_marker_path(self, epoch: int | str) -> Path:
+        return self.path / str(epoch) / self.COMPLETE_MARKER_FILENAME
+
+    @staticmethod
+    def _fsync_directory(path: Path) -> None:
+        dir_fd = os.open(path, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+
+    def mark_checkpoint_complete(self, epoch: int | str) -> None:
+        """Sync checkpoint files, then atomically publish the marker."""
+        epoch_dir = self.path / str(epoch)
+        for f in epoch_dir.rglob("*"):
+            if f.is_file() and not f.is_symlink():
+                with f.open("rb") as fh:
+                    os.fsync(fh.fileno())
+
+        marker = self.complete_marker_path(epoch)
+        temporary_marker = marker.with_name(f".{marker.name}.tmp")
+        try:
+            with temporary_marker.open("wb") as fh:
+                os.fsync(fh.fileno())
+            os.replace(temporary_marker, marker)
+            self._fsync_directory(epoch_dir)
+        except Exception:
+            temporary_marker.unlink(missing_ok=True)
+            raise
 
     def _copy_train_command(self, epoch: int | str) -> None:
         src = self.path / self.TRAIN_COMMAND_FILENAME

--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -234,19 +234,41 @@ class BaseCheckpointer:
         except (json.JSONDecodeError, KeyError, ValueError, TypeError):
             return None
 
-    def read_best_epoch(self) -> int | None:
-        """Return the epoch that `checkpoint_best` points to."""
+    def _resolve_committed_best_epoch(self) -> tuple[int, Path] | None:
+        """Resolve `checkpoint_best` only when it names a committed local epoch."""
         best_path = self.best_path()
-        if not best_path.exists() or not best_path.is_symlink():
+        if not best_path.is_symlink():
             return None
         try:
-            target = best_path.readlink()
-        except OSError:
+            checkpoint_root = self.path.resolve(strict=True)
+            target = best_path.resolve(strict=True)
+        except (OSError, RuntimeError):
+            logger.warning("Ignoring unreadable checkpoint_best link at %s", best_path)
+            return None
+
+        if not target.is_dir() or target.parent != checkpoint_root:
+            logger.warning(
+                "Ignoring checkpoint_best target outside the checkpoint root: %s", target
+            )
             return None
         try:
-            return int(Path(target).name)
+            epoch = int(target.name)
         except ValueError:
+            logger.warning("Ignoring non-epoch checkpoint_best target: %s", target)
             return None
+        if epoch < 0 or not (target / self.COMPLETE_MARKER_FILENAME).is_file():
+            logger.warning(
+                "Ignoring incomplete checkpoint_best target at %s: missing '%s' marker",
+                target,
+                self.COMPLETE_MARKER_FILENAME,
+            )
+            return None
+        return epoch, target
+
+    def read_best_epoch(self) -> int | None:
+        """Return the committed local epoch that `checkpoint_best` points to."""
+        resolved = self._resolve_committed_best_epoch()
+        return None if resolved is None else resolved[0]
 
     def load_model_state_dict_for_epoch(
         self, model: PreTrainedModel, epoch: int, float_dtype: torch.dtype | None = None
@@ -261,6 +283,12 @@ class BaseCheckpointer:
 
     @_rank0_only
     def update_best_symlink(self, epoch: int):
+        if not self.complete_marker_path(epoch).is_file():
+            raise FileNotFoundError(
+                f"Cannot publish checkpoint_best for incomplete epoch {epoch}: missing "
+                f"'{self.COMPLETE_MARKER_FILENAME}' marker"
+            )
+
         best_path = self.best_path()
         target = Path(str(epoch))  # relative symlink inside checkpoint root
 
@@ -283,6 +311,12 @@ class BaseCheckpointer:
         # Safety checks
         if not keep_dir.exists() or not keep_dir.is_dir():
             raise FileNotFoundError(f"Best epoch dir does not exist: {keep_dir}")
+        resolved_best = self._resolve_committed_best_epoch()
+        if resolved_best is None or resolved_best[0] != best_epoch:
+            raise ValueError(
+                "Refusing cleanup without checkpoint_best pointing to the requested "
+                "committed epoch"
+            )
 
         train_cmd_file = self.path / self.TRAIN_COMMAND_FILENAME
 

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -570,6 +570,8 @@ class Trainer:
             return
 
         root_logger.info(f"Saving checkpoint to {self.checkpointer.path / str(epoch)}")
+        if not self.is_distributed or dist.get_rank() == 0:
+            self.checkpointer.clear_checkpoint_complete(epoch)
         self.checkpointer.save_checkpoint(self.model, self.optimizers, epoch)
         if self.schedulers:
             self.checkpointer.save_scheduler_state_dict(self.schedulers, epoch)
@@ -598,6 +600,8 @@ class Trainer:
             return
 
         if self.config.save_best:
+            if not self.is_distributed or dist.get_rank() == 0:
+                self.checkpointer.clear_checkpoint_complete(epoch)
             self.checkpointer.save_checkpoint(self.model, self.optimizers, epoch)
             if self.schedulers:
                 self.checkpointer.save_scheduler_state_dict(self.schedulers, epoch)

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -587,6 +587,8 @@ class Trainer:
                     if old.is_symlink():
                         old.unlink()
                 link_name.symlink_to(target)
+        if not self.is_distributed or dist.get_rank() == 0:
+            self.checkpointer.mark_checkpoint_complete(epoch)
         root_logger.info(f"Checkpoint saved to {self.checkpointer.path / str(epoch)}")
 
     def maybe_update_best(self, epoch: int, val_metrics: dict | None):
@@ -606,6 +608,8 @@ class Trainer:
 
         self.best_val_loss = val_metrics["loss_epoch"]
         self.checkpointer.save_val_metrics(epoch, val_metrics)
+        if not self.is_distributed or dist.get_rank() == 0:
+            self.checkpointer.mark_checkpoint_complete(epoch)
         self.checkpointer.update_best_symlink(epoch)
         root_logger.info(
             f"Updated checkpoint_best -> {epoch} (loss_epoch={self.best_val_loss:.6f})"

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -39,13 +39,90 @@ def _make_minimal_trainer(tmp_path: Path, checkpoint_freq: int, save_best: bool)
     return trainer
 
 
+def _mark_complete(tmp_path: Path, epoch: int | str) -> None:
+    (tmp_path / str(epoch) / SingleGPUCheckpointer.COMPLETE_MARKER_FILENAME).touch()
+
+
 def test_previous_epoch_ignores_checkpoint_best(tmp_path: Path):
     (tmp_path / "0").mkdir()
     (tmp_path / "2").mkdir()
+    _mark_complete(tmp_path, 0)
+    _mark_complete(tmp_path, 2)
     (tmp_path / "checkpoint_best").symlink_to("0", target_is_directory=True)
 
     cp = SingleGPUCheckpointer(str(tmp_path))
     assert cp.previous_epoch == 2
+
+
+def test_previous_epoch_skips_unmarked_dir(tmp_path: Path):
+    """A crash mid-save leaves an epoch dir without the completeness marker;
+    resume must fall back to the newest complete checkpoint."""
+    (tmp_path / "0").mkdir()
+    _mark_complete(tmp_path, 0)
+    (tmp_path / "1").mkdir()
+    (tmp_path / "1" / "model.safetensors").write_bytes(b"truncated")  # no marker
+
+    cp = SingleGPUCheckpointer(str(tmp_path))
+    assert cp.previous_epoch == 0
+
+
+def test_mark_checkpoint_complete_enables_resume(tmp_path: Path):
+    (tmp_path / "3").mkdir()
+    (tmp_path / "3" / "model.safetensors").write_bytes(b"weights")
+
+    cp = SingleGPUCheckpointer(str(tmp_path))
+    assert cp.previous_epoch == -1
+
+    cp.mark_checkpoint_complete(3)
+    assert (tmp_path / "3" / cp.COMPLETE_MARKER_FILENAME).exists()
+    assert SingleGPUCheckpointer(str(tmp_path)).previous_epoch == 3
+
+
+def test_mark_checkpoint_complete_fsyncs_temp_marker_before_publish(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    epoch_dir = tmp_path / "3"
+    epoch_dir.mkdir()
+    (epoch_dir / "model.safetensors").write_bytes(b"weights")
+
+    fsynced_inodes: set[int] = set()
+    real_fsync = os.fsync
+    real_replace = os.replace
+
+    def tracking_fsync(fd: int) -> None:
+        fsynced_inodes.add(os.fstat(fd).st_ino)
+        real_fsync(fd)
+
+    def checking_replace(source: str | Path, destination: str | Path) -> None:
+        assert Path(source).stat().st_ino in fsynced_inodes
+        real_replace(source, destination)
+
+    monkeypatch.setattr(os, "fsync", tracking_fsync)
+    monkeypatch.setattr(os, "replace", checking_replace)
+
+    cp = SingleGPUCheckpointer(str(tmp_path))
+    cp.mark_checkpoint_complete(3)
+
+    assert cp.complete_marker_path(3).exists()
+    assert not (epoch_dir / ".checkpoint_complete.tmp").exists()
+
+
+def test_maybe_save_checkpoint_writes_marker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    trainer = _make_minimal_trainer(tmp_path, checkpoint_freq=1, save_best=False)
+
+    def fake_cp_save_checkpoint(_model, _opt, epoch):
+        (tmp_path / str(epoch)).mkdir(exist_ok=True)
+
+    monkeypatch.setattr(
+        trainer.checkpointer, "save_checkpoint", fake_cp_save_checkpoint
+    )
+    trainer.maybe_save_checkpoint(0, local_step=0)
+
+    marker = tmp_path / "0" / SingleGPUCheckpointer.COMPLETE_MARKER_FILENAME
+    assert marker.exists()
+    assert SingleGPUCheckpointer(str(tmp_path)).previous_epoch == 0
 
 
 def test_update_best_symlink_creates_and_updates(tmp_path: Path):

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -125,6 +125,57 @@ def test_maybe_save_checkpoint_writes_marker(
     assert SingleGPUCheckpointer(str(tmp_path)).previous_epoch == 0
 
 
+def test_clear_checkpoint_complete_fsyncs_epoch_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    epoch_dir = tmp_path / "3"
+    epoch_dir.mkdir()
+    marker = epoch_dir / SingleGPUCheckpointer.COMPLETE_MARKER_FILENAME
+    marker.touch()
+
+    fsynced_inodes: set[int] = set()
+    real_fsync = os.fsync
+
+    def tracking_fsync(fd: int) -> None:
+        fsynced_inodes.add(os.fstat(fd).st_ino)
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", tracking_fsync)
+
+    SingleGPUCheckpointer(str(tmp_path)).clear_checkpoint_complete(3)
+
+    assert not marker.exists()
+    assert epoch_dir.stat().st_ino in fsynced_inodes
+
+
+def test_failed_same_epoch_rewrite_cannot_retain_completion_marker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    trainer = _make_minimal_trainer(tmp_path, checkpoint_freq=1, save_best=False)
+    save_calls = 0
+
+    def fake_cp_save_checkpoint(_model, _opt, epoch):
+        nonlocal save_calls
+        save_calls += 1
+        epoch_dir = tmp_path / str(epoch)
+        epoch_dir.mkdir(exist_ok=True)
+        (epoch_dir / "model.safetensors").write_bytes(b"partial")
+        if save_calls == 2:
+            raise RuntimeError("injected rewrite failure")
+
+    monkeypatch.setattr(
+        trainer.checkpointer, "save_checkpoint", fake_cp_save_checkpoint
+    )
+    trainer.maybe_save_checkpoint(0, local_step=1)
+
+    with pytest.raises(RuntimeError, match="injected rewrite failure"):
+        trainer.maybe_save_checkpoint(0, local_step=2)
+
+    marker = tmp_path / "0" / SingleGPUCheckpointer.COMPLETE_MARKER_FILENAME
+    assert not marker.exists()
+    assert SingleGPUCheckpointer(str(tmp_path)).previous_epoch == -1
+
+
 def test_update_best_symlink_creates_and_updates(tmp_path: Path):
     (tmp_path / "1").mkdir()
     (tmp_path / "3").mkdir()

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -179,6 +179,8 @@ def test_failed_same_epoch_rewrite_cannot_retain_completion_marker(
 def test_update_best_symlink_creates_and_updates(tmp_path: Path):
     (tmp_path / "1").mkdir()
     (tmp_path / "3").mkdir()
+    _mark_complete(tmp_path, 1)
+    _mark_complete(tmp_path, 3)
 
     cp = SingleGPUCheckpointer(str(tmp_path))
     cp.update_best_symlink(1)
@@ -338,6 +340,87 @@ def test_checkpoint_freq_flag_controls_saves(
     assert best_path.resolve() == (tmp_path / "5").resolve()
 
 
+def test_checkpoint_best_ignores_incomplete_target(tmp_path: Path):
+    (tmp_path / "0").mkdir()
+    _mark_complete(tmp_path, 0)
+    (tmp_path / "1").mkdir()
+    (tmp_path / "1" / "val_metrics.json").write_text('{"loss_epoch": 0.01}')
+    (tmp_path / "checkpoint_best").symlink_to("1", target_is_directory=True)
+
+    cp = SingleGPUCheckpointer(str(tmp_path))
+    assert cp.previous_epoch == 0
+    assert cp.read_best_epoch() is None
+    assert cp.load_best_val_loss() is None
+
+
+def test_checkpoint_best_rejects_target_outside_checkpoint_root(tmp_path: Path):
+    (tmp_path / "0").mkdir()
+    _mark_complete(tmp_path, 0)
+    external = tmp_path.parent / f"{tmp_path.name}-external"
+    external.mkdir()
+    _mark_complete(external.parent, external.name)
+    (tmp_path / "checkpoint_best").symlink_to(external, target_is_directory=True)
+
+    cp = SingleGPUCheckpointer(str(tmp_path))
+    assert cp.read_best_epoch() is None
+    assert cp.load_best_val_loss() is None
+
+
+def test_checkpoint_best_ignores_symlink_loop(tmp_path: Path):
+    (tmp_path / "checkpoint_best").symlink_to("checkpoint_best")
+
+    cp = SingleGPUCheckpointer(str(tmp_path))
+    assert cp.read_best_epoch() is None
+    assert cp.load_best_val_loss() is None
+
+
+def test_cleanup_rejects_incomplete_best_target(tmp_path: Path):
+    (tmp_path / "0").mkdir()
+    _mark_complete(tmp_path, 0)
+    (tmp_path / "1").mkdir()
+    (tmp_path / "checkpoint_best").symlink_to("1", target_is_directory=True)
+
+    cp = SingleGPUCheckpointer(str(tmp_path))
+    with pytest.raises(ValueError, match="requested committed epoch"):
+        cp.cleanup_keep_only_best(1)
+
+    assert (tmp_path / "0").is_dir()
+    assert (tmp_path / "1").is_dir()
+
+
+def test_update_best_symlink_requires_complete_epoch(tmp_path: Path):
+    (tmp_path / "1").mkdir()
+    cp = SingleGPUCheckpointer(str(tmp_path))
+
+    with pytest.raises(FileNotFoundError, match="incomplete epoch 1"):
+        cp.update_best_symlink(1)
+
+
+def test_maybe_update_best_publishes_marker_before_best_symlink(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    trainer = _make_minimal_trainer(tmp_path, checkpoint_freq=1, save_best=False)
+    calls: list[str] = []
+    original_mark = trainer.checkpointer.mark_checkpoint_complete
+    original_update = trainer.checkpointer.update_best_symlink
+
+    def mark(epoch: int) -> None:
+        calls.append("mark")
+        original_mark(epoch)
+
+    def update(epoch: int) -> None:
+        calls.append("best")
+        assert trainer.checkpointer.complete_marker_path(epoch).is_file()
+        original_update(epoch)
+
+    monkeypatch.setattr(trainer.checkpointer, "mark_checkpoint_complete", mark)
+    monkeypatch.setattr(trainer.checkpointer, "update_best_symlink", update)
+
+    trainer.maybe_update_best(0, {"loss_epoch": 0.1})
+
+    assert calls == ["mark", "best"]
+
+
 def test_save_and_load_val_metrics(tmp_path: Path):
     cp = SingleGPUCheckpointer(str(tmp_path))
 
@@ -347,12 +430,14 @@ def test_save_and_load_val_metrics(tmp_path: Path):
     # Save val_metrics for epoch 0 and point checkpoint_best at it
     (tmp_path / "0").mkdir()
     cp.save_val_metrics(0, {"loss_epoch": 0.123456, "full_acc_0_epoch": 0.5})
+    _mark_complete(tmp_path, 0)
     cp.update_best_symlink(0)
     assert cp.load_best_val_loss() == pytest.approx(0.123456)
 
     # Save better metrics for epoch 1 and update best
     (tmp_path / "1").mkdir()
     cp.save_val_metrics(1, {"loss_epoch": 0.05, "full_acc_0_epoch": 0.7})
+    _mark_complete(tmp_path, 1)
     cp.update_best_symlink(1)
     assert cp.load_best_val_loss() == pytest.approx(0.05)
 
@@ -362,6 +447,7 @@ def test_best_val_loss_restored_on_resume(tmp_path: Path):
 
     cp = SingleGPUCheckpointer(str(tmp_path))
     cp.save_val_metrics(4, {"loss_epoch": 0.42, "full_acc_0_epoch": 0.6})
+    _mark_complete(tmp_path, 4)
     cp.update_best_symlink(4)
 
     trainer = Trainer.__new__(Trainer)

--- a/tests/unit/train/test_save_train_command.py
+++ b/tests/unit/train/test_save_train_command.py
@@ -129,6 +129,7 @@ class TestCopyTrainCommand:
         (tmp_path / "1" / "model.safetensors").touch()
 
         cp = SingleGPUCheckpointer(str(tmp_path))
+        cp.mark_checkpoint_complete(1)
         cp.update_best_symlink(1)
         cp.cleanup_keep_only_best(1)
 

--- a/tests/unit/train/test_setup_model.py
+++ b/tests/unit/train/test_setup_model.py
@@ -193,6 +193,7 @@ def checkpoint_dir(tmp_path, tiny_model_on_gpu):
     checkpointer = SingleGPUCheckpointer(ckpt_dir)
     optimizer = torch.optim.AdamW(tiny_model_on_gpu.parameters(), lr=1e-4)
     checkpointer.save_checkpoint(tiny_model_on_gpu, optimizer, epoch=0)
+    checkpointer.mark_checkpoint_complete(0)
     return ckpt_dir
 
 
@@ -413,6 +414,7 @@ def test_weight_precedence(eagle3_config, pretrained_dir, tmp_path):
     checkpointer = SingleGPUCheckpointer(ckpt_dir)
     optimizer = torch.optim.AdamW(loaded.parameters(), lr=1e-4)
     checkpointer.save_checkpoint(loaded, optimizer, epoch=0)
+    checkpointer.mark_checkpoint_complete(0)
 
     # Load checkpoint into a model that had pretrained value (66.0)
     with patch.object(Eagle3DraftModel, "load_verifier_weights"):


### PR DESCRIPTION
# fix(train): crash-safe checkpoints — completeness marker gating resume

## Summary

`save_checkpoint()` writes `model.safetensors` / `optimizer_state_dict.pt` /
etc. directly to their final paths, and `_get_previous_epoch()` (which resume
uses to find the latest checkpoint) trusts **any directory whose name parses
as an integer** — nothing distinguishes a fully written checkpoint from one
truncated by a crash mid-save.

Failure mode:

1. `save_checkpoint()` for epoch N is killed mid-`save_pretrained()` (OOM,
   preemption, node failure) — directory `N/` now exists with a truncated
   `model.safetensors`.
2. The job restarts; `_get_previous_epoch()` sees `N`, returns it.
3. `load_model_state_dict()` hits the truncated file: best case safetensors
   throws a parse error and the run is stuck until someone deletes `N/` by
   hand; worst case (`optimizer_state_dict.pt` via `torch.load`) a partial
   read surfaces as a confusing unpickling error.

`training_state.json` does not guard this: resume only reads it to pick
mid-epoch vs end-of-epoch, and a missing/corrupt one silently falls back to
"advance to next epoch" — still loading model/optimizer from the broken dir.

## Fix

SpecForge had the identical bug class; the fix follows the same design as
sgl-project/SpecForge#659: a completeness marker written last, gating resume.

- `BaseCheckpointer.mark_checkpoint_complete(epoch)`: fsync every file in the
  epoch dir, then write a `checkpoint_complete` marker (fsync it and the
  directory). The fsyncs matter: after a hard host crash, files can survive
  at full length with truncated content, so the marker must not claim
  completeness before the data is durable.
- `Trainer` calls it once all files of an epoch are in place (model,
  optimizer, scheduler, `training_state.json`, val metrics — the last writes
  happen in the trainer, which is why the marker call lives there).
- `_get_previous_epoch()` skips integer dirs without the marker, logging a
  warning with explicit instructions (`touch .../checkpoint_complete`) —
  the same warn-and-instruct pattern already used for `interrupted/` dirs.
  This also covers checkpoints from before this change.

## Test plan

`tests/unit/train/test_checkpoint.py` (extends the existing suite, CPU-only):

- a dir with files but no marker is skipped; resume falls back to the newest
  complete checkpoint (the crash scenario);
- `mark_checkpoint_complete` makes a checkpoint visible to a fresh
  checkpointer;
- `maybe_save_checkpoint` end-to-end writes the marker.

Full `tests/unit/train/` suite passes (113 passed; 1 pre-existing failure is
a hub-connectivity issue in `test_setup_model.py`, unrelated).


Also require `checkpoint_best` to resolve to a completed checkpoint, so best-validation state cannot be restored from an incomplete epoch.
