### PR TITLE
refactor(data): remove --turn-dropout

### DIFF
--- a/docs/cli/prepare_data.md
+++ b/docs/cli/prepare_data.md
@@ -44,8 +44,6 @@ python scripts/prepare_data.py \
 
 - **`--assistant-pattern`** (str, default: `None`) Custom regex pattern for matching assistant responses. If not provided, auto-detected from chat template.
 
-- **`--turn-dropout`** (flag) Enable turn dropout: randomly keeps first N consecutive turns per conversation for data augmentation.
-
 - **`--minimum-valid-tokens`** (int, default: `None`) Drop samples whose loss mask contains fewer than this many trainable tokens.
 
 ### Output Arguments
@@ -70,6 +68,5 @@ python scripts/prepare_data.py \
   --output ./prepared_data \
   --seq-length 4096 \
   --max-samples 10000 \
-  --turn-dropout \
   --num-preprocessing-workers 16
 ```

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -133,14 +133,6 @@ def parse_args():
             "If not provided, auto-detected from chat template."
         ),
     )
-    parser.add_argument(
-        "--turn-dropout",
-        action="store_true",
-        help=(
-            "Enable turn dropout: randomly keeps first N consecutive turns "
-            "per conversation for data augmentation."
-        ),
-    )
 
     # Output arguments
     parser.add_argument(
@@ -233,7 +225,6 @@ def main():
         max_samples=args.max_samples,
         token_freq_path=token_freq_path,
         assistant_pattern=args.assistant_pattern,
-        turn_dropout=args.turn_dropout,
         minimum_valid_tokens=args.minimum_valid_tokens,
         allow_empty_output=args.allow_empty_output,
         trust_remote_code=args.trust_remote_code,

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -1,6 +1,5 @@
 import bisect
 import json
-import random
 import re
 from collections.abc import Callable
 from contextlib import nullcontext
@@ -76,22 +75,17 @@ def _visualize_sample(preprocessed: HFDataset, processor: ProcessorLike, idx: in
 
 def _normalize_conversation(
     conv: list[dict],
-    turn_dropout: bool = False,
 ) -> list[dict]:
     """Normalize conversation to standard format with role/content keys.
 
     Args:
         conv: Raw conversation turns
-        turn_dropout: If True, randomly keeps first N consecutive turns (1 to len(conv))
 
     Returns:
-        Normalized conversation with optional turn dropout applied
+        Normalized conversation
     """
-    # Randomly pick how many consecutive turns to keep from the start
-    num_turns_to_keep = random.randint(1, len(conv)) if turn_dropout else len(conv)
-
     normalized = []
-    for i, turn in enumerate(conv):
+    for turn in conv:
         role = turn.get("from", turn.get("role", ""))
         content = turn.get("value") or turn.get("content") or ""
 
@@ -123,11 +117,6 @@ def _normalize_conversation(
             normalized_turn["reasoning_content"] = thinking
 
         normalized.append(normalized_turn)
-
-        # Stop if we've reached the truncation point
-        if i + 1 >= num_turns_to_keep and role == "assistant":
-            # Only break after an assistant turn
-            break
 
     return normalized
 
@@ -543,7 +532,6 @@ def _preprocess_batch(
     processor: ProcessorLike,
     max_length: int,
     assistant_pattern: str | Pattern[str] | None,
-    turn_dropout: bool = False,
     minimum_valid_tokens: int | None = None,
 ) -> dict[str, list]:
     """Process a batch of conversations into tokenized format with loss masks."""
@@ -578,8 +566,8 @@ def _preprocess_batch(
         if not conv or not isinstance(conv, list):
             continue
 
-        # Normalize to standard format with optional turn dropout
-        normalized_conv = _normalize_conversation(conv, turn_dropout)
+        # Normalize to standard format
+        normalized_conv = _normalize_conversation(conv)
         if not normalized_conv:
             continue
 
@@ -634,7 +622,6 @@ def build_eagle3_dataset(
     max_length: int = 2048,
     num_proc: int = 8,
     assistant_pattern: str | Pattern[str] | None = None,
-    turn_dropout: bool = False,
     minimum_valid_tokens: int | None = None,
 ) -> HFDataset:
     """Build EAGLE3 dataset by tokenizing conversations and creating loss masks.
@@ -649,19 +636,15 @@ def build_eagle3_dataset(
         assistant_pattern: Optional custom regex pattern for matching assistant
                           responses. If None, pattern will be auto-detected from
                           chat template.
-        turn_dropout: If True, randomly keeps first N consecutive turns per
-                     conversation
         minimum_valid_tokens: Number of tokens to consider for a valid sample
     """
     original_cols = dataset.column_names
     # These rows carry the generation boundary as their mask, so _preprocess_batch
-    # passes them through: no chat template, no span detection, no turn dropout.
+    # passes them through: no chat template, no span detection.
     pretokenized = {"input_ids", "loss_mask"} <= set(original_cols)
 
     if pretokenized:
         log.info("Pre-tokenized rows: using their loss mask, skipping chat template")
-        if turn_dropout:
-            log.warning("turn_dropout does not apply to pre-tokenized rows; ignoring")
         if assistant_pattern is not None:
             log.warning(
                 "assistant_pattern does not apply to pre-tokenized rows; ignoring"
@@ -689,7 +672,6 @@ def build_eagle3_dataset(
                 processor,
                 max_length,
                 assistant_pattern,
-                turn_dropout,
                 minimum_valid_tokens,
             ),
             batched=True,
@@ -846,7 +828,6 @@ def load_and_preprocess_dataset(
     max_samples: int | None = None,
     token_freq_path: Path | str = "./token_freq.pt",  # noqa: S107
     assistant_pattern: str | None = None,
-    turn_dropout: bool = False,
     minimum_valid_tokens: int | None = None,
     allow_empty_output: bool = False,
     trust_remote_code: bool = False,
@@ -868,8 +849,6 @@ def load_and_preprocess_dataset(
         assistant_pattern: Optional custom regex pattern for matching assistant
                           responses. If None, pattern will be auto-detected from
                           chat template.
-        turn_dropout: If True, randomly keeps first N consecutive turns per
-                     conversation
         minimum_valid_tokens: Number of tokens to consider for a valid sample
         allow_empty_output: If True, allow returning an empty dataset instead of
                           raising when no samples survive preprocessing.
@@ -916,16 +895,12 @@ def load_and_preprocess_dataset(
 
         log.info(f"Loaded {len(raw_dataset)} samples")
 
-        if turn_dropout:
-            log.info("Turn dropout enabled: randomly keeping N consecutive turns")
-
         preprocessed_dataset = build_eagle3_dataset(
             dataset=raw_dataset,
             processor=processor,
             max_length=seq_length,
             num_proc=build_dataset_num_proc,
             assistant_pattern=assistant_pattern,
-            turn_dropout=turn_dropout,
             minimum_valid_tokens=minimum_valid_tokens,
         )
         if minimum_valid_tokens is not None:

--- a/tests/integration/datagen/test_preprocessing.py
+++ b/tests/integration/datagen/test_preprocessing.py
@@ -1004,43 +1004,6 @@ def test_build_eagle3_dataset_minimum_valid_tokens_filters_short_samples():
     assert remaining_valid_count >= threshold
 
 
-# Tests for turn dropout feature
-
-
-@pytest.mark.sanity
-def test_preprocess_batch_with_turn_dropout():
-    """Test preprocessing batch with turn dropout enabled."""
-    processor = load_processor(TEXT_MODEL_REPO, trust_remote_code=True)
-
-    if not hasattr(processor, "apply_chat_template") or processor.chat_template is None:
-        pytest.skip("Processor does not support chat templates")
-
-    examples = {
-        "conversations": [
-            [
-                {"role": "user", "content": "Hello"},
-                {"role": "assistant", "content": "Hi there!"},
-                {"role": "user", "content": "How are you?"},
-                {"role": "assistant", "content": "I'm good!"},
-            ]
-        ]
-    }
-
-    assistant_pattern = _detect_assistant_pattern(processor)
-    results = _preprocess_batch(
-        examples,
-        processor,
-        max_length=512,
-        assistant_pattern=assistant_pattern,
-        turn_dropout=True,
-    )
-
-    # Should still produce valid results
-    assert "input_ids" in results
-    assert "loss_mask" in results
-    assert len(results["input_ids"]) > 0
-
-
 # Tests for custom assistant pattern feature
 
 


### PR DESCRIPTION
## Purpose

`--turn-dropout` was added in #195 as a data-augmentation option: during preprocessing it randomly truncates each conversation to keep only the first N turns (N picked at random), so the model would train on conversations of varying lengths and "learn to generate continuations from various conversation contexts." It also had a reasoning-model angle: models like Qwen3 keep only the last turn's thinking tokens at inference (earlier turns' thinking is dropped), so randomly varying which turn is last let each turn's thinking get trained at least some of the time.

This PR removes it. That goal isn't served on either data path today, and after #729 the flag is dead code on the on-policy path.

**On-policy (regen).** #729 made regen emit pre-tokenized rows (`input_ids` + a generation-boundary `loss_mask`) that skip normalization via the passthrough in `_preprocess_batch`, so turn-dropout never runs — `build_eagle3_dataset` already logs `turn_dropout does not apply to pre-tokenized rows; ignoring`.

**Off-policy (chat template + mask).** On this path every assistant turn is already trained on. Turn-dropout just cuts a conversation short, keeping the first few turns and dropping the rest. But because the model only looks at earlier tokens, a kept turn is trained the same way whether or not later turns follow it — so the full conversation already covers everything the kept turns would, and dropping the rest only removes training signal, never adds any.

Net: removing it changes no real training data. Deletes the flag, the `turn_dropout` parameter and its now-dead code across preprocessing, the turn-dropout test, and two doc references.

**Follow-up.** The thinking-token case deserves a real fix rather than turn-dropout's random workaround: keep (uncompress) thinking tokens in every turn — as trl and llama-factory do for multi-turn SFT — instead of dropping them for turns `:n-1` the way inference does. We plan a separate PR for this, which also lets a multi-turn conversation train as a single row rather than fanning out to one row per assistant turn.

## Tests

- Unit/integration: `pytest -k normalize_conversation` (9) and the pre-tokenized passthrough tests (3) pass; `ruff` clean.
- Full offline e2e on `Qwen/Qwen3-0.6B` (prepare_data → vLLM hidden states → train → acceptance) passes — training consumes the prepared `input_ids`/`loss_mask` and produces a checkpoint.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.

---

This is a followup PR of the sig-spec-decode meeting. @fynnsu 

cc code owner: @shanjiaz 
