### PR TITLE
[Dataset] [Tool call] Add When2Call single-turn tool-use dataset

### DIFF
--- a/docs/cli/response_regeneration.md
+++ b/docs/cli/response_regeneration.md
@@ -124,6 +124,7 @@ The text presets from the shared dataset registry (`DATASET_CONFIGS` in `specula
 | `magpie`            | `Magpie-Align/Magpie-Llama-3.1-Pro-300K-Filtered` | `train`       |
 | `nemotron`          | `nvidia/Llama-Nemotron-Post-Training-Dataset`     | `chat`        |
 | `open-perfectblend` | `mlabonne/open-perfectblend`                      | `train`       |
+| `when2call`         | `nvidia/When2Call`                                | `train`       |
 
 The registry's multimodal preset, `sharegpt4v_coco`, is **off-policy only** and `--dataset` rejects it. Its turns carry image content parts, which the Chat Completions API rejects, and the pre-tokenized output row has nowhere to keep pixel data. Use it with `prepare-data`.
 

--- a/src/speculators/data_generation/configs.py
+++ b/src/speculators/data_generation/configs.py
@@ -49,6 +49,12 @@ def _normalize_nemotron(example: dict) -> dict:
     }
 
 
+def _normalize_when2call(example: dict) -> dict:
+    # When2Call already stores the dialogue as role/content ``messages``;
+    # the parallel ``tools`` column is preserved by the map for tool-aware runs.
+    return {"conversations": example["messages"]}
+
+
 def get_coco_dir():
     return os.getenv("COCO_DIR") or "coco/"
 
@@ -150,5 +156,12 @@ DATASET_CONFIGS: dict[str, DatasetConfig] = {
         name="open-perfectblend",
         hf_path="mlabonne/open-perfectblend",
         split="train",
+    ),
+    "when2call": DatasetConfig(
+        name="when2call",
+        hf_path="nvidia/When2Call",
+        subset="train_sft",
+        split="train",
+        normalize_fn=_normalize_when2call,
     ),
 }


### PR DESCRIPTION
## Purpose

Add the **When2Call** dataset (`nvidia/When2Call`, `train_sft` config) as a predefined preset, to support tool-use / function-calling speculator training.

why:

- We're adding on-policy tool-call regeneration; a single-turn tool-use dataset is the natural training fixture for it.
- When2Call is a single-turn function-calling SFT dataset (originally for post-training) that also teaches *when not to* call a tool — useful signal for a draft model.
- License **CC-BY-4.0** (permissive). Verified **no overlap** with the `nvidia/SPEED-Bench` eval set — SPEED-Bench contains no function-calling data, and When2Call is not among its 24 source datasets.

Rebased onto `main` after #777, the followup that collapsed the two dataset registries into one. This is now a **single** entry in `src/speculators/data_generation/configs.py` — since #777 the regeneration script consumes that same registry, so the preset reaches both pipelines (`prepare-data` and `--dataset`) by construction, with no change to `scripts/response_regeneration/script.py`. `docs/cli/response_regeneration.md` gains the matching row.

> [!WARNING]
> **Draft: on-policy regeneration is the wrong signal for this preset.**
>
> Because #777 makes every registry preset a valid `--dataset` by construction, this entry also enables `--dataset when2call`. That is not usable yet: When2Call rows are exactly `[user, assistant]` with **no system turn**, and the tool schemas live in a parallel `tools` column that never enters the conversation. On-policy regeneration would therefore send the model a bare user prompt with **no tools attached** and regenerate a *prose* answer — precisely the wrong supervision for a dataset whose purpose is teaching when *not* to call a tool. Off-policy `prepare-data` is unaffected.
>
> Holding this as draft until the tool-aware regeneration path (#750) lands, or the preset is gated off-policy-only the way #777 gates `sharegpt4v_coco`.

### Notes for reviewers

- `configs.py`: `_normalize_when2call` maps the OpenAI `messages` column to `conversations`. Once #688 (automatic `messages`→`conversations` rename) lands, this normalizer becomes redundant and the entry can be simplified to a bare `DatasetConfig`. Kept for now so the preset works on current `main`.
- The `tools` column (a list of JSON-encoded schemas) is preserved as-is; it is not consumed by the offline path on `main` yet — it is there for the tool-aware regeneration path. #750

## Tests

- `make quality` (ruff check, ruff format, mdformat, mypy): clean.
- `pytest tests/unit/scripts tests/unit/data_generation`: **49 passed**.
- Schema verified against the real data file — 2485 rows parsed from `train/when2call_train_sft.jsonl`: **every** row is exactly `[user, assistant]` (role/content) alongside a parallel `tools` column. No multi-turn rows, no system turns. Config/split resolve confirmed against the Hub API (`train_sft` config → `train` split, CC-BY-4.0).
- Registry sanity: `_normalize_when2call` maps a real When2Call row to `conversations` while the `tools` column survives the map; `prepare_row()` on that row yields `[user]`; `when2call` appears in the `--dataset` CLI choices with `script.py` byte-identical to `main`.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
