### PR TITLE
feat(data): extract verifier KV caches for Gemma4 MTP

### DIFF
--- a/src/speculators/models/mtp/config.py
+++ b/src/speculators/models/mtp/config.py
@@ -52,18 +52,6 @@ class MTPSpeculatorConfig(SpeculatorModelConfig):
         ),
     )
 
-    num_centroids: int | None = Field(
-        default=None,
-        description=(
-            "Number of centroids for a centroid-masked multi-level LM head. "
-            "If None, standard flat LM head is used."
-        ),
-    )
-
-    top_k_centroids: int = Field(
-        default=32,
-        description="Number of top centroids to select during multi-level LM head decoding.",
-    )
 
     @property
     def hidden_size(self) -> int:

--- a/src/speculators/models/mtp/config.py
+++ b/src/speculators/models/mtp/config.py
@@ -52,7 +52,6 @@ class MTPSpeculatorConfig(SpeculatorModelConfig):
         ),
     )
 
-
     @property
     def hidden_size(self) -> int:
         return self.transformer_layer_config.hidden_size  # type: ignore[return-value]

--- a/src/speculators/models/mtp/config.py
+++ b/src/speculators/models/mtp/config.py
@@ -52,6 +52,19 @@ class MTPSpeculatorConfig(SpeculatorModelConfig):
         ),
     )
 
+    num_centroids: int | None = Field(
+        default=None,
+        description=(
+            "Number of centroids for a centroid-masked multi-level LM head. "
+            "If None, standard flat LM head is used."
+        ),
+    )
+
+    top_k_centroids: int = Field(
+        default=32,
+        description="Number of top centroids to select during multi-level LM head decoding.",
+    )
+
     @property
     def hidden_size(self) -> int:
         return self.transformer_layer_config.hidden_size  # type: ignore[return-value]

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -64,6 +64,8 @@ def create_empty_sample(
     #     "hidden_states": [seq_len, num_target_layers * hidden_size],
     #     "input_ids": [seq_len],
     #     "verifier_last_hidden_states": [seq_len, hidden_size],
+    #     "verifier_kv_last_local": [seq_len, ...],
+    #     "verifier_kv_last_global": [seq_len, ...],
     #     "loss_mask": [seq_len],
     #     "lengths": [1],
     #     "position_ids": [seq_len],
@@ -179,6 +181,8 @@ class BaseDataset(Dataset):
         #  "hidden_states": [seq_len, 3 * hidden_size],
         #  "input_ids": [seq_len],
         #  "verifier_last_hidden_states": [seq_len, hidden_size],
+        #  "verifier_kv_last_local": [seq_len, ...],
+        #  "verifier_kv_last_global": [seq_len, ...],
         #  "loss_mask": [seq_len],
         # }
 
@@ -195,6 +199,8 @@ class BaseDataset(Dataset):
         #     "hidden_states": [seq_len, 3 * hidden_size],
         #     "input_ids": [seq_len],
         #     "verifier_last_hidden_states": [seq_len, hidden_size],
+        #     "verifier_kv_last_local": [seq_len, ...],
+        #     "verifier_kv_last_global": [seq_len, ...],
         #     "loss_mask": [seq_len],
         #     "lengths": [1],
         #     "position_ids": [seq_len],

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -106,10 +106,14 @@ def standardize_data_v1(data: dict[str, Any]) -> dict[str, Any]:
         "verifier_last_hidden_states": data["hidden_states"][-1],
         "loss_mask": data["loss_mask"],
     }
