### PR TITLE
Add support sample_from_anchor logic to DFlash/DSpark 

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -156,6 +156,8 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 - **`--block-size`** (int, default: `8`) Block size for DFlash model.
 
+- **`--sample-from-anchor`** / **`--no-sample-from-anchor`** (bool, default: algorithm-specific) Whether to sample from the anchor position. `True`: sample from anchor and all mask positions (default for dspark, produces block_size tokens). `False`: anchor is bonus token (default for dflash, produces block_size-1 tokens).
+
 - **`--max-anchors`** (int, default: `256`) Maximum anchor positions for DFlash training.
 
 - **`--dflash-decay-gamma`** (float, default: `4.0`) Decay gamma for DFlash loss weighting.

--- a/docs/user_guide/algorithms/dflash.md
+++ b/docs/user_guide/algorithms/dflash.md
@@ -17,6 +17,18 @@ The target model produces hidden states (fused target context features) and deco
 3. **Verify blocks:** Target model verifies the predicted blocks
 4. **Accept valid tokens:** Use the longest valid prefix
 
+### Sample From Anchor
+
+DFlash supports two sampling modes controlled by the `sample_from_anchor` config field:
+
+- **`False` (default for DFlash)**: Anchor is the bonus token, only mask tokens predict. Slot 0 is not trained. Produces `block_size - 1` speculative tokens.
+
+- **`True` (default for DSpark)**: Sample from anchor and all mask positions. All slots predict future tokens and are trained. Produces `block_size` speculative tokens. This matches the approach from the DSpark paper.
+
+The sampling mode affects both training (which targets are used and which slots are masked) and inference (how predictions are harvested from draft model outputs). When deploying to inference engines, ensure the engine's `sample_from_anchor` setting matches your model's config.
+
+**Training:** Use `--sample-from-anchor` / `--no-sample-from-anchor` flags:
+
 ## Pretrained Models
 
 Pretrained DFlash speculator models are available on HuggingFace from the [RedHatAI speculator models collection](https://huggingface.co/collections/RedHatAI/speculator-models):

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -971,6 +971,13 @@ def parse_args():
         help="Block size for DFlash model (default: 8)",
     )
     parser.add_argument(
+        "--sample-from-anchor",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Sample from the anchor position (all positions predict). "
+        "Default: False for dflash, True for dspark. ",
+    )
+    parser.add_argument(
         "--max-anchors",
         type=int,
         default=3072,

--- a/src/speculators/models/dflash/config.py
+++ b/src/speculators/models/dflash/config.py
@@ -70,6 +70,17 @@ class DFlashSpeculatorConfig(SpeculatorModelConfig):
         "bidirectional.",
     )
 
+    sample_from_anchor: bool = Field(
+        default=False,
+        description=(
+            "Whether to sample from the anchor position. "
+            "False: anchor is the bonus token, only mask tokens predict "
+            "(block_size-1 speculative tokens). "
+            "True: sample from anchor and all mask positions "
+            "(block_size speculative tokens). "
+        ),
+    )
+
     @field_serializer("transformer_layer_config")
     def serialize_transformer_config(self, value: PretrainedConfig) -> dict:
         """Serialize transformer config to dict."""

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -1,3 +1,4 @@
+import logging
 from typing import ClassVar
 
 import torch
@@ -21,6 +22,8 @@ from speculators.models.dflash.utils import (
 )
 from speculators.models.metrics import LossConfig, resolve_loss_config
 from speculators.models.utils import conditional_torch_compile, resolve_target_layer_ids
+
+logger = logging.getLogger(__name__)
 
 
 @SpeculatorModel.register("dflash")
@@ -105,6 +108,15 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         )
         self.verifier_norm.weight.requires_grad = False
         self.block_size = config.block_size
+
+        # Warn if using DFlash with sample_from_anchor=True (may not be supported)
+        if type(self).__name__ == "DFlashDraftModel" and config.sample_from_anchor:
+            logger.warning(
+                "DFlash with sample_from_anchor=True may not be supported in "
+                "all inference engines (e.g., vLLM). Verify compatibility with your "
+                "deployment target."
+            )
+
         self.post_init()
 
     @property
@@ -174,6 +186,17 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             "draft_attn_impl", "simple_flex_attention"
         )
         block_size = kwargs.get("block_size", 8)
