### PR TITLE
Fix numerical issues by holding params in fp32

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -130,6 +130,9 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 - **`--muon-adjust-lr-fn`** (str, default: `"match_rms_adamw"`) Muon LR adjustment strategy. Options: `original`, `match_rms_adamw`. Only used with `--optimizer muon`.
 
+!!! note "fp32 master weights"
+    Optimizer updates always accumulate in fp32 master weights; forward/backward compute stays in `--hidden-states-dtype` (bf16 by default). Under FSDP2 (torchrun) the sharded parameters and optimizer state are held in fp32 and cast to the compute dtype at all-gather; on a single GPU the optimizer keeps an fp32 master copy of the trainable weights. Without this, updates smaller than a bf16 ulp would round away every step.
+
 ### Eagle3-Specific Arguments
 
 - **`--use-off-policy-tokens`** (flag) Use off-policy tokens during training (required for [regenerated data](response_regeneration.md)).

--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -270,21 +270,30 @@ class SingleGPUCheckpointer(BaseCheckpointer):
 
     def load_optimizer_state_dict(
         self,
-        model: PreTrainedModel,
+        model: PreTrainedModel,  # noqa: ARG002 (kept for the base-class interface)
         optimizer: OptimizerOrList,
-        float_dtype: torch.dtype | None = None,
+        float_dtype: torch.dtype | None = None,  # noqa: ARG002
     ):
+        optimizer_path = self.optimizer_path(self.previous_epoch)
+        if not optimizer_path.exists():
+            logger.warning(
+                f"No optimizer state found at {optimizer_path}; "
+                "resuming with a fresh optimizer state."
+            )
+            return
         device = get_current_device()
         loaded = torch.load(
-            self.optimizer_path(self.previous_epoch),
+            optimizer_path,
             weights_only=True,
             map_location=device,
         )
         optimizers = _as_list(optimizer)
         loaded_list = loaded if isinstance(loaded, list) else [loaded]
-        dtype = float_dtype or model.dtype
+        # Optimizer state is loaded in its saved dtypes: fp32 master weights and
+        # moments (FP32MasterOptimizer) must not be downcast. Bare optimizers
+        # cast float state to their params' dtype in load_state_dict anyway.
         for opt, state_dict in zip(optimizers, loaded_list, strict=True):
-            opt.load_state_dict(convert_float_dtype(state_dict, dtype))
+            opt.load_state_dict(state_dict)
 
     def save_checkpoint(
         self,
@@ -296,9 +305,10 @@ class SingleGPUCheckpointer(BaseCheckpointer):
         model_state_dict = convert_float_dtype(model.state_dict(), float_dtype)
         model.save_pretrained(self.path / str(epoch), state_dict=model_state_dict)
         optimizers = _as_list(optimizer)
-        state_dicts = [
-            convert_float_dtype(opt.state_dict(), float_dtype) for opt in optimizers
-        ]
+        # Save optimizer state in its native dtypes: downcasting would destroy
+        # fp32 master weights / moments across a resume. (Without fp32 masters
+        # the state is already in the model's dtype, so nothing changes.)
+        state_dicts = [opt.state_dict() for opt in optimizers]
         # Preserve the legacy single-optimizer format when there is only one.
         payload = state_dicts[0] if len(state_dicts) == 1 else state_dicts
         torch.save(payload, self.optimizer_path(epoch))
@@ -326,19 +336,44 @@ class DistributedCheckpointer(BaseCheckpointer):
         )
         dist.barrier()
 
+    # Key marking the optimizer payload as the fp32-master format: the payload
+    # additionally carries the fp32 trainable params so resume is lossless while
+    # model.safetensors stays in the deployable (bf16) dtype.
+    FP32_PARAMS_KEY = "fp32_params"
+    OPTIMIZERS_KEY = "optimizers"
+
     def load_optimizer_state_dict(
         self,
         model,
         optimizer: OptimizerOrList,
         float_dtype: torch.dtype | None = None,
     ):
+        optimizer_path = self.optimizer_path(self.previous_epoch)
+        if not optimizer_path.exists():
+            # All ranks see the same shared filesystem, so every rank takes
+            # this branch consistently (no barrier divergence).
+            logger.warning(
+                f"No optimizer state found at {optimizer_path}; "
+                "resuming with a fresh optimizer state."
+            )
+            return
         optimizers = _as_list(optimizer)
         full_state_dict = torch.load(
-            self.optimizer_path(self.previous_epoch),
+            optimizer_path,
             mmap=True,
             weights_only=True,
             map_location="cpu",
         )
