### PR TITLE
[Long Context] TV Loss triton fusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ exclude = ["venv", "build", "dist"]
 follow_imports = 'silent'
 
 [[tool.mypy.overrides]]
-module = ["datasets.*", "transformers.*", "setuptools.*", "setuptools_git_versioning.*", "vllm.*"]
+module = ["datasets.*", "transformers.*", "setuptools.*", "setuptools_git_versioning.*", "vllm.*", "triton.*"]
 ignore_missing_imports=true
 
 [tool.ruff]

--- a/src/speculators/models/fused_tv_loss.py
+++ b/src/speculators/models/fused_tv_loss.py
@@ -1,0 +1,188 @@
+"""Fused Triton kernels for the acceptance-rate losses, computed from logits.
+
+The primitive is the draft/target overlap ``alpha = sum_v min(p_v, q_v)`` (the
+acceptance rate); ``fused_tv_loss`` returns ``1 - alpha`` and ``fused_nla_loss``
+returns ``-log(alpha)``, both per-position ``[1, T]`` to match ``_LOSS_FN_MAP``.
+Softmax is fused in, so the ``[T, V]`` distributions are never materialized or
+saved for backward (the memory win over the eager losses); only five per-row
+scalars are kept.
+
+Derived from SpecForge specforge/core/loss.py (Apache-2.0, Unsloth/Liger lineage);
+TV gradient sign convention matches Liger ops/tvd.py.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+MAX_FUSED_SIZE = 131072
+
+
+def _calculate_settings(n):
+    BLOCK_SIZE = min(triton.next_power_of_2(n), MAX_FUSED_SIZE)
+    num_warps = 4
+    if BLOCK_SIZE >= 32768:
+        num_warps = 32
+    elif BLOCK_SIZE >= 8192:
+        num_warps = 16
+    elif BLOCK_SIZE >= 2048:
+        num_warps = 8
+    if getattr(torch.version, "hip", None) is not None:  # AMD wavefronts are 64-wide
+        num_warps //= 2
+    return BLOCK_SIZE, num_warps
+
+
+@triton.jit
+def _online_stats(row_ptr, n_cols, BLOCK_SIZE: tl.constexpr):
+    """Online max (m) and sum-exp (d) over one row."""
+    m = float("-inf")
+    d = 0.0
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        x = tl.load(row_ptr + offsets, mask=mask, other=float("-inf")).cast(tl.float32)
+        block_max = tl.max(tl.where(mask, x, float("-inf")))
+        m_new = tl.maximum(m, block_max)
+        d = d * tl.exp(m - m_new) + tl.sum(tl.where(mask, tl.exp(x - m_new), 0.0))
+        m = m_new
+    return m, d
+
+
+@triton.jit
+def tv_forward_kernel(
+    logits_ptr,
+    targets_ptr,
+    loss_ptr,
+    stats_ptr,
+    stats_row,
+    n_cols,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """TV forward: online softmax stats for both rows, then an overlap pass.
+
+    ``stats`` is [5, n_rows] row-major; scalar k of row ``pid`` is at k*stats_row + pid.
+    """
+    pid = tl.program_id(0).to(tl.int64)
+    logits_ptr += pid * n_cols
+    targets_ptr += pid * n_cols
+
+    m_p, d_p = _online_stats(logits_ptr, n_cols, BLOCK_SIZE)
+    m_q, d_q = _online_stats(targets_ptr, n_cols, BLOCK_SIZE)
+
+    overlap = 0.0
+    s_s = 0.0
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        x = tl.load(logits_ptr + offsets, mask=mask, other=0.0).cast(tl.float32)
+        y = tl.load(targets_ptr + offsets, mask=mask, other=0.0).cast(tl.float32)
+        p = tl.exp(x - m_p) / d_p
+        q = tl.exp(y - m_q) / d_q
+        overlap += tl.sum(tl.where(mask, tl.minimum(p, q), 0.0))
+        s_s += tl.sum(tl.where(mask & (p <= q), p, 0.0))
+
+    tl.store(loss_ptr + pid, 1.0 - overlap)
+    tl.store(stats_ptr + 0 * stats_row + pid, m_p)
+    tl.store(stats_ptr + 1 * stats_row + pid, d_p)
+    tl.store(stats_ptr + 2 * stats_row + pid, m_q)
+    tl.store(stats_ptr + 3 * stats_row + pid, d_q)
+    tl.store(stats_ptr + 4 * stats_row + pid, s_s)
+
+
+@triton.jit
+def tv_backward_kernel(
+    logits_ptr,
+    targets_ptr,
+    grad_in_ptr,
+    grad_out_ptr,
+    stats_ptr,
+    stats_row,
+    n_cols,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0).to(tl.int64)
+    logits_ptr += pid * n_cols
+    targets_ptr += pid * n_cols
+    grad_in_ptr += pid * n_cols
+
+    go = tl.load(grad_out_ptr + pid).cast(tl.float32)
+    if go == 0.0:
+        for i in range(0, n_cols, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            mask = offsets < n_cols
+            tl.store(grad_in_ptr + offsets, 0.0, mask=mask)
+        return
+
+    m_p = tl.load(stats_ptr + 0 * stats_row + pid)
+    d_p = tl.load(stats_ptr + 1 * stats_row + pid)
+    m_q = tl.load(stats_ptr + 2 * stats_row + pid)
+    d_q = tl.load(stats_ptr + 3 * stats_row + pid)
+    s_s = tl.load(stats_ptr + 4 * stats_row + pid)
+
+    for i in range(0, n_cols, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        x = tl.load(logits_ptr + offsets, mask=mask, other=0.0).cast(tl.float32)
+        y = tl.load(targets_ptr + offsets, mask=mask, other=0.0).cast(tl.float32)
+        p = tl.exp(x - m_p) / d_p
+        q = tl.exp(y - m_q) / d_q
+        ind = (p <= q).to(tl.float32)
+        grad = -go * p * (ind - s_s)
+        tl.store(grad_in_ptr + offsets, grad, mask=mask)
+
+
+class FusedTVLoss(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, logits, targets):
+        B, T, V = logits.shape
+        logits_flat = logits.contiguous().view(B * T, V)
+        targets_flat = targets.contiguous().view(B * T, V)
+        loss = torch.empty(B * T, device=logits.device, dtype=torch.float32)
+        stats = torch.empty(5, B * T, device=logits.device, dtype=torch.float32)
+        BLOCK_SIZE, num_warps = _calculate_settings(V)
+        tv_forward_kernel[(B * T,)](
+            logits_flat,
+            targets_flat,
+            loss,
+            stats,
+            stats.stride(0),
+            V,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+        ctx.save_for_backward(logits_flat, targets_flat, stats)
+        ctx.shape = (B, T, V)
+        ctx.settings = (BLOCK_SIZE, num_warps)
+        return loss.view(B, T)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logits_flat, targets_flat, stats = ctx.saved_tensors
+        B, T, V = ctx.shape
+        BLOCK_SIZE, num_warps = ctx.settings
+        grad_in = torch.empty_like(logits_flat)
+        tv_backward_kernel[(B * T,)](
+            logits_flat,
+            targets_flat,
+            grad_in,
+            grad_output.contiguous().view(-1),
+            stats,
+            stats.stride(0),
+            V,
+            BLOCK_SIZE=BLOCK_SIZE,
+            num_warps=num_warps,
+        )
+        return grad_in.view(B, T, V), None
+
+
+_EPS = 1e-5  # matches models/metrics.py neg_log_acceptance_loss
+
+
+def fused_tv_loss(logits, targets):
+    """Per-position TV distance ``[1, T]`` from draft/target logits (fused Triton)."""
+    return FusedTVLoss.apply(logits, targets)
+
+
+def fused_nla_loss(logits, targets):
+    """Per-position negative-log-acceptance ``[1, T] = -log(alpha)``; composes on TV."""
+    return -torch.log((1.0 - fused_tv_loss(logits, targets)).clamp_min(_EPS))

--- a/src/speculators/models/fused_tv_loss.py
+++ b/src/speculators/models/fused_tv_loss.py
@@ -11,6 +11,11 @@ Derived from SpecForge specforge/core/loss.py (Apache-2.0, Unsloth/Liger lineage
 TV gradient sign convention matches Liger ops/tvd.py.
 """
 