+
+        default_sample_from_anchor = algorithm == "dspark"
+        sample_from_anchor = kwargs.get(
+            "sample_from_anchor", default_sample_from_anchor
+        )
+
+        # Calculate speculative tokens based on sample_from_anchor
+        # False: anchor is bonus token (block_size - 1 tokens)
+        # True: sample from anchor too (block_size tokens)
+        speculative_tokens = block_size if sample_from_anchor else block_size - 1
+
         return {
             "transformer_layer_config": verifier_config,
             "draft_vocab_size": kwargs["draft_vocab_size"],
@@ -181,11 +204,11 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             "aux_hidden_state_layer_ids": target_layer_ids,
             "mask_token_id": kwargs.get("mask_token_id"),
             "sliding_window_non_causal": kwargs.get("sliding_window_non_causal", False),
+            "sample_from_anchor": sample_from_anchor,
             "speculators_config": SpeculatorsConfig(
                 algorithm=algorithm,
                 proposal_methods=[
-                    # First block position is the anchor, not emitted during gen.
-                    GreedyTokenProposalConfig(speculative_tokens=block_size - 1)
+                    GreedyTokenProposalConfig(speculative_tokens=speculative_tokens)
                 ],
                 default_proposal_method="greedy",
                 verifier=VerifierConfig.from_pretrained(
@@ -351,8 +374,10 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             verifier_logits = self.verifier_lm_head(
                 self.verifier_norm(verifier_last_hidden_states)
             )
-            # Shift right by 1 so verifier_logits[i] predicts token at position i
-            verifier_logits = torch.roll(verifier_logits, 1, dims=1)
+            if not self.config.sample_from_anchor:
+                # False: shift right by 1 so slot j predicts token at position j
+                verifier_logits = torch.roll(verifier_logits, 1, dims=1)
+            # else: True, slot k predicts token at position k+1 (next), no shift
             targets = verifier_logits[:, anchored_block_indices]
             # shape: [1, num_anchors*block_size, draft_vocab_size]
 
@@ -383,7 +408,9 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             .to(aligned_loss_mask.dtype)
         )  # shape: [1, num_anchors*block_size]
 
-        aligned_loss_mask[:, :: self.block_size] = 0
+        # For sample_from_anchor=False, mask slot 0 (anchor) since it's not trained
+        if not self.config.sample_from_anchor:
+            aligned_loss_mask[:, :: self.block_size] = 0
 
         return hidden, logits, targets, aligned_loss_mask, anchored_block_indices
 

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -188,8 +188,11 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         block_size = kwargs.get("block_size", 8)
 
         default_sample_from_anchor = algorithm == "dspark"
-        sample_from_anchor = kwargs.get(
-            "sample_from_anchor", default_sample_from_anchor
+        sample_from_anchor_arg = kwargs.get("sample_from_anchor")
+        sample_from_anchor = (
+            default_sample_from_anchor
+            if sample_from_anchor_arg is None
+            else sample_from_anchor_arg
         )
 
         # Calculate speculative tokens based on sample_from_anchor
@@ -449,6 +452,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             loss_config=loss_config,
             per_position_loss_weight=per_position_loss_weight,
             dpace_alpha=dpace_alpha,
+            sample_from_anchor=self.config.sample_from_anchor,
         )
         draft_tokens = torch.argmax(logits, dim=-1)
 

--- a/src/speculators/models/dflash/metrics.py
+++ b/src/speculators/models/dflash/metrics.py
@@ -26,6 +26,7 @@ def compute_metrics(
     loss_config: LossConfig | None = None,
     per_position_loss_weight: str = "fixed-exp-decay",
     dpace_alpha: float = 0.5,
+    sample_from_anchor: bool = False,
 ) -> tuple[torch.Tensor, dict]:
     """Compute loss and accuracy metrics for draft model predictions.
 
@@ -85,14 +86,16 @@ def compute_metrics(
     for term_name, term_val in term_losses.items():
         metrics[f"{term_name}_sum"] = term_val
         metrics[f"{term_name}_total"] = ones
-    # Position 0 is the anchor — intentionally excluded from accuracy
-    metrics["full_acc_sum"] = correct_per_pos[1:].sum()
-    metrics["full_acc_total"] = total_per_pos[1:].sum()
+
+    # Start position: 0 if sample_from_anchor else 1 (skip anchor)
+    start_pos = 0 if sample_from_anchor else 1
+    metrics["full_acc_sum"] = correct_per_pos[start_pos:].sum()
+    metrics["full_acc_total"] = total_per_pos[start_pos:].sum()
 
     # EAL = sum_k prod_{i<=k} acc_i over drafted positions
     eal = torch.zeros((), device=logits.device)
     cum = torch.ones((), device=logits.device)
-    for pos in range(1, block_size):
+    for pos in range(start_pos, block_size):
         metrics[f"position_{pos}_acc_sum"] = correct_per_pos[pos]
         metrics[f"position_{pos}_acc_total"] = total_per_pos[pos]
         acc = correct_per_pos[pos] / total_per_pos[pos].clamp(min=1.0)

--- a/src/speculators/models/dspark/config.py
+++ b/src/speculators/models/dspark/config.py
@@ -25,6 +25,18 @@ class DSparkSpeculatorConfig(DFlashSpeculatorConfig):
         description="Model architectures that can load these weights",
     )
 
+    sample_from_anchor: bool = Field(
+        default=True,
+        description=(
+            "Whether to sample from the anchor position. "
+            "False: anchor is the bonus token, only mask tokens predict "
+            "(block_size-1 speculative tokens). "
+            "True: sample from anchor and all mask positions "
+            "(block_size speculative tokens). "
+            "Default True matches DeepSeek/DeepSpec convention."
+        ),
+    )
+
     # Sequential (Markov) head.
     markov_rank: int = Field(
         default=256,

--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -64,12 +64,22 @@ class DSparkDraftModel(DFlashDraftModel):
         **kwargs,
     ) -> "DSparkDraftModel":
         """Create a DSpark model from training arguments (mirrors DFlash)."""
+        enable_confidence_head_arg = kwargs.get("enable_confidence_head")
+        confidence_head_with_markov_arg = kwargs.get("confidence_head_with_markov")
         config = DSparkSpeculatorConfig(
             **cls._build_base_config_kwargs("dspark", verifier_config, **kwargs),
             markov_rank=kwargs.get("markov_rank", 256),
             markov_head_type=kwargs.get("markov_head_type", "vanilla"),
-            enable_confidence_head=kwargs.get("enable_confidence_head", True),
-            confidence_head_with_markov=kwargs.get("confidence_head_with_markov", True),
+            enable_confidence_head=(
+                True
+                if enable_confidence_head_arg is None
+                else enable_confidence_head_arg
+            ),
+            confidence_head_with_markov=(
+                True
+                if confidence_head_with_markov_arg is None
+                else confidence_head_with_markov_arg
+            ),
         )
 
         model = cls(config=config)
@@ -177,6 +187,7 @@ class DSparkDraftModel(DFlashDraftModel):
             confidence_head_alpha=confidence_head_alpha,
             per_position_loss_weight=per_position_loss_weight,
             dpace_alpha=dpace_alpha,
+            sample_from_anchor=self.config.sample_from_anchor,
         )
         draft_tokens = torch.argmax(logits, dim=-1)
         return draft_tokens, loss, metrics

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -56,6 +56,7 @@ def compute_metrics(
     confidence_head_alpha: float = 1.0,
     per_position_loss_weight: str = "fixed-exp-decay",
     dpace_alpha: float = 0.5,
+    sample_from_anchor: bool = True,
 ) -> tuple[torch.Tensor, dict]:
     """Compute the DSpark loss and a metrics dict (``*_sum``/``*_total`` pairs)."""
 
@@ -141,15 +142,17 @@ def compute_metrics(
         metrics["accept_len_sum"] = (per_block_len * block_valid).sum()
         metrics["accept_len_total"] = block_valid.sum().clamp_min(1.0)
 
-    # Per-position greedy accuracy (position 0 is the anchor — excluded).
+    # Per-position greedy accuracy
+    # Start position: 0 if sample_from_anchor else 1 (skip anchor)
+    start_pos = 0 if sample_from_anchor else 1
     pred_ids = torch.argmax(logits, dim=-1)
     target_ids = torch.argmax(targets, dim=-1)
     correct_per_pos, total_per_pos = compute_accuracy_multi_step(
         pred_ids, target_ids, loss_mask, pos_idx, block_size
     )
-    metrics["full_acc_sum"] = correct_per_pos[1:].sum()
-    metrics["full_acc_total"] = total_per_pos[1:].sum()
-    for pos in range(1, block_size):
+    metrics["full_acc_sum"] = correct_per_pos[start_pos:].sum()
+    metrics["full_acc_total"] = total_per_pos[start_pos:].sum()
+    for pos in range(start_pos, block_size):
         metrics[f"position_{pos}_acc_sum"] = correct_per_pos[pos]
         metrics[f"position_{pos}_acc_total"] = total_per_pos[pos]
 

--- a/tests/unit/models/test_sample_from_anchor.py
+++ b/tests/unit/models/test_sample_from_anchor.py
@@ -1,0 +1,82 @@
+"""Tests for sample_from_anchor behavior in DFlash and DSpark models."""
+
+from transformers import AutoConfig
+
+from speculators.models.dflash import DFlashSpeculatorConfig
+from speculators.models.dflash.core import DFlashDraftModel
+from speculators.models.dspark import DSparkSpeculatorConfig
+
+
+class TestSampleFromAnchorDFlash:
+    """Tests for DFlash sample_from_anchor behavior."""
+
+    def test_default_is_false(self):
+        """DFlash should default to sample_from_anchor=False."""
+        config = DFlashSpeculatorConfig(draft_vocab_size=128, block_size=4)
+        assert not config.sample_from_anchor
+
+    def test_can_set_to_true(self):
+        """DFlash can be configured with sample_from_anchor=True."""
+        config = DFlashSpeculatorConfig(
+            draft_vocab_size=128, block_size=4, sample_from_anchor=True
+        )
+        assert config.sample_from_anchor
+
+
+class TestSampleFromAnchorDSpark:
+    """Tests for DSpark sample_from_anchor behavior."""
+
+    def test_default_is_true(self):
+        """DSpark should default to sample_from_anchor=True."""
+        config = DSparkSpeculatorConfig(draft_vocab_size=128, block_size=4)
+        assert config.sample_from_anchor
+
+    def test_can_override_to_false(self):
+        """DSpark can be configured with sample_from_anchor=False."""
+        config = DSparkSpeculatorConfig(
+            draft_vocab_size=128, block_size=4, sample_from_anchor=False
+        )
+        assert not config.sample_from_anchor
+
+
+class TestSpeculativeTokensCalculation:
+    """Test that speculative_tokens is calculated correctly."""
+
+    def test_false_produces_block_size_minus_one(self):
+        """sample_from_anchor=False should produce block_size - 1 tokens."""
+        kwargs = DFlashDraftModel._build_base_config_kwargs(
+            algorithm="dflash",
+            verifier_config=AutoConfig.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct"),
+            verifier_name_or_path="Qwen/Qwen2.5-0.5B-Instruct",
+            draft_vocab_size=128,
+            block_size=8,
+            sample_from_anchor=False,
+            target_layer_ids=[0],
+        )
+        assert kwargs["speculators_config"].proposal_methods[0].speculative_tokens == 7
+
+    def test_true_produces_block_size(self):
+        """sample_from_anchor=True should produce block_size tokens."""
+        kwargs = DFlashDraftModel._build_base_config_kwargs(
+            algorithm="dflash",
+            verifier_config=AutoConfig.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct"),
+            verifier_name_or_path="Qwen/Qwen2.5-0.5B-Instruct",
+            draft_vocab_size=128,
+            block_size=8,
+            sample_from_anchor=True,
+            target_layer_ids=[0],
+        )
+        assert kwargs["speculators_config"].proposal_methods[0].speculative_tokens == 8
+
+    def test_dspark_defaults_to_true(self):
+        """DSpark algorithm should default to sample_from_anchor=True."""
+        kwargs = DFlashDraftModel._build_base_config_kwargs(
+            algorithm="dspark",
+            verifier_config=AutoConfig.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct"),
+            verifier_name_or_path="Qwen/Qwen2.5-0.5B-Instruct",
+            draft_vocab_size=128,
+            block_size=8,
+            target_layer_ids=[0],
+        )
+        assert kwargs["sample_from_anchor"]
+        assert kwargs["speculators_config"].proposal_methods[0].speculative_tokens == 8


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Currently, DFlash and DSpark block slot `k` predicts token `anchor + k` (e.g. the query token itself). This is based on a convention from DFlash. However, DSpark implementation sometimes predict token `anchor + k + 1` instead. 

This pr adds a configuration option to both alg configs indicating the prediction mode. It also adds support for `anchor + k + 1` style training to speculators. 

Config change:

Both DFlash and DSpark configs now include a
```
sample_from_anchor: bool
```
field. The default for DFlash is `False` and the default for DSpark is `True`. 

## Tests

Working on creating a test checkpoint. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