+        fp32_params = None
+        if (
+            isinstance(full_state_dict, dict)
+            and self.FP32_PARAMS_KEY in full_state_dict
+        ):
+            fp32_params = full_state_dict[self.FP32_PARAMS_KEY]
+            full_state_dict = full_state_dict[self.OPTIMIZERS_KEY]
+        # With fp32 master weights the model params are fp32, so this converts
+        # legacy bf16 optimizer state up to fp32 and is a no-op for new
+        # checkpoints (saved in native fp32).
         full_state_dict = convert_float_dtype(
             full_state_dict, float_dtype or model.dtype
         )
@@ -356,6 +391,17 @@ class DistributedCheckpointer(BaseCheckpointer):
                 if "step" in state and isinstance(state["step"], torch.Tensor):
                     state["step"] = state["step"].float()
 
+        if fp32_params is not None:
+            # Restore the exact fp32 master weights over the bf16-rounded values
+            # loaded from model.safetensors.
+            set_model_state_dict(
+                model,
+                fp32_params,
+                options=StateDictOptions(
+                    full_state_dict=True, broadcast_from_rank0=True, strict=False
+                ),
+            )
+
         dist.barrier()
 
     def save_checkpoint(
@@ -365,22 +411,41 @@ class DistributedCheckpointer(BaseCheckpointer):
         epoch: int | str,
         float_dtype: torch.dtype = torch.bfloat16,
     ):
-        model_state_dict = get_model_state_dict(
+        full_model_state_dict = get_model_state_dict(
             model, options=StateDictOptions(full_state_dict=True, cpu_offload=True)
         )
-        model_state_dict = convert_float_dtype(model_state_dict, float_dtype)
+        model_state_dict = convert_float_dtype(full_model_state_dict, float_dtype)
 
         optimizer_state_dict = get_optimizer_state_dict(
             model,
             _as_list(optimizer),
             options=StateDictOptions(full_state_dict=True, cpu_offload=True),
         )
-        optimizer_state_dict = convert_float_dtype(optimizer_state_dict, float_dtype)
+        # Optimizer state is saved in its native dtypes: with fp32 master
+        # weights (fp32 sharded params) the moments are fp32 and downcasting
+        # them would defeat the master-weight precision across a resume.
+
+        # In fp32-master mode, also persist the fp32 trainable params in the
+        # optimizer payload: model.safetensors stays bf16 (deployable), but
+        # resume restores the exact fp32 masters.
+        fp32_param_names = [
+            name
+            for name, param in model.named_parameters()
+            if param.requires_grad and param.dtype == torch.float32
+        ]
+        payload = optimizer_state_dict
+        if fp32_param_names and float_dtype != torch.float32:
+            payload = {
+                self.OPTIMIZERS_KEY: optimizer_state_dict,
+                self.FP32_PARAMS_KEY: {
+                    name: full_model_state_dict[name] for name in fp32_param_names
+                },
+            }
 
         if dist.get_rank() == 0:
             # Only rank 0 saves the checkpoint
             model.save_pretrained(self.path / str(epoch), state_dict=model_state_dict)
-            torch.save(optimizer_state_dict, self.optimizer_path(epoch))
+            torch.save(payload, self.optimizer_path(epoch))
             self._copy_train_command(epoch)
 
         dist.barrier()

--- a/src/speculators/train/distributed.py
+++ b/src/speculators/train/distributed.py
@@ -194,15 +194,23 @@ def maybe_destroy_distributed() -> None:
     _dp_group = None
 
 
-def apply_fully_sharded(model: torch.nn.Module):
+def apply_fully_sharded(
+    model: torch.nn.Module, param_dtype: torch.dtype = torch.bfloat16
+):
     """Applies torch FSDP fully_shard to the model, wrapping layers in FSDPModule.
 
     Assumes the model has a `layers` attribute containing the decoder layers.
     Model should be validated with SpeculatorModel.verify_training_compatible()
     before calling this function.
+
+    ``param_dtype`` is the compute dtype: parameters are cast to it when
+    all-gathered for forward/backward. Keeping the model's own (sharded)
+    parameters in fp32 while passing ``param_dtype=torch.bfloat16`` yields
+    fp32 master weights with unchanged bf16 compute — the optimizer then steps
+    directly on the fp32 shards. Gradients are always reduced in fp32.
     """
     mp_policy = MixedPrecisionPolicy(
-        param_dtype=torch.bfloat16,
+        param_dtype=param_dtype,
         reduce_dtype=torch.float32,
     )
 

--- a/src/speculators/train/optimizers.py
+++ b/src/speculators/train/optimizers.py
@@ -10,9 +10,16 @@ embedding / LM-head matrices, following standard Muon practice).
 Muon works transparently for both single-GPU and multi-GPU (FSDP2) training: when the
 model is sharded with ``fully_shard`` the parameters become ``DTensor``s and Muon's
 Newton-Schulz orthogonalization dispatches across ranks automatically.
