### PR TITLE
[Regen][tool call] Support tool calls in on-policy response regeneration

### DIFF
--- a/docs/cli/response_regeneration.md
+++ b/docs/cli/response_regeneration.md
@@ -35,6 +35,8 @@ Orchestrates the entire pipeline: starts a vLLM server (with optional data/tenso
 
 - **`--keep-server`** (flag) Don't stop the vLLM server after processing completes.
 
+- **`--tool-call-parser`** (str) vLLM tool-call parser (e.g. `hermes`, `llama3_json`). Adds `--enable-auto-tool-choice --tool-call-parser` to the server; required for tool-call regeneration, otherwise tool calls arrive as raw text and are not regenerated as tools.
+
 All other arguments are passed through to `script.py`.
 
 ### Full Example

--- a/docs/cli/response_regeneration.md
+++ b/docs/cli/response_regeneration.md
@@ -130,11 +130,11 @@ The registry's multimodal preset, `sharegpt4v_coco`, is **off-policy only** and 
 
 ## Output Format
 
-Rows are pre-tokenized and ready for training: one row per assistant turn, holding the prompt the target conditioned on followed by the tokens it generated. The endpoint must support `return_token_ids`, which the script uses to read the generation boundary directly instead of re-tokenizing the text and recovering the boundary with a regex.
+Rows are pre-tokenized and ready for training: one row per target generation, holding the prompt the target conditioned on followed by the tokens it generated. The endpoint must support `return_token_ids`, which the script uses to read the generation boundary directly instead of re-tokenizing the text and recovering the boundary with a regex.
 
 ```json
 {
-  "id": "conv-abc_turn0",
+  "id": "conv-abc_gen0",
   "primary_id": "conv-abc",
   "input_ids": [151644, 872, ...],
   "loss_mask": [0, 0, ..., 1, 1],
@@ -145,6 +145,7 @@ Rows are pre-tokenized and ready for training: one row per assistant turn, holdi
   "metadata": {
     "idx": 0,
     "finish_reason": "stop",
+    "is_tool_call": false,
     "usage": {...},
     "endpoint": "http://127.0.0.1:8000/v1/chat/completions",
     "sampling_params": {...}
@@ -153,11 +154,12 @@ Rows are pre-tokenized and ready for training: one row per assistant turn, holdi
 ```
 
 - `loss_mask` is `0` over the prompt and `1` over the generated tokens. This *is* the generation boundary, so training applies no further masking.
-- A conversation with N assistant turns yields N rows, each carrying the history before it. Turn `k`'s row is `{primary_id}_turn{k}`.
-- `primary_id` is the conversation's stable id, used by `--resume`. The row `id` is turn-suffixed and never matches it.
+- A conversation yields one row per target generation, each carrying the history before it. Generation `k`'s row is `{primary_id}_gen{k}`. A plain assistant turn is one generation; a turn that calls a tool is two or more (see [Tool calls](#tool-calls)).
+- `primary_id` is the conversation's stable id, used by `--resume`. The row `id` is generation-suffixed and never matches it.
+- `is_tool_call` marks a row whose generated tokens are a tool call rather than a final answer.
 - `conversations` is a human-readable twin of `input_ids` for review only. Training drops it.
 
-Rows are written only after every turn of a conversation succeeds. A conversation that fails partway writes nothing to the output file and one row to a sibling error file instead (`--outfile out.jsonl` gives `out.errors.jsonl`), so `--resume` retries it whole:
+Rows are written only once a conversation finishes. A conversation that fails partway writes nothing to the output file and one row to a sibling error file instead (`--outfile out.jsonl` gives `out.errors.jsonl`), so `--resume` retries it whole:
 
 ```json
 {
@@ -165,10 +167,18 @@ Rows are written only after every turn of a conversation succeeds. A conversatio
   "metadata": {
     "idx": 0,
     "error": "ConnectionError(...)",
-    "turns_completed": 1,
+    "generations_completed": 1,
     "endpoint": "http://127.0.0.1:8000/v1/chat/completions"
   }
 }
 ```
+
+### Tool calls
+
+If a source row carries a `tools` schema (or a legacy `functions` list), it is forwarded to the endpoint on every request and the target regenerates its own tool calls, which are supervised like any other generation.
+
+Tools are **not executed**. The target's *k*-th regenerated call is paired with the *k*-th cached tool result already present in the source row, spliced back as a `tool` message so the conversation can continue. This keeps the call tokens on-policy while the results stay off-policy.
+
+A conversation stops early — keeping the rows completed so far — when the target emits a call that cannot be paired 1:1 with a cached result: either it has exhausted the cached results, or it emitted parallel calls in a single generation. Such conversations are counted under `truncated` in the progress bar.
 
 If `--outfile` is not specified, the filename is auto-generated based on dataset and model (e.g., `magpie_Llama-3.3-70B-Instruct.jsonl`).

--- a/docs/cli/response_regeneration.md
+++ b/docs/cli/response_regeneration.md
@@ -177,10 +177,10 @@ Rows are written only once a conversation finishes. A conversation that fails pa
 
 ### Tool calls
 
-If a source row carries a `tools` schema (or a legacy `functions` list), it is forwarded to the endpoint on every request and the target regenerates its own tool calls, which are supervised like any other generation.
+If a source row carries a `tools` schema, it is forwarded to the endpoint on every request and the target regenerates its own tool calls, which are supervised like any other generation.
 
 Tools are **not executed**. The target's *k*-th regenerated call is paired with the *k*-th cached tool result already present in the source row, spliced back as a `tool` message so the conversation can continue. This keeps the call tokens on-policy while the results stay off-policy.
 
-A conversation stops early — keeping the rows completed so far — when the target emits a call that cannot be paired 1:1 with a cached result: either it has exhausted the cached results, or it emitted parallel calls in a single generation. Such conversations are counted under `truncated` in the progress bar.
+A conversation stops early — keeping the rows completed so far — when the target emits a call that cannot be paired 1:1 with a cached result: it has exhausted the cached results, emitted parallel calls in a single generation, or called a different tool than the next cached result answers. Such conversations are counted under `truncated` in the progress bar.
 
 If `--outfile` is not specified, the filename is auto-generated based on dataset and model (e.g., `magpie_Llama-3.3-70B-Instruct.jsonl`).

--- a/docs/user_guide/tutorials/response_regeneration.md
+++ b/docs/user_guide/tutorials/response_regeneration.md
@@ -50,11 +50,11 @@ For larger models, use data parallelism and/or tensor parallelism:
 
 ## Step 2: Verify the Output
 
-The output is a JSONL file with one pre-tokenized row per assistant turn. `loss_mask` is `0` over the prompt the target conditioned on and `1` over the tokens it generated, so training needs no further masking:
+The output is a JSONL file with one pre-tokenized row per target generation. `loss_mask` is `0` over the prompt the target conditioned on and `1` over the tokens it generated, so training needs no further masking:
 
 ```json
 {
-  "id": "conv-abc_turn0",
+  "id": "conv-abc_gen0",
   "primary_id": "conv-abc",
   "input_ids": [151644, 872, ...],
   "loss_mask": [0, 0, ..., 1, 1],
@@ -65,13 +65,14 @@ The output is a JSONL file with one pre-tokenized row per assistant turn. `loss_
   "metadata": {
     "idx": 0,
     "finish_reason": "stop",
+    "is_tool_call": false,
     "usage": {...},
     "endpoint": "http://127.0.0.1:8000/v1/chat/completions"
   }
 }
 ```
 
-A conversation with N assistant turns produces N rows, so expect more lines than input conversations. `conversations` is a review-only twin of `input_ids`; training drops it.
+Each assistant turn produces at least one row — and more when the target calls a tool, since every call is its own generation — so expect more lines than input conversations. `conversations` is a review-only twin of `input_ids`; training drops it.
 
 Check that the output looks correct:
 

--- a/scripts/response_regeneration/run_all.sh
+++ b/scripts/response_regeneration/run_all.sh
@@ -9,6 +9,7 @@
 #   ./run_all.sh --model "Qwen/Qwen2.5-72B-Instruct" --dp-size 4 --tp-size 2 --dataset magpie
 #   ./run_all.sh --model "Qwen/Qwen2.5-72B-Instruct" --gpus 0,1,2,4 --tp-size 4 --dataset magpie
 #   ./run_all.sh --model "Qwen/Qwen2.5-72B-Instruct" --dataset magpie --keep-server
+#   ./run_all.sh --model "Qwen/Qwen3-8B" --tool-call-parser hermes --dataset hermes-fc
 #
 
 set -e  # Exit on error
@@ -22,6 +23,7 @@ DP_SIZE=""
 TP_SIZE=""
 MAX_MODEL_LEN=""
 REASONING_PARSER=""
+TOOL_CALL_PARSER=""
 GPUS=""
 KEEP_SERVER=false
 
@@ -47,6 +49,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --reasoning-parser)
             REASONING_PARSER="$2"
+            shift 2
+            ;;
+        --tool-call-parser)
+            TOOL_CALL_PARSER="$2"
             shift 2
             ;;
         --model)
@@ -77,7 +83,7 @@ done
 # Validate required arguments
 if [ -z "$MODEL" ]; then
     echo "Error: --model is required."
-    echo "Usage: $0 --model MODEL [--gpus GPUS] [--dp-size N] [--tp-size N] [--max-model-len N] [--reasoning-parser PARSER] [--dataset DATASET] [...]"
+    echo "Usage: $0 --model MODEL [--gpus GPUS] [--dp-size N] [--tp-size N] [--max-model-len N] [--reasoning-parser PARSER] [--tool-call-parser PARSER] [--dataset DATASET] [...]"
     exit 1
 fi
 
@@ -87,6 +93,10 @@ VLLM_CMD=(vllm serve "$MODEL" --host 127.0.0.1 --port "$PORT" --api-key "")
 [ -n "$TP_SIZE" ] && VLLM_CMD+=(--tensor-parallel-size "$TP_SIZE")
 [ -n "$MAX_MODEL_LEN" ] && VLLM_CMD+=(--max-model-len "$MAX_MODEL_LEN")
 [ -n "$REASONING_PARSER" ] && VLLM_CMD+=(--reasoning-parser "$REASONING_PARSER")
+# Structured tool calls need both flags; otherwise vLLM emits them as text in
+# `content` and regen sees no tools.
+[ -n "$TOOL_CALL_PARSER" ] &&
+    VLLM_CMD+=(--enable-auto-tool-choice --tool-call-parser "$TOOL_CALL_PARSER")
 
 # Cleanup function
 cleanup() {
@@ -114,6 +124,7 @@ echo "  Model: $MODEL"
 [ -n "$TP_SIZE" ] && echo "  Tensor parallel size: $TP_SIZE"
 [ -n "$MAX_MODEL_LEN" ] && echo "  Max model len: $MAX_MODEL_LEN"
 [ -n "$REASONING_PARSER" ] && echo "  Reasoning parser: $REASONING_PARSER"
+[ -n "$TOOL_CALL_PARSER" ] && echo "  Tool-call parser: $TOOL_CALL_PARSER (auto tool choice)"
 echo "  Command: ${VLLM_CMD[*]}"
 echo ""
 

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -570,6 +570,8 @@ async def regenerate_conversation(
             # To continue past a tool call we need exactly one call and a cached
             # result to pair with it; otherwise keep this (committed) call row
             # and truncate.
+            # TODO(regen): support parallel/multi tool calls -- a turn with >1
+            # call truncates here (dropped ~16/50 rows in a Hermes validation run).
             if len(tool_calls) != 1 or not tool_results:
                 truncated = True
                 break

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import sys
+from collections import deque
 from typing import Any
 
 import aiohttp
@@ -33,6 +34,11 @@ def _dataset_choice(name: str) -> str:
             "images yet. Use it off-policy with `prepare-data`."
         )
     return name
+
+
+# ---------------------------------------------------------------------------
+# CLI & run configuration
+# ---------------------------------------------------------------------------
 
 
 def parse_args():
@@ -136,6 +142,19 @@ def sanitize_filename(name: str) -> str:
     return name.strip("._")
 
 
+# ---------------------------------------------------------------------------
+# Row ingestion: user/system turns, tool schema, cached tool results
+# ---------------------------------------------------------------------------
+
+
+def _conversation_messages(row: dict[str, Any]) -> list:
+    """The ``messages`` or ``conversations`` list from a row, else []."""
+    convs = row.get("messages")
+    if not (isinstance(convs, list) and convs):
+        convs = row.get("conversations")
+    return convs if isinstance(convs, list) else []
+
+
 def extract_turns(
     row: dict[str, Any], prompt_field: str | None
 ) -> list[dict[str, Any]]:
@@ -147,28 +166,23 @@ def extract_turns(
     Rows without a usable conversation fall back to a single user turn taken
     from ``prompt_field``.
     """
-    convs = row.get("messages")
-    if not (isinstance(convs, list) and convs):
-        convs = row.get("conversations")
+    turns = []
+    for m in _conversation_messages(row):
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role") or m.get("from")
+        content = m.get("content") or m.get("value")
+        if not content:
+            continue
+        if role == "system":
+            turns.append({"role": "system", "content": content})
+        elif role in ("user", "human"):
+            turns.append({"role": "user", "content": content})
+        # original assistant/gpt turns are dropped and regenerated
+    if any(turn["role"] == "user" for turn in turns):
+        return turns
 
-    if isinstance(convs, list) and convs:
-        turns = []
-        for m in convs:
-            if not isinstance(m, dict):
-                continue
-            role = m.get("role") or m.get("from")
-            content = m.get("content") or m.get("value")
-            if not content:
-                continue
-            if role == "system":
-                turns.append({"role": "system", "content": content})
-            elif role in ("user", "human"):
-                turns.append({"role": "user", "content": content})
-            # original assistant/gpt turns are dropped and regenerated
-        if any(turn["role"] == "user" for turn in turns):
-            return turns
-        # no usable user turn: fall through to the prompt_field fallback
-
+    # no usable user turn: fall back to the prompt_field
     prompt = row.get(prompt_field)
     if prompt:
         return [{"role": "user", "content": prompt}]
@@ -186,6 +200,69 @@ def prepare_row(row: dict[str, Any], config: DatasetConfig) -> list[dict[str, An
     if config.normalize_fn is not None:
         row = {**row, **config.normalize_fn(row)}
     return extract_turns(row, config.prompt_field)
+
+
+def _maybe_json(value: Any):
+    """Best-effort JSON decode; return None if the value is not valid JSON."""
+    try:
+        return json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return None
+
+
+def _list_field(row, key) -> list | None:
+    """Non-empty list from ``row[key]`` (JSON-decoded if a string), else None."""
+    value = row.get(key)
+    if isinstance(value, str):
+        value = _maybe_json(value)
+    return value if isinstance(value, list) and value else None
+
+
+def extract_tools(row) -> list | None:
+    """Return the OpenAI-style ``tools`` schema for a row, or ``None``.
+
+    Accepts a ``tools`` list/JSON-string, or a legacy ``functions`` list (each
+    wrapped as ``{"type": "function", "function": ...}``), forwarded to the Chat
+    Completions API on every request. Tool-free datasets return ``None``.
+    """
+    tools = _list_field(row, "tools")
+    if tools:
+        return tools
+    functions = _list_field(row, "functions")
+    if functions:
+        return [{"type": "function", "function": fn} for fn in functions]
+    return None
+
+
+# Roles that carry a tool/function result across the conversation schemas we ingest.
+_TOOL_RESULT_ROLES = {"tool", "function", "observation", "function_response"}
+
+
+def extract_tool_results(row) -> list:
+    """Ordered tool-result payloads from a conversation, for positional reuse.
+
+    Tools are not executed during regeneration; the i-th cached result is spliced
+    back after the target's i-th regenerated tool call. Returns ``[]`` for the
+    plain (tool-free) datasets, leaving their regeneration unchanged.
+    """
+    results: list = []
+    for m in _conversation_messages(row):
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role") or m.get("from")
+        if role not in _TOOL_RESULT_ROLES:
+            continue
+        content = m.get("content")
+        if content is None:
+            content = m.get("value")
+        if content is not None:
+            results.append(content)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Resume state & vLLM server IO
+# ---------------------------------------------------------------------------
 
 
 def _is_present(value: Any) -> bool:
@@ -217,11 +294,12 @@ def _primary_identifier(row: dict[str, Any]) -> str:
 def load_seen(path: str) -> set[str]:
     """Load previously completed conversation ids from the output file.
 
-    A conversation fans out to one row per assistant turn, whose ``id`` carries a
-    ``_turn<N>`` suffix; the conversation's own :func:`_primary_identifier` is
-    kept alongside it as ``primary_id``. Resume keys on that, since the suffixed
-    ids never match a recomputed one. Rows are written only after every turn
-    succeeds, so one row is enough to mark the conversation done.
+    A conversation fans out to one row per target generation -- a tool call or a
+    final answer -- whose ``id`` carries a ``_gen<N>`` suffix; the conversation's
+    own :func:`_primary_identifier` is kept alongside it as ``primary_id``.
+    Resume keys on that, since the suffixed ids never match a recomputed one.
+    Rows are written only after the conversation finishes, so one row is enough
+    to mark it done.
 
     ``id`` is the fallback for output files written before the fan-out, where the
     top-level ``id`` *was* the primary identifier.
@@ -306,6 +384,11 @@ async def _post_chat(
         return await response.json()
 
 
+# ---------------------------------------------------------------------------
+# Regeneration: model response -> boundary training samples
+# ---------------------------------------------------------------------------
+
+
 def build_boundary_sample(
     prompt_token_ids: list[int],
     completion_token_ids: list[int],
@@ -319,6 +402,177 @@ def build_boundary_sample(
     return input_ids, loss_mask
 
 
+def _tool_result_message(tool_call: dict, content: Any) -> dict[str, Any]:
+    """Build the ``tool`` message that feeds a cached (off-policy) result back to
+    the target, paired to the id of the call the target just generated."""
+    if not isinstance(content, str):
+        content = json.dumps(content, ensure_ascii=False)
+    message: dict[str, Any] = {"role": "tool", "content": content}
+    call_id = tool_call.get("id")
+    if call_id:
+        message["tool_call_id"] = call_id
+    return message
+
+
+def _sample_from_response(
+    data: dict[str, Any],
+    *,
+    prefix: list[dict[str, Any]],
+    conv_id: str,
+    sample_index: int,
+    idx: int,
+    endpoint: str,
+    sampling_params: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any], list | None]:
+    """Turn one chat-completion response into a boundary sample and the assistant
+    message to append to the running prefix.
+
+    Returns ``(sample, assistant_msg, tool_calls)``; ``tool_calls`` is truthy when
+    the target emitted a tool call (its content may be empty). Raises on a wholly
+    empty generation or a response missing the ``return_token_ids`` payload.
+    """
+    choice = data["choices"][0]
+    message = choice["message"]
+    content = message.get("content")
+    tool_calls = message.get("tool_calls")
+
+    # A tool call legitimately has empty content; only a wholly empty generation
+    # corrupts the next prefix and must fail the conversation.
+    if not content and not tool_calls:
+        raise ValueError(f"empty assistant generation (sample {sample_index})")
+
+    prompt_token_ids = data.get("prompt_token_ids")
+    completion_token_ids = choice.get("token_ids")
+    if not prompt_token_ids or not completion_token_ids:
+        raise ValueError(
+            "endpoint returned no token ids; it must support return_token_ids"
+        )
+
+    input_ids, loss_mask = build_boundary_sample(prompt_token_ids, completion_token_ids)
+    if tool_calls:
+        # History keeps the parsed call; any generated <think> is supervised in
+        # this row's completion tokens, not re-rendered.
+        assistant_msg = {
+            "role": "assistant",
+            "content": content or "",
+            "tool_calls": tool_calls,
+        }
+    else:
+        assistant_msg = {"role": "assistant", "content": content}
+
+    sample = {
+        "id": f"{conv_id}_gen{sample_index}",
+        # Conversation-level key for --resume; the row `id` is generation-suffixed
+        # and would never match a recomputed one.
+        "primary_id": conv_id,
+        "input_ids": input_ids,
+        "loss_mask": loss_mask,
+        # Review-only twin of input_ids; ignored by training.
+        "conversations": [*prefix, assistant_msg],
+        "metadata": {
+            "idx": idx,
+            "finish_reason": choice.get("finish_reason"),
+            "is_tool_call": bool(tool_calls),
+            "usage": data.get("usage") or {},
+            "endpoint": endpoint,
+            "sampling_params": sampling_params,
+        },
+    }
+    return sample, assistant_msg, tool_calls
+
+
+async def regenerate_conversation(
+    post_fn,
+    item: dict[str, Any],
+    *,
+    model: str,
+    max_tokens: int,
+    endpoint: str,
+    sampling_params: dict[str, Any],
+    samples: list[dict[str, Any]],
+) -> bool:
+    """Regenerate one conversation into per-generation boundary samples.
+
+    Each target generation -- a tool call *or* a final answer -- becomes one
+    boundary row (prompt loss_mask 0, generated tokens 1). Tool calls are not
+    executed: the target's i-th regenerated call is followed by the i-th cached
+    tool result from the source data (positional reuse).
+
+    The conversation is truncated after the last committed sample -- returning
+    ``True`` -- when the target emits more tool calls than we have cached results
+    for, or a parallel (multi) tool call we cannot pair 1:1.
+
+    Completed rows are appended to ``samples`` as they are built, so the caller
+    still holds the partial result if this raises partway through. Returns
+    whether the conversation was truncated.
+    """
+    turns = item["turns"]
+    tools = item.get("tools")
+    tool_results = deque(item.get("tool_results") or [])
+    conv_id = item["primary_id"]
+
+    prefix: list[dict[str, Any]] = []
+    truncated = False
+
+    for turn in turns:
+        if turn["role"] == "system":
+            prefix.append({"role": "system", "content": turn["content"]})
+            continue
+
+        prefix.append({"role": "user", "content": turn["content"]})
+
+        # Tool-call loop: a tool call splices a cached result and continues;
+        # a final answer ends the turn.
+        while True:
+            payload: dict[str, Any] = {
+                # Spread first: the keys below are ours to own and must not be
+                # overridden by user-supplied sampling params.
+                **sampling_params,
+                "model": model,
+                "messages": prefix,
+                "max_tokens": max_tokens,
+                "return_token_ids": True,  # prompt_token_ids + completion token_ids
+            }
+            if tools:
+                payload["tools"] = tools
+                payload["tool_choice"] = "auto"
+
+            data = await post_fn(payload)
+            sample, assistant_msg, tool_calls = _sample_from_response(
+                data,
+                prefix=prefix,
+                conv_id=conv_id,
+                sample_index=len(samples),
+                idx=item["idx"],
+                endpoint=endpoint,
+                sampling_params=sampling_params,
+            )
+            samples.append(sample)
+            prefix.append(assistant_msg)
+
+            if not tool_calls:
+                break  # final answer: this user turn is done
+
+            # To continue past a tool call we need exactly one call and a cached
+            # result to pair with it; otherwise keep this (committed) call row
+            # and truncate.
+            if len(tool_calls) != 1 or not tool_results:
+                truncated = True
+                break
+
+            prefix.append(_tool_result_message(tool_calls[0], tool_results.popleft()))
+
+        if truncated:
+            break
+
+    return truncated
+
+
+# ---------------------------------------------------------------------------
+# Worker pool & orchestration
+# ---------------------------------------------------------------------------
+
+
 async def worker(
     session: aiohttp.ClientSession,
     queue: "asyncio.Queue[dict[str, Any]]",
@@ -329,99 +583,55 @@ async def worker(
     progress,
     stats: dict[str, int],
 ):
-    """Regenerate each queued conversation into pre-tokenized training samples.
+    """Pull conversations off the queue and regenerate them into boundary rows.
 
-    One sample per assistant turn: the prompt the target conditioned on
-    (loss_mask 0) followed by the tokens it generated (1).
+    Each target generation becomes one boundary sample; tool calls reuse the
+    source data's cached results (see ``regenerate_conversation``). Truncated
+    conversations still emit the rows completed before the cut.
     """
+
+    async def post(payload: dict[str, Any]) -> dict[str, Any]:
+        return await _post_chat(
+            session, endpoint, payload, max_retries=args.max_retries
+        )
+
     while True:
         item = await queue.get()
         if item is None:
             queue.task_done()
             return
 
-        idx = item["idx"]
-        turns = item["turns"]
         conv_id = item["primary_id"]
-
-        prefix: list[dict[str, Any]] = []
+        # Held by the caller so a mid-conversation failure can still report how
+        # many rows had been completed.
         samples: list[dict[str, Any]] = []
         try:
-            for turn in turns:
-                if turn["role"] == "system":
-                    prefix.append({"role": "system", "content": turn["content"]})
-                    continue
-
-                prefix.append({"role": "user", "content": turn["content"]})
-
-                payload = {
-                    **args.sampling_params,
-                    "model": args.model,
-                    "messages": prefix,
-                    "max_tokens": args.max_tokens,
-                    "return_token_ids": True,  # prompt_token_ids + completion token_ids
-                }
-                data = await _post_chat(
-                    session,
-                    endpoint,
-                    payload,
-                    max_retries=args.max_retries,
-                )
-
-                choice = data["choices"][0]
-                generated_text = choice["message"].get("content")
-
-                # Empty content corrupts the next turn's prefix; fail the conversation.
-                if not generated_text:
-                    raise ValueError(f"empty assistant content (turn {len(samples)})")
-
-                prompt_token_ids = data.get("prompt_token_ids")
-                completion_token_ids = choice.get("token_ids")
-                if not prompt_token_ids or not completion_token_ids:
-                    raise ValueError(
-                        "endpoint returned no token ids; it must support "
-                        "return_token_ids"
-                    )
-
-                input_ids, loss_mask = build_boundary_sample(
-                    prompt_token_ids, completion_token_ids
-                )
-                # History keeps parsed content; the generated <think> is supervised
-                # in this turn's completion tokens above.
-                assistant_msg = {"role": "assistant", "content": generated_text}
-                samples.append(
-                    {
-                        "id": f"{conv_id}_turn{len(samples)}",
-                        # Conversation-level key for --resume; the row `id` is
-                        # turn-suffixed and would never match a recomputed one.
-                        "primary_id": conv_id,
-                        "input_ids": input_ids,
-                        "loss_mask": loss_mask,
-                        # Review-only twin of input_ids; ignored by training.
-                        "conversations": [*prefix, assistant_msg],
-                        "metadata": {
-                            "idx": idx,
-                            "finish_reason": choice.get("finish_reason"),
-                            "usage": data.get("usage") or {},
-                            "endpoint": endpoint,
-                            "sampling_params": args.sampling_params,
-                        },
-                    }
-                )
-                prefix.append(assistant_msg)
-
-            # Written only after every turn succeeds, so any row in the output
-            # file means the whole conversation is done (see load_seen).
+            truncated = await regenerate_conversation(
+                post,
+                item,
+                model=args.model,
+                max_tokens=args.max_tokens,
+                endpoint=endpoint,
+                sampling_params=args.sampling_params,
+                samples=samples,
+            )
+            # Written only after the conversation finishes -- a clean truncation
+            # included, since rerunning it would truncate again. An exception
+            # writes nothing, so any row in the output file means the
+            # conversation needs no rerun (see load_seen).
             for sample in samples:
                 out_fh.write(json.dumps(sample, ensure_ascii=False) + "\n")
             out_fh.flush()
-            stats["ok"] += 1
+            if samples:
+                stats["ok"] += 1
+            if truncated:
+                stats["truncated"] += 1
         except Exception as e:  # noqa: BLE001
             # Failures go to a separate error file, not the training output.
             error_output = {
                 "id": conv_id,
                 "metadata": {
-                    "idx": idx,
+                    "idx": item["idx"],
                     "error": repr(e),
                     "turns_completed": len(samples),
                     "endpoint": endpoint,
@@ -434,6 +644,7 @@ async def worker(
             progress.set_postfix(
                 ok=stats["ok"],
                 errors=stats["errors"],
+                truncated=stats["truncated"],
                 refresh=False,
             )
             progress.update(1)
@@ -506,7 +717,7 @@ async def main():
                 dynamic_ncols=True,
             ) as progress,
         ):
-            stats = {"ok": 0, "errors": 0}
+            stats = {"ok": 0, "errors": 0, "truncated": 0}
             workers = [
                 asyncio.create_task(
                     worker(
@@ -544,6 +755,8 @@ async def main():
                         "idx": index,
                         "primary_id": primary_id,
                         "turns": turns,
+                        "tools": extract_tools(row),
+                        "tool_results": extract_tool_results(row),
                     }
                 )
                 processed_count += 1

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -677,7 +677,7 @@ async def worker(
                 "metadata": {
                     "idx": item["idx"],
                     "error": repr(e),
-                    "turns_completed": len(samples),
+                    "generations_completed": len(samples),
                     "endpoint": endpoint,
                 },
             }
@@ -809,7 +809,7 @@ async def main():
                         "metadata": {
                             "idx": index,
                             "error": repr(exc),
-                            "turns_completed": 0,
+                            "generations_completed": 0,
                             "endpoint": endpoint,
                         },
                     }

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -192,17 +192,39 @@ def extract_turns(
     return []
 
 
-def prepare_row(row: dict[str, Any], config: DatasetConfig) -> list[dict[str, Any]]:
-    """Extract regeneration turns from a raw dataset row, ``[]`` to skip it.
+def normalize_row(row: dict[str, Any], config: DatasetConfig) -> dict[str, Any] | None:
+    """Apply the preset's ingestion rules to a raw row, ``None`` to skip it.
 
     Mirrors off-policy ingestion: ``filter_fn`` sees the raw row, and
     ``normalize_fn`` is merged over it (HF ``map`` semantics keep raw columns).
+
+    Turns, tools and cached tool results must all be read from this one
+    normalized row: under presets that carry a ``normalize_fn`` the conversation
+    only appears in ``messages`` once it has run, so extracting tools from the
+    raw row would silently find none.
     """
     if config.filter_fn is not None and not config.filter_fn(row):
-        return []
+        return None
     if config.normalize_fn is not None:
-        row = {**row, **config.normalize_fn(row)}
-    return extract_turns(row, config.prompt_field)
+        return {**row, **config.normalize_fn(row)}
+    return row
+
+
+def prepare_row(
+    row: dict[str, Any], config: DatasetConfig
+) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
+    """The normalized row and its regeneration turns, or ``None`` to skip it.
+
+    Returns the normalized row alongside the turns so that callers extract tools
+    and cached tool results from the same row the turns came from.
+    """
+    normalized = normalize_row(row, config)
+    if normalized is None:
+        return None
+    turns = extract_turns(normalized, config.prompt_field)
+    if not turns:
+        return None
+    return normalized, turns
 
 
 def _maybe_json(value: Any):
@@ -764,9 +786,10 @@ async def main():
                 if args.language_filter and row.get("language") != args.language_filter:
                     continue
 
-                turns = prepare_row(row, dataset_config)
-                if not turns:
+                prepared = prepare_row(row, dataset_config)
+                if prepared is None:
                     continue
+                normalized, turns = prepared
 
                 primary_id = _primary_identifier(row)
                 if primary_id in seen_ids:
@@ -774,7 +797,7 @@ async def main():
 
                 # Broken input tool schema: record and skip (don't crash the run).
                 try:
-                    tools = extract_tools(row)
+                    tools = extract_tools(normalized)
                 except ValueError as exc:
                     logger.warning(
                         "Skipping row %s: input tool schema is broken (%s)",
@@ -804,7 +827,7 @@ async def main():
                         "primary_id": primary_id,
                         "turns": turns,
                         "tools": tools,
-                        "tool_results": extract_tool_results(row),
+                        "tool_results": extract_tool_results(normalized),
                     }
                 )
                 processed_count += 1

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -218,20 +218,33 @@ def _list_field(row, key) -> list | None:
     return value if isinstance(value, list) and value else None
 
 
+def _normalize_tool(entry: Any) -> dict | None:
+    """Coerce one tool entry to OpenAI ``{"type": "function", "function": ...}`` shape.
+
+    Decodes JSON-string entries, wraps bare function specs, passes already-wrapped
+    dicts through, and returns ``None`` for anything that is not a dict.
+    """
+    if isinstance(entry, str):
+        entry = _maybe_json(entry)
+    if not isinstance(entry, dict):
+        return None
+    if isinstance(entry.get("function"), dict):
+        return entry
+    return {"type": "function", "function": entry}
+
+
 def extract_tools(row) -> list | None:
     """Return the OpenAI-style ``tools`` schema for a row, or ``None``.
 
-    Accepts a ``tools`` list/JSON-string, or a legacy ``functions`` list (each
-    wrapped as ``{"type": "function", "function": ...}``), forwarded to the Chat
-    Completions API on every request. Tool-free datasets return ``None``.
+    Reads a ``tools`` list (or JSON-string), else a legacy ``functions`` list, and
+    normalizes each entry via :func:`_normalize_tool`. Undecodable entries are
+    dropped; a row with no usable schema returns ``None``.
     """
-    tools = _list_field(row, "tools")
-    if tools:
-        return tools
-    functions = _list_field(row, "functions")
-    if functions:
-        return [{"type": "function", "function": fn} for fn in functions]
-    return None
+    raw = _list_field(row, "tools") or _list_field(row, "functions")
+    if not raw:
+        return None
+    tools = [tool for tool in (_normalize_tool(entry) for entry in raw) if tool]
+    return tools or None
 
 
 # Roles that carry a tool/function result across the conversation schemas we ingest.

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -243,38 +243,19 @@ def _list_field(row, key) -> list | None:
     return value if isinstance(value, list) and value else None
 
 
-def _normalize_tool(entry: Any) -> dict | None:
-    """Coerce one tool entry to OpenAI ``{"type": "function", "function": ...}`` shape.
-
-    Decodes JSON-string entries, wraps bare function specs, passes already-wrapped
-    dicts through, and returns ``None`` for anything that is not a dict.
-    """
-    if isinstance(entry, str):
-        entry = _maybe_json(entry)
-    if not isinstance(entry, dict):
-        return None
-    if isinstance(entry.get("function"), dict):
-        return entry
-    return {"type": "function", "function": entry}
-
-
 def extract_tools(row) -> list | None:
     """Return the OpenAI-style ``tools`` schema for a row, or ``None``.
 
-    Reads a ``tools`` list (or JSON-string), else a legacy ``functions`` list, and
-    normalizes each entry via :func:`_normalize_tool` (individual junk entries are
-    dropped). A row that declares no tools returns ``None``; one that *declares*
-    tools we cannot turn into any function schema raises ``ValueError`` instead of
-    silently regenerating tool-free.
+    Reads the ``tools`` column -- a list, or a JSON-string encoding one, as the
+    Hermes function-calling dataset stores it. A row that declares a ``tools``
+    field we cannot read as a list raises ``ValueError`` rather than silently
+    regenerating tool-free; a tool-free row returns ``None``.
     """
-    raw = _list_field(row, "tools") or _list_field(row, "functions")
-    if raw:
-        tools = [tool for tool in (_normalize_tool(entry) for entry in raw) if tool]
-        if not tools:
-            raise ValueError(f"tools present but none valid: {raw!r:.100}")
+    tools = _list_field(row, "tools")
+    if tools:
         return tools
-    if any(row.get(key) not in (None, "", [], {}) for key in ("tools", "functions")):
-        raise ValueError("a tools/functions field is present but not a usable list")
+    if row.get("tools") not in (None, "", [], {}):
+        raise ValueError("a tools field is present but not a usable list")
     return None
 
 

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -208,33 +208,18 @@ def extract_conversation(
     return [], []
 
 
-def normalize_row(row: dict[str, Any], config: DatasetConfig) -> dict[str, Any] | None:
-    """Apply the preset's ingestion rules to a raw row, ``None`` to skip it.
-
-    ``filter_fn`` sees the raw row; ``normalize_fn`` is merged over it (HF
-    ``map`` semantics keep raw columns). Turns, tools and results are all read
-    from this one normalized row -- under a ``normalize_fn`` preset the
-    conversation only appears in ``messages`` after it runs, so reading the raw
-    row would find none.
-    """
-    if config.filter_fn is not None and not config.filter_fn(row):
-        return None
-    if config.normalize_fn is not None:
-        return {**row, **config.normalize_fn(row)}
-    return row
-
-
 def prepare_row(
     row: dict[str, Any], config: DatasetConfig
 ) -> tuple[dict[str, Any], list[dict[str, Any]], list[tuple[Any, list[str]]]] | None:
     """The normalized row, its regeneration turns, and cached tool results.
 
-    Reads turns and results from one normalized row (see
-    :func:`extract_conversation`) so they stay paired; ``None`` to skip the row.
+    ``filter_fn`` sees the raw row; ``normalize_fn`` is merged over it (HF
+    ``map`` keeps raw columns). Turns and results are read from that one
+    normalized row so they stay paired; ``None`` to skip the row.
     """
-    normalized = normalize_row(row, config)
-    if normalized is None:
+    if config.filter_fn is not None and not config.filter_fn(row):
         return None
+    normalized = {**row, **config.normalize_fn(row)} if config.normalize_fn else row
     turns, tool_results = extract_conversation(normalized, config.prompt_field)
     if not turns:
         return None

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -259,10 +259,6 @@ def extract_tools(row) -> list | None:
     return None
 
 
-# Roles that carry a tool/function result across the conversation schemas we ingest.
-_TOOL_RESULT_ROLES = {"tool", "function", "observation", "function_response"}
-
-
 def extract_tool_results(row) -> list:
     """Ordered tool-result payloads from a conversation, for positional reuse.
 
@@ -275,7 +271,7 @@ def extract_tool_results(row) -> list:
         if not isinstance(m, dict):
             continue
         role = m.get("role") or m.get("from")
-        if role not in _TOOL_RESULT_ROLES:
+        if role != "tool":
             continue
         content = m.get("content")
         if content is None:

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -3,6 +3,7 @@ import argparse
 import asyncio
 import hashlib
 import json
+import logging
 import os
 import re
 import sys
@@ -19,6 +20,8 @@ from speculators.data_generation.vllm_client import (
     InvalidResponseError,
     with_retries,
 )
+
+logger = logging.getLogger(__name__)
 
 # On-policy regeneration has no multimodal support yet; off-policy `prepare-data`
 # does, so these presets are gated here rather than dropped from the registry.
@@ -769,12 +772,38 @@ async def main():
                 if primary_id in seen_ids:
                     continue
 
+                # Broken input tool schema: record and skip (don't crash the run).
+                try:
+                    tools = extract_tools(row)
+                except ValueError as exc:
+                    logger.warning(
+                        "Skipping row %s: input tool schema is broken (%s)",
+                        primary_id,
+                        exc,
+                    )
+                    error_output = {
+                        "id": primary_id,
+                        "metadata": {
+                            "idx": index,
+                            "error": repr(exc),
+                            "turns_completed": 0,
+                            "endpoint": endpoint,
+                        },
+                    }
+                    error_file.write(
+                        json.dumps(error_output, ensure_ascii=False) + "\n"
+                    )
+                    error_file.flush()
+                    stats["errors"] += 1
+                    progress.update(1)
+                    continue
+
                 await queue.put(
                     {
                         "idx": index,
                         "primary_id": primary_id,
                         "turns": turns,
-                        "tools": extract_tools(row),
+                        "tools": tools,
                         "tool_results": extract_tool_results(row),
                     }
                 )

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -158,38 +158,54 @@ def _conversation_messages(row: dict[str, Any]) -> list:
     return convs if isinstance(convs, list) else []
 
 
-def extract_turns(
-    row: dict[str, Any], prompt_field: str | None
-) -> list[dict[str, Any]]:
-    """Extract ordered system/user turns from a dataset row.
+def _message_role_content(m: dict) -> tuple[str | None, Any]:
+    """Canonical ``(role, content)`` for a message across the role/content and
+    from/value schemas. ``role`` collapses ``human`` to ``user``; ``system`` and
+    ``tool`` pass through; anything else (assistant/gpt) returns ``None``."""
+    role = m.get("role") or m.get("from")
+    content = m.get("content")
+    if content is None:
+        content = m.get("value")
+    if role in ("user", "human"):
+        return "user", content
+    if role in ("system", "tool"):
+        return role, content
+    return None, content
 
-    Multi-turn conversations are read from a ``messages`` or ``conversations``
-    field (either the role/content or from/value schema), preserving any system
-    prompt and dropping the original assistant turns so they can be regenerated.
-    Rows without a usable conversation fall back to a single user turn taken
-    from ``prompt_field``.
+
+def extract_conversation(
+    row: dict[str, Any], prompt_field: str | None
+) -> tuple[list[dict[str, Any]], list[tuple[Any, list[str]]]]:
+    """Read the regeneration turns and the cached tool results in one pass.
+
+    Walks a ``messages``/``conversations`` field (role/content or from/value
+    schema). System and user turns drive regeneration; the original assistant
+    turns are dropped and regenerated. Each tool-result turn is captured as a
+    ``(content, tool_names)`` pair, where ``tool_names`` are the tools that
+    result answers (read from its ``<tool_response>`` payload) -- used to guard
+    the positional splice against a call for a different tool. Rows without a
+    usable conversation fall back to a single ``prompt_field`` user turn and
+    carry no results.
     """
-    turns = []
+    turns: list[dict[str, Any]] = []
+    results: list[tuple[Any, list[str]]] = []
     for m in _conversation_messages(row):
         if not isinstance(m, dict):
             continue
-        role = m.get("role") or m.get("from")
-        content = m.get("content") or m.get("value")
-        if not content:
-            continue
-        if role == "system":
-            turns.append({"role": "system", "content": content})
-        elif role in ("user", "human"):
-            turns.append({"role": "user", "content": content})
+        role, content = _message_role_content(m)
+        if role in ("system", "user") and content:
+            turns.append({"role": role, "content": content})
+        elif role == "tool" and content is not None:
+            results.append((content, _tool_result_names(content)))
         # original assistant/gpt turns are dropped and regenerated
     if any(turn["role"] == "user" for turn in turns):
-        return turns
+        return turns, results
 
     # no usable user turn: fall back to the prompt_field
-    prompt = row.get(prompt_field)
+    prompt = row.get(prompt_field) if prompt_field else None
     if prompt:
-        return [{"role": "user", "content": prompt}]
-    return []
+        return [{"role": "user", "content": prompt}], []
+    return [], []
 
 
 def normalize_row(row: dict[str, Any], config: DatasetConfig) -> dict[str, Any] | None:
@@ -212,19 +228,19 @@ def normalize_row(row: dict[str, Any], config: DatasetConfig) -> dict[str, Any] 
 
 def prepare_row(
     row: dict[str, Any], config: DatasetConfig
-) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
-    """The normalized row and its regeneration turns, or ``None`` to skip it.
+) -> tuple[dict[str, Any], list[dict[str, Any]], list[tuple[Any, list[str]]]] | None:
+    """The normalized row, its regeneration turns, and cached tool results.
 
-    Returns the normalized row alongside the turns so that callers extract tools
-    and cached tool results from the same row the turns came from.
+    Reads turns and results from one normalized row (see
+    :func:`extract_conversation`) so they stay paired; ``None`` to skip the row.
     """
     normalized = normalize_row(row, config)
     if normalized is None:
         return None
-    turns = extract_turns(normalized, config.prompt_field)
+    turns, tool_results = extract_conversation(normalized, config.prompt_field)
     if not turns:
         return None
-    return normalized, turns
+    return normalized, turns, tool_results
 
 
 def _maybe_json(value: Any):
@@ -259,26 +275,29 @@ def extract_tools(row) -> list | None:
     return None
 
 
-def extract_tool_results(row) -> list:
-    """Ordered tool-result payloads from a conversation, for positional reuse.
+_TOOL_RESPONSE_RE = re.compile(r"<tool_response>\s*(.*?)\s*</tool_response>", re.DOTALL)
 
-    Tools are not executed during regeneration; the i-th cached result is spliced
-    back after the target's i-th regenerated tool call. Returns ``[]`` for the
-    plain (tool-free) datasets, leaving their regeneration unchanged.
+
+def _tool_result_names(content: Any) -> list[str]:
+    """Tool names a cached result answers, for the splice name-match guard.
+
+    Hermes embeds the answering tool's name in each ``<tool_response>`` payload.
+    Returns ``[]`` when no name can be read, which disables the guard for that
+    result rather than blocking the splice on our own parse miss.
     """
-    results: list = []
-    for m in _conversation_messages(row):
-        if not isinstance(m, dict):
-            continue
-        role = m.get("role") or m.get("from")
-        if role != "tool":
-            continue
-        content = m.get("content")
-        if content is None:
-            content = m.get("value")
-        if content is not None:
-            results.append(content)
-    return results
+    if not isinstance(content, str):
+        return []
+    names = []
+    for block in _TOOL_RESPONSE_RE.findall(content):
+        obj = _maybe_json(block)
+        if isinstance(obj, dict) and isinstance(obj.get("name"), str):
+            names.append(obj["name"])
+    return names
+
+
+def _norm_tool(name: str | None) -> str:
+    """Normalize a tool name for matching (some sources prefix ``functions.``)."""
+    return (name or "").removeprefix("functions.")
 
 
 # ---------------------------------------------------------------------------
@@ -521,7 +540,8 @@ async def regenerate_conversation(
 
     The conversation is truncated after the last committed sample -- returning
     ``True`` -- when the target emits more tool calls than we have cached results
-    for, or a parallel (multi) tool call we cannot pair 1:1.
+    for, a parallel (multi) tool call we cannot pair 1:1, or a call for a
+    different tool than the next cached result answers (name mismatch).
 
     Completed rows are appended to ``samples`` as they are built, so the caller
     still holds the partial result if this raises partway through. Returns
@@ -581,7 +601,18 @@ async def regenerate_conversation(
                 truncated = True
                 break
 
-            prefix.append(_tool_result_message(tool_calls[0], tool_results.popleft()))
+            content, result_names = tool_results.popleft()
+            call_name = (tool_calls[0].get("function") or {}).get("name")
+            # Splice only if the regenerated call is for the tool this cached
+            # result answers; a different tool cannot be paired coherently, so
+            # keep the committed call row and truncate.
+            if result_names and _norm_tool(call_name) not in {
+                _norm_tool(n) for n in result_names
+            }:
+                truncated = True
+                break
+
+            prefix.append(_tool_result_message(tool_calls[0], content))
 
         if truncated:
             break
@@ -766,7 +797,7 @@ async def main():
                 prepared = prepare_row(row, dataset_config)
                 if prepared is None:
                     continue
-                normalized, turns = prepared
+                normalized, turns, tool_results = prepared
 
                 primary_id = _primary_identifier(row)
                 if primary_id in seen_ids:
@@ -804,7 +835,7 @@ async def main():
                         "primary_id": primary_id,
                         "turns": turns,
                         "tools": tools,
-                        "tool_results": extract_tool_results(normalized),
+                        "tool_results": tool_results,
                     }
                 )
                 processed_count += 1

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -211,13 +211,11 @@ def extract_conversation(
 def normalize_row(row: dict[str, Any], config: DatasetConfig) -> dict[str, Any] | None:
     """Apply the preset's ingestion rules to a raw row, ``None`` to skip it.
 
-    Mirrors off-policy ingestion: ``filter_fn`` sees the raw row, and
-    ``normalize_fn`` is merged over it (HF ``map`` semantics keep raw columns).
-
-    Turns, tools and cached tool results must all be read from this one
-    normalized row: under presets that carry a ``normalize_fn`` the conversation
-    only appears in ``messages`` once it has run, so extracting tools from the
-    raw row would silently find none.
+    ``filter_fn`` sees the raw row; ``normalize_fn`` is merged over it (HF
+    ``map`` semantics keep raw columns). Turns, tools and results are all read
+    from this one normalized row -- under a ``normalize_fn`` preset the
+    conversation only appears in ``messages`` after it runs, so reading the raw
+    row would find none.
     """
     if config.filter_fn is not None and not config.filter_fn(row):
         return None
@@ -293,11 +291,6 @@ def _tool_result_names(content: Any) -> list[str]:
         if isinstance(obj, dict) and isinstance(obj.get("name"), str):
             names.append(obj["name"])
     return names
-
-
-def _norm_tool(name: str | None) -> str:
-    """Normalize a tool name for matching (some sources prefix ``functions.``)."""
-    return (name or "").removeprefix("functions.")
 
 
 # ---------------------------------------------------------------------------
@@ -442,11 +435,9 @@ def build_boundary_sample(
     return input_ids, loss_mask
 
 
-def _tool_result_message(tool_call: dict, content: Any) -> dict[str, Any]:
+def _tool_result_message(tool_call: dict, content: str) -> dict[str, Any]:
     """Build the ``tool`` message that feeds a cached (off-policy) result back to
     the target, paired to the id of the call the target just generated."""
-    if not isinstance(content, str):
-        content = json.dumps(content, ensure_ascii=False)
     message: dict[str, Any] = {"role": "tool", "content": content}
     call_id = tool_call.get("id")
     if call_id:
@@ -533,19 +524,16 @@ async def regenerate_conversation(
 ) -> bool:
     """Regenerate one conversation into per-generation boundary samples.
 
-    Each target generation -- a tool call *or* a final answer -- becomes one
-    boundary row (prompt loss_mask 0, generated tokens 1). Tool calls are not
-    executed: the target's i-th regenerated call is followed by the i-th cached
-    tool result from the source data (positional reuse).
+    Each target generation -- a tool call *or* a final answer -- is one boundary
+    row (loss_mask 0 over the prompt, 1 over the generated tokens). Tool calls
+    are not executed: the target's i-th regenerated call is paired with the i-th
+    cached result from the source row.
 
-    The conversation is truncated after the last committed sample -- returning
-    ``True`` -- when the target emits more tool calls than we have cached results
-    for, a parallel (multi) tool call we cannot pair 1:1, or a call for a
-    different tool than the next cached result answers (name mismatch).
-
-    Completed rows are appended to ``samples`` as they are built, so the caller
-    still holds the partial result if this raises partway through. Returns
-    whether the conversation was truncated.
+    Returns whether the conversation was truncated -- which happens when a call
+    cannot be paired 1:1 with a cached result (results exhausted, a parallel
+    call, or a different tool than the result answers). Completed rows are
+    appended to ``samples`` as they go, so the caller keeps partial progress if
+    this raises.
     """
     turns = item["turns"]
     tools = item.get("tools")
@@ -606,9 +594,7 @@ async def regenerate_conversation(
             # Splice only if the regenerated call is for the tool this cached
             # result answers; a different tool cannot be paired coherently, so
             # keep the committed call row and truncate.
-            if result_names and _norm_tool(call_name) not in {
-                _norm_tool(n) for n in result_names
-            }:
+            if result_names and call_name not in result_names:
                 truncated = True
                 break
 

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -237,14 +237,20 @@ def extract_tools(row) -> list | None:
     """Return the OpenAI-style ``tools`` schema for a row, or ``None``.
 
     Reads a ``tools`` list (or JSON-string), else a legacy ``functions`` list, and
-    normalizes each entry via :func:`_normalize_tool`. Undecodable entries are
-    dropped; a row with no usable schema returns ``None``.
+    normalizes each entry via :func:`_normalize_tool` (individual junk entries are
+    dropped). A row that declares no tools returns ``None``; one that *declares*
+    tools we cannot turn into any function schema raises ``ValueError`` instead of
+    silently regenerating tool-free.
     """
     raw = _list_field(row, "tools") or _list_field(row, "functions")
-    if not raw:
-        return None
-    tools = [tool for tool in (_normalize_tool(entry) for entry in raw) if tool]
-    return tools or None
+    if raw:
+        tools = [tool for tool in (_normalize_tool(entry) for entry in raw) if tool]
+        if not tools:
+            raise ValueError(f"tools present but none valid: {raw!r:.100}")
+        return tools
+    if any(row.get(key) not in (None, "", [], {}) for key in ("tools", "functions")):
+        raise ValueError("a tools/functions field is present but not a usable list")
+    return None
 
 
 # Roles that carry a tool/function result across the conversation schemas we ingest.

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -810,9 +810,8 @@ def test_prepare_row_normalizes_like_off_policy():
         "input": [{"role": "user", "content": "Hi"}],
         "output": "<original answer to drop>",
     }
-    assert regen.prepare_row(row, DATASET_CONFIGS["nemotron"]) == [
-        {"role": "user", "content": "Hi"}
-    ]
+    _, turns = regen.prepare_row(row, DATASET_CONFIGS["nemotron"])
+    assert turns == [{"role": "user", "content": "Hi"}]
 
 
 def test_prepare_row_applies_filter_fn():
@@ -823,10 +822,9 @@ def test_prepare_row_applies_filter_fn():
         filter_fn=lambda row: row["keep"],
     )
     row = {"keep": False, "conversations": [{"role": "user", "content": "Hi"}]}
-    assert regen.prepare_row(row, config) == []
-    assert regen.prepare_row(row | {"keep": True}, config) == [
-        {"role": "user", "content": "Hi"}
-    ]
+    assert regen.prepare_row(row, config) is None
+    _, turns = regen.prepare_row(row | {"keep": True}, config)
+    assert turns == [{"role": "user", "content": "Hi"}]
 
 
 def test_prepare_row_merges_normalize_output_over_raw_row():
@@ -838,12 +836,45 @@ def test_prepare_row_merges_normalize_output_over_raw_row():
         normalize_fn=lambda row: {"conversations": []},
         prompt_field="prompt",
     )
-    assert regen.prepare_row({"prompt": "Hi"}, config) == [
-        {"role": "user", "content": "Hi"}
-    ]
+    _, turns = regen.prepare_row({"prompt": "Hi"}, config)
+    assert turns == [{"role": "user", "content": "Hi"}]
 
 
 def test_dataset_choice_rejects_multimodal_with_a_reason():
     with pytest.raises(argparse.ArgumentTypeError, match="does not support images"):
         regen._dataset_choice("sharegpt4v_coco")
     assert regen._dataset_choice("ultrachat") == "ultrachat"
+
+
+def test_tools_and_results_are_read_from_the_normalized_row():
+    # Under a normalize_fn preset the conversation only appears in `messages`
+    # after normalization; reading tools off the raw row regenerates tool-free.
+    config = DatasetConfig(
+        name="toolcalls",
+        hf_path="t",
+        split="train",
+        normalize_fn=lambda row: {"messages": row["input"]},
+    )
+    row = {
+        "input": [
+            {"role": "user", "content": "weather in Tokyo?"},
+            {"role": "tool", "content": "sunny"},
+        ],
+        "tools": [{"type": "function", "function": {"name": "get_weather"}}],
+    }
+
+    normalized = regen.normalize_row(row, config)
+
+    assert regen.extract_tools(normalized) == [
+        {"type": "function", "function": {"name": "get_weather"}}
+    ]
+    assert regen.extract_tool_results(normalized) == ["sunny"]
+    # the raw row hides the conversation behind `input`: results would be lost
+    assert regen.extract_tool_results(row) == []
+
+
+def test_normalize_row_returns_none_for_a_filtered_row():
+    config = DatasetConfig(
+        name="t", hf_path="t", split="train", filter_fn=lambda row: row["keep"]
+    )
+    assert regen.normalize_row({"keep": False}, config) is None

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -599,43 +599,19 @@ def _regen(
 # --- ingestion: tools + tool results carried out of the raw row ---
 
 
-def test_extract_tools_list_passthrough_and_functions_wrapping():
+def test_extract_tools_passthrough_and_json_string():
     tools = [{"type": "function", "function": {"name": "f"}}]
+    # A list passes through; a JSON-string column (the Hermes shape) is decoded.
     assert regen.extract_tools({"tools": tools}) == tools
-    # JSON-encoded tools string is decoded.
     assert regen.extract_tools({"tools": json.dumps(tools)}) == tools
-    # Legacy bare `functions` list is wrapped into OpenAI tool shape.
-    assert regen.extract_tools({"functions": [{"name": "f"}]}) == [
-        {"type": "function", "function": {"name": "f"}}
-    ]
     # Absent / empty -> None (tool-free datasets unchanged).
     assert regen.extract_tools({"prompt": "hi"}) is None
     assert regen.extract_tools({"tools": []}) is None
 
 
-def test_extract_tools_normalizes_stringified_and_bare_specs():
-    bare = {"name": "get_weather", "parameters": {"type": "object", "properties": {}}}
-    wrapped = {"type": "function", "function": bare}
-    # Bare spec as a JSON string (nvidia/When2Call shape) is decoded and wrapped.
-    assert regen.extract_tools({"tools": [json.dumps(bare)]}) == [wrapped]
-    # Bare spec as a dict is wrapped too.
-    assert regen.extract_tools({"tools": [bare]}) == [wrapped]
-    # Mixed list: wrapped entries pass through, bare/stringified get wrapped.
-    passthrough = {"type": "function", "function": {"name": "f"}}
-    assert regen.extract_tools({"tools": [passthrough, json.dumps(bare)]}) == [
-        passthrough,
-        wrapped,
-    ]
-    # A junk entry is dropped as long as at least one tool survives.
-    mixed = {"tools": [json.dumps(bare), "not json", 5]}
-    assert regen.extract_tools(mixed) == [wrapped]
-
-
 def test_extract_tools_raises_when_declared_but_unusable():
-    # A row that advertises tools we cannot parse must fail loud, not silently
-    # regenerate tool-free.
-    with pytest.raises(ValueError):
-        regen.extract_tools({"tools": ["junk", 5]})  # non-empty list, none decode
+    # A row that advertises a tools field we cannot read as a list must fail
+    # loud, not silently regenerate tool-free.
     with pytest.raises(ValueError):
         regen.extract_tools({"tools": {"name": "f"}})  # present but not a list
     with pytest.raises(ValueError):

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -51,7 +51,7 @@ regen = _load_regen_module()
 
 
 # ---------------------------------------------------------------------------
-# 1. extract_turns over the real dataset shapes
+# 1. extract_conversation over the real dataset shapes
 # ---------------------------------------------------------------------------
 
 # HuggingFaceH4/ultrachat_200k: full conversation in `messages` (role/content).
@@ -178,13 +178,13 @@ _EXTRACT_CASES = [
 
 
 @pytest.mark.parametrize(("row", "prompt_field", "expected"), _EXTRACT_CASES)
-def test_extract_turns(row, prompt_field, expected):
-    assert regen.extract_turns(row, prompt_field) == expected
+def test_extract_conversation_turns(row, prompt_field, expected):
+    assert regen.extract_conversation(row, prompt_field)[0] == expected
 
 
-def test_extract_turns_no_usable_input_returns_empty():
+def test_extract_conversation_no_usable_input_returns_empty():
     # No conversation field and no prompt_field value -> nothing to regenerate.
-    assert regen.extract_turns({"answer": "orphan"}, "question") == []
+    assert regen.extract_conversation({"answer": "orphan"}, "question")[0] == []
 
 
 # ---------------------------------------------------------------------------
@@ -622,27 +622,57 @@ def test_extract_tools_raises_when_declared_but_unusable():
     assert regen.extract_tools({"tools": ""}) is None
 
 
-def test_extract_tool_results_ordered_across_schemas():
-    # `messages` with role=tool, in order.
+def test_extract_conversation_collects_ordered_results():
+    # role=tool results without a <tool_response> wrapper -> content, no names.
     row = {
         "messages": [
             {"role": "user", "content": "q"},
             {"role": "assistant", "tool_calls": [_tool_call()]},
             {"role": "tool", "content": "r1"},
-            {"role": "assistant", "content": "a"},
             {"role": "user", "content": "q2"},
             {"role": "tool", "content": "r2"},
         ]
     }
-    assert regen.extract_tool_results(row) == ["r1", "r2"]
+    assert regen.extract_conversation(row, None)[1] == [("r1", []), ("r2", [])]
     # from/value schema (the Hermes shape), non-dict elements skipped.
-    conv = {"conversations": ["x", {"from": "tool", "value": "r"}]}
-    assert regen.extract_tool_results(conv) == ["r"]
-    # Tool-free row -> [] (unchanged regeneration).
-    assert (
-        regen.extract_tool_results({"messages": [{"role": "user", "content": "q"}]})
-        == []
-    )
+    conv = {
+        "conversations": [
+            {"from": "human", "value": "q"},
+            "x",
+            {"from": "tool", "value": "r"},
+        ]
+    }
+    assert regen.extract_conversation(conv, None)[1] == [("r", [])]
+    # Tool-free row -> no results.
+    only_user = {"messages": [{"role": "user", "content": "q"}]}
+    assert regen.extract_conversation(only_user, None)[1] == []
+
+
+def test_extract_conversation_pairs_hermes_results_with_tool_names():
+    # Hermes shape: the tool turn's <tool_response> embeds the answering tool's
+    # name, which the result carries for the splice name-match guard.
+    row = {
+        "conversations": [
+            {"from": "system", "value": "sys"},
+            {"from": "human", "value": "weather?"},
+            {"from": "gpt", "value": '<tool_call>{"name": "get_weather"}</tool_call>'},
+            {
+                "from": "tool",
+                "value": '<tool_response>\n{"name": "get_weather", "content": "15C"}\n'
+                "</tool_response>",
+            },
+            {"from": "gpt", "value": "It is 15C."},
+        ]
+    }
+    turns, results = regen.extract_conversation(row, None)
+    assert turns == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "weather?"},
+    ]
+    assert len(results) == 1
+    content, names = results[0]
+    assert names == ["get_weather"]
+    assert "<tool_response>" in content
 
 
 # --- per-response validation guards (the empty-content-is-a-tool-call bug fix) ---
@@ -712,7 +742,7 @@ def test_regenerate_splices_cached_result_after_regenerated_call():
         "primary_id": "u1",
         "turns": [{"role": "user", "content": "weather?"}],
         "tools": [{"type": "function", "function": {"name": "get_weather"}}],
-        "tool_results": ["15C"],
+        "tool_results": [("15C", ["get_weather"])],
     }
     responses = [
         _response(  # target regenerates a tool call (empty content)
@@ -748,7 +778,8 @@ def test_regenerate_splices_cached_result_after_regenerated_call():
     ("tool_calls", "tool_results"),
     [
         ([_tool_call()], []),  # no cached result left to splice
-        ([_tool_call("a"), _tool_call("b")], ["r"]),  # parallel call: no 1:1 pairing
+        # parallel call: no 1:1 pairing (result shape is (content, names))
+        ([_tool_call("a"), _tool_call("b")], [("r", [])]),
     ],
     ids=["no_cached_result", "parallel_calls"],
 )
@@ -775,6 +806,31 @@ def test_regenerate_truncates_but_keeps_committed_call_row(tool_calls, tool_resu
     assert len(sent) == 1  # no follow-up request once we cannot continue coherently
 
 
+def test_regenerate_truncates_on_tool_name_mismatch():
+    # The cached result answers `get_weather`; the target regenerates a call for
+    # a different tool, so it cannot be spliced coherently -> truncate.
+    item = {
+        "idx": 3,
+        "primary_id": "u",
+        "turns": [{"role": "user", "content": "q"}],
+        "tools": [{"type": "function", "function": {"name": "get_time"}}],
+        "tool_results": [("<tool_response>15C</tool_response>", ["get_weather"])],
+    }
+    responses = [
+        _response(
+            prompt_token_ids=[1],
+            token_ids=[2],
+            tool_calls=[_tool_call(call_id="c", name="get_time")],
+            finish="tool_calls",
+        )
+    ]
+    samples, truncated, sent = _regen(item, responses)
+
+    assert truncated
+    assert len(samples) == 1  # the committed call row is kept
+    assert len(sent) == 1  # no splice, no follow-up request
+
+
 # ---------------------------------------------------------------------------
 # 6. Every shared-registry preset works on-policy (off-policy parity).
 # ---------------------------------------------------------------------------
@@ -786,7 +842,7 @@ def test_prepare_row_normalizes_like_off_policy():
         "input": [{"role": "user", "content": "Hi"}],
         "output": "<original answer to drop>",
     }
-    _, turns = regen.prepare_row(row, DATASET_CONFIGS["nemotron"])
+    _, turns, _ = regen.prepare_row(row, DATASET_CONFIGS["nemotron"])
     assert turns == [{"role": "user", "content": "Hi"}]
 
 
@@ -799,7 +855,7 @@ def test_prepare_row_applies_filter_fn():
     )
     row = {"keep": False, "conversations": [{"role": "user", "content": "Hi"}]}
     assert regen.prepare_row(row, config) is None
-    _, turns = regen.prepare_row(row | {"keep": True}, config)
+    _, turns, _ = regen.prepare_row(row | {"keep": True}, config)
     assert turns == [{"role": "user", "content": "Hi"}]
 
 
@@ -812,7 +868,7 @@ def test_prepare_row_merges_normalize_output_over_raw_row():
         normalize_fn=lambda row: {"conversations": []},
         prompt_field="prompt",
     )
-    _, turns = regen.prepare_row({"prompt": "Hi"}, config)
+    _, turns, _ = regen.prepare_row({"prompt": "Hi"}, config)
     assert turns == [{"role": "user", "content": "Hi"}]
 
 
@@ -844,9 +900,9 @@ def test_tools_and_results_are_read_from_the_normalized_row():
     assert regen.extract_tools(normalized) == [
         {"type": "function", "function": {"name": "get_weather"}}
     ]
-    assert regen.extract_tool_results(normalized) == ["sunny"]
+    assert regen.extract_conversation(normalized, None)[1] == [("sunny", [])]
     # the raw row hides the conversation behind `input`: results would be lost
-    assert regen.extract_tool_results(row) == []
+    assert regen.extract_conversation(row, None)[1] == []
 
 
 def test_normalize_row_returns_none_for_a_filtered_row():

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -608,10 +608,9 @@ def test_extract_tools_list_passthrough_and_functions_wrapping():
     assert regen.extract_tools({"functions": [{"name": "f"}]}) == [
         {"type": "function", "function": {"name": "f"}}
     ]
-    # No schema / empty / bad JSON -> None (tool-free datasets unchanged).
+    # Absent / empty -> None (tool-free datasets unchanged).
     assert regen.extract_tools({"prompt": "hi"}) is None
     assert regen.extract_tools({"tools": []}) is None
-    assert regen.extract_tools({"tools": "not json"}) is None
 
 
 def test_extract_tools_normalizes_stringified_and_bare_specs():
@@ -627,10 +626,24 @@ def test_extract_tools_normalizes_stringified_and_bare_specs():
         passthrough,
         wrapped,
     ]
-    # Undecodable entries are dropped; an all-unusable list -> tool-free.
+    # A junk entry is dropped as long as at least one tool survives.
     mixed = {"tools": [json.dumps(bare), "not json", 5]}
     assert regen.extract_tools(mixed) == [wrapped]
-    assert regen.extract_tools({"tools": ["not json", 5]}) is None
+
+
+def test_extract_tools_raises_when_declared_but_unusable():
+    # A row that advertises tools we cannot parse must fail loud, not silently
+    # regenerate tool-free.
+    with pytest.raises(ValueError):
+        regen.extract_tools({"tools": ["junk", 5]})  # non-empty list, none decode
+    with pytest.raises(ValueError):
+        regen.extract_tools({"tools": {"name": "f"}})  # present but not a list
+    with pytest.raises(ValueError):
+        regen.extract_tools({"tools": "not json"})  # present but not a list
+    # Absent or explicitly empty stays tool-free.
+    assert regen.extract_tools({}) is None
+    assert regen.extract_tools({"tools": []}) is None
+    assert regen.extract_tools({"tools": ""}) is None
 
 
 def test_extract_tool_results_ordered_across_schemas():

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -895,18 +895,11 @@ def test_tools_and_results_are_read_from_the_normalized_row():
         "tools": [{"type": "function", "function": {"name": "get_weather"}}],
     }
 
-    normalized = regen.normalize_row(row, config)
+    normalized, _, tool_results = regen.prepare_row(row, config)
 
     assert regen.extract_tools(normalized) == [
         {"type": "function", "function": {"name": "get_weather"}}
     ]
-    assert regen.extract_conversation(normalized, None)[1] == [("sunny", [])]
+    assert tool_results == [("sunny", [])]
     # the raw row hides the conversation behind `input`: results would be lost
     assert regen.extract_conversation(row, None)[1] == []
-
-
-def test_normalize_row_returns_none_for_a_filtered_row():
-    config = DatasetConfig(
-        name="t", hf_path="t", split="train", filter_fn=lambda row: row["keep"]
-    )
-    assert regen.normalize_row({"keep": False}, config) is None

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -9,6 +9,7 @@ The script is not a package, so it is imported by path.
 
 import argparse
 import asyncio
+import copy
 import importlib.util
 import json
 from pathlib import Path
@@ -251,8 +252,8 @@ def test_pretokenized_passthrough_rejects_length_mismatch():
 # The prior resume keyed rows on ``uuid or idx`` (idx = streaming enumeration
 # index), which is unstable across --limit/--language-filter/order changes and
 # never matched the emitted output. A conversation now fans out to one row per
-# assistant turn, so the row ``id`` is turn-suffixed and cannot itself be the
-# resume key; each row carries the conversation's ``primary_id`` for that.
+# target generation, so the row ``id`` is generation-suffixed and cannot itself
+# be the resume key; each row carries the conversation's ``primary_id`` for that.
 # ---------------------------------------------------------------------------
 
 
@@ -476,7 +477,7 @@ def _run_worker(responses, tmp_path, stem):
         queue: asyncio.Queue = asyncio.Queue()
         await queue.put(_TWO_TURN_ITEM)
         await queue.put(None)
-        stats = {"ok": 0, "errors": 0}
+        stats = {"ok": 0, "errors": 0, "truncated": 0}
         await regen.worker(
             _FakeSession(responses),
             queue,
@@ -499,16 +500,16 @@ def _run_worker(responses, tmp_path, stem):
 
 def test_worker_row_identity_and_all_or_nothing_writes(tmp_path):
     # Two assistant turns -> two rows. `primary_id` is the queue item's stable id
-    # (never the streaming `idx`); `id` is that id plus a turn suffix; and resume
-    # keys on the former, so a re-run of this conversation is skipped.
+    # (never the streaming `idx`); `id` is that id plus a generation suffix; and
+    # resume keys on the former, so a re-run of this conversation is skipped.
     stats, out_path, _ = _run_worker(
         [_ok([1, 2], [3, 4], "four"), _ok([1, 2, 3, 4, 5], [6], "six")],
         tmp_path,
         "ok",
     )
-    assert stats == {"ok": 1, "errors": 0}
+    assert stats == {"ok": 1, "errors": 0, "truncated": 0}
     rows = [json.loads(line) for line in out_path.read_text().splitlines()]
-    assert [r["id"] for r in rows] == ["conv-abc_turn0", "conv-abc_turn1"]
+    assert [r["id"] for r in rows] == ["conv-abc_gen0", "conv-abc_gen1"]
     assert {r["primary_id"] for r in rows} == {"conv-abc"}
     # The boundary is the mask: prompt 0s then completion 1s.
     assert rows[0]["input_ids"] == [1, 2, 3, 4]
@@ -525,12 +526,245 @@ def test_worker_row_identity_and_all_or_nothing_writes(tmp_path):
         tmp_path,
         "fail",
     )
-    assert stats == {"ok": 0, "errors": 1}
+    assert stats == {"ok": 0, "errors": 1, "truncated": 0}
     assert out_path.read_text() == ""
     assert regen.load_seen(str(out_path)) == set()
     error = json.loads(err_path.read_text())
     assert error["id"] == "conv-abc"
+    # The failed conversation still reports the row it had completed.
     assert error["metadata"]["turns_completed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Tool-call regeneration: tools/results are carried in, tool-call tokens are
+#    regenerated on-policy, and cached results are spliced back positionally.
+# ---------------------------------------------------------------------------
+
+
+def _tool_call(call_id="call_1", name="get_weather", arguments='{"city": "Tokyo"}'):
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+def _response(
+    *, prompt_token_ids, token_ids, content=None, tool_calls=None, finish="stop"
+):
+    """A vLLM chat-completion response with ``return_token_ids`` populated."""
+    return {
+        "choices": [
+            {
+                "message": {"content": content, "tool_calls": tool_calls},
+                "finish_reason": finish,
+                "token_ids": token_ids,
+            }
+        ],
+        "prompt_token_ids": prompt_token_ids,
+        "usage": {"completion_tokens": len(token_ids)},
+    }
+
+
+def _fake_post(responses):
+    """A post_fn returning canned responses in order and recording sent payloads."""
+    sent = []
+
+    async def post(payload):
+        sent.append(copy.deepcopy(payload))
+        return responses[len(sent) - 1]
+
+    return post, sent
+
+
+def _regen(
+    item, responses, *, model="m", max_tokens=64, endpoint="ep", sampling_params=None
+):
+    post, sent = _fake_post(responses)
+    samples: list = []
+    truncated = asyncio.run(
+        regen.regenerate_conversation(
+            post,
+            item,
+            model=model,
+            max_tokens=max_tokens,
+            endpoint=endpoint,
+            sampling_params=sampling_params or {},
+            samples=samples,
+        )
+    )
+    return samples, truncated, sent
+
+
+# --- ingestion: tools + tool results carried out of the raw row ---
+
+
+def test_extract_tools_list_passthrough_and_functions_wrapping():
+    tools = [{"type": "function", "function": {"name": "f"}}]
+    assert regen.extract_tools({"tools": tools}) == tools
+    # JSON-encoded tools string is decoded.
+    assert regen.extract_tools({"tools": json.dumps(tools)}) == tools
+    # Legacy bare `functions` list is wrapped into OpenAI tool shape.
+    assert regen.extract_tools({"functions": [{"name": "f"}]}) == [
+        {"type": "function", "function": {"name": "f"}}
+    ]
+    # No schema / empty / bad JSON -> None (tool-free datasets unchanged).
+    assert regen.extract_tools({"prompt": "hi"}) is None
+    assert regen.extract_tools({"tools": []}) is None
+    assert regen.extract_tools({"tools": "not json"}) is None
+
+
+def test_extract_tool_results_ordered_across_schemas():
+    # OpenAI `messages` with role=tool, in order, aliases recognised.
+    row = {
+        "messages": [
+            {"role": "user", "content": "q"},
+            {"role": "assistant", "tool_calls": [_tool_call()]},
+            {"role": "tool", "content": "r1"},
+            {"role": "assistant", "content": "a"},
+            {"role": "user", "content": "q2"},
+            {"role": "observation", "content": "r2"},
+        ]
+    }
+    assert regen.extract_tool_results(row) == ["r1", "r2"]
+    # from/value schema, non-dict elements skipped.
+    conv = {"conversations": ["x", {"from": "tool", "value": "r"}]}
+    assert regen.extract_tool_results(conv) == ["r"]
+    # Tool-free row -> [] (unchanged regeneration).
+    assert (
+        regen.extract_tool_results({"messages": [{"role": "user", "content": "q"}]})
+        == []
+    )
+
+
+# --- per-response validation guards (the empty-content-is-a-tool-call bug fix) ---
+
+
+def test_sample_from_response_rejects_empty_and_missing_token_ids():
+    # Neither content nor tool_calls -> empty generation.
+    with pytest.raises(ValueError, match="empty assistant generation"):
+        regen._sample_from_response(
+            _response(prompt_token_ids=[1], token_ids=[2], content=None),
+            prefix=[],
+            conv_id="c",
+            sample_index=0,
+            idx=0,
+            endpoint="ep",
+            sampling_params={},
+        )
+    # Content present but the endpoint returned no token ids.
+    bad = {
+        "choices": [{"message": {"content": "hi"}, "token_ids": []}],
+        "prompt_token_ids": [],
+    }
+    with pytest.raises(ValueError, match="return_token_ids"):
+        regen._sample_from_response(
+            bad,
+            prefix=[],
+            conv_id="c",
+            sample_index=0,
+            idx=0,
+            endpoint="ep",
+            sampling_params={},
+        )
+
+
+# --- the tool-call loop: splice, truncate, and the unchanged plain path ---
+
+
+def test_sampling_params_reach_the_request_and_metadata():
+    item = {"idx": 0, "primary_id": "u", "turns": [{"role": "user", "content": "hi"}]}
+    responses = [_response(prompt_token_ids=[1, 2], token_ids=[3], content="hello")]
+    # `max_tokens` is ours to own: a user-supplied value must not win.
+    params = {"temperature": 0.6, "top_p": 0.95, "max_tokens": 1}
+    samples, _, sent = _regen(item, responses, max_tokens=64, sampling_params=params)
+
+    assert sent[0]["temperature"] == 0.6
+    assert sent[0]["top_p"] == 0.95
+    assert sent[0]["max_tokens"] == 64
+    # Recorded for reproducibility of the generated row.
+    assert samples[0]["metadata"]["sampling_params"] == params
+
+
+def test_regenerate_plain_conversation_is_unchanged_and_sends_no_tools():
+    item = {"idx": 0, "primary_id": "u", "turns": [{"role": "user", "content": "hi"}]}
+    responses = [_response(prompt_token_ids=[1, 2], token_ids=[3], content="hello")]
+    samples, truncated, sent = _regen(item, responses)
+
+    assert not truncated
+    assert len(samples) == 1
+    assert samples[0]["metadata"]["is_tool_call"] is False
+    # Tool-free path must not advertise tools to the endpoint.
+    assert "tools" not in sent[0]
+
+
+def test_regenerate_splices_cached_result_after_regenerated_call():
+    item = {
+        "idx": 1,
+        "primary_id": "u1",
+        "turns": [{"role": "user", "content": "weather?"}],
+        "tools": [{"type": "function", "function": {"name": "get_weather"}}],
+        "tool_results": ["15C"],
+    }
+    responses = [
+        _response(  # target regenerates a tool call (empty content)
+            prompt_token_ids=[1, 2],
+            token_ids=[3, 4],
+            tool_calls=[_tool_call(call_id="call_1")],
+            finish="tool_calls",
+        ),
+        _response(  # target's final answer, conditioned on prompt+call+result
+            prompt_token_ids=[1, 2, 3, 4, 5, 6],
+            token_ids=[7, 8],
+            content="It is 15C.",
+        ),
+    ]
+    samples, truncated, sent = _regen(item, responses)
+
+    assert not truncated
+    assert len(samples) == 2
+    # Row 0 is the on-policy tool call: its generated tokens get loss_mask 1.
+    assert samples[0]["loss_mask"] == [0, 0, 1, 1]
+    assert samples[0]["metadata"]["is_tool_call"] is True
+    # The second request replays the regenerated call and the spliced cached result.
+    assert sent[0]["tool_choice"] == "auto"
+    assert sent[1]["messages"][-2]["tool_calls"] == [_tool_call(call_id="call_1")]
+    assert sent[1]["messages"][-1] == {
+        "role": "tool",
+        "content": "15C",
+        "tool_call_id": "call_1",
+    }
+
+
+@pytest.mark.parametrize(
+    ("tool_calls", "tool_results"),
+    [
+        ([_tool_call()], []),  # no cached result left to splice
+        ([_tool_call("a"), _tool_call("b")], ["r"]),  # parallel call: no 1:1 pairing
+    ],
+    ids=["no_cached_result", "parallel_calls"],
+)
+def test_regenerate_truncates_but_keeps_committed_call_row(tool_calls, tool_results):
+    item = {
+        "idx": 2,
+        "primary_id": "u",
+        "turns": [{"role": "user", "content": "q"}],
+        "tools": [{"type": "function", "function": {"name": "f"}}],
+        "tool_results": tool_results,
+    }
+    responses = [
+        _response(
+            prompt_token_ids=[1],
+            token_ids=[2],
+            tool_calls=tool_calls,
+            finish="tool_calls",
+        )
+    ]
+    samples, truncated, sent = _regen(item, responses)
+
+    assert truncated
+    assert len(samples) == 1  # committed tool-call row kept; continuation stopped
+    assert len(sent) == 1  # no follow-up request once we cannot continue coherently
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -623,7 +623,7 @@ def test_extract_tools_raises_when_declared_but_unusable():
 
 
 def test_extract_tool_results_ordered_across_schemas():
-    # OpenAI `messages` with role=tool, in order, aliases recognised.
+    # `messages` with role=tool, in order.
     row = {
         "messages": [
             {"role": "user", "content": "q"},
@@ -631,11 +631,11 @@ def test_extract_tool_results_ordered_across_schemas():
             {"role": "tool", "content": "r1"},
             {"role": "assistant", "content": "a"},
             {"role": "user", "content": "q2"},
-            {"role": "observation", "content": "r2"},
+            {"role": "tool", "content": "r2"},
         ]
     }
     assert regen.extract_tool_results(row) == ["r1", "r2"]
-    # from/value schema, non-dict elements skipped.
+    # from/value schema (the Hermes shape), non-dict elements skipped.
     conv = {"conversations": ["x", {"from": "tool", "value": "r"}]}
     assert regen.extract_tool_results(conv) == ["r"]
     # Tool-free row -> [] (unchanged regeneration).

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -532,7 +532,7 @@ def test_worker_row_identity_and_all_or_nothing_writes(tmp_path):
     error = json.loads(err_path.read_text())
     assert error["id"] == "conv-abc"
     # The failed conversation still reports the row it had completed.
-    assert error["metadata"]["turns_completed"] == 1
+    assert error["metadata"]["generations_completed"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -614,6 +614,25 @@ def test_extract_tools_list_passthrough_and_functions_wrapping():
     assert regen.extract_tools({"tools": "not json"}) is None
 
 
+def test_extract_tools_normalizes_stringified_and_bare_specs():
+    bare = {"name": "get_weather", "parameters": {"type": "object", "properties": {}}}
+    wrapped = {"type": "function", "function": bare}
+    # Bare spec as a JSON string (nvidia/When2Call shape) is decoded and wrapped.
+    assert regen.extract_tools({"tools": [json.dumps(bare)]}) == [wrapped]
+    # Bare spec as a dict is wrapped too.
+    assert regen.extract_tools({"tools": [bare]}) == [wrapped]
+    # Mixed list: wrapped entries pass through, bare/stringified get wrapped.
+    passthrough = {"type": "function", "function": {"name": "f"}}
+    assert regen.extract_tools({"tools": [passthrough, json.dumps(bare)]}) == [
+        passthrough,
+        wrapped,
+    ]
+    # Undecodable entries are dropped; an all-unusable list -> tool-free.
+    mixed = {"tools": [json.dumps(bare), "not json", 5]}
+    assert regen.extract_tools(mixed) == [wrapped]
+    assert regen.extract_tools({"tools": ["not json", 5]}) is None
+
+
 def test_extract_tool_results_ordered_across_schemas():
     # OpenAI `messages` with role=tool, in order, aliases recognised.
     row = {


### PR DESCRIPTION


## Purpose

Before this PR speculator doesn't support tool use regen. This PR fixes it. 

Design:

* **Semi-on-policy** tool call regen: the target regenerates the **tool-call tokens on-policy**, but tools are **not executed** — the *i*-th cached tool result from the source data is spliced positionally after the target's *i*-th regenerated call.
* Fail loud on malform input tool. 


> Q: Why semi-on-policy (and not full agentic replay)? 
> A: Full agentic replay requires sandbox env, which is expensive and extremely slow. 


**SpecForge drops tool call same as our main. This PR will be a differentiator.**

## Requirements

- **Server:** must run with `--enable-auto-tool-choice --tool-call-parser <hermes|llama3_json|...>`,   otherwise tool calls come back as raw text in `content` rather than structured   `tool_calls`.

## Limitation

* Parallel tool call is out of scope. Currently truncate to the first call. 
* need to cleanup name normalization after  #688 landed


## Tests

Tool-free datasets are byte-for-byte unchanged: `extract_tools` returns `None`, `extract_tool_results` returns `[]`, and no `tools` field is sent.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
