### PR TITLE
Enable Ascend NPU training: opt-in transfer_to_npu + robust device_id

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,5 +1,6 @@
 import argparse
 import gc
+import importlib.util
 import logging
 import random
 import warnings
@@ -8,6 +9,19 @@ from pathlib import Path
 
 import numpy as np
 import torch
+
+# Ascend NPU: torch.cuda.is_available() is False on Ascend, so import
+# transfer_to_npu to monkeypatch torch.cuda.* -> torch.npu.* (dist backend ->
+# hccl) and let the trainer's CUDA-assuming code run unchanged. Gated on torch_npu
+# actually being installed, so a CUDA-misconfigured or CPU-only host does NOT enter
+# the NPU path (no spurious NPU message) -- it falls through to normal accelerator
+# resolution. CUDA hosts skip this via the outer check.
+if not torch.cuda.is_available() and importlib.util.find_spec("torch_npu"):
+    try:
+        from torch_npu.contrib import transfer_to_npu  # noqa: F401
+    except ImportError as e:
+        logging.getLogger(__name__).warning("torch_npu present but failed to import: %s", e)
+
 import transformers
 from packaging import version
 from transformers import LlamaConfig, PretrainedConfig

--- a/src/speculators/train/distributed.py
+++ b/src/speculators/train/distributed.py
@@ -153,7 +153,9 @@ def maybe_setup_distributed(sp_size: int = 1) -> None:
     if acc is None:
         raise ValueError("No accelerator found")
     backend = torch.distributed.get_default_backend_for_device(acc)
-    dist.init_process_group(backend, device_id=local_rank)
+    # Explicit torch.device, not a bare int: torch>=2.x reads device_id.type, and
+    # some backends (Ascend transfer_to_npu) rewrite the int.
+    dist.init_process_group(backend, device_id=torch.device(acc.type, local_rank))
 
     _rank = dist.get_rank()
     _world_size = dist.get_world_size()


### PR DESCRIPTION
- scripts/train.py: when CUDA is unavailable, best-effort import torch_npu.contrib.transfer_to_npu so the trainer's torch.cuda.* perf timer + seeding run unmodified on Ascend. Guarded by torch.cuda.is_available() -> a strict no-op on CUDA/CPU.
- distributed.py: pass device_id as an explicit torch.device(acc.type, local_rank) to init_process_group instead of a bare int. torch>=2.x reads device_id.type; the explicit device is correct on CUDA and fixes backends that rewrite the int (e.g. NPU).

<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

## Tests

## Checklist

I have filled in:

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [ ] I (a human) have written or reviewed the code in this pr to the best of my ability.