+# Triton kernels idiomatically use uppercase constexpr/dim names (B, T, V,
+# BLOCK_SIZE) and inline block-size tuning thresholds; exempt this file from the
+# pep8-naming and magic-value lints rather than fight those conventions.
+# ruff: noqa: N803, N806, PLR2004
+
 import torch
 import triton
 import triton.language as tl

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -1,6 +1,7 @@
 import json
 import math
 from collections.abc import Callable
+from functools import cache
 
 import torch
 
@@ -386,38 +387,32 @@ def dpace_loss_decay(
 # Ascend NPU where mainline Triton has no backend. ``logits.is_cuda`` gates
 # CUDA/ROCm; the import is lazy so this module imports without Triton installed.
 
-_FUSED_KERNELS = None  # None = not yet tried; False = unavailable; else (tv, nla)
 
-
-def _fused_kernels():
-    """Lazily import and cache the fused TV/NLA kernels; ``None`` if unavailable."""
-    global _FUSED_KERNELS  # noqa: PLW0603
-    if _FUSED_KERNELS is None:
-        try:
-            from speculators.models.fused_tv_loss import (  # noqa: PLC0415
-                fused_nla_loss,
-                fused_tv_loss,
-            )
-
-            _FUSED_KERNELS = (fused_tv_loss, fused_nla_loss)
-        except ImportError:
-            _FUSED_KERNELS = False
-    return _FUSED_KERNELS or None
+@cache
+def _fused_kernel(name: str):
+    """Import and cache a fused kernel by name; ``None`` if Triton is unavailable."""
+    try:
+        from speculators.models import fused_tv_loss as mod  # noqa: PLC0415
+    except ImportError:
+        return None
+    return getattr(mod, name)
 
 
 def tv_loss_fused_or_eager(logits: torch.Tensor, targets: torch.Tensor):
     """TV loss: fused Triton on CUDA/ROCm (fp32), eager ``tv_loss`` on CPU/NPU."""
-    kernels = _fused_kernels()
-    if kernels is not None and logits.is_cuda:
-        return kernels[0](logits, targets)
+    if logits.is_cuda:
+        kernel = _fused_kernel("fused_tv_loss")
+        if kernel is not None:
+            return kernel(logits, targets)
     return tv_loss(logits, targets)
 
 
 def nla_loss_fused_or_eager(logits: torch.Tensor, targets: torch.Tensor):
     """NLA loss: fused Triton on CUDA/ROCm (fp32), eager on CPU/NPU."""
-    kernels = _fused_kernels()
-    if kernels is not None and logits.is_cuda:
-        return kernels[1](logits, targets)
+    if logits.is_cuda:
+        kernel = _fused_kernel("fused_nla_loss")
+        if kernel is not None:
+            return kernel(logits, targets)
     return neg_log_acceptance_loss(logits, targets)
 
 

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -4,8 +4,6 @@ from collections.abc import Callable
 
 import torch
 
-from speculators.models.fused_tv_loss import fused_nla_loss, fused_tv_loss
-
 _EPS = 1e-5
 
 LossConfig = dict[
@@ -382,17 +380,54 @@ def dpace_loss_decay(
     return weight.reshape(1, -1)
 
 
-# ``tv`` and ``nla`` train through the fused Triton kernels (much lower peak memory
-# at long context; see models/fused_tv_loss.py). The eager ``tv_loss`` /
-# ``neg_log_acceptance_loss`` above are kept only as the numeric reference the
-# kernels are tested against, so importing this module requires Triton.
+# ``tv`` and ``nla`` run the fused Triton kernels on CUDA/ROCm (much lower peak
+# memory at long context; see models/fused_tv_loss.py) and fall back to the eager
+# losses above on every other backend -- CPU, or non-CUDA accelerators such as
+# Ascend NPU where mainline Triton has no backend. ``logits.is_cuda`` gates
+# CUDA/ROCm; the import is lazy so this module imports without Triton installed.
+
+_FUSED_KERNELS = None  # None = not yet tried; False = unavailable; else (tv, nla)
+
+
+def _fused_kernels():
+    """Lazily import and cache the fused TV/NLA kernels; ``None`` if unavailable."""
+    global _FUSED_KERNELS  # noqa: PLW0603
+    if _FUSED_KERNELS is None:
+        try:
+            from speculators.models.fused_tv_loss import (  # noqa: PLC0415
+                fused_nla_loss,
+                fused_tv_loss,
+            )
+
+            _FUSED_KERNELS = (fused_tv_loss, fused_nla_loss)
+        except ImportError:
+            _FUSED_KERNELS = False
+    return _FUSED_KERNELS or None
+
+
+def tv_loss_fused_or_eager(logits: torch.Tensor, targets: torch.Tensor):
+    """TV loss: fused Triton on CUDA/ROCm (fp32), eager ``tv_loss`` on CPU/NPU."""
+    kernels = _fused_kernels()
+    if kernels is not None and logits.is_cuda:
+        return kernels[0](logits, targets)
+    return tv_loss(logits, targets)
+
+
+def nla_loss_fused_or_eager(logits: torch.Tensor, targets: torch.Tensor):
+    """NLA loss: fused Triton on CUDA/ROCm (fp32), eager on CPU/NPU."""
+    kernels = _fused_kernels()
+    if kernels is not None and logits.is_cuda:
+        return kernels[1](logits, targets)
+    return neg_log_acceptance_loss(logits, targets)
+
+
 _LOSS_FN_MAP: dict[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = {
     "kl_div": kl_div_loss,
     "rkl": reverse_kl_div_loss,
     "jsd": js_div_loss,
     "ce": ce_loss,
-    "tv": fused_tv_loss,
-    "nla": fused_nla_loss,
+    "tv": tv_loss_fused_or_eager,
+    "nla": nla_loss_fused_or_eager,
     "lk_hybrid": lk_hybrid_loss,
 }
 

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -380,13 +380,52 @@ def dpace_loss_decay(
     return weight.reshape(1, -1)
 
 
+# ``tv`` and ``nla`` use a fused Triton kernel on CUDA (lower peak memory; see
+# models/fused_tv_loss.py) and fall back to the eager losses above on CPU or when
+# Triton is unavailable. The import is lazy so CPU-only installs never require it.
+
+_FUSED_KERNELS = None  # None = not yet tried; False = unavailable; else (tv, nla)
+
+
+def _fused_kernels():
+    """Lazily import and cache the fused TV/NLA kernels; ``None`` if unavailable."""
+    global _FUSED_KERNELS
+    if _FUSED_KERNELS is None:
+        try:
+            from speculators.models.fused_tv_loss import (  # noqa: PLC0415
+                fused_nla_loss,
+                fused_tv_loss,
+            )
+
+            _FUSED_KERNELS = (fused_tv_loss, fused_nla_loss)
+        except ImportError:
+            _FUSED_KERNELS = False
+    return _FUSED_KERNELS or None
+
+
+def tv_loss_fused_or_eager(logits: torch.Tensor, targets: torch.Tensor):
+    """TV loss via the fused Triton kernel on CUDA, eager ``tv_loss`` otherwise."""
+    kernels = _fused_kernels()
+    if kernels is not None and logits.is_cuda:
+        return kernels[0](logits, targets).to(logits.dtype)
+    return tv_loss(logits, targets)
+
+
+def nla_loss_fused_or_eager(logits: torch.Tensor, targets: torch.Tensor):
+    """NLA loss via the fused Triton kernel on CUDA, eager fallback otherwise."""
+    kernels = _fused_kernels()
+    if kernels is not None and logits.is_cuda:
+        return kernels[1](logits, targets).to(logits.dtype)
+    return neg_log_acceptance_loss(logits, targets)
+
+
 _LOSS_FN_MAP: dict[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = {
     "kl_div": kl_div_loss,
     "rkl": reverse_kl_div_loss,
     "jsd": js_div_loss,
     "ce": ce_loss,
-    "tv": tv_loss,
-    "nla": neg_log_acceptance_loss,
+    "tv": tv_loss_fused_or_eager,
+    "nla": nla_loss_fused_or_eager,
     "lk_hybrid": lk_hybrid_loss,
 }
 

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -389,7 +389,7 @@ _FUSED_KERNELS = None  # None = not yet tried; False = unavailable; else (tv, nl
 
 def _fused_kernels():
     """Lazily import and cache the fused TV/NLA kernels; ``None`` if unavailable."""
-    global _FUSED_KERNELS
+    global _FUSED_KERNELS  # noqa: PLW0603
     if _FUSED_KERNELS is None:
         try:
             from speculators.models.fused_tv_loss import (  # noqa: PLC0415
@@ -404,18 +404,18 @@ def _fused_kernels():
 
 
 def tv_loss_fused_or_eager(logits: torch.Tensor, targets: torch.Tensor):
-    """TV loss via the fused Triton kernel on CUDA, eager ``tv_loss`` otherwise."""
+    """Fused Triton TV loss on CUDA (fp32, like eager ``tv_loss``); eager fallback."""
     kernels = _fused_kernels()
     if kernels is not None and logits.is_cuda:
-        return kernels[0](logits, targets).to(logits.dtype)
+        return kernels[0](logits, targets)
     return tv_loss(logits, targets)
 
 
 def nla_loss_fused_or_eager(logits: torch.Tensor, targets: torch.Tensor):
-    """NLA loss via the fused Triton kernel on CUDA, eager fallback otherwise."""
+    """Fused Triton NLA loss on CUDA (fp32, like the eager loss); eager fallback."""
     kernels = _fused_kernels()
     if kernels is not None and logits.is_cuda:
-        return kernels[1](logits, targets).to(logits.dtype)
+        return kernels[1](logits, targets)
     return neg_log_acceptance_loss(logits, targets)
 
 

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -4,6 +4,8 @@ from collections.abc import Callable
 
 import torch
 
+from speculators.models.fused_tv_loss import fused_nla_loss, fused_tv_loss
+
 _EPS = 1e-5
 
 LossConfig = dict[
@@ -380,52 +382,17 @@ def dpace_loss_decay(
     return weight.reshape(1, -1)
 
 
-# ``tv`` and ``nla`` use a fused Triton kernel on CUDA (lower peak memory; see
-# models/fused_tv_loss.py) and fall back to the eager losses above on CPU or when
-# Triton is unavailable. The import is lazy so CPU-only installs never require it.
-
-_FUSED_KERNELS = None  # None = not yet tried; False = unavailable; else (tv, nla)
-
-
-def _fused_kernels():
-    """Lazily import and cache the fused TV/NLA kernels; ``None`` if unavailable."""
-    global _FUSED_KERNELS  # noqa: PLW0603
-    if _FUSED_KERNELS is None:
-        try:
-            from speculators.models.fused_tv_loss import (  # noqa: PLC0415
-                fused_nla_loss,
-                fused_tv_loss,
-            )
-
-            _FUSED_KERNELS = (fused_tv_loss, fused_nla_loss)
-        except ImportError:
-            _FUSED_KERNELS = False
-    return _FUSED_KERNELS or None
-
-
-def tv_loss_fused_or_eager(logits: torch.Tensor, targets: torch.Tensor):
-    """Fused Triton TV loss on CUDA (fp32, like eager ``tv_loss``); eager fallback."""
-    kernels = _fused_kernels()
-    if kernels is not None and logits.is_cuda:
-        return kernels[0](logits, targets)
-    return tv_loss(logits, targets)
-
-
-def nla_loss_fused_or_eager(logits: torch.Tensor, targets: torch.Tensor):
-    """Fused Triton NLA loss on CUDA (fp32, like the eager loss); eager fallback."""
-    kernels = _fused_kernels()
-    if kernels is not None and logits.is_cuda:
-        return kernels[1](logits, targets)
-    return neg_log_acceptance_loss(logits, targets)
-
-
+# ``tv`` and ``nla`` train through the fused Triton kernels (much lower peak memory
+# at long context; see models/fused_tv_loss.py). The eager ``tv_loss`` /
+# ``neg_log_acceptance_loss`` above are kept only as the numeric reference the
+# kernels are tested against, so importing this module requires Triton.
 _LOSS_FN_MAP: dict[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = {
     "kl_div": kl_div_loss,
     "rkl": reverse_kl_div_loss,
     "jsd": js_div_loss,
     "ce": ce_loss,
-    "tv": tv_loss_fused_or_eager,
-    "nla": nla_loss_fused_or_eager,
+    "tv": fused_tv_loss,
+    "nla": fused_nla_loss,
     "lk_hybrid": lk_hybrid_loss,
 }
 

--- a/tests/unit/models/test_dspark_metrics.py
+++ b/tests/unit/models/test_dspark_metrics.py
@@ -1,22 +1,15 @@
 """Unit tests for the DSpark loss and metrics."""
 
-import pytest
 import torch
 
 from speculators.models.dspark.metrics import compute_metrics
 from speculators.models.metrics import resolve_loss_config
 
-# DSpark's default loss includes `tv`, which routes to the fused Triton kernel;
-# that kernel is CUDA-only, so these metric tests run on GPU.
-pytestmark = pytest.mark.skipif(
-    not torch.cuda.is_available(), reason="fused tv loss requires CUDA"
-)
-
 _DEFAULT_LOSS = resolve_loss_config('{"ce": 0.1, "tv": 0.9}')
 
 
 def _ids_to_logits(ids: torch.Tensor, vocab_size: int) -> torch.Tensor:
-    logits = torch.zeros(*ids.shape, vocab_size, device=ids.device)
+    logits = torch.zeros(*ids.shape, vocab_size)
     logits.scatter_(-1, ids.unsqueeze(-1), 100.0)
     return logits
 
@@ -24,10 +17,10 @@ def _ids_to_logits(ids: torch.Tensor, vocab_size: int) -> torch.Tensor:
 class TestComputeMetrics:
     def test_perfect_draft_low_loss_high_accept(self):
         # block_size=2; position 0 is the anchor (masked), position 1 supervised.
-        ids = torch.tensor([[0, 1, 0, 2]], device="cuda")
+        ids = torch.tensor([[0, 1, 0, 2]])
         logits = _ids_to_logits(ids, 8)
         targets = logits.clone()
-        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32, device="cuda")
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
         loss, metrics = compute_metrics(
             logits,
             targets,
@@ -49,11 +42,11 @@ class TestComputeMetrics:
     def test_confidence_target_is_overlap(self):
         # When draft == target, accept rate == 1, so a confidence logit that is
         # very positive (sigmoid -> 1) yields ~zero abs error.
-        ids = torch.tensor([[0, 1, 0, 2]], device="cuda")
+        ids = torch.tensor([[0, 1, 0, 2]])
         logits = _ids_to_logits(ids, 8)
         targets = logits.clone()
-        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32, device="cuda")
-        confidence_logits = torch.full((1, 4), 20.0, device="cuda")  # sigmoid ~ 1.0
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
+        confidence_logits = torch.full((1, 4), 20.0)  # sigmoid ~ 1.0
         _, metrics = compute_metrics(
             logits,
             targets,
@@ -70,10 +63,10 @@ class TestComputeMetrics:
         assert "confidence_loss_sum" in metrics
 
     def test_confidence_term_changes_loss(self):
-        ids = torch.tensor([[0, 1, 0, 2]], device="cuda")
+        ids = torch.tensor([[0, 1, 0, 2]])
         logits = _ids_to_logits(ids, 8)
-        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]], device="cuda"), 8)
-        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32, device="cuda")
+        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]]), 8)
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
         loss_no_conf, _ = compute_metrics(
             logits,
             targets,
@@ -84,7 +77,7 @@ class TestComputeMetrics:
         )
         # A badly-calibrated confidence head (predicts accept~1 when accept~0)
         # must add positive BCE on top of the base loss.
-        confidence_logits = torch.full((1, 4), 20.0, device="cuda")
+        confidence_logits = torch.full((1, 4), 20.0)
         loss_conf, _ = compute_metrics(
             logits,
             targets,
@@ -99,11 +92,11 @@ class TestComputeMetrics:
     def test_confidence_cumprod_bias_sign(self):
         # Draft != target so accept rate is ~0; an over-confident head (predicts
         # accept ~1) must show a positive cumulative-product calibration bias.
-        ids = torch.tensor([[0, 1, 0, 2]], device="cuda")
+        ids = torch.tensor([[0, 1, 0, 2]])
         logits = _ids_to_logits(ids, 8)
-        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]], device="cuda"), 8)
-        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32, device="cuda")
-        confidence_logits = torch.full((1, 4), 20.0, device="cuda")  # sigmoid ~ 1.0
+        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]]), 8)
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
+        confidence_logits = torch.full((1, 4), 20.0)  # sigmoid ~ 1.0
         _, metrics = compute_metrics(
             logits,
             targets,
@@ -119,10 +112,10 @@ class TestComputeMetrics:
         assert float(bias) > 0.5
 
     def test_alpha_weighting(self):
-        ids = torch.tensor([[0, 1, 0, 2]], device="cuda")
+        ids = torch.tensor([[0, 1, 0, 2]])
         logits = _ids_to_logits(ids, 8)
-        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]], device="cuda"), 8)
-        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32, device="cuda")
+        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]]), 8)
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
         loss_small, _ = compute_metrics(
             logits,
             targets,
@@ -142,14 +135,14 @@ class TestComputeMetrics:
         assert float(loss_large) > float(loss_small)
 
     def test_metric_keys_present(self):
-        ids = torch.tensor([[0, 1, 0, 2]], device="cuda")
+        ids = torch.tensor([[0, 1, 0, 2]])
         logits = _ids_to_logits(ids, 8)
         targets = logits.clone()
-        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32, device="cuda")
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
         _, metrics = compute_metrics(
             logits,
             targets,
-            torch.zeros(1, 4, device="cuda"),
+            torch.zeros(1, 4),
             loss_mask,
             block_size=2,
             loss_config=_DEFAULT_LOSS,

--- a/tests/unit/models/test_dspark_metrics.py
+++ b/tests/unit/models/test_dspark_metrics.py
@@ -1,15 +1,22 @@
 """Unit tests for the DSpark loss and metrics."""
 
+import pytest
 import torch
 
 from speculators.models.dspark.metrics import compute_metrics
 from speculators.models.metrics import resolve_loss_config
 
+# DSpark's default loss includes `tv`, which routes to the fused Triton kernel;
+# that kernel is CUDA-only, so these metric tests run on GPU.
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="fused tv loss requires CUDA"
+)
+
 _DEFAULT_LOSS = resolve_loss_config('{"ce": 0.1, "tv": 0.9}')
 
 
 def _ids_to_logits(ids: torch.Tensor, vocab_size: int) -> torch.Tensor:
-    logits = torch.zeros(*ids.shape, vocab_size)
+    logits = torch.zeros(*ids.shape, vocab_size, device=ids.device)
     logits.scatter_(-1, ids.unsqueeze(-1), 100.0)
     return logits
 
@@ -17,10 +24,10 @@ def _ids_to_logits(ids: torch.Tensor, vocab_size: int) -> torch.Tensor:
 class TestComputeMetrics:
     def test_perfect_draft_low_loss_high_accept(self):
         # block_size=2; position 0 is the anchor (masked), position 1 supervised.
-        ids = torch.tensor([[0, 1, 0, 2]])
+        ids = torch.tensor([[0, 1, 0, 2]], device="cuda")
         logits = _ids_to_logits(ids, 8)
         targets = logits.clone()
-        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32, device="cuda")
         loss, metrics = compute_metrics(
             logits,
             targets,
@@ -42,11 +49,11 @@ class TestComputeMetrics:
     def test_confidence_target_is_overlap(self):
         # When draft == target, accept rate == 1, so a confidence logit that is
         # very positive (sigmoid -> 1) yields ~zero abs error.
-        ids = torch.tensor([[0, 1, 0, 2]])
+        ids = torch.tensor([[0, 1, 0, 2]], device="cuda")
         logits = _ids_to_logits(ids, 8)
         targets = logits.clone()
-        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
-        confidence_logits = torch.full((1, 4), 20.0)  # sigmoid ~ 1.0
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32, device="cuda")
+        confidence_logits = torch.full((1, 4), 20.0, device="cuda")  # sigmoid ~ 1.0
         _, metrics = compute_metrics(
             logits,
             targets,
@@ -63,10 +70,10 @@ class TestComputeMetrics:
         assert "confidence_loss_sum" in metrics
 
     def test_confidence_term_changes_loss(self):
-        ids = torch.tensor([[0, 1, 0, 2]])
+        ids = torch.tensor([[0, 1, 0, 2]], device="cuda")
         logits = _ids_to_logits(ids, 8)
-        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]]), 8)
-        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
+        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]], device="cuda"), 8)
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32, device="cuda")
         loss_no_conf, _ = compute_metrics(
             logits,
             targets,
@@ -77,7 +84,7 @@ class TestComputeMetrics:
         )
         # A badly-calibrated confidence head (predicts accept~1 when accept~0)
         # must add positive BCE on top of the base loss.