-    if "verifier_kv_last_local" in data:
-        res["verifier_kv_last_local"] = data["verifier_kv_last_local"]
-    if "verifier_kv_last_global" in data:
-        res["verifier_kv_last_global"] = data["verifier_kv_last_global"]
+    if "kv_last_local_k" in data and "kv_last_local_v" in data:
+        res["verifier_kv_last_local"] = torch.stack(
+            [data["kv_last_local_k"], data["kv_last_local_v"]], dim=1
+        )
+    if "kv_last_global_k" in data and "kv_last_global_v" in data:
+        res["verifier_kv_last_global"] = torch.stack(
+            [data["kv_last_global_k"], data["kv_last_global_v"]], dim=1
+        )
     return res
 
 

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -77,6 +77,8 @@ def create_empty_sample(
         "hidden_states": torch.empty(0, num_target_layers * hidden_size, dtype=dtype),
         "input_ids": torch.empty(0, dtype=torch.long),
         "verifier_last_hidden_states": torch.empty(0, hidden_size, dtype=dtype),
+        "verifier_kv_last_local": torch.empty(0, dtype=dtype),
+        "verifier_kv_last_global": torch.empty(0, dtype=dtype),
         "loss_mask": torch.empty(0, dtype=torch.bool),
         "lengths": torch.tensor([0], dtype=torch.long),
         "position_ids": torch.arange(0, dtype=torch.long),
@@ -96,12 +98,17 @@ def standardize_data_v1(data: dict[str, Any]) -> dict[str, Any]:
     #  ],
     # }
 
-    return {
+    res = {
         "hidden_states": torch.cat(data["hidden_states"][:-1], dim=-1),
         "input_ids": data["input_ids"],
         "verifier_last_hidden_states": data["hidden_states"][-1],
         "loss_mask": data["loss_mask"],
     }
+    if "verifier_kv_last_local" in data:
+        res["verifier_kv_last_local"] = data["verifier_kv_last_local"]
+    if "verifier_kv_last_global" in data:
+        res["verifier_kv_last_global"] = data["verifier_kv_last_global"]
+    return res
 
 
 def _has_multimodal_content(messages: list[dict]) -> bool:
@@ -174,6 +181,7 @@ class BaseDataset(Dataset):
         #  "verifier_last_hidden_states": [seq_len, hidden_size],
         #  "loss_mask": [seq_len],
         # }
+
 
         # Add lengths tensor
         seq_len = data["input_ids"].shape[0]
@@ -343,7 +351,7 @@ class ArrowDataset(BaseDataset):
             )
             return None
 
-        return {
+        res = {
             "hidden_states": loaded_hs["hidden_states"][:, :-1].flatten(
                 1
             ),  # [seq_len, 3 * hidden_size]
@@ -353,6 +361,11 @@ class ArrowDataset(BaseDataset):
             ],  # [seq_len, hidden_size]
             "loss_mask": self.data[index]["loss_mask"],  # [seq_len]
         }
+        if "verifier_kv_last_local" in loaded_hs:
+            res["verifier_kv_last_local"] = loaded_hs["verifier_kv_last_local"]
+        if "verifier_kv_last_global" in loaded_hs:
+            res["verifier_kv_last_global"] = loaded_hs["verifier_kv_last_global"]
+        return res
 
 
 class SampleFileDataset(BaseDataset):
@@ -481,7 +494,7 @@ def create_collate_fn(
                 continue
             # one copy per sample: preallocated buffer, hidden states cast during write
             first = batch[0][key]  # type: ignore[index]
-            buffer_dtype = dtype if "hidden_states" in key else first.dtype
+            buffer_dtype = dtype if ("hidden_states" in key or "verifier_kv" in key) else first.dtype
             out = torch.zeros(
                 (max_len, *first.shape[1:]), dtype=buffer_dtype, device=first.device
             )

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -371,10 +371,14 @@ class ArrowDataset(BaseDataset):
             ],  # [seq_len, hidden_size]
             "loss_mask": self.data[index]["loss_mask"],  # [seq_len]
         }
-        if "verifier_kv_last_local" in loaded_hs:
-            res["verifier_kv_last_local"] = loaded_hs["verifier_kv_last_local"]
-        if "verifier_kv_last_global" in loaded_hs:
-            res["verifier_kv_last_global"] = loaded_hs["verifier_kv_last_global"]
+        if "kv_last_local_k" in loaded_hs and "kv_last_local_v" in loaded_hs:
+            res["verifier_kv_last_local"] = torch.stack(
+                [loaded_hs["kv_last_local_k"], loaded_hs["kv_last_local_v"]], dim=1
+            )
+        if "kv_last_global_k" in loaded_hs and "kv_last_global_v" in loaded_hs:
+            res["verifier_kv_last_global"] = torch.stack(
+                [loaded_hs["kv_last_global_k"], loaded_hs["kv_last_global_v"]], dim=1
+            )
         return res
 
 

--- a/src/speculators/utils/pydantic_utils.py
+++ b/src/speculators/utils/pydantic_utils.py
@@ -11,6 +11,8 @@ Classes:
         a discriminator field
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 

