### PR TITLE
feat(mtp): implement QueryOnlyGemma2Attention for Gemma4 MTP draft models

### DIFF
--- a/src/speculators/models/base_components.py
+++ b/src/speculators/models/base_components.py
@@ -12,12 +12,14 @@ from transformers.models.qwen3.modeling_qwen3 import (
     Qwen3RMSNorm,
     Qwen3RotaryEmbedding,
 )
+HAS_GEMMA2 = False
 try:
     from transformers.models.gemma2.modeling_gemma2 import (
         Gemma2DecoderLayer,
         Gemma2RMSNorm,
         Gemma2RotaryEmbedding,
     )
+    HAS_GEMMA2 = True
 except ImportError:
     pass
 
@@ -59,15 +61,13 @@ model_classes: dict[str, ModelComponents] = {
     ),
 }
 
-try:
+if HAS_GEMMA2:
     model_classes["gemma2"] = ModelComponents(
         Gemma2DecoderLayer,
         Gemma2DecoderLayer,
         Gemma2RMSNorm,
         Gemma2RotaryEmbedding,
     )
-except NameError:
-    pass
 
 try:
     from transformers.models.qwen3_next.modeling_qwen3_next import (

--- a/src/speculators/models/base_components.py
+++ b/src/speculators/models/base_components.py
@@ -12,6 +12,14 @@ from transformers.models.qwen3.modeling_qwen3 import (
     Qwen3RMSNorm,
     Qwen3RotaryEmbedding,
 )
+try:
+    from transformers.models.gemma2.modeling_gemma2 import (
+        Gemma2DecoderLayer,
+        Gemma2RMSNorm,
+        Gemma2RotaryEmbedding,
+    )
+except ImportError:
+    pass
 
 
 class ModelComponents(NamedTuple):
@@ -50,6 +58,16 @@ model_classes: dict[str, ModelComponents] = {
         Qwen3RotaryEmbedding,
     ),
 }
+
+try:
+    model_classes["gemma2"] = ModelComponents(
+        Gemma2DecoderLayer,
+        Gemma2DecoderLayer,
+        Gemma2RMSNorm,
+        Gemma2RotaryEmbedding,
+    )
+except NameError:
+    pass
 
 try:
     from transformers.models.qwen3_next.modeling_qwen3_next import (

--- a/src/speculators/models/mtp/config.py
+++ b/src/speculators/models/mtp/config.py
@@ -2,6 +2,7 @@
 
 from typing import Any, Literal
 
+import pydantic
 from pydantic import Field, field_serializer, field_validator
 from transformers import AutoConfig, PretrainedConfig
 from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
@@ -52,6 +53,29 @@ class MTPSpeculatorConfig(SpeculatorModelConfig):
         ),
     )
 
+    num_centroids: int | None = Field(
+        default=None,
+        description=(
+            "Number of centroids for a centroid-masked multi-level LM head. "
+            "If None, standard flat LM head is used."
+        ),
+    )
+
+    centroid_intermediate_top_k: int = Field(
+        default=32,
+        description="Number of top centroids to select during multi-level LM head decoding.",
+    )
+
+    @pydantic.model_validator(mode="after")
+    def validate_centroids(self) -> "MTPSpeculatorConfig":
+        if self.num_centroids is not None:
+            if self.num_centroids < 1:
+                raise ValueError(f"num_centroids must be >= 1, got {self.num_centroids}")
+            if self.vocab_size % self.num_centroids != 0:
+                raise ValueError(f"vocab_size ({self.vocab_size}) must be divisible by num_centroids ({self.num_centroids})")
+            if self.centroid_intermediate_top_k > self.num_centroids:
+                raise ValueError(f"centroid_intermediate_top_k ({self.centroid_intermediate_top_k}) cannot exceed num_centroids ({self.num_centroids})")
+        return self
     @property
     def hidden_size(self) -> int:
         return self.transformer_layer_config.hidden_size  # type: ignore[return-value]

--- a/src/speculators/models/mtp/config.py
+++ b/src/speculators/models/mtp/config.py
@@ -52,18 +52,6 @@ class MTPSpeculatorConfig(SpeculatorModelConfig):
         ),
     )
 
-    num_centroids: int | None = Field(
-        default=None,
-        description=(
-            "Number of centroids for a centroid-masked multi-level LM head. "
-            "If None, standard flat LM head is used."
-        ),
-    )
-
-    top_k_centroids: int = Field(
-        default=32,
-        description="Number of top centroids to select during multi-level LM head decoding.",
-    )
 
     @property
     def hidden_size(self) -> int:

--- a/src/speculators/models/mtp/config.py
+++ b/src/speculators/models/mtp/config.py
@@ -52,7 +52,6 @@ class MTPSpeculatorConfig(SpeculatorModelConfig):
         ),
     )
 
-
     @property
     def hidden_size(self) -> int:
         return self.transformer_layer_config.hidden_size  # type: ignore[return-value]

--- a/src/speculators/models/mtp/config.py
+++ b/src/speculators/models/mtp/config.py
@@ -52,6 +52,19 @@ class MTPSpeculatorConfig(SpeculatorModelConfig):
         ),
     )
 
+    num_centroids: int | None = Field(
+        default=None,
+        description=(
+            "Number of centroids for a centroid-masked multi-level LM head. "
+            "If None, standard flat LM head is used."
+        ),
+    )
+
+    top_k_centroids: int = Field(
+        default=32,
+        description="Number of top centroids to select during multi-level LM head decoding.",
+    )
+
     @property
     def hidden_size(self) -> int:
         return self.transformer_layer_config.hidden_size  # type: ignore[return-value]

--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -212,6 +212,8 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
                 attention_mask=causal_mask,
                 position_ids=step_pos_ids,
                 position_embeddings=step_pos_emb,
+                verifier_kv_last_local=kwargs.get("verifier_kv_last_local"),
+                verifier_kv_last_global=kwargs.get("verifier_kv_last_global"),
             )
 
             logits = self.lm_head(mtp_output)

--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -63,6 +63,8 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
         "verifier_lm_head.weight",
         "t2d",
         "d2t",
+        "masked_embedding.centroids.weight",
+        "masked_embedding.token_ordering",
     ]
 
     t2d: torch.Tensor | None
@@ -86,6 +88,17 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
         self.rotary_emb = self._model_definitions.rotary_emb_class(tc)
 
         self.post_init()
+
+        if getattr(self.config, "num_centroids", None) is not None:
+            from speculators.models.mtp.head import MultiLevelLMHead
+
+            self.masked_embedding = MultiLevelLMHead(
+                hidden_size=tc.hidden_size,
+                vocab_size=tc.vocab_size,
+                num_centroids=self.config.num_centroids,
+            )
+        else:
+            self.masked_embedding = None
 
     @property
     def layers(self) -> nn.ModuleList:
@@ -208,12 +221,20 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
                 step_targets = step_targets.clone()
                 step_targets[step_mask == 0] = _IGNORE_INDEX
             weight = step_weights[step] if step_weights is not None else 1.0
+
             unreduced = nn.functional.cross_entropy(
                 logits.permute(0, 2, 1),
                 step_targets,
                 ignore_index=_IGNORE_INDEX,
                 reduction="none",
             )
+
+            if getattr(self, "masked_embedding", None) is not None:
+                unreduced += self.masked_embedding.compute_centroid_loss(
+                    hidden_states=mtp_output,
+                    targets=step_targets,
+                    ignore_index=_IGNORE_INDEX,
+                )
             valid_count = (step_targets != _IGNORE_INDEX).sum()
             step_loss = weight * unreduced.sum() / valid_count.clamp(min=1)
             total_loss = total_loss + step_loss

--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -65,6 +65,7 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
         "d2t",
         "masked_embedding.centroids.weight",
         "masked_embedding.token_ordering",
+        "masked_embedding.token_ordering_inv",
     ]
 
     t2d: torch.Tensor | None

--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -69,6 +69,7 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
 
     t2d: torch.Tensor | None
     d2t: torch.Tensor | None
+    masked_embedding: nn.Module | None
 
     def __init__(self, config: MTPSpeculatorConfig) -> None:
         if config.transformer_layer_config._attn_implementation is None:  # noqa: SLF001
@@ -230,7 +231,7 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
             )
 
             if getattr(self, "masked_embedding", None) is not None:
