### PR TITLE
train: --init-on-meta for large draft model construction

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1,4 +1,5 @@
 import argparse
+import contextlib
 import gc
 import logging
 import random
@@ -28,6 +29,7 @@ from speculators.models.utils import (
 )
 from speculators.train.dataloader import create_train_val_loaders
 from speculators.train.distributed import (
+    build_on_meta,
     get_rank,
     maybe_destroy_distributed,
     maybe_setup_distributed,
@@ -422,12 +424,20 @@ def build_draft_model(
         )
 
     args.draft_vocab_size = draft_vocab_size
-    return model_class.from_training_args(
-        verifier_config=transformer_layer_config,
-        t2d=t2d,
-        d2t=d2t,
-        **vars(args),
+    # --init-on-meta: non-rank0 build params on meta (no N-way host-RAM copy); real
+    # weights arrive via broadcast_from_rank0 in FSDP setup. Only rank 0 builds real.
+    meta_ctx = (
+        build_on_meta()
+        if args.init_on_meta and get_rank() != 0
+        else contextlib.nullcontext()
     )
+    with meta_ctx:
+        return model_class.from_training_args(
+            verifier_config=transformer_layer_config,
+            t2d=t2d,
+            d2t=d2t,
+            **vars(args),
+        )
 
 
 def main(args: argparse.Namespace):  # noqa: C901
@@ -822,6 +832,15 @@ def parse_args():
     parser.add_argument("--log-dir", type=str, default="./logs")
     parser.add_argument("--run-name", type=str, default=None)
     parser.add_argument("--num-layers", type=int, default=1)
+    parser.add_argument(
+        "--init-on-meta",
+        action="store_true",
+        help=(
+            "Build the draft on meta on all ranks except rank 0 (no N-way host-RAM "
+            "copy); real weights broadcast from rank 0 in FSDP setup. Requires the "
+            "model to no-op data-init on meta params (guard param.is_meta)."
+        ),
+    )
     parser.add_argument(
         "--draft-arch",
         type=str,

--- a/src/speculators/model.py
+++ b/src/speculators/model.py
@@ -128,6 +128,13 @@ class DraftVocabMixin(nn.Module):
         is True. Subclasses can override to load additional weights (e.g. norms,
         tokenizer) by calling super().load_verifier_weights() first.
         """
+        # Meta-device init (--init-on-meta): params carry no data, so skip the
+        # verifier load; real weights arrive via set_model_state_dict(
+        # broadcast_from_rank0=True) in the trainer's FSDP setup. (isnan() below
+        # would raise on a meta tensor.)
+        if self.embed_tokens.weight.is_meta:
+            return
+
         import warnings  # noqa: PLC0415
 
         from speculators.utils.loading import load_model_layers  # noqa: PLC0415

--- a/src/speculators/model.py
+++ b/src/speculators/model.py
@@ -128,11 +128,16 @@ class DraftVocabMixin(nn.Module):
         is True. Subclasses can override to load additional weights (e.g. norms,
         tokenizer) by calling super().load_verifier_weights() first.
         """
-        # Meta-device init (--init-on-meta): params carry no data, so skip the
-        # verifier load; real weights arrive via set_model_state_dict(
-        # broadcast_from_rank0=True) in the trainer's FSDP setup. (isnan() below
-        # would raise on a meta tensor.)
+        # --init-on-meta: params carry no data, so skip the verifier load (isnan()
+        # below would raise on meta); real weights arrive via broadcast in FSDP setup.
+        # Still freeze here -- requires_grad_() works on meta, and the trainable-param
+        # set must match across ranks or FSDP2's grad reduce_scatter hangs.
         if self.embed_tokens.weight.is_meta:
+            self.embed_tokens.weight.requires_grad_(False)
+            self.lm_head.weight.requires_grad_(False)
+            self.verifier_lm_head.weight.requires_grad_(False)
+            if hasattr(self, "verifier_norm"):
+                self.verifier_norm.weight.requires_grad_(False)  # type: ignore[union-attr]
             return
 
         import warnings  # noqa: PLC0415

--- a/src/speculators/train/distributed.py
+++ b/src/speculators/train/distributed.py
@@ -7,11 +7,13 @@ maintaining their own distributed state.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 
 import torch
 import torch.distributed as dist
+from torch import nn
 from torch.distributed import ProcessGroup
 from torch.distributed.fsdp import MixedPrecisionPolicy, fully_shard
 
@@ -192,6 +194,32 @@ def maybe_destroy_distributed() -> None:
     _dp_rank = 0
     _sp_group = None
     _dp_group = None
+
+
+@contextlib.contextmanager
+def build_on_meta():
+    """Build module PARAMETERS on the meta device (buffers stay real).
+
+    Overrides ``register_parameter`` so a large model is constructed with ~zero
+    resident memory. Used on non-rank0 ranks; their real weights arrive via
+    ``set_model_state_dict(broadcast_from_rank0=True)`` in the FSDP setup. Explicit
+    ``.to("meta")`` is robust to device-remapping layers (e.g. transfer_to_npu).
+
+    Contract: a model built under this must no-op data-init on meta params
+    (guard with ``param.is_meta``).
+    """
+    orig = nn.Module.register_parameter
+
+    def _register_on_meta(self, name, param):
+        if param is not None and not param.is_meta:
+            param = nn.Parameter(param.data.to("meta"), requires_grad=param.requires_grad)
+        orig(self, name, param)
+
+    nn.Module.register_parameter = _register_on_meta
+    try:
+        yield
+    finally:
+        nn.Module.register_parameter = orig
 
 
 def apply_fully_sharded(model: torch.nn.Module):

--- a/src/speculators/train/distributed.py
+++ b/src/speculators/train/distributed.py
@@ -198,15 +198,12 @@ def maybe_destroy_distributed() -> None:
 
 @contextlib.contextmanager
 def build_on_meta():
-    """Build module PARAMETERS on the meta device (buffers stay real).
+    """Build module parameters on the meta device (buffers stay real).
 
-    Overrides ``register_parameter`` so a large model is constructed with ~zero
-    resident memory. Used on non-rank0 ranks; their real weights arrive via
-    ``set_model_state_dict(broadcast_from_rank0=True)`` in the FSDP setup. Explicit
-    ``.to("meta")`` is robust to device-remapping layers (e.g. transfer_to_npu).
-
-    Contract: a model built under this must no-op data-init on meta params
-    (guard with ``param.is_meta``).
+    Overrides ``register_parameter`` so a large model constructs with ~zero resident
+    memory. Used on non-rank0 ranks; real weights then arrive via
+    ``set_model_state_dict(broadcast_from_rank0=True)`` in FSDP setup. Contract: the
+    model must no-op data-init on meta params (guard with ``param.is_meta``).
     """
     orig = nn.Module.register_parameter
 

--- a/tests/e2e/smoke/init_on_meta_worker.py
+++ b/tests/e2e/smoke/init_on_meta_worker.py
@@ -1,26 +1,14 @@
-"""torchrun worker for the ``--init-on-meta`` e2e test (``test_init_on_meta.py``).
+"""torchrun worker for the --init-on-meta e2e test (test_init_on_meta.py).
 
-Not a pytest module (not ``test_*``); launched via ``torch.distributed.run`` by the
-test. Mirrors the trainer's REAL build+materialize path and asserts the meta-init
-memory optimization does not change the result:
-
-  * build           -- rank0 builds the draft with real weights; non-rank0 builds
-                       under ``build_on_meta`` (== scripts/train.py's --init-on-meta
-                       branch: ``build_on_meta() if init_on_meta and rank != 0``);
-  * shard+broadcast -- ``apply_fully_sharded`` then ``set_model_state_dict(
-                       broadcast_from_rank0=True)`` (== trainer.py distributed setup).
-
-Assertions:
-  1. before broadcast: non-rank0 params are on ``meta`` (proof the allocation was
-     skipped -> the memory win), rank0 params are real;
-  2. after broadcast:  every rank's local shard is real (not meta) and finite (no NaN);
-  3. after broadcast:  the full state gathered from every rank's shard equals rank0's
-     original weights (so non-rank0 materialized exactly rank0's values).
-
-Prints ``PASS`` and exits 0 on success; raises (nonzero exit) on any failure.
-
-Usage (the test does this):
-    torchrun --nproc_per_node 2 init_on_meta_worker.py [shared_tmp_dir]
+Not a pytest module (not test_*); launched via torch.distributed.run. Mirrors the
+trainer's real path (rank0 builds real, non-rank0 under build_on_meta, then
+apply_fully_sharded + set_model_state_dict(broadcast_from_rank0=True)) and checks that
+--init-on-meta changes nothing:
+  1. non-rank0 params are on meta before broadcast (the memory win);
+  2. every rank's shard is real + finite after broadcast;
+  3. requires_grad matches across ranks (else FSDP2 grad-reduce hangs);
+  4. gathered full weights equal rank0's originals.
+Prints PASS / exits 0 on success. Usage: torchrun --nproc_per_node 2 <this> [tmp_dir].
 """
 
 import contextlib
@@ -128,11 +116,9 @@ def main() -> None:
     else:
         assert embed_is_meta, "non-rank0 must build on meta (--init-on-meta)"
 
-    # Snapshot rank0's weights TWICE. `bcast_src` is the broadcast source handed to
-    # set_model_state_dict below, which MUTATES its input dict into DTensors in place.
-    # `ref_np` is a SEPARATE, frozen numpy copy used only for the comparison in (3) --
-    # numpy so nothing torch/DTensor can retroactively touch it (reusing one dict for
-    # both makes the compare call a rank0-only collective on the now-DTensor ref).
+    # Two snapshots: `bcast_src` is the broadcast source (set_model_state_dict mutates
+    # its input dict into DTensors in place); `ref_np` is a frozen numpy copy for the
+    # (3) compare, immune to that mutation.
     ref_np = (
         {
             k: v.detach().cpu().float().numpy().copy()
@@ -163,10 +149,32 @@ def main() -> None:
         assert not local.is_meta, f"[rank{rank}] {name} still on meta after broadcast"
         assert not torch.isnan(local.float()).any(), f"[rank{rank}] {name} has NaN"
 
-    # (3) each param, gathered from every rank's shard, equals rank0's original
-    #     weights. full_tensor() is a COLLECTIVE, so ALL ranks gather (same order)
-    #     FIRST; only rank0 then compares, against the frozen numpy reference, so there
-    #     is NO distributed op inside `if rank == 0` (that would hang the other ranks).
+    # (2b) requires_grad must match across ranks, or FSDP2 post_backward collects a
+    #      different trainable-param set per rank and the first backward hangs.
+    #      named_parameters() is identically ordered on every rank -> flags line up.
+    flags = torch.tensor(
+        [1 if p.requires_grad else 0 for _, p in model.named_parameters()],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    gathered_flags = [torch.zeros_like(flags) for _ in range(world)]
+    dist.all_gather(gathered_flags, flags)
+    for other, gf in enumerate(gathered_flags):
+        if not torch.equal(gf, flags):
+            mism = [
+                name
+                for i, (name, _) in enumerate(model.named_parameters())
+                if gf[i] != flags[i]
+            ]
+            raise AssertionError(
+                f"[rank{rank}] requires_grad differs from rank{other} on {mism} "
+                "-> FSDP2 gradient-reduction mismatch (training would hang)"
+            )
+    tick("requires_grad is consistent across ranks")
+
+    # (3) full weights gathered from every rank's shard == rank0's originals.
+    #     full_tensor() is a collective -> ALL ranks gather first, then rank0-only
+    #     compares numpy (no distributed op inside `if rank == 0`, which would hang).
     def _gather_np(t: torch.Tensor):
         if isinstance(t, DTensor):  # sharded -> all-gather to a plain tensor
             t = t.full_tensor()

--- a/tests/e2e/smoke/init_on_meta_worker.py
+++ b/tests/e2e/smoke/init_on_meta_worker.py
@@ -1,0 +1,198 @@
+"""torchrun worker for the ``--init-on-meta`` e2e test (``test_init_on_meta.py``).
+
+Not a pytest module (not ``test_*``); launched via ``torch.distributed.run`` by the
+test. Mirrors the trainer's REAL build+materialize path and asserts the meta-init
+memory optimization does not change the result:
+
+  * build           -- rank0 builds the draft with real weights; non-rank0 builds
+                       under ``build_on_meta`` (== scripts/train.py's --init-on-meta
+                       branch: ``build_on_meta() if init_on_meta and rank != 0``);
+  * shard+broadcast -- ``apply_fully_sharded`` then ``set_model_state_dict(
+                       broadcast_from_rank0=True)`` (== trainer.py distributed setup).
+
+Assertions:
+  1. before broadcast: non-rank0 params are on ``meta`` (proof the allocation was
+     skipped -> the memory win), rank0 params are real;
+  2. after broadcast:  every rank's local shard is real (not meta) and finite (no NaN);
+  3. after broadcast:  the full state gathered from every rank's shard equals rank0's
+     original weights (so non-rank0 materialized exactly rank0's values).
+
+Prints ``PASS`` and exits 0 on success; raises (nonzero exit) on any failure.
+
+Usage (the test does this):
+    torchrun --nproc_per_node 2 init_on_meta_worker.py [shared_tmp_dir]
+"""
+
+import contextlib
+import os
+import sys
+import tempfile
+import time
+
+import torch
+import torch.distributed as dist
+from torch.distributed.checkpoint.state_dict import (
+    StateDictOptions,
+    set_model_state_dict,
+)
+from transformers import LlamaForCausalLM
+from transformers.models.llama.configuration_llama import LlamaConfig
+
+from speculators.models.eagle3 import Eagle3DraftModel
+from speculators.train.distributed import (
+    apply_fully_sharded,
+    build_on_meta,
+    get_rank,
+    get_world_size,
+    maybe_destroy_distributed,
+    maybe_setup_distributed,
+)
+
+
+def _tiny_config() -> LlamaConfig:
+    return LlamaConfig(
+        vocab_size=64,
+        hidden_size=32,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=8,
+        max_position_embeddings=32,
+        rms_norm_eps=1e-6,
+        tie_word_embeddings=False,
+    )
+
+
+def _build_draft(verifier_dir: str) -> Eagle3DraftModel:
+    # == scripts/train.py: build under build_on_meta on non-rank0 only.
+    meta_ctx = build_on_meta() if get_rank() != 0 else contextlib.nullcontext()
+    with meta_ctx:
+        return Eagle3DraftModel.from_training_args(
+            verifier_config=_tiny_config(),
+            t2d=None,
+            d2t=None,
+            draft_vocab_size=64,
+            norm_before_residual=False,
+            ttt_steps=1,
+            draft_attn_impl="eager",
+            target_layer_ids=[0, 1],
+            verifier_name_or_path=verifier_dir,
+        )
+
+
+def main() -> None:
+    import numpy as np
+    from torch.distributed.tensor import DTensor
+
+    t0 = time.perf_counter()
+    maybe_setup_distributed()
+    world = get_world_size()
+    if world < 2:
+        raise SystemExit("run with torchrun --nproc_per_node >=2 (need >1 rank)")
+    rank = get_rank()
+
+    def tick(msg: str) -> None:
+        if rank == 0:
+            print(f"[+{time.perf_counter() - t0:5.1f}s] {msg}", flush=True)
+
+    tick("distributed initialized")
+
+    # rank0 writes a tiny verifier WITH weights so rank0's load_verifier_weights
+    # succeeds; all ranks read it (torchrun ranks share the node filesystem). The
+    # shared dir is passed in by the test (its tmp_path) so runs stay hermetic.
+    shared_root = sys.argv[1] if len(sys.argv) > 1 else tempfile.gettempdir()
+    verifier_dir = os.path.join(shared_root, "init_on_meta_tiny_verifier")
+    if rank == 0:
+        LlamaForCausalLM(_tiny_config()).save_pretrained(verifier_dir)
+    dist.barrier()
+
+    model = _build_draft(verifier_dir)
+    tick("draft model built (rank0 real, non-rank0 on meta)")
+
+    # rank0 is the single source of truth: ensure it has no nan params (safety net
+    # that also decouples this check from verifier-loading details).
+    if rank == 0:
+        with torch.no_grad():
+            for p in model.parameters():
+                if p.is_meta:
+                    raise AssertionError("rank0 unexpectedly built on meta")
+                nan = torch.isnan(p)
+                if nan.any():
+                    p[nan] = torch.randn_like(p[nan]) * 0.02
+
+    # (1) the optimization engaged: non-rank0 built on meta, rank0 did not.
+    embed_is_meta = model.embed_tokens.weight.is_meta
+    if rank == 0:
+        assert not embed_is_meta, "rank0 should hold real weights"
+    else:
+        assert embed_is_meta, "non-rank0 must build on meta (--init-on-meta)"
+
+    # Snapshot rank0's weights TWICE. `bcast_src` is the broadcast source handed to
+    # set_model_state_dict below, which MUTATES its input dict into DTensors in place.
+    # `ref_np` is a SEPARATE, frozen numpy copy used only for the comparison in (3) --
+    # numpy so nothing torch/DTensor can retroactively touch it (reusing one dict for
+    # both makes the compare call a rank0-only collective on the now-DTensor ref).
+    ref_np = (
+        {
+            k: v.detach().cpu().float().numpy().copy()
+            for k, v in model.state_dict().items()
+        }
+        if rank == 0
+        else {}
+    )
+    bcast_src = model.state_dict() if rank == 0 else {}
+
+    # == trainer.py distributed setup (shard, then broadcast-materialize from rank0).
+    apply_fully_sharded(model)
+    set_model_state_dict(
+        model,
+        bcast_src,
+        options=StateDictOptions(
+            full_state_dict=True,
+            broadcast_from_rank0=True,
+            strict=False,
+        ),
+    )
+    dist.barrier()
+    tick("apply_fully_sharded + broadcast-materialize done")
+
+    # (2) every rank's local shard is real and finite after the broadcast.
+    for name, p in model.named_parameters():
+        local = p.to_local() if isinstance(p, DTensor) else p
+        assert not local.is_meta, f"[rank{rank}] {name} still on meta after broadcast"
+        assert not torch.isnan(local.float()).any(), f"[rank{rank}] {name} has NaN"
+
+    # (3) each param, gathered from every rank's shard, equals rank0's original
+    #     weights. full_tensor() is a COLLECTIVE, so ALL ranks gather (same order)
+    #     FIRST; only rank0 then compares, against the frozen numpy reference, so there
+    #     is NO distributed op inside `if rank == 0` (that would hang the other ranks).
+    def _gather_np(t: torch.Tensor):
+        if isinstance(t, DTensor):  # sharded -> all-gather to a plain tensor
+            t = t.full_tensor()
+        return t.detach().cpu().float().numpy()
+
+    gathered = {name: _gather_np(p) for name, p in model.named_parameters()}
+    dist.barrier()
+    tick("full weights gathered")
+
+    if rank == 0:
+        bad = [
+            name
+            for name, got in gathered.items()
+            if not np.allclose(got, ref_np[name], rtol=1e-2, atol=1e-3)
+        ]
+        assert not bad, f"materialized weights differ from rank0 reference: {bad}"
+
+    dist.barrier()
+    if rank == 0:
+        print(
+            f"PASS ({world} ranks): non-rank0 built on meta, all ranks materialized "
+            "real+finite weights, and the gathered state matches rank0 exactly.",
+            flush=True,
+        )
+    maybe_destroy_distributed()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/smoke/test_init_on_meta.py
+++ b/tests/e2e/smoke/test_init_on_meta.py
@@ -1,0 +1,42 @@
+"""E2E: ``--init-on-meta`` is a pure memory optimization (result unchanged).
+
+Launches the trainer's real build + broadcast-materialize path under torchrun and
+asserts that non-rank0 ranks build the draft on the meta device, then materialize --
+via ``set_model_state_dict(broadcast_from_rank0=True)`` -- real, finite weights that
+are bit-equal to rank0. See ``init_on_meta_worker.py`` for the assertions.
+
+Runs on 2 GPUs; skipped when fewer than 2 are available.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from loguru import logger
+
+from tests.conftest import requires_multi_gpu
+
+WORKER = Path(__file__).resolve().parent / "init_on_meta_worker.py"
+
+
+@pytest.mark.e2e
+@pytest.mark.slow
+@requires_multi_gpu
+def test_init_on_meta_matches_rank0(tmp_path: Path):
+    cmd = [
+        sys.executable,
+        "-m",
+        "torch.distributed.run",
+        "--nproc_per_node",
+        "2",
+        str(WORKER),
+        str(tmp_path),  # shared dir for the tiny verifier (ranks share the fs)
+    ]
+    logger.info("Running --init-on-meta distributed check: {}", " ".join(cmd))
+    result = subprocess.run(  # noqa: S603
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False
+    )
+    logger.info("worker output:\n{}", result.stdout)
+    assert result.returncode == 0, f"--init-on-meta check failed:\n{result.stdout}"
+    assert "PASS" in result.stdout, f"worker did not report PASS:\n{result.stdout}"

--- a/tests/unit/train/test_build_on_meta.py
+++ b/tests/unit/train/test_build_on_meta.py
@@ -44,16 +44,10 @@ def test_build_on_meta_restores_register_parameter():
 
 
 def test_from_training_args_under_build_on_meta(tmp_path):
-    """A real speculator builds fully under build_on_meta: all params land on meta
-    and buffers stay real. Exercises the base-class ``is_meta`` guard -- with meta
-    params, ``load_verifier_weights`` must early-return instead of calling
-    ``isnan()`` on a meta param (that raises "Tensor.item() cannot be called on
-    meta tensors").
-
-    ``from_training_args`` resolves the verifier's config.json up front (for
-    architectures via ``VerifierConfig.from_pretrained``), so point it at a local
-    dir to keep the build offline. The verifier *weights* are never read: the meta
-    guard returns first.
+    """A real speculator builds under build_on_meta: params land on meta, buffers stay
+    real, and the base-class is_meta guard makes load_verifier_weights early-return
+    (instead of calling isnan() on a meta param). A local verifier dir keeps config
+    resolution offline; the verifier weights themselves are never read.
     """
     copy.deepcopy(_TINY).save_pretrained(tmp_path)  # writes config.json only
 

--- a/tests/unit/train/test_build_on_meta.py
+++ b/tests/unit/train/test_build_on_meta.py
@@ -1,0 +1,63 @@
+"""Tests for build_on_meta (meta-device construction for --init-on-meta)."""
+
+import copy
+
+import torch
+from torch import nn
+from transformers.models.llama.configuration_llama import LlamaConfig
+
+from speculators.models.eagle3 import Eagle3DraftModel
+from speculators.train.distributed import build_on_meta
+
+_TINY = LlamaConfig(
+    vocab_size=64,
+    hidden_size=32,
+    intermediate_size=128,
+    num_hidden_layers=2,
+    num_attention_heads=4,
+    num_key_value_heads=4,
+    head_dim=8,
+    max_position_embeddings=32,
+    rms_norm_eps=1e-6,  # type: ignore[arg-type]
+    tie_word_embeddings=False,
+    _attn_implementation="eager",  # type: ignore[call-arg]
+)
+
+
+def test_build_on_meta_params_meta_buffers_real():
+    """Parameters land on meta; buffers keep their real storage and values."""
+    with build_on_meta():
+        m = nn.Linear(4, 4)
+        m.register_buffer("buf", torch.ones(4))
+    assert m.weight.is_meta and m.bias.is_meta
+    assert not m.buf.is_meta
+    assert m.buf.sum().item() == 4.0
+
+
+def test_build_on_meta_restores_register_parameter():
+    """The register_parameter monkeypatch is undone on exit (no global leak)."""
+    orig = nn.Module.register_parameter
+    with build_on_meta():
+        assert nn.Module.register_parameter is not orig
+    assert nn.Module.register_parameter is orig
+    assert not nn.Linear(2, 2).weight.is_meta  # params are real again after exit
+
+
+def test_from_training_args_under_build_on_meta():
+    """A real speculator builds under build_on_meta: all params land on meta and
+    buffers stay real. Also exercises the base-class ``is_meta`` guard: with meta
+    params, ``load_verifier_weights`` must early-return -- it neither touches the
+    (nonexistent) verifier path nor calls ``isnan()`` on a meta tensor."""
+    with build_on_meta():
+        model = Eagle3DraftModel.from_training_args(
+            verifier_config=copy.deepcopy(_TINY),
+            t2d=None,
+            d2t=None,
+            draft_vocab_size=64,
+            norm_before_residual=False,
+            ttt_steps=1,
+            # never fetched: the meta guard returns before the verifier load
+            verifier_name_or_path="does-not-exist/verifier",
+        )
+    assert all(p.is_meta for p in model.parameters())
+    assert all(not b.is_meta for b in model.buffers())

--- a/tests/unit/train/test_build_on_meta.py
+++ b/tests/unit/train/test_build_on_meta.py
@@ -43,11 +43,20 @@ def test_build_on_meta_restores_register_parameter():
     assert not nn.Linear(2, 2).weight.is_meta  # params are real again after exit
 
 
-def test_from_training_args_under_build_on_meta():
-    """A real speculator builds under build_on_meta: all params land on meta and
-    buffers stay real. Also exercises the base-class ``is_meta`` guard: with meta
-    params, ``load_verifier_weights`` must early-return -- it neither touches the
-    (nonexistent) verifier path nor calls ``isnan()`` on a meta tensor."""
+def test_from_training_args_under_build_on_meta(tmp_path):
+    """A real speculator builds fully under build_on_meta: all params land on meta
+    and buffers stay real. Exercises the base-class ``is_meta`` guard -- with meta
+    params, ``load_verifier_weights`` must early-return instead of calling
+    ``isnan()`` on a meta param (that raises "Tensor.item() cannot be called on
+    meta tensors").
+
+    ``from_training_args`` resolves the verifier's config.json up front (for
+    architectures via ``VerifierConfig.from_pretrained``), so point it at a local
+    dir to keep the build offline. The verifier *weights* are never read: the meta
+    guard returns first.
+    """
+    copy.deepcopy(_TINY).save_pretrained(tmp_path)  # writes config.json only
+
     with build_on_meta():
         model = Eagle3DraftModel.from_training_args(
             verifier_config=copy.deepcopy(_TINY),
@@ -56,8 +65,9 @@ def test_from_training_args_under_build_on_meta():
             draft_vocab_size=64,
             norm_before_residual=False,
             ttt_steps=1,
-            # never fetched: the meta guard returns before the verifier load
-            verifier_name_or_path="does-not-exist/verifier",
+            draft_attn_impl="eager",
+            target_layer_ids=[0, 1],  # explicit -> resolve skips the config fetch
+            verifier_name_or_path=str(tmp_path),
         )
     assert all(p.is_meta for p in model.parameters())
     assert all(not b.is_meta for b in model.buffers())


### PR DESCRIPTION
Adds build_on_meta(): a context manager that builds nn.Module parameters on the meta device (buffers stay real), so a large draft is not replicated in host RAM on every rank during construction. Wired into scripts/train.py via --init-on-meta: non-rank0 ranks build on meta and receive real weights via set_model_state_dict(broadcast_from_rank0=True) in FSDP setup; only rank 0 builds real weights. This is the torchtitan/torchtune large-model init pattern.

Opt-in and off by default. The base `load_verifier_weights` now no-ops on meta params, so the built-in speculators work under it through the shared load path (verified end-to-end for Eagle3 — see Tests). The general contract still holds for any *custom* draft: data-dependent init (weight load, or anything calling `.item()`/`.isnan()` on a param) must be guarded with `param.is_meta`.

  <!-- markdownlint-disable -->

  ## Purpose

  For large draft models, having every rank build the full model in host RAM during construction is wasteful — only rank 0's weights survive (the rest are overwritten by the rank-0 broadcast in FSDP setup). `--init-on-meta` lets non-rank0 ranks construct the draft on the `meta` device (≈0 resident memory); real weights then arrive via the trainer's existing `set_model_state_dict(broadcast_from_rank0=True)`. Pure memory optimization — the resulting weights are identical to a normal build.

  Changes:
  - `build_on_meta()` context manager (`speculators/train/distributed.py`): overrides `register_parameter` so params land on `meta`, buffers stay real, and restores the original on exit.
  - `--init-on-meta` flag (`scripts/train.py`, opt-in): wraps draft construction in `build_on_meta()` on non-rank0 ranks.
  - Base `SpeculatorModel.load_verifier_weights()` early-returns when params are on `meta`. Without this, `from_training_args` crashes calling `.isnan()` on a meta tensor (`Tensor.item()
  cannot be called on meta tensors`). Covers eagle3/dflash/dspark/peagle (which don't override the method); harmless no-op for mtp.

## Tests

  **Unit (CPU, runs in CI)** — `tests/unit/train/test_build_on_meta.py`:
  - params land on `meta` while buffers keep real storage/values;
  - the `register_parameter` monkeypatch is restored on exit (no global leak);
  - a real `Eagle3DraftModel.from_training_args(...)` builds under `build_on_meta` (all params meta / buffers real), exercising the `is_meta` guard so the verifier load no-ops instead of
  crashing.

  ```
  $ pytest tests/unit/train/test_build_on_meta.py -v
  3 passed
  ```

  **Multi-GPU (e2e, `@requires_multi_gpu` — auto-skips with <2 GPUs)** — `tests/e2e/smoke/test_init_on_meta.py`:
  - launches the trainer's real build + broadcast-materialize under `torchrun` and asserts non-rank0 ranks build on `meta`, then after `set_model_state_dict(broadcast_from_rank0=True)`
  every rank holds real, finite weights **bit-equal to rank 0** — i.e. `--init-on-meta` does not change the result. Validated on 2 and 8 GPUs.

  ```
  $ pytest tests/e2e/smoke/test_init_on_meta.py -v
  PASS (2 ranks): non-rank0 built on meta, all ranks materialized real+finite weights, and the gathered state matches rank0 exactly.
  1 passed
  ```
## Checklist

  I have filled in:

  - [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
  - [x] The test plan/results, such as providing test command and pasting the results.
  - [ ] (Optional) The necessary documentation update.
  - [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