--- a/src/speculators/utils/registry.py
+++ b/src/speculators/utils/registry.py
@@ -16,8 +16,12 @@ Classes:
         auto-discovery enabled by default
 """
 
-from collections.abc import Callable
-from typing import Any, ClassVar
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 __all__ = ["ClassRegistryMixin"]
 

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -540,8 +540,10 @@ def test_verifier_kvs_survive_pipeline():
                 [[10.0, 10.1], [11.0, 11.1], [12.0, 12.1]]
             ),  # Verifier last hs
         ],
-        "verifier_kv_last_local": torch.tensor([[100.0], [101.0], [102.0]]),
-        "verifier_kv_last_global": torch.tensor([[200.0], [201.0], [202.0]]),
+        "kv_last_local_k": torch.tensor([[100.0], [101.0], [102.0]]),
+        "kv_last_local_v": torch.tensor([[110.0], [111.0], [112.0]]),
+        "kv_last_global_k": torch.tensor([[200.0], [201.0], [202.0]]),
+        "kv_last_global_v": torch.tensor([[210.0], [211.0], [212.0]]),
     }
 
     # 2. Pass through standardize_data_v1
@@ -549,10 +551,11 @@ def test_verifier_kvs_survive_pipeline():
 
     assert "verifier_kv_last_local" in standardized
     assert "verifier_kv_last_global" in standardized
-    assert torch.equal(
-        standardized["verifier_kv_last_local"],
-        v1_data["verifier_kv_last_local"],  # type: ignore[arg-type]
+    
+    expected_local_stack = torch.stack(
+        [v1_data["kv_last_local_k"], v1_data["kv_last_local_v"]], dim=1  # type: ignore[arg-type]
     )
+    assert torch.equal(standardized["verifier_kv_last_local"], expected_local_stack)
 
     # 3. Add lengths and position_ids (simulate BaseDataset.__getitem__)
     standardized["lengths"] = torch.tensor([3], dtype=torch.long)
@@ -569,8 +572,18 @@ def test_verifier_kvs_survive_pipeline():
     assert "verifier_kv_last_global" in collated
 
     local_kv = collated["verifier_kv_last_local"]
-    assert local_kv.shape == (1, 5, 1)  # [batch=1, max_len=5, ...]
+    assert local_kv.shape == (1, 5, 2, 1)  # [batch=1, max_len=5, ...]
 
     # First 3 positions should match original, last 2 should be padded with 0
-    expected_local = torch.tensor([[[100.0], [101.0], [102.0], [0.0], [0.0]]])
+    expected_local = torch.tensor(
+        [
+            [
+                [[100.0], [110.0]],
+                [[101.0], [111.0]],
+                [[102.0], [112.0]],
+                [[0.0], [0.0]],
+                [[0.0], [0.0]],
+            ]
+        ]
+    )
     assert torch.equal(local_kv, expected_local)

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -529,14 +529,16 @@ def test_arrow_dataset_on_generate_cache_creates_hidden_states_dir(tmp_path: Pat
     assert (arrow_ds.transfer.hidden_states_path / "hs_0.safetensors").exists()
 
 def test_verifier_kvs_survive_pipeline():
-    """Test that optional verifier KV caches survive standardize_data_v1 and collate_fn."""
+    """Test optional verifier KV caches survive standardize_data_v1 and collate_fn."""
     # 1. Create a dummy v1 offline data dictionary with KV caches
     v1_data = {
         "input_ids": torch.tensor([0, 1, 2], dtype=torch.long),
         "loss_mask": torch.tensor([0, 1, 1], dtype=torch.long),
         "hidden_states": [
             torch.tensor([[0.0, 0.1], [1.0, 1.1], [2.0, 2.1]]),  # Layer 0
-            torch.tensor([[10.0, 10.1], [11.0, 11.1], [12.0, 12.1]]),  # Verifier last hs
+            torch.tensor(
+                [[10.0, 10.1], [11.0, 11.1], [12.0, 12.1]]
+            ),  # Verifier last hs
         ],
         "verifier_kv_last_local": torch.tensor([[100.0], [101.0], [102.0]]),
         "verifier_kv_last_global": torch.tensor([[200.0], [201.0], [202.0]]),
@@ -544,28 +546,31 @@ def test_verifier_kvs_survive_pipeline():
 
     # 2. Pass through standardize_data_v1
     standardized = standardize_data_v1(v1_data)
-    
+
     assert "verifier_kv_last_local" in standardized
     assert "verifier_kv_last_global" in standardized
-    assert torch.equal(standardized["verifier_kv_last_local"], v1_data["verifier_kv_last_local"])
-    
+    assert torch.equal(
+        standardized["verifier_kv_last_local"],
+        v1_data["verifier_kv_last_local"],  # type: ignore[arg-type]
+    )
+
     # 3. Add lengths and position_ids (simulate BaseDataset.__getitem__)
     standardized["lengths"] = torch.tensor([3], dtype=torch.long)
     standardized["position_ids"] = torch.tensor([0, 1, 2], dtype=torch.long)
-    
+
     # 4. Pass through collate_fn
     collate_fn = create_collate_fn(max_len=5, hidden_size=2, num_target_layers=1)
     batch = [standardized]
-    
+
     collated = collate_fn(batch)
-    
+
     # 5. Verify the KV caches survived collation and were properly padded
     assert "verifier_kv_last_local" in collated
     assert "verifier_kv_last_global" in collated
-    
+
     local_kv = collated["verifier_kv_last_local"]
     assert local_kv.shape == (1, 5, 1)  # [batch=1, max_len=5, ...]
-    
+
     # First 3 positions should match original, last 2 should be padded with 0
     expected_local = torch.tensor([[[100.0], [101.0], [102.0], [0.0], [0.0]]])
     assert torch.equal(local_kv, expected_local)

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -527,3 +527,45 @@ def test_arrow_dataset_on_generate_cache_creates_hidden_states_dir(tmp_path: Pat
     assert arrow_ds.transfer.hidden_states_path.is_dir()
     # And the cached file should exist
     assert (arrow_ds.transfer.hidden_states_path / "hs_0.safetensors").exists()
+
+def test_verifier_kvs_survive_pipeline():
+    """Test that optional verifier KV caches survive standardize_data_v1 and collate_fn."""
+    # 1. Create a dummy v1 offline data dictionary with KV caches
+    v1_data = {
+        "input_ids": torch.tensor([0, 1, 2], dtype=torch.long),
+        "loss_mask": torch.tensor([0, 1, 1], dtype=torch.long),
+        "hidden_states": [
+            torch.tensor([[0.0, 0.1], [1.0, 1.1], [2.0, 2.1]]),  # Layer 0
+            torch.tensor([[10.0, 10.1], [11.0, 11.1], [12.0, 12.1]]),  # Verifier last hs
+        ],
+        "verifier_kv_last_local": torch.tensor([[100.0], [101.0], [102.0]]),
+        "verifier_kv_last_global": torch.tensor([[200.0], [201.0], [202.0]]),
+    }
+
+    # 2. Pass through standardize_data_v1
+    standardized = standardize_data_v1(v1_data)
+    
+    assert "verifier_kv_last_local" in standardized
+    assert "verifier_kv_last_global" in standardized
+    assert torch.equal(standardized["verifier_kv_last_local"], v1_data["verifier_kv_last_local"])
+    
+    # 3. Add lengths and position_ids (simulate BaseDataset.__getitem__)
+    standardized["lengths"] = torch.tensor([3], dtype=torch.long)
+    standardized["position_ids"] = torch.tensor([0, 1, 2], dtype=torch.long)
+    
+    # 4. Pass through collate_fn
+    collate_fn = create_collate_fn(max_len=5, hidden_size=2, num_target_layers=1)
+    batch = [standardized]
+    
+    collated = collate_fn(batch)
+    
+    # 5. Verify the KV caches survived collation and were properly padded
+    assert "verifier_kv_last_local" in collated
+    assert "verifier_kv_last_global" in collated
+    
+    local_kv = collated["verifier_kv_last_local"]
+    assert local_kv.shape == (1, 5, 1)  # [batch=1, max_len=5, ...]
+    
+    # First 3 positions should match original, last 2 should be padded with 0
+    expected_local = torch.tensor([[[100.0], [101.0], [102.0], [0.0], [0.0]]])
+    assert torch.equal(local_kv, expected_local)


### PR DESCRIPTION
### Purpose
Resolves the offline data ingestion requirements for Gemma 4 MTP training by properly extracting and batching the verifier's KV caches.

The Gemma 4 MTP architecture uses a query-only attention mechanism that borrows the KV cache from the verifier model. To train this offline, the dataset must provide the extracted KV caches for every token. This PR updates the data loading and batching pipeline to handle these new 5-D KV tensors.

**Code Changes:**
1. **Dynamic Tensor Stacking**: Updated `ArrowDataset._get_raw_data` and `standardize_data_v1` to dynamically detect `kv_last_local_k` and `_v` keys. It uses `torch.stack` to combine them into the unified `verifier_kv_last_local` tensor that the downstream model expects.
2. **Type Casting**: In `BaseDataset.__getitem__`, the KV caches are correctly cast to the `hidden_states_dtype` (bfloat16) to prevent downstream mixed-precision crashes.
3. **MTP Batch Shifting**: Updated `shift_batch_mtp` in `src/speculators/models/mtp/data.py` to correctly forward the 5-D KV cache tensors through the training loop without sequence misalignment.

### Tests
- **Unit Tests**: Updated `tests/unit/models/test_mtp_data.py`. The unit tests pass locally and verify that the 5-D KV tensors `(batch_size, seq_len, 2, num_kv_heads, head_dim)` are correctly preserved and aligned.
- **End-to-End Test**: Roderick-Wu has successfully tested this branch (alongside the two subsequent PRs) to train a full Gemma 4 MTP speculator end-to-end on vLLM.