-                unreduced += self.masked_embedding.compute_centroid_loss(
+                unreduced = unreduced + self.masked_embedding.compute_centroid_loss(
                     hidden_states=mtp_output,
                     targets=step_targets,
                     ignore_index=_IGNORE_INDEX,

--- a/src/speculators/models/mtp/head.py
+++ b/src/speculators/models/mtp/head.py
@@ -19,7 +19,7 @@ class MultiLevelLMHead(nn.Module):
         self.centroids = nn.Linear(hidden_size, num_centroids, bias=False)
         # Token ordering mapping (centroid subsets -> token IDs)
         self.register_buffer("token_ordering", torch.arange(vocab_size, dtype=torch.long))
-        self.register_buffer("token_ordering_inv", torch.empty_like(self.token_ordering))
+        self.register_buffer("token_ordering_inv", torch.empty_like(self.token_ordering), persistent=False)
         self._rebuild_inverse()
 
     def _rebuild_inverse(self) -> None:

--- a/src/speculators/models/mtp/head.py
+++ b/src/speculators/models/mtp/head.py
@@ -10,10 +10,22 @@ class MultiLevelLMHead(nn.Module):
 
     def __init__(self, hidden_size: int, vocab_size: int, num_centroids: int):
         super().__init__()
+        if num_centroids <= 0:
+            raise ValueError(f"num_centroids must be positive, got {num_centroids}.")
+        if vocab_size % num_centroids != 0:
+            raise ValueError(f"vocab_size ({vocab_size}) must be divisible by num_centroids ({num_centroids}).")
+        
         self.tokens_per_centroid = vocab_size // num_centroids
         self.centroids = nn.Linear(hidden_size, num_centroids, bias=False)
         # Token ordering mapping (centroid subsets -> token IDs)
         self.register_buffer("token_ordering", torch.arange(vocab_size, dtype=torch.long))
+        self.register_buffer("token_ordering_inv", torch.empty_like(self.token_ordering))
+        self._rebuild_inverse()
+
+    def _rebuild_inverse(self) -> None:
+        """Rebuild the cached inverse mapping from token IDs to centroid IDs."""
+        positions = torch.arange(self.token_ordering.shape[0], device=self.token_ordering.device)
+        self.token_ordering_inv[self.token_ordering] = positions // self.tokens_per_centroid
 
     def compute_centroid_loss(
         self, hidden_states: torch.Tensor, targets: torch.Tensor, ignore_index: int = -100
@@ -27,13 +39,9 @@ class MultiLevelLMHead(nn.Module):
         if valid_hidden.shape[0] == 0:
             return loss
 
-        # Inverse mapping: token_id -> centroid_id
-        inverse = torch.empty_like(self.token_ordering)
-        positions = torch.arange(self.token_ordering.shape[0], device=self.token_ordering.device)
-        inverse[self.token_ordering] = positions // self.tokens_per_centroid
-        
         centroid_logits = self.centroids(valid_hidden)
-        target_centroids = inverse[valid_targets]
-        loss[valid_mask] = F.cross_entropy(centroid_logits, target_centroids, reduction="none")
+        target_centroids = self.token_ordering_inv[valid_targets]
+        valid_loss = F.cross_entropy(centroid_logits, target_centroids, reduction="none")
         
+        loss = loss.masked_scatter(valid_mask, valid_loss.to(loss.dtype))
         return loss

--- a/src/speculators/models/mtp/head.py
+++ b/src/speculators/models/mtp/head.py
@@ -1,0 +1,39 @@
+"""Multi-level LM head for Gemma4 MTP."""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+class MultiLevelLMHead(nn.Module):
+    """Auxiliary centroid projection for Gemma4 MTP."""
+
+    def __init__(self, hidden_size: int, vocab_size: int, num_centroids: int):
+        super().__init__()
+        self.tokens_per_centroid = vocab_size // num_centroids
+        self.centroids = nn.Linear(hidden_size, num_centroids, bias=False)
+        # Token ordering mapping (centroid subsets -> token IDs)
+        self.register_buffer("token_ordering", torch.arange(vocab_size, dtype=torch.long))
+
+    def compute_centroid_loss(
+        self, hidden_states: torch.Tensor, targets: torch.Tensor, ignore_index: int = -100
+    ) -> torch.Tensor:
+        """Compute the unreduced centroid cross-entropy loss."""
+        valid_mask = targets != ignore_index
+        valid_hidden = hidden_states[valid_mask]
+        valid_targets = targets[valid_mask]
+
+        loss = torch.zeros_like(targets, dtype=hidden_states.dtype)
+        if valid_hidden.shape[0] == 0:
+            return loss
+
+        # Inverse mapping: token_id -> centroid_id
+        inverse = torch.empty_like(self.token_ordering)
+        positions = torch.arange(self.token_ordering.shape[0], device=self.token_ordering.device)
+        inverse[self.token_ordering] = positions // self.tokens_per_centroid
+        
+        centroid_logits = self.centroids(valid_hidden)
+        target_centroids = inverse[valid_targets]
+        loss[valid_mask] = F.cross_entropy(centroid_logits, target_centroids, reduction="none")
+        
+        return loss

--- a/src/speculators/models/mtp/model_definitions.py
+++ b/src/speculators/models/mtp/model_definitions.py
@@ -264,6 +264,14 @@ if "gemma2" in base_components.model_classes:
             if getattr(self.config, "_attn_implementation", "eager") != "eager":
                 attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
 
+            # In eager mode, sliding_window is often dropped by the interface.
+            # We enforce it directly onto the causal mask here if configured.
+            if self.sliding_window is not None and self.sliding_window > 0 and attention_mask is not None:
+                seq_len = attention_mask.shape[-1]
+                window_mask = torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool, device=attention_mask.device))
+                window_mask = torch.triu(window_mask, diagonal=-self.sliding_window + 1)
+                attention_mask = attention_mask.masked_fill(~window_mask.view(1, 1, seq_len, seq_len), torch.finfo(query_states.dtype).min)
+
             attn_output, attn_weights = attention_interface(
                 self,
                 query_states,
@@ -272,7 +280,6 @@ if "gemma2" in base_components.model_classes:
                 attention_mask,
                 dropout=self.attention_dropout if self.training else 0.0,
                 scaling=self.scaling,
-                sliding_window=self.sliding_window,
                 softcap=self.attn_logit_softcapping,
                 **kwargs,
             )

--- a/src/speculators/models/mtp/model_definitions.py
+++ b/src/speculators/models/mtp/model_definitions.py
@@ -245,13 +245,13 @@ if "gemma2" in base_components.model_classes:
                 # Fallback to zeros if not provided (e.g. dummy forward passes)
                 batch_sz, seq_len = input_shape
                 kv_tensor = torch.zeros(
-                    (batch_sz, seq_len, 2, self.num_key_value_heads, self.head_dim),
+                    (batch_sz, seq_len, 2, self.config.num_key_value_heads, self.head_dim),
                     dtype=query_states.dtype,
                     device=query_states.device
                 )
             elif kv_tensor.dim() == 3:
                 batch_sz, seq_len, _ = kv_tensor.shape
-                kv_tensor = kv_tensor.view(batch_sz, seq_len, 2, self.num_key_value_heads, self.head_dim)
+                kv_tensor = kv_tensor.view(batch_sz, seq_len, 2, self.config.num_key_value_heads, self.head_dim)
 
             key_states = kv_tensor[..., 0, :, :].transpose(1, 2)
             value_states = kv_tensor[..., 1, :, :].transpose(1, 2)

--- a/src/speculators/models/mtp/model_definitions.py
+++ b/src/speculators/models/mtp/model_definitions.py
@@ -203,3 +203,91 @@ if "qwen3_5_moe_text" in base_components.model_classes:
     mtp_model_classes["qwen3_5_moe_text"] = base_components.override_components(
         "qwen3_5_moe_text", first_layer_class=Qwen35MoeMTPLayer
     )
+
+if "gemma2" in base_components.model_classes:
+    from typing import Optional, Tuple, Any
+    from transformers.models.gemma2.modeling_gemma2 import (
+        Gemma2DecoderLayer,
+        Gemma2RMSNorm,
+        Gemma2Attention,
+        apply_rotary_pos_emb,
+        eager_attention_forward,
+        ALL_ATTENTION_FUNCTIONS
+    )
+
+    class QueryOnlyGemma2Attention(Gemma2Attention):
+        def __init__(self, config, layer_idx: Optional[int] = None):
+            super().__init__(config, layer_idx)
+            # Strip out K/V projections since we use verifier's KV cache
+            self.k_proj = None
+            self.v_proj = None
+
+        def forward(
+            self,
+            hidden_states: torch.Tensor,
+            position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+            attention_mask: Optional[torch.Tensor],
+            past_key_values: Optional[Any] = None,
+            cache_position: Optional[torch.LongTensor] = None,
+            verifier_kv_last_local: Optional[torch.Tensor] = None,
+            verifier_kv_last_global: Optional[torch.Tensor] = None,
+            **kwargs: Any,
+        ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+            input_shape = hidden_states.shape[:-1]
+            hidden_shape = (*input_shape, -1, self.head_dim)
+
+            query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+            is_local = (self.sliding_window is not None and self.sliding_window > 0)
+            kv_tensor = verifier_kv_last_local if is_local else verifier_kv_last_global
+
+            if kv_tensor is None:
+                # Fallback to zeros if not provided (e.g. dummy forward passes)
+                batch_sz, seq_len = input_shape
+                kv_tensor = torch.zeros(
+                    (batch_sz, seq_len, 2, self.num_key_value_heads, self.head_dim),
+                    dtype=query_states.dtype,
+                    device=query_states.device
+                )
+            elif kv_tensor.dim() == 3:
+                batch_sz, seq_len, _ = kv_tensor.shape
+                kv_tensor = kv_tensor.view(batch_sz, seq_len, 2, self.num_key_value_heads, self.head_dim)
+
+            key_states = kv_tensor[..., 0, :, :].transpose(1, 2)
+            value_states = kv_tensor[..., 1, :, :].transpose(1, 2)
+
+            cos, sin = position_embeddings
+            # Only apply RoPE to queries; verifier's KV cache already has RoPE applied
+            query_states, _ = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+            attention_interface = eager_attention_forward
+            if getattr(self.config, "_attn_implementation", "eager") != "eager":
+                attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+            attn_output, attn_weights = attention_interface(
+                self,
+                query_states,
+                key_states,
+                value_states,
+                attention_mask,
+                dropout=self.attention_dropout if self.training else 0.0,
+                scaling=self.scaling,
+                sliding_window=self.sliding_window,
+                softcap=self.attn_logit_softcapping,
+                **kwargs,
+            )
+
+            attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+            attn_output = self.o_proj(attn_output)
+            return attn_output, attn_weights
+
+    class Gemma2MTPLayer(MTPLayerMixin, Gemma2DecoderLayer):
+        def __init__(self, config: PretrainedConfig, layer_idx: int = 0) -> None:
+            super().__init__(config, layer_idx)
+            self._setup_mtp_modules(config, Gemma2RMSNorm)
+            # Replace the standard attention with query-only attention
+            self.self_attn = QueryOnlyGemma2Attention(config, layer_idx)
+
+    mtp_model_classes["gemma2"] = base_components.override_components(
+        "gemma2", first_layer_class=Gemma2MTPLayer
+    )

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -58,7 +58,7 @@ StandardizeFnSig = Callable[[dict[str, Any]], dict[str, Any]]
 
 
 def create_empty_sample(
-    hidden_size: int, num_target_layers: int = 3, dtype: torch.dtype = torch.bfloat16
+    hidden_size: int, num_target_layers: int = 3, dtype: torch.dtype = torch.bfloat16, kv_feature_dim: int = 0
 ):
     # data structure: {
     #     "hidden_states": [seq_len, num_target_layers * hidden_size],
@@ -79,8 +79,8 @@ def create_empty_sample(
         "hidden_states": torch.empty(0, num_target_layers * hidden_size, dtype=dtype),
         "input_ids": torch.empty(0, dtype=torch.long),
         "verifier_last_hidden_states": torch.empty(0, hidden_size, dtype=dtype),
-        "verifier_kv_last_local": torch.empty(0, dtype=dtype),
-        "verifier_kv_last_global": torch.empty(0, dtype=dtype),
+        "verifier_kv_last_local": torch.empty(0, kv_feature_dim, dtype=dtype) if kv_feature_dim > 0 else torch.empty(0, dtype=dtype),
+        "verifier_kv_last_global": torch.empty(0, kv_feature_dim, dtype=dtype) if kv_feature_dim > 0 else torch.empty(0, dtype=dtype),
         "loss_mask": torch.empty(0, dtype=torch.bool),
         "lengths": torch.tensor([0], dtype=torch.long),
         "position_ids": torch.arange(0, dtype=torch.long),
@@ -484,6 +484,7 @@ def create_collate_fn(
     num_target_layers: int = 3,
     dtype: torch.dtype = torch.bfloat16,
     preprocess: Callable[[BatchType], BatchType] | None = None,
+    kv_feature_dim: int = 0,
 ):
     def collate_fn(batch: list[BatchType | None]) -> BatchType:
         # Apply per-sample preprocessing and filter failed samples
@@ -495,7 +496,7 @@ def create_collate_fn(
             # Match the configured `dtype` so the placeholder doesn't crash
             # downstream layers loaded at a different precision (e.g. bf16
             # weights vs fp32 default placeholders).
-            empty = create_empty_sample(hidden_size, num_target_layers, dtype=dtype)
+            empty = create_empty_sample(hidden_size, num_target_layers, dtype=dtype, kv_feature_dim=kv_feature_dim)
             if preprocess:
                 empty = preprocess(empty)
             batch = [empty]

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -64,6 +64,8 @@ def create_empty_sample(
     #     "hidden_states": [seq_len, num_target_layers * hidden_size],
     #     "input_ids": [seq_len],
     #     "verifier_last_hidden_states": [seq_len, hidden_size],
+    #     "verifier_kv_last_local": [seq_len, ...],
+    #     "verifier_kv_last_global": [seq_len, ...],
     #     "loss_mask": [seq_len],
     #     "lengths": [1],
     #     "position_ids": [seq_len],
@@ -179,6 +181,8 @@ class BaseDataset(Dataset):
         #  "hidden_states": [seq_len, 3 * hidden_size],
         #  "input_ids": [seq_len],
         #  "verifier_last_hidden_states": [seq_len, hidden_size],
+        #  "verifier_kv_last_local": [seq_len, ...],
+        #  "verifier_kv_last_global": [seq_len, ...],
         #  "loss_mask": [seq_len],
         # }
 
@@ -195,6 +199,8 @@ class BaseDataset(Dataset):
         #     "hidden_states": [seq_len, 3 * hidden_size],
         #     "input_ids": [seq_len],
         #     "verifier_last_hidden_states": [seq_len, hidden_size],
+        #     "verifier_kv_last_local": [seq_len, ...],
+        #     "verifier_kv_last_global": [seq_len, ...],
         #     "loss_mask": [seq_len],
         #     "lengths": [1],
         #     "position_ids": [seq_len],

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -500,20 +500,35 @@ def create_collate_fn(
                 empty = preprocess(empty)
             batch = [empty]
 
+        all_keys = set()
+        for b in batch:
+            all_keys.update(b.keys())
+
         collated_data = {}
-        for key in batch[0]:  # type: ignore[union-attr]
+        for key in all_keys:
             if key == "lengths":
-                collated_data[key] = torch.cat([b[key] for b in batch], dim=0)  # type: ignore[index]
+                collated_data[key] = torch.cat([b[key] for b in batch if key in b], dim=0)
                 continue
+            
+            # Find the first sample that actually has this key to use as a template
+            template = next(b[key] for b in batch if key in b)
+            # Apply dtype casting for hidden states and KV caches
+            buffer_dtype = dtype if ("hidden_states" in key or "verifier_kv" in key) else template.dtype
+            
             # one copy per sample: preallocated buffer, hidden states cast during write
-            first = batch[0][key]  # type: ignore[index]
-            buffer_dtype = dtype if ("hidden_states" in key or "verifier_kv" in key) else first.dtype
             out = torch.zeros(
-                (max_len, *first.shape[1:]), dtype=buffer_dtype, device=first.device
+                (max_len, *template.shape[1:]), dtype=buffer_dtype, device=template.device
             )
             offset = 0
             for b in batch:
-                tensor = b[key]  # type: ignore[index]
+                if key in b:
+                    tensor = b[key]
+                else:
+                    # If this sample is missing the key, pad with zeros matching its sequence length
+                    seq_len = b["input_ids"].shape[0] if "input_ids" in b else 0
+                    dummy_shape = (seq_len,) + template.shape[1:]
+                    tensor = torch.zeros(dummy_shape, dtype=buffer_dtype, device=template.device)
+
                 num_rows = min(tensor.shape[0], max_len - offset)
                 out[offset : offset + num_rows] = tensor[:num_rows]
                 offset += num_rows

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -190,7 +190,6 @@ class BaseDataset(Dataset):
         #  "loss_mask": [seq_len],
         # }
 
-
         # Add lengths tensor
         seq_len = data["input_ids"].shape[0]
         data["lengths"] = torch.tensor([seq_len], dtype=torch.long)

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -106,10 +106,14 @@ def standardize_data_v1(data: dict[str, Any]) -> dict[str, Any]:
         "verifier_last_hidden_states": data["hidden_states"][-1],
         "loss_mask": data["loss_mask"],
     }
-    if "verifier_kv_last_local" in data:
-        res["verifier_kv_last_local"] = data["verifier_kv_last_local"]
-    if "verifier_kv_last_global" in data:
-        res["verifier_kv_last_global"] = data["verifier_kv_last_global"]
+    if "kv_last_local_k" in data and "kv_last_local_v" in data:
+        res["verifier_kv_last_local"] = torch.stack(
+            [data["kv_last_local_k"], data["kv_last_local_v"]], dim=1
+        )
+    if "kv_last_global_k" in data and "kv_last_global_v" in data:
+        res["verifier_kv_last_global"] = torch.stack(
+            [data["kv_last_global_k"], data["kv_last_global_v"]], dim=1
+        )
     return res
 
 

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -77,6 +77,8 @@ def create_empty_sample(
         "hidden_states": torch.empty(0, num_target_layers * hidden_size, dtype=dtype),
         "input_ids": torch.empty(0, dtype=torch.long),
         "verifier_last_hidden_states": torch.empty(0, hidden_size, dtype=dtype),
+        "verifier_kv_last_local": torch.empty(0, dtype=dtype),
+        "verifier_kv_last_global": torch.empty(0, dtype=dtype),
         "loss_mask": torch.empty(0, dtype=torch.bool),
         "lengths": torch.tensor([0], dtype=torch.long),
         "position_ids": torch.arange(0, dtype=torch.long),
@@ -96,12 +98,17 @@ def standardize_data_v1(data: dict[str, Any]) -> dict[str, Any]:
     #  ],
     # }
 
-    return {
+    res = {
         "hidden_states": torch.cat(data["hidden_states"][:-1], dim=-1),
         "input_ids": data["input_ids"],
         "verifier_last_hidden_states": data["hidden_states"][-1],
         "loss_mask": data["loss_mask"],
     }
+    if "verifier_kv_last_local" in data:
+        res["verifier_kv_last_local"] = data["verifier_kv_last_local"]
+    if "verifier_kv_last_global" in data:
+        res["verifier_kv_last_global"] = data["verifier_kv_last_global"]
+    return res
 
 
 def _has_multimodal_content(messages: list[dict]) -> bool:
@@ -174,6 +181,7 @@ class BaseDataset(Dataset):
         #  "verifier_last_hidden_states": [seq_len, hidden_size],
         #  "loss_mask": [seq_len],
         # }
+
 
         # Add lengths tensor
         seq_len = data["input_ids"].shape[0]
@@ -343,7 +351,7 @@ class ArrowDataset(BaseDataset):
             )
             return None
 
-        return {
+        res = {
             "hidden_states": loaded_hs["hidden_states"][:, :-1].flatten(
                 1
             ),  # [seq_len, 3 * hidden_size]
@@ -353,6 +361,11 @@ class ArrowDataset(BaseDataset):
             ],  # [seq_len, hidden_size]
             "loss_mask": self.data[index]["loss_mask"],  # [seq_len]
         }
+        if "verifier_kv_last_local" in loaded_hs:
+            res["verifier_kv_last_local"] = loaded_hs["verifier_kv_last_local"]
+        if "verifier_kv_last_global" in loaded_hs:
+            res["verifier_kv_last_global"] = loaded_hs["verifier_kv_last_global"]
+        return res
 
 
 class SampleFileDataset(BaseDataset):
@@ -481,7 +494,7 @@ def create_collate_fn(
                 continue
             # one copy per sample: preallocated buffer, hidden states cast during write
             first = batch[0][key]  # type: ignore[index]
-            buffer_dtype = dtype if "hidden_states" in key else first.dtype
+            buffer_dtype = dtype if ("hidden_states" in key or "verifier_kv" in key) else first.dtype
             out = torch.zeros(
                 (max_len, *first.shape[1:]), dtype=buffer_dtype, device=first.device
             )

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -371,10 +371,14 @@ class ArrowDataset(BaseDataset):
             ],  # [seq_len, hidden_size]
             "loss_mask": self.data[index]["loss_mask"],  # [seq_len]
         }
-        if "verifier_kv_last_local" in loaded_hs:
-            res["verifier_kv_last_local"] = loaded_hs["verifier_kv_last_local"]
-        if "verifier_kv_last_global" in loaded_hs:
-            res["verifier_kv_last_global"] = loaded_hs["verifier_kv_last_global"]
+        if "kv_last_local_k" in loaded_hs and "kv_last_local_v" in loaded_hs:
+            res["verifier_kv_last_local"] = torch.stack(
+                [loaded_hs["kv_last_local_k"], loaded_hs["kv_last_local_v"]], dim=1
+            )
+        if "kv_last_global_k" in loaded_hs and "kv_last_global_v" in loaded_hs:
+            res["verifier_kv_last_global"] = torch.stack(
+                [loaded_hs["kv_last_global_k"], loaded_hs["kv_last_global_v"]], dim=1
+            )
         return res
 
 

--- a/src/speculators/utils/pydantic_utils.py
+++ b/src/speculators/utils/pydantic_utils.py
@@ -11,6 +11,8 @@ Classes:
         a discriminator field
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 

--- a/src/speculators/utils/registry.py
+++ b/src/speculators/utils/registry.py
@@ -16,8 +16,12 @@ Classes:
         auto-discovery enabled by default
 """
 
-from collections.abc import Callable
-from typing import Any, ClassVar
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 __all__ = ["ClassRegistryMixin"]
 

--- a/tests/unit/models/test_mtp_gemma2.py
+++ b/tests/unit/models/test_mtp_gemma2.py
@@ -2,7 +2,7 @@
 
 import pytest
 import torch
-from transformers import PretrainedConfig
+from transformers.models.gemma2.configuration_gemma2 import Gemma2Config
 
 from speculators.models.base_components import model_classes
 from speculators.models.mtp.model_definitions import mtp_model_classes
@@ -15,22 +15,20 @@ from speculators.models.mtp.model_definitions import QueryOnlyGemma2Attention
 
 @pytest.fixture
 def gemma2_config():
-    config = PretrainedConfig(
+    config = Gemma2Config(
         hidden_size=64,
         num_attention_heads=4,
         num_key_value_heads=2,
         head_dim=16,
         attention_bias=False,
         attention_dropout=0.0,
-        _attn_implementation="eager"
     )
-    # Mock some Gemma2 specific attrs
+    # Mock some Gemma2 specific attrs that we override
+    config._attn_implementation = "eager"
     config.sliding_window = 4096
     config.query_pre_attn_scalar = 224
-    config.hidden_size = 64
-    config.num_attention_heads = 4
-    config.num_key_value_heads = 2
-    config.head_dim = 16
+    config.attn_logit_softcapping = 50.0
+    config.layer_types = ["sliding_attention"]
     return config
 
 
@@ -45,23 +43,45 @@ def test_query_only_gemma2_attention_local_kv(gemma2_config):
     local_kv = torch.randn(batch_sz, seq_len, 2, 2, 16)
     global_kv = torch.randn(batch_sz, seq_len, 2, 2, 16)
     
-    # Mock position embeddings (cos, sin)
-    cos = torch.randn(1, 1, seq_len, 16)
-    sin = torch.randn(1, 1, seq_len, 16)
+    # Mock position embeddings (cos, sin) - shape [batch, seq_len, head_dim]
+    cos = torch.randn(batch_sz, seq_len, 16)
+    sin = torch.randn(batch_sz, seq_len, 16)
     
-    output, _ = attn(
+    output1, _ = attn(
         hidden_states=hidden_states,
         position_embeddings=(cos, sin),
         attention_mask=None,
         verifier_kv_last_local=local_kv,
         verifier_kv_last_global=global_kv,
     )
+    assert output1.shape == (batch_sz, seq_len, 64)
     
-    assert output.shape == (batch_sz, seq_len, 64)
+    # Change global_kv (the inactive cache)
+    global_kv_changed = torch.randn_like(global_kv)
+    output2, _ = attn(
+        hidden_states=hidden_states,
+        position_embeddings=(cos, sin),
+        attention_mask=None,
+        verifier_kv_last_local=local_kv,
+        verifier_kv_last_global=global_kv_changed,
+    )
+    assert torch.equal(output1, output2)
+    
+    # Change local_kv (the active cache)
+    local_kv_changed = torch.randn_like(local_kv)
+    output3, _ = attn(
+        hidden_states=hidden_states,
+        position_embeddings=(cos, sin),
+        attention_mask=None,
+        verifier_kv_last_local=local_kv_changed,
+        verifier_kv_last_global=global_kv,
+    )
+    assert not torch.equal(output1, output3)
 
 
 def test_query_only_gemma2_attention_global_kv(gemma2_config):
-    """Test that global KV cache is used when sliding_window is 0 or None."""
+    """Test that global KV cache is used when layer_types is full_attention."""
+    gemma2_config.layer_types = ["full_attention"]
     gemma2_config.sliding_window = None
     attn = QueryOnlyGemma2Attention(gemma2_config, layer_idx=0)
     
@@ -71,15 +91,36 @@ def test_query_only_gemma2_attention_global_kv(gemma2_config):
     local_kv = torch.randn(batch_sz, seq_len, 2, 2, 16)
     global_kv = torch.randn(batch_sz, seq_len, 2, 2, 16)
     
-    cos = torch.randn(1, 1, seq_len, 16)
-    sin = torch.randn(1, 1, seq_len, 16)
+    cos = torch.randn(batch_sz, seq_len, 16)
+    sin = torch.randn(batch_sz, seq_len, 16)
     
-    output, _ = attn(
+    output1, _ = attn(
         hidden_states=hidden_states,
         position_embeddings=(cos, sin),
         attention_mask=None,
         verifier_kv_last_local=local_kv,
         verifier_kv_last_global=global_kv,
     )
+    assert output1.shape == (batch_sz, seq_len, 64)
     
-    assert output.shape == (batch_sz, seq_len, 64)
+    # Change local_kv (the inactive cache)
+    local_kv_changed = torch.randn_like(local_kv)
+    output2, _ = attn(
+        hidden_states=hidden_states,
+        position_embeddings=(cos, sin),
+        attention_mask=None,
+        verifier_kv_last_local=local_kv_changed,
+        verifier_kv_last_global=global_kv,
+    )
+    assert torch.equal(output1, output2)
+    
+    # Change global_kv (the active cache)
+    global_kv_changed = torch.randn_like(global_kv)
+    output3, _ = attn(
+        hidden_states=hidden_states,
+        position_embeddings=(cos, sin),
+        attention_mask=None,
+        verifier_kv_last_local=local_kv,
+        verifier_kv_last_global=global_kv_changed,
+    )
+    assert not torch.equal(output1, output3)

--- a/tests/unit/models/test_mtp_gemma2.py
+++ b/tests/unit/models/test_mtp_gemma2.py
@@ -124,3 +124,49 @@ def test_query_only_gemma2_attention_global_kv(gemma2_config):
         verifier_kv_last_global=global_kv_changed,
     )
     assert not torch.equal(output1, output3)
+
+
+def test_query_only_gemma2_attention_sliding_window_mask(gemma2_config):
+    """Test that sliding window masking actually restricts attention when a mask is provided."""
+    gemma2_config.sliding_window = 2
+    attn = QueryOnlyGemma2Attention(gemma2_config, layer_idx=0)
+    
+    batch_sz, seq_len = 1, 5
+    hidden_states = torch.randn(batch_sz, seq_len, 64)
+    
+    local_kv = torch.randn(batch_sz, seq_len, 2, 2, 16)
+    global_kv = torch.randn(batch_sz, seq_len, 2, 2, 16)
+    
+    cos = torch.randn(batch_sz, seq_len, 16)
+    sin = torch.randn(batch_sz, seq_len, 16)
+    
+    # Base causal mask (lower triangular) - 0 for allowed, min_val for masked
+    attention_mask = torch.zeros(batch_sz, 1, seq_len, seq_len)
+    causal_mask = torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool))
+    attention_mask = attention_mask.masked_fill(~causal_mask.view(1, 1, seq_len, seq_len), torch.finfo(hidden_states.dtype).min)
+    
+    output1, _ = attn(
+        hidden_states=hidden_states,
+        position_embeddings=(cos, sin),
+        attention_mask=attention_mask,
+        verifier_kv_last_local=local_kv,
+        verifier_kv_last_global=global_kv,
+    )
+    
+    # Perturb local_kv at index 0 (which should be masked out for queries at index >= 2)
+    local_kv_changed = local_kv.clone()
+    local_kv_changed[:, 0, ...] = torch.randn_like(local_kv[:, 0, ...])
+    
+    output2, _ = attn(
+        hidden_states=hidden_states,
+        position_embeddings=(cos, sin),
+        attention_mask=attention_mask,
+        verifier_kv_last_local=local_kv_changed,
+        verifier_kv_last_global=global_kv,
+    )
+    
+    # Output at index 4 should be identical because index 0 is outside the sliding window (window size 2)
+    assert torch.equal(output1[:, 4], output2[:, 4])
+    
+    # Output at index 0 should change since it attends to index 0
+    assert not torch.equal(output1[:, 0], output2[:, 0])

--- a/tests/unit/models/test_mtp_gemma2.py
+++ b/tests/unit/models/test_mtp_gemma2.py
@@ -1,0 +1,85 @@
+"""Unit tests for Gemma2 MTP Query-Only Attention."""
+
+import pytest
+import torch
+from transformers import PretrainedConfig
+
+from speculators.models.base_components import model_classes
+from speculators.models.mtp.model_definitions import mtp_model_classes
+
+if "gemma2" not in model_classes:
+    pytest.skip("transformers < 4.42 installed, skipping gemma2 tests", allow_module_level=True)
+
+from speculators.models.mtp.model_definitions import QueryOnlyGemma2Attention
+
+
+@pytest.fixture
+def gemma2_config():
+    config = PretrainedConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        attention_bias=False,
+        attention_dropout=0.0,
+        _attn_implementation="eager"
+    )
+    # Mock some Gemma2 specific attrs
+    config.sliding_window = 4096
+    config.query_pre_attn_scalar = 224
+    config.hidden_size = 64
+    config.num_attention_heads = 4
+    config.num_key_value_heads = 2
+    config.head_dim = 16
+    return config
+
+
+def test_query_only_gemma2_attention_local_kv(gemma2_config):
+    """Test that local KV cache is used when sliding_window > 0."""
+    attn = QueryOnlyGemma2Attention(gemma2_config, layer_idx=0)
+    
+    batch_sz, seq_len = 2, 5
+    hidden_states = torch.randn(batch_sz, seq_len, 64)
+    
+    # [batch, seq_len, 2, num_kv_heads, head_dim]
+    local_kv = torch.randn(batch_sz, seq_len, 2, 2, 16)
+    global_kv = torch.randn(batch_sz, seq_len, 2, 2, 16)
+    
+    # Mock position embeddings (cos, sin)
+    cos = torch.randn(1, 1, seq_len, 16)
+    sin = torch.randn(1, 1, seq_len, 16)
+    
+    output, _ = attn(
+        hidden_states=hidden_states,
+        position_embeddings=(cos, sin),
+        attention_mask=None,
+        verifier_kv_last_local=local_kv,
+        verifier_kv_last_global=global_kv,
+    )
+    
+    assert output.shape == (batch_sz, seq_len, 64)
+
+
+def test_query_only_gemma2_attention_global_kv(gemma2_config):
+    """Test that global KV cache is used when sliding_window is 0 or None."""
+    gemma2_config.sliding_window = None
+    attn = QueryOnlyGemma2Attention(gemma2_config, layer_idx=0)
+    
+    batch_sz, seq_len = 2, 5
+    hidden_states = torch.randn(batch_sz, seq_len, 64)
+    
+    local_kv = torch.randn(batch_sz, seq_len, 2, 2, 16)
+    global_kv = torch.randn(batch_sz, seq_len, 2, 2, 16)
+    
+    cos = torch.randn(1, 1, seq_len, 16)
+    sin = torch.randn(1, 1, seq_len, 16)
+    
+    output, _ = attn(
+        hidden_states=hidden_states,
+        position_embeddings=(cos, sin),
+        attention_mask=None,
+        verifier_kv_last_local=local_kv,
+        verifier_kv_last_global=global_kv,
+    )
+    
+    assert output.shape == (batch_sz, seq_len, 64)

--- a/tests/unit/models/test_mtp_head.py
+++ b/tests/unit/models/test_mtp_head.py
@@ -1,0 +1,138 @@
+"""Unit tests for MultiLevelLMHead in Gemma4 MTP."""
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from speculators.models.mtp.head import MultiLevelLMHead
+
+
+@pytest.fixture
+def head_setup():
+    hidden_size = 16
+    vocab_size = 256
+    num_centroids = 4
+    head = MultiLevelLMHead(hidden_size, vocab_size, num_centroids)
+    return head
+
+
+def test_initialization(head_setup):
+    """Test that the head initializes and tokens_per_centroid is computed correctly."""
+    head = head_setup
+    assert head.tokens_per_centroid == 256 // 4
+    assert head.centroids.in_features == 16
+    assert head.centroids.out_features == 4
+    assert head.token_ordering.shape == (256,)
+    
+    # Check that sequential token mapping works
+    assert torch.equal(head.token_ordering, torch.arange(256))
+
+
+def test_compute_centroid_loss_basic(head_setup):
+    """Test basic loss computation without ignore_index."""
+    head = head_setup
+    batch_size, seq_len = 2, 3
+    hidden_states = torch.randn(batch_size, seq_len, 16)
+    
+    # Targets for the first 3 centroids
+    targets = torch.tensor([
+        [0, 64, 128], # belongs to centroids 0, 1, 2
+        [192, 10, 70] # belongs to centroids 3, 0, 1
+    ])
+    expected_centroids = torch.tensor([
+        [0, 1, 2],
+        [3, 0, 1]
+    ])
+    
+    loss = head.compute_centroid_loss(hidden_states, targets)
+    
+    # Loss should have the same shape as targets
+    assert loss.shape == (batch_size, seq_len)
+    
+    # Manually compute the expected loss
+    flat_hidden = hidden_states.view(-1, 16)
+    expected_logits = head.centroids(flat_hidden)
+    expected_loss = F.cross_entropy(
+        expected_logits, 
+        expected_centroids.view(-1), 
+        reduction="none"
+    ).view(batch_size, seq_len)
+    
+    assert torch.allclose(loss, expected_loss)
+
+
+def test_compute_centroid_loss_with_ignore_index(head_setup):
+    """Test that ignore_index is properly masked out."""
+    head = head_setup
+    batch_size, seq_len = 2, 3
+    hidden_states = torch.randn(batch_size, seq_len, 16)
+    
+    targets = torch.tensor([
+        [0, -100, 128], 
+        [-100, -100, 70]
+    ])
+    expected_centroids = torch.tensor([
+        [0, -100, 2],
+        [-100, -100, 1]
+    ])
+    
+    loss = head.compute_centroid_loss(hidden_states, targets, ignore_index=-100)
+    
+    # Loss should be 0.0 where ignore_index was used
+    assert loss[0, 1].item() == 0.0
+    assert loss[1, 0].item() == 0.0
+    assert loss[1, 1].item() == 0.0
+    
+    # Check valid positions
+    valid_mask = targets != -100
+    valid_hidden = hidden_states[valid_mask]
+    valid_centroids = expected_centroids[valid_mask]
+    
+    expected_logits = head.centroids(valid_hidden)
+    expected_loss = F.cross_entropy(
+        expected_logits, 
+        valid_centroids, 
+        reduction="none"
+    )
+    
+    assert torch.allclose(loss[valid_mask], expected_loss)
+
+
+def test_compute_centroid_loss_all_ignored(head_setup):
+    """Test behavior when all targets are ignore_index."""
+    head = head_setup
+    batch_size, seq_len = 2, 3
+    hidden_states = torch.randn(batch_size, seq_len, 16)
+    
+    targets = torch.full((batch_size, seq_len), -100, dtype=torch.long)
+    
+    loss = head.compute_centroid_loss(hidden_states, targets, ignore_index=-100)
+    
+    assert loss.shape == (batch_size, seq_len)
+    assert torch.all(loss == 0.0)
+
+
+def test_compute_centroid_loss_with_custom_ordering(head_setup):
+    """Test that the token_ordering buffer correctly scrambles the target mapping."""
+    head = head_setup
+    
+    # Reverse the token ordering
+    head.token_ordering.copy_(torch.arange(255, -1, -1))
+    
+    hidden_states = torch.randn(1, 1, 16)
+    
+    # The token '0' is now at the very end of the array (position 255)
+    # Position 255 belongs to centroid 255 // 64 = 3
+    targets = torch.tensor([[0]])
+    
+    loss = head.compute_centroid_loss(hidden_states, targets)
+    
+    # Manually check that target centroid is 3
+    expected_logits = head.centroids(hidden_states.view(-1, 16))
+    expected_loss = F.cross_entropy(
+        expected_logits, 
+        torch.tensor([3]), 
+        reduction="none"
+    ).view(1, 1)
+    
+    assert torch.allclose(loss, expected_loss)

--- a/tests/unit/models/test_mtp_head.py
+++ b/tests/unit/models/test_mtp_head.py
@@ -118,6 +118,7 @@ def test_compute_centroid_loss_with_custom_ordering(head_setup):
     
     # Reverse the token ordering
     head.token_ordering.copy_(torch.arange(255, -1, -1))
+    head._rebuild_inverse()
     
     hidden_states = torch.randn(1, 1, 16)
     
@@ -136,3 +137,56 @@ def test_compute_centroid_loss_with_custom_ordering(head_setup):
     ).view(1, 1)
     
     assert torch.allclose(loss, expected_loss)
+
+
+def test_initialization_validation():
+    """Test constructor argument validation."""
+    with pytest.raises(ValueError, match="num_centroids must be positive"):
+        MultiLevelLMHead(16, 256, 0)
+        
+    with pytest.raises(ValueError, match="must be divisible by num_centroids"):
+        MultiLevelLMHead(16, 256, 3)
+
+
+def test_mtp_draft_model_integration_centroid_loss():
+    """Test that MTPDraftModel includes centroid loss when num_centroids is configured."""
+    from speculators.models.mtp.core import MTPDraftModel
+    from speculators.models.mtp.config import MTPSpeculatorConfig
+    from speculators.config import SpeculatorsConfig
+    from speculators.proposals.greedy import GreedyTokenProposalConfig
+    from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+    
+    tc = Qwen2Config(hidden_size=16, vocab_size=256, num_hidden_layers=1, num_attention_heads=2)
+    config = MTPSpeculatorConfig(
+        transformer_layer_config=tc,
+        num_centroids=4,
+        speculators_config=SpeculatorsConfig(
+            algorithm="mtp",
+            proposal_methods=[GreedyTokenProposalConfig(speculative_tokens=1)],
+            default_proposal_method="greedy"
+        )
+    )
+    
+    model = MTPDraftModel(config)
+    assert model.masked_embedding is not None
+    
+    batch_sz, seq_len = 1, 3
+    input_ids = torch.randint(0, 256, (batch_sz, seq_len))
+    hidden_states = torch.randn(batch_sz, seq_len, 16)
+    
+    _, loss, metrics = model(input_ids, hidden_states)
+    
+    # The total loss should include the masked_embedding centroid loss.
+    # We can verify the masked_embedding was called by replacing its compute_centroid_loss with a mock.
+    original_compute = model.masked_embedding.compute_centroid_loss
+    called = False
+    
+    def mock_compute(*args, **kwargs):
+        nonlocal called
+        called = True
+        return original_compute(*args, **kwargs)
+        
+    model.masked_embedding.compute_centroid_loss = mock_compute
+    model(input_ids, hidden_states)
+    
+    assert called, "centroid loss was not computed during forward pass"

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -492,6 +492,104 @@ def test_arrow_dataset_default_split_ratio_does_not_crash(tmp_path: Path):
     assert arrow_ds._map_to_file_idx(5) == 5
 
 
+<<<<<<< HEAD
+=======
+def test_verifier_kvs_survive_pipeline():
+    """Test that optional verifier KV caches survive standardize_data_v1 and collate_fn."""
+    # 1. Create a dummy v1 offline data dictionary with KV caches
+    v1_data = {
+        "input_ids": torch.tensor([0, 1, 2], dtype=torch.long),
+        "loss_mask": torch.tensor([0, 1, 1], dtype=torch.long),
+        "hidden_states": [
+            torch.tensor([[0.0, 0.1], [1.0, 1.1], [2.0, 2.1]]),  # Layer 0
+            torch.tensor([[10.0, 10.1], [11.0, 11.1], [12.0, 12.1]]),  # Verifier last hs
+        ],
+        "verifier_kv_last_local": torch.tensor([[100.0], [101.0], [102.0]]),
+        "verifier_kv_last_global": torch.tensor([[200.0], [201.0], [202.0]]),
+    }
+
+    # 2. Pass through standardize_data_v1
+    standardized = standardize_data_v1(v1_data)
+    
+    assert "verifier_kv_last_local" in standardized
+    assert "verifier_kv_last_global" in standardized
+    assert torch.equal(standardized["verifier_kv_last_local"], v1_data["verifier_kv_last_local"])
+    
+    # 3. Add lengths and position_ids (simulate BaseDataset.__getitem__)
+    standardized["lengths"] = torch.tensor([3], dtype=torch.long)
+    standardized["position_ids"] = torch.tensor([0, 1, 2], dtype=torch.long)
+    
+    # 4. Pass through collate_fn
+    collate_fn = create_collate_fn(max_len=5, hidden_size=2, num_target_layers=1)
+    batch = [standardized]
+    
+    collated = collate_fn(batch)
+    
+    # 5. Verify the KV caches survived collation and were properly padded
+    assert "verifier_kv_last_local" in collated
+    assert "verifier_kv_last_global" in collated
+    
+    local_kv = collated["verifier_kv_last_local"]
+    assert local_kv.shape == (1, 5, 1)  # [batch=1, max_len=5, ...]
+    
+    # First 3 positions should match original, last 2 should be padded with 0
+    expected_local = torch.tensor([[[100.0], [101.0], [102.0], [0.0], [0.0]]])
+    assert torch.equal(local_kv, expected_local)
+
+
+def test_verifier_kvs_mixed_batch():
+    """KV-present and KV-absent samples in one batch should not crash or drop data."""
+    from speculators.train.data import create_collate_fn
+    
+    with_kv = {
+        "input_ids": torch.tensor([0]),
+        "loss_mask": torch.tensor([1]),
+        "hidden_states": torch.tensor([[0.0]]),
+        "verifier_last_hidden_states": torch.tensor([[0.0]]),
+        "verifier_kv_last_local": torch.tensor([[100.0]]),
+        "lengths": torch.tensor([1]),
+        "position_ids": torch.tensor([0]),
+    }
+    without_kv = {k: v for k, v in with_kv.items() if not k.startswith("verifier_kv")}
+    collate_fn = create_collate_fn(max_len=5, hidden_size=1, num_target_layers=1)
+    
+    # Depending on which element is first, it either raises KeyError or drops the field.
+    # We verify the invariant holds.
+    try:
+        collated = collate_fn([with_kv, without_kv])
+    except KeyError:
+        pass
+
+
+def test_verifier_kvs_dtype_cast():
+    """Verify BaseDataset.__getitem__ casts verifier KV tensors when hidden_states_dtype is bfloat16."""
+    from speculators.train.data import BaseDataset
+    
+    class DummyDataset(BaseDataset):
+        def __len__(self):
+            return 1
+            
+        def _get_raw_data(self, idx):
+            return {
+                "input_ids": torch.tensor([0]),
+                "loss_mask": torch.tensor([1]),
+                "hidden_states": torch.tensor([[0.0]], dtype=torch.float32),
+                "verifier_last_hidden_states": torch.tensor([[0.0]], dtype=torch.float32),
+                "verifier_kv_last_local": torch.tensor([[100.0]], dtype=torch.float32),
+            }
+            
+    ds = DummyDataset(
+        max_len=128,
+        hidden_states_dtype=torch.bfloat16,
+    )
+    
+    item = ds[0]
+    assert item["verifier_kv_last_local"].dtype == torch.bfloat16
+    assert item["hidden_states"].dtype == torch.bfloat16
+    assert item["verifier_last_hidden_states"].dtype == torch.bfloat16
+
+
+>>>>>>> 40e5d06 (fix(mtp): address PR 767 CodeRabbit and collaborator comments)
 def test_arrow_dataset_on_generate_cache_creates_hidden_states_dir(tmp_path: Path):
     """on_generate="cache" must create the cache dir when cache() is called —
     otherwise shutil.move into it raises FileNotFoundError, which _maybe_generate_hs

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -540,8 +540,10 @@ def test_verifier_kvs_survive_pipeline():
                 [[10.0, 10.1], [11.0, 11.1], [12.0, 12.1]]
             ),  # Verifier last hs
         ],
-        "verifier_kv_last_local": torch.tensor([[100.0], [101.0], [102.0]]),
-        "verifier_kv_last_global": torch.tensor([[200.0], [201.0], [202.0]]),
+        "kv_last_local_k": torch.tensor([[100.0], [101.0], [102.0]]),
+        "kv_last_local_v": torch.tensor([[110.0], [111.0], [112.0]]),
+        "kv_last_global_k": torch.tensor([[200.0], [201.0], [202.0]]),
+        "kv_last_global_v": torch.tensor([[210.0], [211.0], [212.0]]),
     }
 
     # 2. Pass through standardize_data_v1
@@ -549,10 +551,11 @@ def test_verifier_kvs_survive_pipeline():
 
     assert "verifier_kv_last_local" in standardized
     assert "verifier_kv_last_global" in standardized
-    assert torch.equal(
-        standardized["verifier_kv_last_local"],
-        v1_data["verifier_kv_last_local"],  # type: ignore[arg-type]
+    
+    expected_local_stack = torch.stack(
+        [v1_data["kv_last_local_k"], v1_data["kv_last_local_v"]], dim=1  # type: ignore[arg-type]
     )
+    assert torch.equal(standardized["verifier_kv_last_local"], expected_local_stack)
 
     # 3. Add lengths and position_ids (simulate BaseDataset.__getitem__)
     standardized["lengths"] = torch.tensor([3], dtype=torch.long)
@@ -569,8 +572,18 @@ def test_verifier_kvs_survive_pipeline():
     assert "verifier_kv_last_global" in collated
 
     local_kv = collated["verifier_kv_last_local"]
-    assert local_kv.shape == (1, 5, 1)  # [batch=1, max_len=5, ...]
+    assert local_kv.shape == (1, 5, 2, 1)  # [batch=1, max_len=5, ...]
 
     # First 3 positions should match original, last 2 should be padded with 0
-    expected_local = torch.tensor([[[100.0], [101.0], [102.0], [0.0], [0.0]]])
+    expected_local = torch.tensor(
+        [
+            [
+                [[100.0], [110.0]],
+                [[101.0], [111.0]],
+                [[102.0], [112.0]],
+                [[0.0], [0.0]],
+                [[0.0], [0.0]],
+            ]
+        ]
+    )
     assert torch.equal(local_kv, expected_local)

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -553,12 +553,20 @@ def test_verifier_kvs_mixed_batch():
     without_kv = {k: v for k, v in with_kv.items() if not k.startswith("verifier_kv")}
     collate_fn = create_collate_fn(max_len=5, hidden_size=1, num_target_layers=1)
     
-    # Depending on which element is first, it either raises KeyError or drops the field.
-    # We verify the invariant holds.
-    try:
-        collated = collate_fn([with_kv, without_kv])
-    except KeyError:
-        pass
+    # Test both orderings
+    for batch in [[with_kv, without_kv], [without_kv, with_kv]]:
+        collated = collate_fn(batch)
+        
+        assert "verifier_kv_last_local" in collated
+        local_kv = collated["verifier_kv_last_local"]
+        assert local_kv.shape == (1, 5, 1)
+        
+        if batch[0] == with_kv:
+            expected = torch.tensor([[[100.0], [0.0], [0.0], [0.0], [0.0]]])
+        else:
+            expected = torch.tensor([[[0.0], [100.0], [0.0], [0.0], [0.0]]])
+            
+        assert torch.equal(local_kv, expected)
 
 
 def test_verifier_kvs_dtype_cast():
@@ -568,6 +576,9 @@ def test_verifier_kvs_dtype_cast():
     class DummyDataset(BaseDataset):
         def __len__(self):
             return 1
+            
+        def _compute_approx_lengths(self):
+            return [1]
             
         def _get_raw_data(self, idx):
             return {

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -529,14 +529,16 @@ def test_arrow_dataset_on_generate_cache_creates_hidden_states_dir(tmp_path: Pat
     assert (arrow_ds.transfer.hidden_states_path / "hs_0.safetensors").exists()
 
 def test_verifier_kvs_survive_pipeline():
-    """Test that optional verifier KV caches survive standardize_data_v1 and collate_fn."""
+    """Test optional verifier KV caches survive standardize_data_v1 and collate_fn."""
     # 1. Create a dummy v1 offline data dictionary with KV caches
     v1_data = {
         "input_ids": torch.tensor([0, 1, 2], dtype=torch.long),
         "loss_mask": torch.tensor([0, 1, 1], dtype=torch.long),
         "hidden_states": [
             torch.tensor([[0.0, 0.1], [1.0, 1.1], [2.0, 2.1]]),  # Layer 0
-            torch.tensor([[10.0, 10.1], [11.0, 11.1], [12.0, 12.1]]),  # Verifier last hs
+            torch.tensor(
+                [[10.0, 10.1], [11.0, 11.1], [12.0, 12.1]]
+            ),  # Verifier last hs
         ],
         "verifier_kv_last_local": torch.tensor([[100.0], [101.0], [102.0]]),
         "verifier_kv_last_global": torch.tensor([[200.0], [201.0], [202.0]]),
@@ -544,28 +546,31 @@ def test_verifier_kvs_survive_pipeline():
 
     # 2. Pass through standardize_data_v1
     standardized = standardize_data_v1(v1_data)
-    
+
     assert "verifier_kv_last_local" in standardized
     assert "verifier_kv_last_global" in standardized
-    assert torch.equal(standardized["verifier_kv_last_local"], v1_data["verifier_kv_last_local"])
-    
+    assert torch.equal(
+        standardized["verifier_kv_last_local"],
+        v1_data["verifier_kv_last_local"],  # type: ignore[arg-type]
+    )
+
     # 3. Add lengths and position_ids (simulate BaseDataset.__getitem__)
     standardized["lengths"] = torch.tensor([3], dtype=torch.long)
     standardized["position_ids"] = torch.tensor([0, 1, 2], dtype=torch.long)
-    
+
     # 4. Pass through collate_fn
     collate_fn = create_collate_fn(max_len=5, hidden_size=2, num_target_layers=1)
     batch = [standardized]
-    
+
     collated = collate_fn(batch)
-    
+
     # 5. Verify the KV caches survived collation and were properly padded
     assert "verifier_kv_last_local" in collated
     assert "verifier_kv_last_global" in collated
-    
+
     local_kv = collated["verifier_kv_last_local"]
     assert local_kv.shape == (1, 5, 1)  # [batch=1, max_len=5, ...]
-    
+
     # First 3 positions should match original, last 2 should be padded with 0
     expected_local = torch.tensor([[[100.0], [101.0], [102.0], [0.0], [0.0]]])
     assert torch.equal(local_kv, expected_local)

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -527,3 +527,45 @@ def test_arrow_dataset_on_generate_cache_creates_hidden_states_dir(tmp_path: Pat
     assert arrow_ds.transfer.hidden_states_path.is_dir()
     # And the cached file should exist
     assert (arrow_ds.transfer.hidden_states_path / "hs_0.safetensors").exists()
+
+def test_verifier_kvs_survive_pipeline():
+    """Test that optional verifier KV caches survive standardize_data_v1 and collate_fn."""
+    # 1. Create a dummy v1 offline data dictionary with KV caches
+    v1_data = {
+        "input_ids": torch.tensor([0, 1, 2], dtype=torch.long),
+        "loss_mask": torch.tensor([0, 1, 1], dtype=torch.long),
+        "hidden_states": [
+            torch.tensor([[0.0, 0.1], [1.0, 1.1], [2.0, 2.1]]),  # Layer 0
+            torch.tensor([[10.0, 10.1], [11.0, 11.1], [12.0, 12.1]]),  # Verifier last hs
+        ],
+        "verifier_kv_last_local": torch.tensor([[100.0], [101.0], [102.0]]),
+        "verifier_kv_last_global": torch.tensor([[200.0], [201.0], [202.0]]),
+    }
+
+    # 2. Pass through standardize_data_v1
+    standardized = standardize_data_v1(v1_data)
+    
+    assert "verifier_kv_last_local" in standardized
+    assert "verifier_kv_last_global" in standardized
+    assert torch.equal(standardized["verifier_kv_last_local"], v1_data["verifier_kv_last_local"])
+    
+    # 3. Add lengths and position_ids (simulate BaseDataset.__getitem__)
+    standardized["lengths"] = torch.tensor([3], dtype=torch.long)
+    standardized["position_ids"] = torch.tensor([0, 1, 2], dtype=torch.long)
+    
+    # 4. Pass through collate_fn
+    collate_fn = create_collate_fn(max_len=5, hidden_size=2, num_target_layers=1)
+    batch = [standardized]
+    
+    collated = collate_fn(batch)
+    
+    # 5. Verify the KV caches survived collation and were properly padded
+    assert "verifier_kv_last_local" in collated
+    assert "verifier_kv_last_global" in collated
+    
+    local_kv = collated["verifier_kv_last_local"]
+    assert local_kv.shape == (1, 5, 1)  # [batch=1, max_len=5, ...]
+    
+    # First 3 positions should match original, last 2 should be padded with 0
+    expected_local = torch.tensor([[[100.0], [101.0], [102.0], [0.0], [0.0]]])
+    assert torch.equal(local_kv, expected_local)


### PR DESCRIPTION
## Context
This PR introduces the final architecture modifications required for **Gemma4 MTP draft models**, completing the 3-part rollout strategy outlined in Issue #586. 

Unlike Qwen-style MTP which maintains its own full self-attention layers and distinct KV caches, **Gemma4 MTP borrows the verifier's local and global KV caches** directly, stripping K/V projections out of its own layers.

**Dependencies:**
- Depends on **PR #758** (Data pipeline extraction of verifier KV caches - Merged).
- Depends on **PR #767** (Multi-Level LM Head - Under Review). 
*(Note: Commits from #767 currently appear in this PR as this was branched from it for stacking. This will resolve once #767 is merged).*

## Implementation Details
1. **Registered Gemma2 Components**: Added `Gemma2DecoderLayer`, `Gemma2RMSNorm`, and `Gemma2RotaryEmbedding` to the `base_components.py` registry.
2. **`QueryOnlyGemma2Attention`**: Built a specialized customized self-attention module that overrides the base `Gemma2Attention`. It zeroes out K/V linear projections and instead cross-attends into `verifier_kv_last_local` and `verifier_kv_last_global`.
3. **Sliding Window Support**: Dynamic routing of local versus global caches depending on the target layer's `sliding_window` size.
4. **RoPE Handling**: Isolated Rotary Positional Embeddings to only apply to query states since the vLLM extracted verifier KV caches have already been rotated.

## Testing
- Unit tests added in `tests/unit/models/test_mtp_gemma2.py` explicitly mock out the KV cache tensor routing, verifying that local vs. global tensor routing succeeds based on window configuration and shape propagation works as expected.
