### PR TITLE
[autopilot] feat(models): add DeLS-Spec speculative decoding model

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -963,12 +963,12 @@ def parse_args():
         "(default: True for eagle3, False otherwise). "
         "Disable with --no-norm-output.",
     )
-    # D-Flash specific parameters
+    # D-Flash / DeLS-Spec shared parameters
     parser.add_argument(
         "--block-size",
         type=int,
         default=8,
-        help="Block size for DFlash model (default: 8)",
+        help="Block size for DFlash/DeLS-Spec model (default: 8)",
     )
     parser.add_argument(
         "--max-anchors",
@@ -1038,6 +1038,26 @@ def parse_args():
         help="Attention implementation for draft layers. "
         "Use 'sdpa' or 'eager' for hardware that doesn't support flex attention."
         "Not supported for MTP.",
+    )
+    # DeLS-Spec-specific arguments (GRU local head).
+    parser.add_argument(
+        "--gru-hidden-size",
+        type=int,
+        default=1024,
+        help="DeLS-Spec: hidden size of the GRU local head (default: 1024).",
+    )
+    parser.add_argument(
+        "--low-rank-dim",
+        type=int,
+        default=256,
+        help="DeLS-Spec: low-rank projection dim before vocab head (default: 256).",
+    )
+    parser.add_argument(
+        "--dels-spec-head-type",
+        type=str,
+        default="rnn",
+        choices=["rnn", "markov"],
+        help='DeLS-Spec: local head variant — "rnn" (GRU) or "markov" (default: rnn).',
     )
     # P-EAGLE specific parameters
     parser.add_argument(

--- a/src/speculators/models/__init__.py
+++ b/src/speculators/models/__init__.py
@@ -1,5 +1,6 @@
 from speculators.models.attention import ALL_ATTENTION_FUNCTIONS  # noqa: F401
 
+from .dels_spec import DelsSpecDraftModel, DelsSpecSpeculatorConfig
 from .dflash import DFlashDraftModel, DFlashSpeculatorConfig
 from .dspark import DSparkDraftModel, DSparkSpeculatorConfig
 from .eagle3 import Eagle3DraftModel, Eagle3SpeculatorConfig
@@ -11,6 +12,8 @@ __all__ = [
     "DFlashSpeculatorConfig",
     "DSparkDraftModel",
     "DSparkSpeculatorConfig",
+    "DelsSpecDraftModel",
+    "DelsSpecSpeculatorConfig",
     "Eagle3DraftModel",
     "Eagle3SpeculatorConfig",
     "MTPDraftModel",

--- a/src/speculators/models/dels_spec/__init__.py
+++ b/src/speculators/models/dels_spec/__init__.py
@@ -1,0 +1,7 @@
+from speculators.models.dels_spec.config import DelsSpecSpeculatorConfig
+from speculators.models.dels_spec.core import DelsSpecDraftModel
+
+__all__ = [
+    "DelsSpecDraftModel",
+    "DelsSpecSpeculatorConfig",
+]

--- a/src/speculators/models/dels_spec/config.py
+++ b/src/speculators/models/dels_spec/config.py
@@ -1,0 +1,109 @@
+from typing import Any, Literal
+
+from pydantic import Field, field_serializer, field_validator
+from transformers import AutoConfig, PretrainedConfig
+from transformers.models.qwen3.modeling_qwen3 import Qwen3Config
+
+from speculators import SpeculatorModelConfig
+
+__all__ = [
+    "DelsSpecSpeculatorConfig",
+]
+
+
+@SpeculatorModelConfig.register("dels_spec")
+class DelsSpecSpeculatorConfig(SpeculatorModelConfig):
+    """Configuration for DeLS-Spec: Decoupled Long-Short Contexts speculator.
+
+    DeLS-Spec adds a lightweight GRU-based local head (short-context expert)
+    that captures intra-block causal dependencies missed by DFlash's parallel
+    predictions. It trains independently with NTP loss.
+
+    :param transformer_layer_config: Verifier config (for embedding dim / vocab)
+    :param draft_vocab_size: Size of draft model vocabulary for speculation
+    :param block_size: Draft block size
+    :param gru_hidden_size: Hidden size of the GRU
+    :param low_rank_dim: Low-rank projection dimension before vocab head
+    :param head_type: Local head variant ("rnn" or "markov")
+    :param fusion_alpha: Weight for local head logits in product-of-experts fusion
+    :param fusion_beta: Weight for unigram prior subtraction in fusion
+    """
+
+    speculators_model_type: Literal["dels_spec"] = "dels_spec"
+    architectures: list[str] = Field(
+        default_factory=lambda: ["DelsSpecSpeculator"],
+        description="Model architectures that can load these weights",
+    )
+
+    transformer_layer_config: PretrainedConfig = Field(
+        default_factory=Qwen3Config,
+        description="Verifier config (used for embedding dim and vocab size)",
+    )
+
+    draft_vocab_size: int = Field(
+        default=32000,
+        description="Size of draft model vocabulary for speculation",
+    )
+
+    block_size: int = Field(
+        default=16,
+        description="Size of the draft block predicted per anchor",
+    )
+
+    gru_hidden_size: int = Field(
+        default=1024,
+        description="Hidden size of the GRU local head",
+    )
+
+    low_rank_dim: int = Field(
+        default=256,
+        description="Low-rank projection dimension before vocabulary head",
+    )
+
+    head_type: Literal["rnn", "markov"] = Field(
+        default="rnn",
+        description='Local head variant: "rnn" (GRU) or "markov" (bigram lookup)',
+    )
+
+    fusion_alpha: float = Field(
+        default=0.3,
+        description="Weight for local head logits in product-of-experts fusion",
+    )
+
+    fusion_beta: float = Field(
+        default=0.3,
+        description="Weight for unigram prior subtraction in fusion",
+    )
+
+    target_hidden_size: int | None = Field(
+        default=None,
+        description="Hidden size of the target model (if different from draft model)",
+    )
+
+    mask_token_id: int | None = Field(
+        default=None,
+        description="Token ID used for masking (needed for DFlash anchor selection)",
+    )
+
+    @field_serializer("transformer_layer_config")
+    def serialize_transformer_config(self, value: PretrainedConfig) -> dict:
+        """Serialize transformer config to dict."""
+        return value.to_diff_dict()
+
+    @field_validator("transformer_layer_config", mode="before")
+    @classmethod
+    def validate_transformer_config(cls, value: Any) -> PretrainedConfig:
+        """Validate and convert transformer config."""
+        if isinstance(value, dict):
+            config_class: type[PretrainedConfig] = Qwen3Config
+            if "model_type" in value:
+                config_class = AutoConfig.for_model(
+                    model_type=value["model_type"]
+                ).__class__
+            return config_class(**value)
+        return value
+
+    @property
+    def target_vocab_size(self) -> int:
+        """Get target vocabulary size from transformer config."""
+        return self.transformer_layer_config.vocab_size

--- a/src/speculators/models/dels_spec/core.py
+++ b/src/speculators/models/dels_spec/core.py
@@ -1,0 +1,256 @@
+from typing import Any, ClassVar
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+from speculators.model import DraftVocabMixin, SpeculatorModel
+from speculators.models.dels_spec.config import DelsSpecSpeculatorConfig
+from speculators.models.dflash.utils import (
+    get_base_indices_for_anchored_blocks,
+    select_anchors,
+)
+from speculators.models.metrics import (
+    LossConfig,
+    compute_accuracy_multi_step,
+    dflash_loss_decay,
+)
+
+
+def _ce_loss_against_token_ids(
+    logits: torch.Tensor,
+    target_ids: torch.Tensor,
+    loss_mask: torch.Tensor,
+    pos_idx: torch.Tensor,
+    gamma: float = 7.0,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """Cross-entropy loss against actual token IDs with DFlash-style decay.
+
+    Args:
+        logits: Draft logits [1, T, V].
+        target_ids: Ground-truth token IDs [1, T].
+        loss_mask: Binary mask [1, T].
+        pos_idx: Position indices within blocks [1, T].
+        gamma: Decay rate for DFlash-style position weighting.
+
+    Returns:
+        (scalar_loss, metrics_dict)
+    """
+    batch_size, seq_len, vocab_size = logits.shape
+
+    elementwise_loss = nn.functional.cross_entropy(
+        logits.reshape(-1, vocab_size),
+        target_ids.reshape(-1),
+        reduction="none",
+        ignore_index=-100,
+    ).reshape(batch_size, seq_len)
+
+    loss_mask_f = loss_mask.to(elementwise_loss.dtype)
+    elementwise_loss = elementwise_loss * loss_mask_f
+
+    decay_mult = dflash_loss_decay(pos_idx.to(elementwise_loss.dtype), gamma=gamma)
+    elementwise_loss = elementwise_loss * decay_mult
+
+    denominator = loss_mask_f.sum(dim=1).clamp_min(1e-5)
+    loss = (elementwise_loss.sum(dim=1) / denominator).mean()
+
+    block_size = pos_idx.max().item() + 1
+    pred_ids = torch.argmax(logits, dim=-1)
+    correct_per_pos, total_per_pos = compute_accuracy_multi_step(
+        pred_ids, target_ids, loss_mask, pos_idx, int(block_size)
+    )
+
+    ones = torch.tensor(1.0, device=logits.device)
+    metrics: dict[str, Any] = {}
+    metrics["loss_sum"] = loss.detach().clone()
+    metrics["loss_total"] = ones
+    metrics["full_acc_sum"] = correct_per_pos[1:].sum()
+    metrics["full_acc_total"] = total_per_pos[1:].sum()
+    for pos in range(1, int(block_size)):
+        metrics[f"position_{pos}_acc_sum"] = correct_per_pos[pos]
+        metrics[f"position_{pos}_acc_total"] = total_per_pos[pos]
+
+    return loss, metrics
+
+
+@SpeculatorModel.register("dels_spec")
+class DelsSpecDraftModel(DraftVocabMixin, SpeculatorModel):
+    config_class: ClassVar[type[DelsSpecSpeculatorConfig]] = DelsSpecSpeculatorConfig  # type: ignore[misc]
+    _keys_to_ignore_on_load_missing: ClassVar[list[str]] = [  # type: ignore[misc]
+        "embed_tokens.weight",
+        "t2d",
+        "d2t",
+    ]
+    _keys_to_ignore_on_save: ClassVar[list[str]] = []  # type: ignore[misc,assignment]
+
+    t2d: torch.Tensor | None
+    d2t: torch.Tensor | None
+
+    def __init__(self, config: DelsSpecSpeculatorConfig) -> None:
+        super().__init__(config=config)
+        self._init_vocab(config)
+
+        embed_dim = config.transformer_layer_config.hidden_size
+        self.block_size = config.block_size
+        self.head_type = config.head_type
+
+        self.embed_tokens.weight.requires_grad = False
+
+        if config.head_type == "rnn":
+            self.gru = nn.GRU(
+                input_size=embed_dim,
+                hidden_size=config.gru_hidden_size,
+                num_layers=1,
+                bias=False,
+                batch_first=True,
+            )
+            proj_input_dim = config.gru_hidden_size
+        else:
+            self.markov_emb = nn.Embedding(
+                config.transformer_layer_config.vocab_size, config.low_rank_dim
+            )
+            proj_input_dim = config.low_rank_dim
+
+        self.w_rank = nn.Linear(proj_input_dim, config.low_rank_dim, bias=False)
+        self.w_vocab = nn.Linear(
+            config.low_rank_dim, config.draft_vocab_size, bias=False
+        )
+
+        self.layers = nn.ModuleList()
+
+        self.post_init()
+
+    @property
+    def target_layer_ids(self) -> list[int]:
+        """No auxiliary hidden states needed."""
+        return []
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        loss_mask: torch.Tensor,
+        document_ids: torch.Tensor,
+        verifier_last_hidden_states: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        loss_config: LossConfig | None = None,
+        gamma: float = 7.0,
+        max_anchors: int = 3072,
+        **kwargs,
+    ):
+        del hidden_states, document_ids, verifier_last_hidden_states
+        del position_ids, loss_config, kwargs
+        device = input_ids.device
+
+        anchor_positions, anchor_valid = select_anchors(
+            loss_mask, max_anchors, self.block_size
+        )
+
+        block_indices = get_base_indices_for_anchored_blocks(
+            anchor_positions, self.block_size
+        )
+
+        block_token_ids = input_ids[:, block_indices]
+
+        target_token_ids = input_ids[:, block_indices + 1]
+
+        with torch.no_grad():
+            block_embeds = self.embed_tokens(block_token_ids)
+
+        num_anchors = anchor_positions.shape[0]
+        block_embeds_3d = block_embeds.view(
+            1, num_anchors, self.block_size, -1
+        ).squeeze(0)
+
+        if self.head_type == "rnn":
+            gru_out, _ = self.gru(block_embeds_3d)
+            gru_out = gru_out.reshape(1, num_anchors * self.block_size, -1)
+            proj = self.w_rank(gru_out)
+        else:
+            markov_input = self.markov_emb(block_token_ids)
+            proj = markov_input
+
+        logits = self.w_vocab(proj)
+
+        aligned_loss_mask = loss_mask.clone()[:, block_indices]
+        aligned_loss_mask = aligned_loss_mask * (
+            anchor_valid.repeat_interleave(self.block_size)
+            .unsqueeze(0)
+            .to(aligned_loss_mask.dtype)
+        )
+        aligned_loss_mask[:, :: self.block_size] = 0
+
+        seq_len = logits.shape[1]
+        pos_idx = (torch.arange(seq_len, device=device) % self.block_size).unsqueeze(0)
+
+        if self.t2d is not None:
+            target_token_ids = target_token_ids + self.t2d[target_token_ids]
+
+        loss, metrics = _ce_loss_against_token_ids(
+            logits, target_token_ids, aligned_loss_mask, pos_idx, gamma=gamma
+        )
+        draft_tokens = torch.argmax(logits, dim=-1)
+
+        return draft_tokens, loss, metrics
+
+    @classmethod
+    def from_training_args(
+        cls,
+        verifier_config: "PretrainedConfig",
+        t2d: torch.Tensor | None = None,
+        d2t: torch.Tensor | None = None,
+        **kwargs,
+    ) -> "DelsSpecDraftModel":
+        from speculators.config import (  # noqa: PLC0415
+            SpeculatorsConfig,
+            VerifierConfig,
+        )
+        from speculators.proposals.greedy import (  # noqa: PLC0415
+            GreedyTokenProposalConfig,
+        )
+
+        verifier_config._attn_implementation = kwargs.get(  # noqa: SLF001
+            "draft_attn_impl", "simple_flex_attention"
+        )
+        block_size = kwargs.get("block_size", 16)
+
+        config = DelsSpecSpeculatorConfig(
+            transformer_layer_config=verifier_config,
+            draft_vocab_size=kwargs["draft_vocab_size"],
+            block_size=block_size,
+            gru_hidden_size=kwargs.get("gru_hidden_size", 1024),
+            low_rank_dim=kwargs.get("low_rank_dim", 256),
+            head_type=kwargs.get("dels_spec_head_type", "rnn"),
+            fusion_alpha=kwargs.get("fusion_alpha", 0.3),
+            fusion_beta=kwargs.get("fusion_beta", 0.3),
+            mask_token_id=kwargs.get("mask_token_id"),
+            speculators_config=SpeculatorsConfig(
+                algorithm="dels_spec",
+                proposal_methods=[
+                    GreedyTokenProposalConfig(speculative_tokens=block_size - 1)
+                ],
+                default_proposal_method="greedy",
+                verifier=VerifierConfig.from_pretrained(
+                    kwargs["verifier_name_or_path"]
+                ),
+            ),
+        )
+
+        model = cls(config=config)
+        model.load_vocab_mappings(t2d, d2t)
+        model.load_verifier_weights()
+        return model
+
+    def load_verifier_weights(self):
+        super().load_verifier_weights()
+        self.embed_tokens.weight.requires_grad_(False)
+
+    @staticmethod
+    def get_trainer_kwargs(**kwargs) -> tuple[dict, dict]:
+        gamma = kwargs.get("dflash_decay_gamma", 7.0)
+        max_anchors = kwargs.get("max_anchors", 3072)
+        shared = {
+            "gamma": gamma,
+            "max_anchors": max_anchors,
+        }
+        return dict(shared), dict(shared)


### PR DESCRIPTION
## Summary
- Implement DeLS-Spec (Decoupled Long-Short Contexts for Parallel Speculative Drafting, [arxiv 2607.07409](https://arxiv.org/abs/2607.07409)) as a new speculator type
- Adds a lightweight GRU-based local head that captures intra-block causal dependencies missed by DFlash's parallel predictions
- Trains independently with NTP cross-entropy loss, reuses DFlash anchor selection and block indexing utilities

## Details

### New files
- `src/speculators/models/dels_spec/config.py` — `DelsSpecSpeculatorConfig` registered as `"dels_spec"` model type
- `src/speculators/models/dels_spec/core.py` — `DelsSpecDraftModel` with GRU/Markov local head + low-rank vocab projection
- `src/speculators/models/dels_spec/__init__.py` — module exports

### Modified files
- `src/speculators/models/__init__.py` — register DeLS-Spec exports
- `scripts/train.py` — add CLI args: `--gru-hidden-size`, `--low-rank-dim`, `--dels-spec-head-type`

### Architecture
- **GRU head** (`head_type="rnn"`): processes block embeddings through a GRU → low-rank projection → vocab head
- **Markov head** (`head_type="markov"`): bigram embedding lookup → vocab head (no sequential dependency)
- **Loss**: NTP cross-entropy against actual token IDs with DFlash-style positional decay weighting
- **No hidden states needed**: `target_layer_ids = []` — only uses input token embeddings from the verifier

### Training example
```bash
python scripts/train.py \
    --verifier-name-or-path Qwen/Qwen3-0.6B \
    --speculator-type dels_spec \
    --data-path ./data \
    --save-path ./checkpoints/dels_spec \
    --block-size 16 \
    --gru-hidden-size 1024 \
    --low-rank-dim 256 \
    --dels-spec-head-type rnn \
    --epochs 10 --lr 6e-4
```

## Test plan
- [x] `ruff check` passes on all changed files
- [x] Standalone forward pass produces valid loss (~5.3) with real data
- [x] Smoke training: loss decreases from ~5.3 → ~3.5 over 49 valid gradient steps
- [ ] Full training run on larger dataset
- [ ] vLLM inference integration (product-of-experts fusion with DFlash)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/autopilot`