### PR TITLE
Update default optimizer to muon

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -116,11 +116,11 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 ### Optimizer Arguments
 
-- **`--optimizer`** (str, default: `"adamw"`) Optimizer to use. Options: `adamw`, `muon`. The `muon` option applies the Muon optimizer to 2D weight matrices and AdamW to the remaining parameters (norms, biases, embeddings, lm_head).
+- **`--optimizer`** (str, default: `"muon"`) Optimizer to use. Options: `adamw`, `muon`. The `muon` option applies the Muon optimizer to 2D weight matrices and AdamW to the remaining parameters (norms, biases, embeddings, lm_head).
 
 - **`--weight-decay`** (float, default: `0.01`) Weight decay for the AdamW optimizer (and the AdamW group in muon mode).
 
-- **`--muon-lr`** (float, default: `0.02`) Learning rate for the Muon (2D weights) group. Only used with `--optimizer muon`.
+- **`--muon-lr`** (float, default: `10*lr`) Learning rate for the Muon (2D weights) group. Only used with `--optimizer muon`. Defaults to 10× the `--lr` value.
 
 - **`--muon-momentum`** (float, default: `0.95`) Momentum for the Muon optimizer. Only used with `--optimizer muon`.
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1086,7 +1086,7 @@ def parse_args():
     parser.add_argument(
         "--optimizer",
         type=str,
-        default="adamw",
+        default="muon",
         choices=["adamw", "muon"],
         help=(
             "Optimizer to use. 'muon' applies Muon to 2D weight matrices and AdamW to "
@@ -1102,8 +1102,9 @@ def parse_args():
     parser.add_argument(
         "--muon-lr",
         type=float,
-        default=0.02,
-        help="LR for the Muon (2D weights) group. Only used with --optimizer muon.",
+        default=None,
+        help="LR for the Muon (2D weights) group. Only used with --optimizer muon. "
+        "Defaults to 10*lr (and --lr defaults to 1e-4)",
     )
     parser.add_argument("--muon-momentum", type=float, default=0.95)
     parser.add_argument("--muon-weight-decay", type=float, default=0.1)
@@ -1125,6 +1126,8 @@ def parse_args():
         args.norm_before_fc = is_eagle3
     if args.norm_output is None:
         args.norm_output = is_eagle3
+    if args.muon_lr is None:
+        args.muon_lr = 10 * args.lr
 
     provided = explicitly_provided_dests(parser, DECODER_SHAPING_FLAGS)
     validate_draft_init_args(parser, args, provided)


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

The Muon optimizer has been shown to fairly consistently outperform adam. We're updating speculators to make it the default and also updated the default `--muon-lr` to `10 * --lr` instead of the old hardcoded value. 

## Tests

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