-        confidence_logits = torch.full((1, 4), 20.0)
+        confidence_logits = torch.full((1, 4), 20.0, device="cuda")
         loss_conf, _ = compute_metrics(
             logits,
             targets,
@@ -92,11 +99,11 @@ class TestComputeMetrics:
     def test_confidence_cumprod_bias_sign(self):
         # Draft != target so accept rate is ~0; an over-confident head (predicts
         # accept ~1) must show a positive cumulative-product calibration bias.
-        ids = torch.tensor([[0, 1, 0, 2]])
+        ids = torch.tensor([[0, 1, 0, 2]], device="cuda")
         logits = _ids_to_logits(ids, 8)
-        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]]), 8)
-        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
-        confidence_logits = torch.full((1, 4), 20.0)  # sigmoid ~ 1.0
+        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]], device="cuda"), 8)
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32, device="cuda")
+        confidence_logits = torch.full((1, 4), 20.0, device="cuda")  # sigmoid ~ 1.0
         _, metrics = compute_metrics(
             logits,
             targets,
@@ -112,10 +119,10 @@ class TestComputeMetrics:
         assert float(bias) > 0.5
 
     def test_alpha_weighting(self):
-        ids = torch.tensor([[0, 1, 0, 2]])
+        ids = torch.tensor([[0, 1, 0, 2]], device="cuda")
         logits = _ids_to_logits(ids, 8)
-        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]]), 8)
-        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
+        targets = _ids_to_logits(torch.tensor([[0, 3, 0, 4]], device="cuda"), 8)
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32, device="cuda")
         loss_small, _ = compute_metrics(
             logits,
             targets,
@@ -135,14 +142,14 @@ class TestComputeMetrics:
         assert float(loss_large) > float(loss_small)
 
     def test_metric_keys_present(self):
-        ids = torch.tensor([[0, 1, 0, 2]])
+        ids = torch.tensor([[0, 1, 0, 2]], device="cuda")
         logits = _ids_to_logits(ids, 8)
         targets = logits.clone()
-        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32)
+        loss_mask = torch.tensor([[0, 1, 0, 1]], dtype=torch.float32, device="cuda")
         _, metrics = compute_metrics(
             logits,
             targets,
-            torch.zeros(1, 4),
+            torch.zeros(1, 4, device="cuda"),
             loss_mask,
             block_size=2,
             loss_config=_DEFAULT_LOSS,

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -5,6 +5,7 @@ from functools import partial
 import pytest
 import torch
 
+from speculators.models.fused_tv_loss import fused_nla_loss, fused_tv_loss
 from speculators.models.metrics import (
     ce_loss,
     compute_accuracy_single_step,
@@ -15,11 +16,9 @@ from speculators.models.metrics import (
     lk_hybrid_loss,
     loss_function,
     neg_log_acceptance_loss,
-    nla_loss_fused_or_eager,
     resolve_loss_fn,
     reverse_kl_div_loss,
     tv_loss,
-    tv_loss_fused_or_eager,
 )
 
 
@@ -199,8 +198,8 @@ class TestTVLoss:
         assert (out <= 1).all()
 
     def test_resolve_tv(self):
-        """resolve_loss_fn maps 'tv' to the fused-or-eager dispatcher."""
-        assert resolve_loss_fn("tv") is tv_loss_fused_or_eager
+        """resolve_loss_fn maps 'tv' to the fused Triton kernel."""
+        assert resolve_loss_fn("tv") is fused_tv_loss
 
     @pytest.mark.skipif(
         not torch.cuda.is_available(), reason="fused Triton loss requires CUDA"
@@ -217,7 +216,7 @@ class TestTVLoss:
         le = base.clone().to("cuda", torch.bfloat16).requires_grad_(True)
         lf = base.clone().to("cuda", torch.bfloat16).requires_grad_(True)
         out_e = tv_loss(le, targets)
-        out_f = resolve_loss_fn("tv")(lf, targets)
+        out_f = fused_tv_loss(lf, targets)  # direct: never silently falls back to eager
         # both paths return fp32 (fp32 softmax since #788); fused must not downcast
         assert out_e.dtype == torch.float32
         assert out_f.dtype == torch.float32
@@ -267,8 +266,8 @@ class TestNegLogAcceptanceLoss:
         assert torch.isfinite(neg_log_acceptance_loss(logits, targets)).all()
 
     def test_resolve_nla(self):
-        """resolve_loss_fn maps 'nla' to the fused-or-eager dispatcher."""
-        assert resolve_loss_fn("nla") is nla_loss_fused_or_eager
+        """resolve_loss_fn maps 'nla' to the fused Triton kernel."""
+        assert resolve_loss_fn("nla") is fused_nla_loss
 
 
 class TestLKHybridLoss:

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -5,7 +5,6 @@ from functools import partial
 import pytest
 import torch
 
-from speculators.models.fused_tv_loss import fused_nla_loss, fused_tv_loss
 from speculators.models.metrics import (
     ce_loss,
     compute_accuracy_single_step,
@@ -16,9 +15,11 @@ from speculators.models.metrics import (
     lk_hybrid_loss,
     loss_function,
     neg_log_acceptance_loss,
+    nla_loss_fused_or_eager,
     resolve_loss_fn,
     reverse_kl_div_loss,
     tv_loss,
+    tv_loss_fused_or_eager,
 )
 
 
@@ -198,8 +199,8 @@ class TestTVLoss:
         assert (out <= 1).all()
 
     def test_resolve_tv(self):
-        """resolve_loss_fn maps 'tv' to the fused Triton kernel."""
-        assert resolve_loss_fn("tv") is fused_tv_loss
+        """resolve_loss_fn maps 'tv' to the fused-or-eager dispatcher."""
+        assert resolve_loss_fn("tv") is tv_loss_fused_or_eager
 
     @pytest.mark.skipif(
         not torch.cuda.is_available(), reason="fused Triton loss requires CUDA"
@@ -210,6 +211,8 @@ class TestTVLoss:
         Uses bf16 inputs (the real training regime): the loss must be returned in
         fp32 like the eager path, not downcast to the bf16 input dtype.
         """
+        from speculators.models.fused_tv_loss import fused_tv_loss  # noqa: PLC0415
+
         torch.manual_seed(0)
         base = torch.randn(1, 64, 512)
         targets = torch.randn(1, 64, 512, device="cuda", dtype=torch.bfloat16)
@@ -266,8 +269,8 @@ class TestNegLogAcceptanceLoss:
         assert torch.isfinite(neg_log_acceptance_loss(logits, targets)).all()
 
     def test_resolve_nla(self):
-        """resolve_loss_fn maps 'nla' to the fused Triton kernel."""
-        assert resolve_loss_fn("nla") is fused_nla_loss
+        """resolve_loss_fn maps 'nla' to the fused-or-eager dispatcher."""
+        assert resolve_loss_fn("nla") is nla_loss_fused_or_eager
 
 
 class TestLKHybridLoss:

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -206,15 +206,22 @@ class TestTVLoss:
         not torch.cuda.is_available(), reason="fused Triton loss requires CUDA"
     )
     def test_fused_tv_matches_eager_on_cuda(self):
-        """On CUDA the fused kernel matches eager tv_loss in value and gradient."""
+        """On CUDA the fused kernel matches eager tv_loss in value, dtype, gradient.
+
+        Uses bf16 inputs (the real training regime): the loss must be returned in
+        fp32 like the eager path, not downcast to the bf16 input dtype.
+        """
         torch.manual_seed(0)
         base = torch.randn(1, 64, 512)
-        targets = torch.randn(1, 64, 512, device="cuda")
-        le = base.clone().to("cuda").requires_grad_(True)
-        lf = base.clone().to("cuda").requires_grad_(True)
+        targets = torch.randn(1, 64, 512, device="cuda", dtype=torch.bfloat16)
+        le = base.clone().to("cuda", torch.bfloat16).requires_grad_(True)
+        lf = base.clone().to("cuda", torch.bfloat16).requires_grad_(True)
         out_e = tv_loss(le, targets)
         out_f = resolve_loss_fn("tv")(lf, targets)
-        assert torch.allclose(out_f.float(), out_e.float(), atol=1e-3)
+        # both paths return fp32 (fp32 softmax since #788); fused must not downcast
+        assert out_e.dtype == torch.float32
+        assert out_f.dtype == torch.float32
+        assert torch.allclose(out_f, out_e, atol=1e-3)
         out_e.sum().backward()
         out_f.sum().backward()
         assert torch.allclose(lf.grad, le.grad, atol=1e-3)

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -226,6 +226,8 @@ class TestTVLoss:
         assert torch.allclose(out_f, out_e, atol=1e-3)
         out_e.sum().backward()
         out_f.sum().backward()
+        assert lf.grad is not None
+        assert le.grad is not None
         assert torch.allclose(lf.grad, le.grad, atol=1e-3)
 
 

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -15,9 +15,11 @@ from speculators.models.metrics import (
     lk_hybrid_loss,
     loss_function,
     neg_log_acceptance_loss,
+    nla_loss_fused_or_eager,
     resolve_loss_fn,
     reverse_kl_div_loss,
     tv_loss,
+    tv_loss_fused_or_eager,
 )
 
 
@@ -197,8 +199,25 @@ class TestTVLoss:
         assert (out <= 1).all()
 
     def test_resolve_tv(self):
-        """resolve_loss_fn maps 'tv' to tv_loss."""
-        assert resolve_loss_fn("tv") is tv_loss
+        """resolve_loss_fn maps 'tv' to the fused-or-eager dispatcher."""
+        assert resolve_loss_fn("tv") is tv_loss_fused_or_eager
+
+    @pytest.mark.skipif(
+        not torch.cuda.is_available(), reason="fused Triton loss requires CUDA"
+    )
+    def test_fused_tv_matches_eager_on_cuda(self):
+        """On CUDA the fused kernel matches eager tv_loss in value and gradient."""
+        torch.manual_seed(0)
+        base = torch.randn(1, 64, 512)
+        targets = torch.randn(1, 64, 512, device="cuda")
+        le = base.clone().to("cuda").requires_grad_(True)
+        lf = base.clone().to("cuda").requires_grad_(True)
+        out_e = tv_loss(le, targets)
+        out_f = resolve_loss_fn("tv")(lf, targets)
+        assert torch.allclose(out_f.float(), out_e.float(), atol=1e-3)
+        out_e.sum().backward()
+        out_f.sum().backward()
+        assert torch.allclose(lf.grad, le.grad, atol=1e-3)
 
 
 class TestNegLogAcceptanceLoss:
@@ -241,8 +260,8 @@ class TestNegLogAcceptanceLoss:
         assert torch.isfinite(neg_log_acceptance_loss(logits, targets)).all()
 
     def test_resolve_nla(self):
-        """resolve_loss_fn maps 'nla' to neg_log_acceptance_loss."""
-        assert resolve_loss_fn("nla") is neg_log_acceptance_loss
+        """resolve_loss_fn maps 'nla' to the fused-or-eager dispatcher."""
+        assert resolve_loss_fn("nla") is nla_loss_fused_or_eager
 
 
 class TestLKHybridLoss:

--- a/tests/unit/train/test_cli_args.py
+++ b/tests/unit/train/test_cli_args.py
@@ -4,7 +4,8 @@ from scripts.train import parse_args
 from speculators.models.dflash.core import DFlashDraftModel
 from speculators.models.dspark.core import DSparkDraftModel
 from speculators.models.eagle3.core import Eagle3DraftModel
-from speculators.models.metrics import ce_loss, kl_div_loss, tv_loss_fused_or_eager
+from speculators.models.fused_tv_loss import fused_tv_loss
+from speculators.models.metrics import ce_loss, kl_div_loss
 from speculators.models.peagle.core import PEagleDraftModel
 
 
@@ -113,7 +114,7 @@ def test_dspark_compound_loss(monkeypatch):
     assert train_kw["loss_config"]["ce"][0] is ce_loss
     assert train_kw["loss_config"]["ce"][1] == 0.1
     assert "tv" in train_kw["loss_config"]
-    assert train_kw["loss_config"]["tv"][0] is tv_loss_fused_or_eager
+    assert train_kw["loss_config"]["tv"][0] is fused_tv_loss
     assert train_kw["loss_config"]["tv"][1] == 0.9
     assert "ce" in val_kw["loss_config"]
     assert "tv" in val_kw["loss_config"]

--- a/tests/unit/train/test_cli_args.py
+++ b/tests/unit/train/test_cli_args.py
@@ -4,8 +4,7 @@ from scripts.train import parse_args
 from speculators.models.dflash.core import DFlashDraftModel
 from speculators.models.dspark.core import DSparkDraftModel
 from speculators.models.eagle3.core import Eagle3DraftModel
-from speculators.models.fused_tv_loss import fused_tv_loss
-from speculators.models.metrics import ce_loss, kl_div_loss
+from speculators.models.metrics import ce_loss, kl_div_loss, tv_loss_fused_or_eager
 from speculators.models.peagle.core import PEagleDraftModel
 
 
@@ -114,7 +113,7 @@ def test_dspark_compound_loss(monkeypatch):
     assert train_kw["loss_config"]["ce"][0] is ce_loss
     assert train_kw["loss_config"]["ce"][1] == 0.1
     assert "tv" in train_kw["loss_config"]
-    assert train_kw["loss_config"]["tv"][0] is fused_tv_loss
+    assert train_kw["loss_config"]["tv"][0] is tv_loss_fused_or_eager
     assert train_kw["loss_config"]["tv"][1] == 0.9
     assert "ce" in val_kw["loss_config"]
     assert "tv" in val_kw["loss_config"]

--- a/tests/unit/train/test_cli_args.py
+++ b/tests/unit/train/test_cli_args.py
@@ -4,7 +4,7 @@ from scripts.train import parse_args
 from speculators.models.dflash.core import DFlashDraftModel
 from speculators.models.dspark.core import DSparkDraftModel
 from speculators.models.eagle3.core import Eagle3DraftModel
-from speculators.models.metrics import ce_loss, kl_div_loss, tv_loss
+from speculators.models.metrics import ce_loss, kl_div_loss, tv_loss_fused_or_eager
 from speculators.models.peagle.core import PEagleDraftModel
 
 
@@ -113,7 +113,7 @@ def test_dspark_compound_loss(monkeypatch):
     assert train_kw["loss_config"]["ce"][0] is ce_loss
     assert train_kw["loss_config"]["ce"][1] == 0.1
     assert "tv" in train_kw["loss_config"]
-    assert train_kw["loss_config"]["tv"][0] is tv_loss
+    assert train_kw["loss_config"]["tv"][0] is tv_loss_fused_or_eager
     assert train_kw["loss_config"]["tv"][1] == 0.9
     assert "ce" in val_kw["loss_config"]
     assert "tv" in val_kw["loss_config"]


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Long-context draft training is bottlenecked by the **loss region**. The eager acceptance-rate losses (`tv`, `nla`) materialize *both* full softmax distributions to GPU memory:

```python
# src/speculators/models/metrics.py — eager tv_loss
def tv_loss(logits, targets):              # both [1, T, V_draft]
    draft_p  = F.softmax(logits,  dim=-1)  # [T, V] written to HBM
    target_p = F.softmax(targets, dim=-1)  # [T, V] written to HBM
    overlap  = torch.minimum(draft_p, target_p).sum(dim=-1)   # α, [1, T]
    return 1.0 - overlap                                      # 1 − d_TV
```

`draft_p` and `target_p` are **saved for the backward** and kept alive across all `S` TTT steps, so the loss-region peak is `~S · T · V_draft · bytes` and grows *unboundedly* with context length while everything else in the step (draft weights, optimizer, verifier) is fixed. Since #788 the softmax runs in fp32 — 4 bytes/element.

This PR routes `tv`/`nla` through a **fused online-softmax Triton kernel** that computes the same overlap **without ever materializing `draft_p`/`target_p`**: it streams the softmax in registers, saves only five per-row scalars, and recomputes `p, q` in the backward. Peak loss-region memory drops ~40–60% and, unlike the eager path, no longer OOMs at long context (measurements below).

**Why a kernel and not `torch.compile`:** the two softmaxes are **autograd-saved outputs**, not fusable temporaries — `torch.compile` still writes them to HBM to feed the backward. Eliminating them requires the online-softmax reformulation (forward stats → backward recompute), which has to be a hand-written kernel. `tv`/`nla` route straight to the kernels (Triton required — no eager fallback); the eager losses remain only as the numeric reference the kernels are tested against.

Derived from SpecForge's fused loss (Apache-2.0, Liger lineage) — see [SpecForge#185](https://github.com/sgl-project/SpecForge/pull/185). This port keeps a separate gradient buffer.

## Tests

Verified on 8×A100-80GB (kernel imported standalone). Reference = the repo's fp32 eager `tv_loss` (current `main`).

**Correctness** — forward matches the eager loss to **1.2e-7** (bit-exact) and the gradient to cosine **0.99999988**; also verified at DeepSeek-V3 vocab (`V=129280`). `test_fused_tv_matches_eager_on_cuda` now runs on bf16 inputs and asserts the loss stays fp32.

**Peak memory** — loss region, `torch.cuda.max_memory_allocated`, `V=32000`, `S=3`, bf16 logits, joint backward (GiB):

| Context `T` | eager fp32 (`main`) | fused (this PR) |
|---|---|---|
| 4K   | 5.13  | **1.95**  |
| 8K   | 10.25 | **3.91**  |
| 16K  | 20.51 | **7.81**  |
| 32K  | 41.02 | **15.63** |
| 64K  | **OOM** | **31.25** |
| 128K | **OOM** | **62.51** |

The fused peak is a constant **0.38×** of eager fp32 across context length → the loss region is exactly `S · T · V · bytes`, so the saving scales without bound and is *larger* at DeepSeek vocab (**25.6 GiB** saved at `V=129280, T=8K`). Eager OOMs at 64K on an 80 GB card; the fused kernel trains **128K in 62.5 GiB**.

**Scope:** isolated loss-region measurement — it lowers the end-to-end training peak where the loss region is the peak (long context, this PR's target; at ≤8K the backbone/optimizer dominate). Gradients are unchanged.

## Follow-up

- **Shared kernel for the divergence-loss family** — this PR fuses `tv`/`nla` only; the same online-softmax fusion applies unchanged to `kl_div`/`rkl`/`jsd`/`lk_hybrid`, so one generic kernel would cover them without per-loss duplication.
- **In-place gradient write** — that shared kernel then unlocks writing the gradient into the logits buffer instead of a separate one ([SpecForge#185](https://github.com/sgl-project/SpecForge/pull/185)), a further `[T, V]`/step saving.

## Reproduce

The 128K row above as a runnable check — single 80 GB A100, `V_draft=32000`, `S=3`, bf16:

```python
import torch
from speculators.models.fused_tv_loss import fused_tv_loss   # ← swap to metrics.tv_loss for eager

T, V, S = 131072, 32000, 3          # 128K context, 32K draft vocab, 3 TTT steps
dev = torch.device("cuda", 0)
torch.cuda.reset_peak_memory_stats()
total = None
for _ in range(S):                  # steps retained for one joint backward
    logits  = torch.randn(1, T, V, device=dev, dtype=torch.bfloat16, requires_grad=True)
    targets = torch.randn(1, T, V, device=dev, dtype=torch.bfloat16)
    step = fused_tv_loss(logits, targets).float().mean()
    total = step if total is None else total + step
total.backward()
print(f"peak {torch.cuda.max_memory_allocated() / 1024**3:.1f} GiB")
```

```
fused_tv_loss   →  peak 62.5 GiB
metrics.tv_loss →  torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 15.62 GiB
```

Same input, same 80 GB card: the fused kernel fits; the eager loss OOMs on the first fp32 `[T, V]` softmax buffer it materializes (15.62 GiB).

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.