+
+When ``fp32_masters=True`` each optimizer is wrapped in :class:`FP32MasterOptimizer`,
+which keeps an fp32 master copy of the trainable parameters so that updates smaller
+than a bf16 ulp still accumulate. This is the single-device counterpart of the FSDP2
+mixed-precision setup (fp32 sharded params + bf16 ``param_dtype``), which needs no
+wrapper — see ``Trainer.setup_model``.
 """
 
 import logging
+from collections.abc import Callable, Iterable
 
 import torch
 from torch import Tensor
@@ -54,22 +61,165 @@ def split_named_params_for_muon(
     return muon_params, adamw_params
 
 
-def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
+NamedParams = list[tuple[str, Tensor]]
+
+
+class FP32MasterOptimizer(torch.optim.Optimizer):
+    """Wrap an optimizer with fp32 master weights for low-precision training.
+
+    The model's (typically bf16) parameters remain the ones used for forward and
+    backward. This wrapper keeps an fp32 copy of each trainable parameter and, on
+    every :meth:`step`, copies the low-precision gradients into fp32, steps the
+    inner optimizer on the fp32 masters (so its moments are fp32 too), and writes
+    the downcast result back into the model parameters. Updates smaller than a
+    bf16 ulp therefore still accumulate across steps instead of rounding away.
+
+    ``param_groups`` and ``state`` are shared with the inner optimizer, so LR
+    schedulers can drive this wrapper directly. :meth:`state_dict` embeds the
+    fp32 masters alongside the inner optimizer state so resume is lossless;
+    legacy state dicts saved from a bare optimizer load transparently (torch
+    casts their float state to the masters' fp32).
+    """
+
+    def __init__(
+        self,
+        named_params: Iterable[tuple[str, Tensor]],
+        inner_factory: Callable[[NamedParams], torch.optim.Optimizer],
+    ):
+        # Intentionally no super().__init__: param_groups/state/defaults are
+        # mirrored from the inner optimizer below so schedulers and state-dict
+        # consumers see a single coherent optimizer.
+        trainable = [(name, p) for name, p in named_params if p.requires_grad]
+        if not trainable:
+            raise ValueError("No trainable parameters found to optimize.")
+        self._model_params = [p for _, p in trainable]
+        self._masters = [p.detach().clone().to(torch.float32) for _, p in trainable]
+        self.inner = inner_factory(
+            [
+                (name, master)
+                for (name, _), master in zip(trainable, self._masters, strict=True)
+            ]
+        )
+        self.defaults = self.inner.defaults
+        self._mirror_inner()
+
+    def _mirror_inner(self) -> None:
+        self.param_groups = self.inner.param_groups
+        self.state = self.inner.state
+
+    @torch.no_grad()
+    def step(self, closure=None):  # type: ignore[override]
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for param, master in zip(self._model_params, self._masters, strict=True):
+            if param.grad is None:
+                master.grad = None
+                continue
+            if master.grad is None:
+                master.grad = torch.empty_like(master)
+            master.grad.copy_(param.grad)  # exact bf16 -> fp32 upcast
+        self.inner.step()
+        for param, master in zip(self._model_params, self._masters, strict=True):
+            param.data.copy_(master)  # fp32 -> model dtype downcast
+        return loss
+
+    def zero_grad(self, set_to_none: bool = True) -> None:  # type: ignore[override]
+        for param in self._model_params:
+            if param.grad is None:
+                continue
+            if set_to_none:
+                param.grad = None
+            else:
+                param.grad.detach_()
+                param.grad.zero_()
+
+    def state_dict(self) -> dict:  # type: ignore[override]
+        return {
+            "inner": self.inner.state_dict(),
+            "fp32_masters": [master.detach() for master in self._masters],
+        }
+
+    def load_state_dict(self, state_dict: dict) -> None:  # type: ignore[override]
+        if "fp32_masters" in state_dict:
+            saved_masters = state_dict["fp32_masters"]
+            for master, saved in zip(self._masters, saved_masters, strict=True):
+                master.detach().copy_(saved)
+            self.inner.load_state_dict(state_dict["inner"])
+            # Keep the low-precision model params consistent with the restored
+            # masters (the model checkpoint is saved at reduced precision).
+            with torch.no_grad():
+                for param, master in zip(
+                    self._model_params, self._masters, strict=True
+                ):
+                    param.data.copy_(master)
+        else:
+            # Legacy checkpoint saved from a bare optimizer over the model
+            # params; torch casts its float state to the masters' fp32.
+            try:
+                self.inner.load_state_dict(state_dict)
+            except ValueError as err:
+                raise ValueError(
+                    "Failed to load a legacy optimizer checkpoint into "
+                    "FP32MasterOptimizer: it was saved by an older version "
+                    "without fp32 master weights and with a different "
+                    "parameter grouping. Remove the checkpoint's "
+                    "optimizer_state_dict.pt to resume from the model weights "
+                    "with a fresh optimizer state."
+                ) from err
+        # inner.load_state_dict rebinds param_groups/state; re-mirror them.
+        self._mirror_inner()
+
+    def add_param_group(self, param_group: dict) -> None:  # type: ignore[override]
+        raise NotImplementedError(
+            "FP32MasterOptimizer does not support adding param groups after "
+            "construction."
+        )
+
+
+def build_optimizers(
+    model: Module, config, fp32_masters: bool = False
+) -> list[torch.optim.Optimizer]:
     """Build the optimizer(s) for a training run based on ``config.optimizer``.
 
     :param model: The model to optimize.
     :param config: A ``TrainerConfig`` holding the optimizer hyperparameters.
+    :param fp32_masters: When True, wrap each optimizer in
+        :class:`FP32MasterOptimizer` so updates accumulate in fp32 master weights.
+        Used for single-device runs; FSDP2 runs keep the sharded params in fp32
+        instead (see ``Trainer.setup_model``) and need no wrapper.
     :return: A list of optimizers for the trainer to step in tandem. The default
         "adamw" returns a single optimizer; "muon" returns ``[Muon, AdamW]``.
     """
+
+    def adamw_factory(named_params: NamedParams) -> torch.optim.Optimizer:
+        return torch.optim.AdamW(
+            named_params,
+            lr=config.lr,
+            weight_decay=config.weight_decay,
+        )
+
+    def muon_factory(named_params: NamedParams) -> torch.optim.Optimizer:
+        return torch.optim.Muon(
+            named_params,
+            lr=config.muon_lr,
+            momentum=config.muon_momentum,
+            weight_decay=config.muon_weight_decay,
+            ns_steps=config.muon_ns_steps,
+            adjust_lr_fn=config.muon_adjust_lr_fn,
+        )
+
+    def finalize(
+        named_params: NamedParams,
+        factory: Callable[[NamedParams], torch.optim.Optimizer],
+    ) -> torch.optim.Optimizer:
+        if fp32_masters:
+            return FP32MasterOptimizer(named_params, factory)
+        return factory(named_params)
+
     if config.optimizer == "adamw":
-        return [
-            torch.optim.AdamW(
-                model.named_parameters(),
-                lr=config.lr,
-                weight_decay=config.weight_decay,
-            )
-        ]
+        return [finalize(list(model.named_parameters()), adamw_factory)]
 
     if config.optimizer == "muon":
         muon_params, adamw_params = split_named_params_for_muon(model)
@@ -81,24 +231,9 @@ def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
 
         optimizers: list[torch.optim.Optimizer] = []
         if muon_params:
-            optimizers.append(
-                torch.optim.Muon(
-                    muon_params,
-                    lr=config.muon_lr,
-                    momentum=config.muon_momentum,
-                    weight_decay=config.muon_weight_decay,
-                    ns_steps=config.muon_ns_steps,
-                    adjust_lr_fn=config.muon_adjust_lr_fn,
-                )
-            )
+            optimizers.append(finalize(muon_params, muon_factory))
         if adamw_params:
-            optimizers.append(
-                torch.optim.AdamW(
-                    adamw_params,
-                    lr=config.lr,
-                    weight_decay=config.weight_decay,
-                )
-            )
+            optimizers.append(finalize(adamw_params, adamw_factory))
         if not optimizers:
             raise ValueError("No trainable parameters found to optimize.")
         return optimizers

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -266,17 +266,35 @@ class Trainer:
                     f"Restored best_val_loss={self.best_val_loss:.6f} from checkpoint"
                 )
 
+    @property
+    def _fp32_master_mode(self) -> bool:
+        """Whether fp32 master weights are in effect for this run.
+
+        Always on for low-precision training (optimizer updates accumulate in
+        fp32 while compute stays in ``hidden_states_dtype``); a no-op when
+        training already runs in fp32.
+        """
+        return self.config.hidden_states_dtype != torch.float32
+
     def setup_model(self):
         # Verify model is compatible with training infrastructure
         SpeculatorModel.verify_training_compatible(self.model)
 
-        self.model.to(self.config.hidden_states_dtype)  # type: ignore[arg-type]
+        model_dtype = self.config.hidden_states_dtype
+        if self.is_distributed and self._fp32_master_mode:
+            # FSDP2 mixed precision: keep the sharded parameters (the
+            # optimizer's view) in fp32 master precision. Compute is unchanged:
+            # params are cast to hidden_states_dtype when all-gathered for
+            # forward/backward (see apply_fully_sharded's param_dtype).
+            model_dtype = torch.float32
+        self.model.to(model_dtype)  # type: ignore[arg-type]
         load_checkpoint = (
             self.resume_from_checkpoint and self.checkpointer.previous_epoch != -1
         )
 
         if not self.is_distributed:
-            # Single device case
+            # Single device case. In fp32-master mode the model stays in
+            # hidden_states_dtype; the masters live in FP32MasterOptimizer.
             self.model.to(self.local_rank)  # type: ignore[arg-type]
             if load_checkpoint:
                 self.checkpointer.load_model_state_dict(self.model)
@@ -288,7 +306,7 @@ class Trainer:
         if not load_checkpoint and dist.get_rank() == 0:
             full_state_dict = self.model.state_dict()
 
-        apply_fully_sharded(self.model)
+        apply_fully_sharded(self.model, param_dtype=self.config.hidden_states_dtype)
 
         if load_checkpoint:
             self.checkpointer.load_model_state_dict(self.model)
@@ -309,7 +327,13 @@ class Trainer:
     def setup_optimizer(self):
         # Setup optimizer(s). The "muon" option returns two optimizers (Muon for the
         # 2D weight matrices, AdamW for everything else); "adamw" returns a single one.
-        self.optimizers = build_optimizers(self.model, self.config)
+        # In fp32-master mode, distributed runs already hold fp32 sharded params
+        # (see setup_model), so only single-device runs need the wrapper.
+        self.optimizers = build_optimizers(
+            self.model,
+            self.config,
+            fp32_masters=self._fp32_master_mode and not self.is_distributed,
+        )
         last_epoch = -1
         if self.resume_from_checkpoint and self.checkpointer.previous_epoch != -1:
             self.checkpointer.load_optimizer_state_dict(self.model, self.optimizers)

--- a/tests/unit/train/test_fp32_master_optimizer.py
+++ b/tests/unit/train/test_fp32_master_optimizer.py
@@ -1,0 +1,280 @@
+"""Tests for fp32 master weight training.
+
+Covers:
+- FP32MasterOptimizer accumulates sub-bf16-ulp updates that pure-bf16 loses
+- param_groups sharing with the inner optimizer (LR scheduler compatibility)
+- zero_grad clears model param gradients
+- state_dict round-trip preserves fp32 masters bit-exactly
+- legacy (bare-optimizer) state dict loading
+- build_optimizers wrapping for adamw and muon modes
+- Trainer._fp32_master_mode gating
+- SingleGPUCheckpointer round-trip keeps optimizer state in fp32
+"""
+
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+from transformers import PretrainedConfig, PreTrainedModel
+from transformers.optimization import get_linear_schedule_with_warmup
+
+from speculators.train.checkpointer import SingleGPUCheckpointer
+from speculators.train.optimizers import FP32MasterOptimizer, build_optimizers
+from speculators.train.trainer import Trainer, TrainerConfig
+
+# bf16 has 8 mantissa bits: the spacing between representable values at 1.0.
+BF16_ULP_AT_ONE = 2**-8
+
+
+def make_config(**overrides) -> TrainerConfig:
+    return TrainerConfig(
+        lr=1e-4,
+        num_epochs=1,
+        save_path="checkpoint",
+        **overrides,
+    )
+
+
+def adamw_factory(named_params):
+    # weight_decay=0 keeps the constant-gradient update math exact: for a
+    # constant gradient, bias-corrected Adam moves each weight by exactly lr.
+    return torch.optim.AdamW(named_params, lr=1e-5, weight_decay=0.0)
+
+
+def make_bf16_linear(out_features: int = 4) -> nn.Linear:
+    torch.manual_seed(0)
+    linear = nn.Linear(4, out_features, bias=False).to(torch.bfloat16)
+    with torch.no_grad():
+        linear.weight.fill_(1.0)
+    return linear
+
+
+def run_constant_grad_steps(model: nn.Module, opt, num_steps: int):
+    for _ in range(num_steps):
+        opt.zero_grad()
+        for param in model.parameters():
+            param.grad = torch.ones_like(param)
+        opt.step()
+
+
+def test_fp32_masters_accumulate_sub_ulp_updates():
+    # Each AdamW step moves the weights by lr=1e-5, far below the bf16 ulp at
+    # 1.0 (~3.9e-3): a bare bf16 optimizer rounds every update away.
+    num_steps = 300
+    expected = 1.0 - num_steps * 1e-5  # 0.997
+
+    bare_model = make_bf16_linear()
+    bare_opt = adamw_factory(list(bare_model.named_parameters()))
+    run_constant_grad_steps(bare_model, bare_opt, num_steps)
+    assert torch.all(bare_model.weight == 1.0), (
+        "expected pure-bf16 AdamW to lose all sub-ulp updates"
+    )
+
+    master_model = make_bf16_linear()
+    master_opt = FP32MasterOptimizer(
+        list(master_model.named_parameters()), adamw_factory
+    )
+    run_constant_grad_steps(master_model, master_opt, num_steps)
+
+    masters = master_opt.state_dict()["fp32_masters"]
+    assert all(m.dtype == torch.float32 for m in masters)
+    assert torch.allclose(masters[0], torch.full_like(masters[0], expected), atol=1e-4)
+    # The bf16 params track the rounded masters and have visibly moved.
+    assert torch.all(
+        master_model.weight == torch.tensor(expected, dtype=torch.bfloat16)
+    )
+
+
+def test_wrapper_shares_param_groups_with_inner_for_schedulers():
+    model = make_bf16_linear()
+    opt = FP32MasterOptimizer(list(model.named_parameters()), adamw_factory)
+
+    assert isinstance(opt, torch.optim.Optimizer)
+    assert opt.param_groups is opt.inner.param_groups
+
+    scheduler = get_linear_schedule_with_warmup(
+        opt, num_warmup_steps=2, num_training_steps=10
+    )
+    # Warmup step 0: lr is scaled to 0; the inner optimizer must see it too.
+    assert opt.inner.param_groups[0]["lr"] == 0.0
+    run_constant_grad_steps(model, opt, 1)
+    scheduler.step()
+    assert opt.inner.param_groups[0]["lr"] == pytest.approx(1e-5 / 2)
+
+
+def test_zero_grad_clears_model_param_grads():
+    model = make_bf16_linear()
+    opt = FP32MasterOptimizer(list(model.named_parameters()), adamw_factory)
+
+    model.weight.grad = torch.ones_like(model.weight)
+    opt.zero_grad()
+    assert model.weight.grad is None
+
+
+def test_skips_frozen_params_and_requires_a_trainable_one():
+    model = nn.ModuleDict(
+        {"a": nn.Linear(4, 4, bias=False), "b": nn.Linear(4, 4, bias=False)}
+    ).to(torch.bfloat16)
+    model["b"].weight.requires_grad_(False)
+
+    opt = FP32MasterOptimizer(list(model.named_parameters()), adamw_factory)
+    assert len(opt.state_dict()["fp32_masters"]) == 1
+
+    model["a"].weight.requires_grad_(False)
+    with pytest.raises(ValueError, match="No trainable parameters"):
+        FP32MasterOptimizer(list(model.named_parameters()), adamw_factory)
+
+
+def test_state_dict_round_trip_preserves_masters_bit_exactly(tmp_path: Path):
+    model = make_bf16_linear()
+    opt = FP32MasterOptimizer(list(model.named_parameters()), adamw_factory)
+    run_constant_grad_steps(model, opt, 17)
+
+    payload_path = tmp_path / "opt.pt"
+    torch.save(opt.state_dict(), payload_path)
+    loaded = torch.load(payload_path, weights_only=True)
+
+    fresh_model = make_bf16_linear()
+    fresh_opt = FP32MasterOptimizer(list(fresh_model.named_parameters()), adamw_factory)
+    fresh_opt.load_state_dict(loaded)
+
+    original_masters = opt.state_dict()["fp32_masters"]
+    restored_masters = fresh_opt.state_dict()["fp32_masters"]
+    for original, restored in zip(original_masters, restored_masters, strict=True):
+        assert restored.dtype == torch.float32
+        assert torch.equal(original, restored)
+    # Model params are re-synced from the restored masters.
+    assert torch.equal(fresh_model.weight, model.weight)
+    # Inner AdamW moments are fp32 and restored.
+    exp_avg = next(iter(fresh_opt.inner.state.values()))["exp_avg"]
+    assert exp_avg.dtype == torch.float32
+    # param_groups stay shared after load_state_dict rebinds them.
+    assert fresh_opt.param_groups is fresh_opt.inner.param_groups
+
+
+def test_legacy_bare_optimizer_state_dict_loads():
+    model = make_bf16_linear()
+    bare_opt = adamw_factory(list(model.named_parameters()))
+    run_constant_grad_steps(model, bare_opt, 3)
+    legacy_state = bare_opt.state_dict()
+
+    fresh_model = make_bf16_linear()
+    wrapper = FP32MasterOptimizer(list(fresh_model.named_parameters()), adamw_factory)
+    wrapper.load_state_dict(legacy_state)
+
+    # torch casts the legacy (bf16) moments up to the masters' fp32.
+    exp_avg = next(iter(wrapper.inner.state.values()))["exp_avg"]
+    assert exp_avg.dtype == torch.float32
+
+
+def test_legacy_state_dict_mismatch_raises_actionable_error():
+    model = nn.ModuleDict(
+        {"a": nn.Linear(4, 4, bias=False), "b": nn.Linear(4, 4, bias=False)}
+    ).to(torch.bfloat16)
+    bare_opt = adamw_factory(list(model.named_parameters()))
+    legacy_state = bare_opt.state_dict()
+
+    model["b"].weight.requires_grad_(False)  # wrapper keeps only 1 of 2 params
+    wrapper = FP32MasterOptimizer(list(model.named_parameters()), adamw_factory)
+    with pytest.raises(ValueError, match="optimizer_state_dict.pt"):
+        wrapper.load_state_dict(legacy_state)
+
+
+def test_build_optimizers_wraps_adamw():
+    model = make_bf16_linear()
+    optimizers = build_optimizers(
+        model, make_config(optimizer="adamw"), fp32_masters=True
+    )
+    assert len(optimizers) == 1
+    assert isinstance(optimizers[0], FP32MasterOptimizer)
+    assert isinstance(optimizers[0].inner, torch.optim.AdamW)
+
+
+@pytest.mark.skipif(
+    not hasattr(torch.optim, "Muon"), reason="torch.optim.Muon not available"
+)
+def test_build_optimizers_wraps_muon_and_adamw_groups():
+    model = nn.ModuleDict(
+        {
+            "matrix": nn.Linear(4, 4, bias=True),  # 2D weight -> Muon, bias -> AdamW
+            "embed_tokens": nn.Embedding(8, 4),  # 2D but excluded from Muon
+        }
+    ).to(torch.bfloat16)
+    optimizers = build_optimizers(
+        model, make_config(optimizer="muon", muon_lr=1e-3), fp32_masters=True
+    )
+
+    assert len(optimizers) == 2
+    muon_opt, adamw_opt = optimizers
+    assert isinstance(muon_opt, FP32MasterOptimizer)
+    assert isinstance(muon_opt.inner, torch.optim.Muon)
+    assert len(muon_opt.state_dict()["fp32_masters"]) == 1
+    assert isinstance(adamw_opt, FP32MasterOptimizer)
+    assert isinstance(adamw_opt.inner, torch.optim.AdamW)
+    assert len(adamw_opt.state_dict()["fp32_masters"]) == 2  # bias + embedding
+
+
+@pytest.mark.parametrize(
+    ("hidden_states_dtype", "expected"),
+    [
+        (torch.bfloat16, True),
+        (torch.float16, True),
+        (torch.float32, False),  # already training in fp32; masters redundant
+    ],
+)
+def test_trainer_fp32_master_mode_gating(
+    hidden_states_dtype: torch.dtype, expected: bool
+):
+    trainer = Trainer.__new__(Trainer)
+    trainer.config = make_config(hidden_states_dtype=hidden_states_dtype)
+    assert trainer._fp32_master_mode is expected
+
+
+def test_missing_optimizer_state_resumes_fresh(tmp_path: Path):
+    # The legacy-mismatch error advises deleting optimizer_state_dict.pt; the
+    # loader must then no-op instead of crashing on the missing file.
+    (tmp_path / "0").mkdir()
+    checkpointer = SingleGPUCheckpointer(tmp_path)
+    checkpointer.previous_epoch = 0
+
+    model = make_bf16_linear()
+    opt = FP32MasterOptimizer(list(model.named_parameters()), adamw_factory)
+    checkpointer.load_optimizer_state_dict(model, [opt])  # no exception
+
+
+class TinyHFModel(PreTrainedModel):
+    config_class = PretrainedConfig
+
+    def __init__(self, config: PretrainedConfig):
+        super().__init__(config)
+        self.lin = nn.Linear(4, 4, bias=False)
+
+
+def test_single_gpu_checkpointer_round_trip_keeps_fp32_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    # get_current_device() falls back to "cuda:0" on accelerator-less machines.
+    monkeypatch.setattr(
+        "speculators.train.checkpointer.get_current_device", lambda: "cpu"
+    )
+    model = TinyHFModel(PretrainedConfig()).to(torch.bfloat16)
+    opt = FP32MasterOptimizer(list(model.named_parameters()), adamw_factory)
+    run_constant_grad_steps(model, opt, 5)
+    saved_masters = [m.clone() for m in opt.state_dict()["fp32_masters"]]
+
+    checkpointer = SingleGPUCheckpointer(tmp_path)
+    checkpointer.save_checkpoint(model, [opt], epoch=0)
+
+    # The optimizer payload must keep the masters in fp32 (no bf16 downcast).
+    payload = torch.load(checkpointer.optimizer_path(0), weights_only=True)
+    assert all(m.dtype == torch.float32 for m in payload["fp32_masters"])
+
+    fresh_model = TinyHFModel(PretrainedConfig()).to(torch.bfloat16)
+    fresh_opt = FP32MasterOptimizer(list(fresh_model.named_parameters()), adamw_factory)
+    checkpointer.previous_epoch = 0
+    checkpointer.load_optimizer_state_dict(fresh_model, [fresh_opt])
+
+    restored_masters = fresh_opt.state_dict()["fp32_masters"]
+    for saved, restored in zip(saved_masters, restored_masters, strict=True):
+        assert torch.equal(saved, restored)


### PR DESCRIPTION
## Human written explanation (see below for more verbose Clauded version)
All models trained with `speculators` end up with **untrained normalization layers** (`.weight == 1.0`). For example, in all RedHatAI's DFlash speculators for Qwen3-8B, gemma-4-31B-it, Laguna-XS.2 
  - layers.N.input_layernorm.weight 
  - layers.N.post_attention_layernorm.weight 
  - layers.N.self_attn.q_norm.weight
  - layers.N.self_attn.k_norm.weight 
  - hidden_norm.weight
  - norm.weight


are exactly equal to `1.0`. This is happening because our training is done fully in `bf16`. This is a problem for weights which start training from a "large value", in this case normalization layers start from `.weight = 1.0`. In bf16, the step to move away from 1.0 is quite large and therefore the weights are never updated as the gradient update delta is smaller than the step size to move away from 1.0 in bf16 format. This didn't affect linear layers that much because they start from much smaller random init values and the step size is smaller, therefore the gradient update can "move them".  

I already ran some ablations with a manual hacky fix for this and saw ~10-15% improvement:
<img width="738" height="594" alt="image" src="https://github.com/user-attachments/assets/6b16a22d-42ad-4a53-8561-a8c80e5aea6b" />

Don't merge this PR until I confirm that this clean integration also works well and doesn't break something else. 

## Clauded PR description
## TL;DR

Optimizer updates now accumulate in **fp32 master weights** instead of pure bf16. Forward/backward compute is unchanged (still bf16, bit-identical activations) — only the weights the optimizer steps on are fp32. Always on, no flag, matching SpecForge / TorchSpec / DeepSpec.

## Why

In pure-bf16 training, any weight update smaller than half a bf16 ulp (~0.2% relative) is rounded away at `optimizer.step()`. At typical LRs (`1e-4`–`1e-5`) a large fraction of per-step updates is sub-ulp and only survives when momentum happens to push it over the rounding threshold.

From the new test suite — 300 AdamW steps of `1e-5` updates on a weight of `1.0`:

| | final weight |
|---|---|
| pure bf16 (before) | `1.0` — every update lost |
| fp32 masters (after) | `bf16(0.997)` — all updates accumulated |

Every comparable trainer (SpecForge, TorchSpec, DeepSpec) hard-codes fp32 masters for this reason.

## How it works

Two mechanisms, one internal switch (`Trainer._fp32_master_mode` — on for bf16/fp16, skipped when already training in fp32):

| Path | Mechanism |
|---|---|
| **FSDP2 (torchrun)** | Model kept in fp32 before sharding; `apply_fully_sharded` gains a `param_dtype` (compute dtype, default bf16). FSDP2 casts params to bf16 at all-gather → compute unchanged, but sharded params, gradients (`reduce_dtype` was already fp32), grad clipping, and Muon/AdamW moments are all fp32. No wrapper; composes with Muon-on-DTensor and `get_optimizer_state_dict` as-is. |
| **Single GPU** | New `FP32MasterOptimizer` wrapper (`train/optimizers.py`): bf16 model params + fp32 masters of trainable params. Each step: copy bf16 grads → fp32, step inner Muon/AdamW on masters, write downcast result back. Shares `param_groups` with the inner optimizer, so existing LR schedulers work unchanged. Masters only for `requires_grad` params — no fp32 copies of frozen embeddings / verifier lm_head. |

### Checkpointing (`train/checkpointer.py`)

Required so resume doesn't silently defeat the masters:

- Optimizer state is saved in **native dtypes** (no more bf16 downcast). No-op for old pure-bf16 checkpoints.
- Distributed checkpoints embed the fp32 trainable params in the optimizer payload → resume restores exact masters, while **`model.safetensors` stays bf16 and vLLM-deployable**.
- `FP32MasterOptimizer.state_dict()` embeds its masters; round-trip is bit-exact.
- Missing `optimizer_state_dict.pt` now warns + resumes with fresh optimizer state (matches scheduler-loader behavior).

## ⚠️ Compatibility notes

- **Optimizer checkpoints are ~2× larger** (fp32 masters + moments). Old checkpoints still load; bf16 state is upcast on load.
- **Legacy single-GPU `--optimizer adamw` checkpoints** have a different param grouping and can't load into the wrapper — the error message says to delete `optimizer_state_dict.pt` and resume from model weights. Default `muon` checkpoints resume cleanly.
- Optimizer-side GPU memory roughly doubles (sharded across ranks under FSDP2). Activation memory unchanged.

## Testing

- ✅ New `tests/unit/train/test_fp32_master_optimizer.py` — 15 tests: sub-ulp accumulation, scheduler integration, bit-exact checkpoint round-trip, legacy loads (compatible + mismatched), Muon/AdamW group wrapping, frozen-param filtering, dtype gating, missing-file resume.
- ✅ Full `tests/unit`: **437 passed**, 7 skipped (CUDA/multi-GPU).
- ✅ ruff check/format clean.
  