### PR TITLE
Fix on_generate="cache" silently failing on a fresh data directory

### DIFF
--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -273,6 +273,8 @@ class ArrowDataset(BaseDataset):
         self.vllm_endpoint = vllm_endpoint
         self.on_missing = on_missing
         self.on_generate = on_generate
+        if self.on_generate == "cache":
+            self.hidden_states_path.mkdir(parents=True, exist_ok=True)
         self.client: openai.OpenAI | None = None
         self.model = model
         self.request_timeout = request_timeout

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -469,3 +469,26 @@ def test_arrow_dataset_default_split_ratio_does_not_crash(tmp_path: Path):
     # Should not raise AttributeError
     assert arrow_ds._map_to_file_idx(0) == 0
     assert arrow_ds._map_to_file_idx(5) == 5
+
+
+def test_arrow_dataset_on_generate_cache_creates_hidden_states_dir(tmp_path: Path):
+    """on_generate="cache" must create the cache dir up front — otherwise every
+    shutil.move into it raises FileNotFoundError, which _maybe_generate_hs
+    downgrades to a warning, so caching silently fails for every sample."""
+    ds = Dataset.from_dict(
+        {
+            "input_ids": [[1, 2, 3]],
+            "loss_mask": [[1, 1, 1]],
+            "seq_len": [3],
+        }
+    )
+    ds.save_to_disk(str(tmp_path / "data"))
+
+    arrow_ds = ArrowDataset(
+        max_len=128,
+        datapath=str(tmp_path / "data"),
+        on_missing="generate",
+        on_generate="cache",
+    )
+
+    assert arrow_ds.hidden_states_path.is_dir()


### PR DESCRIPTION
## Bug

`ArrowDataset` never creates `hidden_states_path`. On a data directory that has never held a hidden-states cache (the normal first-run case for `--on-generate cache`), every `shutil.move` into it raises `FileNotFoundError`, which `_maybe_generate_hs` catches and downgrades to a warning — so caching silently fails for **every** sample and the run still exits 0. The next epoch/run regenerates everything from scratch, defeating the flag's purpose.

Reproduced live: fresh `--data-path`, 128/128 samples warn `Failed to load/cache hidden states ... No such file or directory`; after a manual `mkdir -p`, the same command caches 128/128. The path was never exercised by tests — e2e online training hardcodes `--on-generate delete`.

## Fix

Create the directory once at dataset construction when `on_generate="cache"`. Regression test included (fails without the fix).