### PR TITLE
fix(train): prevent double-reduction of aliased metric tensors in distributed training

### DIFF
--- a/src/speculators/models/dflash/metrics.py
+++ b/src/speculators/models/dflash/metrics.py
@@ -85,7 +85,7 @@ def compute_metrics(
     metrics["loss_total"] = ones
     for term_name, term_val in term_losses.items():
         metrics[f"{term_name}_sum"] = term_val
-        metrics[f"{term_name}_total"] = ones
+        metrics[f"{term_name}_total"] = ones.clone()
 
     # Start position: 0 if sample_from_anchor else 1 (skip anchor)
     start_pos = 0 if sample_from_anchor else 1
@@ -102,5 +102,5 @@ def compute_metrics(
         cum = cum * acc
         eal = eal + cum
     metrics["eal_sum"] = eal
-    metrics["eal_total"] = ones
+    metrics["eal_total"] = ones.clone()
     return loss, metrics

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -110,7 +110,7 @@ def compute_metrics(
             metrics["confidence_abs_error_total"] = mask_total
             # Mean predicted vs. observed acceptance — a calibration sanity check.
             metrics["confidence_pred_mean_sum"] = (conf_prob * mask_f).sum()
-            metrics["confidence_pred_mean_total"] = mask_total
+            metrics["confidence_pred_mean_total"] = mask_total.clone()
             # Calibration of the cumulative acceptance product, which is what
             # dynamic draft-length thresholding consumes (signed pred - target).
             conf_prefix = (

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -126,7 +126,7 @@ def compute_metrics(
     metrics["loss_total"] = ones
     for term_name, term_val in term_losses.items():
         metrics[f"{term_name}_sum"] = term_val
-        metrics[f"{term_name}_total"] = ones
+        metrics[f"{term_name}_total"] = ones.clone()
 
     # Mean acceptance rate of the (Markov-corrected) drafter.
     with torch.no_grad():

--- a/src/speculators/models/eagle3/metrics.py
+++ b/src/speculators/models/eagle3/metrics.py
@@ -110,7 +110,7 @@ def compute_metrics(
     s_metrics[f"loss_{ttt_step}_total"] = ones
     for term_name, term_val in term_losses.items():
         s_metrics[f"{term_name}_{ttt_step}_sum"] = term_val
-        s_metrics[f"{term_name}_{ttt_step}_total"] = ones
+        s_metrics[f"{term_name}_{ttt_step}_total"] = ones.clone()
     s_metrics[f"full_acc_{ttt_step}_sum"] = full_correct
     s_metrics[f"full_acc_{ttt_step}_total"] = full_total
     s_metrics[f"cond_acc_{ttt_step}_sum"] = cond_correct

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -40,7 +40,7 @@ def compute_accuracy_single_step(
     correct_sum = correct.float().sum()
     full_total = torch.tensor(correct.numel(), dtype=torch.float, device=correct.device)
 
-    return correct_sum, full_total, correct_sum, cond_total
+    return correct_sum, full_total, correct_sum.clone(), cond_total
 
 
 @torch.no_grad()

--- a/src/speculators/models/peagle/metrics.py
+++ b/src/speculators/models/peagle/metrics.py
@@ -69,7 +69,7 @@ def compute_metrics(
     }
     for term_name, term_val in term_losses.items():
         metrics[f"{term_name}_sum"] = term_val
-        metrics[f"{term_name}_total"] = ones
+        metrics[f"{term_name}_total"] = ones.clone()
     for d in range(num_depths):
         metrics[f"position_{d}_acc_sum"] = correct_per_pos[d]
         metrics[f"position_{d}_acc_total"] = total_per_pos[d]


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
Distributed training logs report impossible metric values, e.g. **train/full_acc_0=1.42, val/full_acc_0_epoch=2.52**, because some metric tensors are stored under multiple dict keys and the trainer's in-place distributed reduction then reduces the same tensor once per key.

The trainer reduces metrics by iterating dict values (trainer.py):

```python
for v in metrics.values():
    dist.all_reduce(v, op=dist.ReduceOp.SUM)   # in-place
```

This silently assumes every value is a distinct tensor object. Three metric builders violate that:

1. **eagle3 accuracies (active)**: compute_accuracy_single_step returns the same tensor as both the full-acc and cond-acc numerator (models/metrics.py): return correct_sum, full_total, correct_sum, cond_total. The numerator is summed across ranks twice while denominators are summed once, inflating full_acc/cond_acc by exactly ×world_size in validation (all_reduce) and ~×(2 − 1/W) in train logs (reduce to rank 0). The two metrics correctly share a numerator value — P(steps 0..k all correct) — but must not share the object.
2. **dspark confidence metrics (active)**: one mask_total tensor is stored under both confidence_abs_error_total and confidence_pred_mean_total (models/dspark/metrics.py). Same mechanism on the denominator side, so both metrics read ×world_size too low.
3. **shared ones loss totals (latent)**: eagle3/dflash/dspark/peagle all assign a single ones tensor to loss_total and every {term}_total. Harmless with a single-term loss config (no per-term entries), but with N ≥ 2 loss terms it is reduced N+1 times and all reported losses deflate.

Impact is logging only — gradients, optimizer state, and checkpoints are unaffected. Single-GPU runs never reduce and are correct, which is likely why this went unnoticed.

### Reproduction

Minimal repro (4 CPU ranks, gloo), each rank has 8/10 correct:

```python
correct_sum = torch.tensor(8.0)
metrics = {
    "full_acc_sum": correct_sum,
    "full_acc_total": torch.tensor(10.0),
    "cond_acc_sum": correct_sum,          # alias, not a copy
    "cond_acc_total": torch.tensor(10.0),
}
for v in metrics.values():
    dist.all_reduce(v, op=dist.ReduceOp.SUM)
# full_acc_sum: 8 -> 32 -> 128 (reduced twice); total: 40
# reported acc = 3.20, true acc = 0.80
```

Observed in a real run (EAGLE-3 draft for GLM, torchrun --nproc_per_node 4): train/full_acc_0=1.420, val/full_acc_0_epoch=2.521. Internal consistency check: val cond_acc_1 / full_acc_1 = 1.999/1.260 = 1.587, whose reciprocal (0.63) equals the corrected step-0 val accuracy — exactly what the aliasing model predicts.

### Changes

- models/metrics.py: return correct_sum.clone() for the cond-acc slot in compute_accuracy_single_step.
- models/dspark/metrics.py: use independent tensors for the two confidence-metric denominators.


## Tests
- Manual: 4-rank gloo repro above prints acc=0.80 after the fix (was 3.20); distributed eagle3 train/val accuracies land in [0, 1].

