### PR TITLE
fix(loss): compute divergence losses in float32 under bf16 training

### DIFF
--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -1,3 +1,13 @@
+"""Metrics and loss functions shared across draft-model architectures.
+
+The divergence losses take their softmax in float32 (``dtype=torch.float32``)
+even under bf16 training. Their gradient w.r.t. the draft logits reduces to
+``p_draft - p_target``; once the draft is well trained the two are nearly equal,
+so in bf16 (8-bit mantissa) that subtraction is a catastrophic cancellation and
+the gradient error grows as training succeeds. ``ce_loss`` needs no upcast --
+its gradient is ``p - onehot``, which never cancels.
+"""
+
 import json
 import math
 from collections.abc import Callable
@@ -90,8 +100,8 @@ def kl_div_loss(
     Returns:
         Per-position KL divergence with shape [1, seq_len].
     """
-    logits = torch.nn.functional.log_softmax(logits, dim=-1)
-    target_p = torch.nn.functional.softmax(targets, dim=-1)
+    logits = torch.nn.functional.log_softmax(logits, dim=-1, dtype=torch.float32)
+    target_p = torch.nn.functional.softmax(targets, dim=-1, dtype=torch.float32)
     elementwise_loss = torch.nn.functional.kl_div(
         logits, target_p, reduction="none", log_target=False
     ).sum(dim=-1)  # shape: [1, seq_len]
@@ -112,8 +122,8 @@ def reverse_kl_div_loss(
     Returns:
         Per-position reverse KL divergence with shape [1, seq_len].
     """
-    draft_logq = torch.nn.functional.log_softmax(logits, dim=-1)
-    target_logp = torch.nn.functional.log_softmax(targets, dim=-1)
+    draft_logq = torch.nn.functional.log_softmax(logits, dim=-1, dtype=torch.float32)
+    target_logp = torch.nn.functional.log_softmax(targets, dim=-1, dtype=torch.float32)
     elementwise_loss = torch.nn.functional.kl_div(
         target_logp, draft_logq, reduction="none", log_target=True
     ).sum(dim=-1)  # shape: [1, seq_len]
@@ -203,8 +213,8 @@ def tv_loss(
     Returns:
         Per-position TV distance with shape [1, seq_len].
     """
-    draft_p = torch.nn.functional.softmax(logits, dim=-1)
-    target_p = torch.nn.functional.softmax(targets, dim=-1)
+    draft_p = torch.nn.functional.softmax(logits, dim=-1, dtype=torch.float32)
+    target_p = torch.nn.functional.softmax(targets, dim=-1, dtype=torch.float32)
     overlap = torch.minimum(draft_p, target_p).sum(dim=-1)  # shape: [1, seq_len]
     elementwise_loss = 1.0 - overlap
 
@@ -232,8 +242,8 @@ def neg_log_acceptance_loss(
     Returns:
         Per-position negative log-acceptance with shape [1, seq_len].
     """
-    draft_p = torch.nn.functional.softmax(logits, dim=-1)
-    target_p = torch.nn.functional.softmax(targets, dim=-1)
+    draft_p = torch.nn.functional.softmax(logits, dim=-1, dtype=torch.float32)
+    target_p = torch.nn.functional.softmax(targets, dim=-1, dtype=torch.float32)
     overlap = torch.minimum(draft_p, target_p).sum(dim=-1)  # alpha, shape: [1, seq_len]
     elementwise_loss = -torch.log(overlap.clamp_min(_EPS))
 
@@ -271,8 +281,8 @@ def lk_hybrid_loss(
     Returns:
         Per-position hybrid loss with shape [1, seq_len].
     """
-    draft_p = torch.nn.functional.softmax(logits, dim=-1)
-    target_p = torch.nn.functional.softmax(targets, dim=-1)
+    draft_p = torch.nn.functional.softmax(logits, dim=-1, dtype=torch.float32)
+    target_p = torch.nn.functional.softmax(targets, dim=-1, dtype=torch.float32)
     overlap = torch.minimum(draft_p, target_p).sum(dim=-1)  # alpha, shape: [1, seq_len]
     tv = 1.0 - overlap
     kl = kl_div_loss(logits, targets)  # reuse existing KL, shape: [1, seq_len]
@@ -462,7 +472,7 @@ def compound_loss(
     keyed as ``"{name}_loss"``.  When the config contains a single term the
     dict is empty (the overall loss already captures it).
     """
-    total = torch.tensor(0.0, device=logits.device, dtype=logits.dtype)
+    total = torch.tensor(0.0, device=logits.device, dtype=torch.float32)
     term_losses: dict[str, torch.Tensor] = {}
     multi = len(loss_config) > 1
     for name, (fn, weight) in loss_config.items():

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -1,13 +1,3 @@
-"""Metrics and loss functions shared across draft-model architectures.
-
-The divergence losses take their softmax in float32 (``dtype=torch.float32``)
-even under bf16 training. Their gradient w.r.t. the draft logits reduces to
-``p_draft - p_target``; once the draft is well trained the two are nearly equal,
-so in bf16 (8-bit mantissa) that subtraction is a catastrophic cancellation and
-the gradient error grows as training succeeds. ``ce_loss`` needs no upcast --
-its gradient is ``p - onehot``, which never cancels.
-"""
-
 import json
 import math
 from collections.abc import Callable

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -364,3 +364,68 @@ class TestDecayFunctions:
             0.25
         )
         assert exp_loss_decay(torch.tensor(0.0), gamma=0.5).item() == pytest.approx(1.0)
+
+
+class TestBf16GradientPrecision:
+    """The divergence losses must stay accurate under bf16 training.
+
+    Their gradient is ``p_draft - p_target``. A well-trained draft has
+    ``p ~= q``, so computing that subtraction in bf16 is a catastrophic
+    cancellation: before the float32 upcast these losses carried 8-23%
+    relative gradient error at high acceptance, and it grew as training
+    converged. ``ce_loss`` is the control -- its gradient is ``p - onehot``,
+    which never cancels, so it is accurate in bf16 either way.
+    """
+
+    @staticmethod
+    def _grad(loss_fn, logits_bf16, targets_bf16, dtype):
+        """Gradient from identical bf16 inputs, differing only in compute dtype."""
+        logits = logits_bf16.to(dtype).detach().clone().requires_grad_(True)
+        loss_fn(logits, targets_bf16.to(dtype)).sum().backward()
+        return logits.grad.double()
+
+    @staticmethod
+    def _well_trained_draft(vocab_size=4096, seq_len=8):
+        """bf16 logits for a draft that already agrees closely with the target."""
+        torch.manual_seed(0)
+        targets = (torch.randn(1, seq_len, vocab_size) * 2).bfloat16()
+        logits = (
+            targets.float() + torch.randn(1, seq_len, vocab_size) * 0.10
+        ).bfloat16()
+        return logits, targets
+
+    @pytest.mark.parametrize(
+        "loss_fn",
+        [kl_div_loss, reverse_kl_div_loss, tv_loss, neg_log_acceptance_loss],
+    )
+    def test_divergence_loss_gradient_accurate_in_bf16(self, loss_fn):
+        """bf16 gradients stay within 2% of an exact float64 reference."""
+        logits, targets = self._well_trained_draft()
+
+        exact = self._grad(loss_fn, logits, targets, torch.float64)
+        actual = self._grad(loss_fn, logits, targets, torch.bfloat16)
+
+        rel_err = ((actual - exact).norm() / exact.norm()).item()
+        assert rel_err < 0.02, f"{loss_fn.__name__} bf16 gradient error {rel_err:.1%}"
+
+    def test_ce_loss_gradient_accurate_in_bf16(self):
+        """Control: ce_loss has no cancellation and needs no upcast."""
+        logits, targets = self._well_trained_draft()
+
+        exact = self._grad(ce_loss, logits, targets, torch.float64)
+        actual = self._grad(ce_loss, logits, targets, torch.bfloat16)
+
+        assert ((actual - exact).norm() / exact.norm()).item() < 0.02
+
+    def test_losses_are_float32_under_bf16_logits(self):
+        """The loss itself is float32, so the masked mean does not round in bf16."""
+        logits, targets = self._well_trained_draft()
+
+        for loss_fn in (
+            kl_div_loss,
+            reverse_kl_div_loss,
+            tv_loss,
+            neg_log_acceptance_loss,
+            lk_hybrid_loss,
+        ):
+            assert loss_fn(logits, targets).dtype == torch.float32

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -367,14 +367,15 @@ class TestDecayFunctions:
 
 
 class TestBf16GradientPrecision:
-    """The divergence losses must stay accurate under bf16 training.
+    """Guards the float32 softmax in the divergence losses.
 
-    Their gradient reduces to ``p_draft - p_target``. A well-trained draft has
-    ``p ~= q``, so taking that subtraction in bf16 is a catastrophic
-    cancellation whose error grows as training converges: before the float32
-    upcast these losses carried 8-23% relative gradient error at high
-    acceptance. ``ce_loss`` is deliberately not upcast -- its gradient is
-    ``p - onehot``, which never cancels.
+    These tests FAIL if the losses take their softmax in the logits' dtype
+    (bf16 under training): the gradients come out 8-23% wrong. They PASS with
+    the float32 upcast, which brings the error under 0.2%. Removing
+    ``dtype=torch.float32`` from any divergence loss turns them red.
+
+    ``ce_loss`` is excluded on purpose -- it is accurate in bf16 either way, so
+    a test over it would guard nothing.
     """
 
     @staticmethod
@@ -395,9 +396,12 @@ class TestBf16GradientPrecision:
         ],
     )
     def test_divergence_loss_gradient_accurate_in_bf16(self, loss_fn):
-        """bf16 gradients stay within 2% of an exact float64 reference.
+        """The bf16 gradient must stay within 2% of an exact float64 reference.
 
-        Fails on the bf16 softmax (8-23% error) for every loss listed.
+        Same bf16 logits into both paths, so the only variable is the dtype the
+        loss computes in. With a bf16 softmax this asserts at 8-23% error
+        (kl_div 8.1, rkl 9.3, tv 23.2, nla 23.1, lk_hybrid 23.0); with the
+        float32 softmax every loss lands under 0.2%.
         """
         torch.manual_seed(0)
         vocab_size, seq_len = 4096, 8

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -369,12 +369,12 @@ class TestDecayFunctions:
 class TestBf16GradientPrecision:
     """The divergence losses must stay accurate under bf16 training.
 
-    Their gradient is ``p_draft - p_target``. A well-trained draft has
-    ``p ~= q``, so computing that subtraction in bf16 is a catastrophic
-    cancellation: before the float32 upcast these losses carried 8-23%
-    relative gradient error at high acceptance, and it grew as training
-    converged. ``ce_loss`` is the control -- its gradient is ``p - onehot``,
-    which never cancels, so it is accurate in bf16 either way.
+    Their gradient reduces to ``p_draft - p_target``. A well-trained draft has
+    ``p ~= q``, so taking that subtraction in bf16 is a catastrophic
+    cancellation whose error grows as training converges: before the float32
+    upcast these losses carried 8-23% relative gradient error at high
+    acceptance. ``ce_loss`` is deliberately not upcast -- its gradient is
+    ``p - onehot``, which never cancels.
     """
 
     @staticmethod
@@ -384,48 +384,32 @@ class TestBf16GradientPrecision:
         loss_fn(logits, targets_bf16.to(dtype)).sum().backward()
         return logits.grad.double()
 
-    @staticmethod
-    def _well_trained_draft(vocab_size=4096, seq_len=8):
-        """bf16 logits for a draft that already agrees closely with the target."""
+    @pytest.mark.parametrize(
+        "loss_fn",
+        [
+            kl_div_loss,
+            reverse_kl_div_loss,
+            tv_loss,
+            neg_log_acceptance_loss,
+            lk_hybrid_loss,
+        ],
+    )
+    def test_divergence_loss_gradient_accurate_in_bf16(self, loss_fn):
+        """bf16 gradients stay within 2% of an exact float64 reference.
+
+        Fails on the bf16 softmax (8-23% error) for every loss listed.
+        """
         torch.manual_seed(0)
+        vocab_size, seq_len = 4096, 8
+        # a draft that already agrees closely with the target -- the regime where
+        # p ~= q and the bf16 cancellation is worst
         targets = (torch.randn(1, seq_len, vocab_size) * 2).bfloat16()
         logits = (
             targets.float() + torch.randn(1, seq_len, vocab_size) * 0.10
         ).bfloat16()
-        return logits, targets
-
-    @pytest.mark.parametrize(
-        "loss_fn",
-        [kl_div_loss, reverse_kl_div_loss, tv_loss, neg_log_acceptance_loss],
-    )
-    def test_divergence_loss_gradient_accurate_in_bf16(self, loss_fn):
-        """bf16 gradients stay within 2% of an exact float64 reference."""
-        logits, targets = self._well_trained_draft()
 
         exact = self._grad(loss_fn, logits, targets, torch.float64)
         actual = self._grad(loss_fn, logits, targets, torch.bfloat16)
 
         rel_err = ((actual - exact).norm() / exact.norm()).item()
         assert rel_err < 0.02, f"{loss_fn.__name__} bf16 gradient error {rel_err:.1%}"
-
-    def test_ce_loss_gradient_accurate_in_bf16(self):
-        """Control: ce_loss has no cancellation and needs no upcast."""
-        logits, targets = self._well_trained_draft()
-
-        exact = self._grad(ce_loss, logits, targets, torch.float64)
-        actual = self._grad(ce_loss, logits, targets, torch.bfloat16)
-
-        assert ((actual - exact).norm() / exact.norm()).item() < 0.02
-
-    def test_losses_are_float32_under_bf16_logits(self):
-        """The loss itself is float32, so the masked mean does not round in bf16."""
-        logits, targets = self._well_trained_draft()
-
-        for loss_fn in (
-            kl_div_loss,
-            reverse_kl_div_loss,
-            tv_loss,
-            neg_log_acceptance_loss,
-            lk_hybrid_loss,
-        ):
-            assert loss_fn(logits, targets).dtype == torch.float32


### PR DESCRIPTION
## Purpose

The divergence losses (`kl_div`, `rkl`, `tv`, `nla`, `lk_hybrid`) take their softmax in the logits' dtype, which under our bf16 training (FSDP2 `param_dtype=bfloat16`, no autocast) means the whole loss runs in bf16.

Their gradient w.r.t. the draft logits reduces to **`p_draft - p_target`**. A well-trained draft has `p ≈ q`, so in bf16 (8-bit mantissa) that subtraction is a **catastrophic cancellation** — and the error *grows as training converges*, i.e. it is worst exactly where we want a clean signal.

Measured gradient error vs. an exact float64 reference, feeding **identical bf16 logits** to both paths so the only variable is the compute dtype (V=32k):

| acceptance α | `kl_div` (default) | `tv` | `ce` (control) |
|---|---|---|---|
| 0.88 | 3.0% | 5.7% | 0.14% |
| 0.95 | 9.0% | 7.1% | 0.13% |
| 0.98 | 19.4% | 31.1% | 0.11% |

`ce_loss` is immune and is left unchanged — its gradient is `p - onehot`, which never cancels. Computing the softmax in fp32 drives the error to a flat **~0.15%** (the bf16 gradient-storage floor) at every α.

The error is unbiased noise rather than systematic bias (best-fit gain 0.999), so this is not "training is broken" — but it is 10-20% of gradient magnitude thrown away for free, and every comparable library upcasts here:

- **HF transformers** — `logits = logits.float()` in every CausalLM loss (`loss/loss_utils.py:59`), commented *"Upcast to float ... to avoid potential precision issues"*
- **SpecForge** — `logits.float()` in the eager loss, `.cast(tl.float32)` in the Triton kernel
- **LLaMA-Factory** — `logits.float()` at three sites in `train/trainer_utils.py`
- **unsloth** — fused CE casts to `tl.float32` on load
- **TRL** — `selective_log_softmax` branches on dtype: *"logsumexp approach is unstable with bfloat16"*

Complementary to #765 (fp32 master weights), which fixes bf16 rounding at `optimizer.step()` and explicitly leaves forward/backward in bf16. Same disease, different organ.

## End-to-end drafter quality

Because the fix corrects an *unbiased-noise* error in the gradient (not a bias), it does **not** move the training loss — bf16 and fp32 loss curves overlap. The effect surfaces in the drafter's **acceptance / EAL**, not the loss.

Both refs continue-trained from the published [`RedHatAI/Qwen3-8B-speculator.eagle3`](https://huggingface.co/RedHatAI/Qwen3-8B-speculator.eagle3) on 18k on-policy ultrachat samples (`tv` loss, 15 epochs, lr 5e-5, seed 42; the two arms differ **only** by the softmax dtype):

| metric | base (bf16) | head (fp32, #788) |
| --- | --- | --- |
| `cond_acc` (d0 / d1 / d2) | 0.388 / 0.337 / 0.315 | 0.406 / 0.356 / 0.346 |
| **EAL** | **0.559** | **0.601 (+7.5%)** |
| `loss_epoch` | 1.997 | 1.951 |
| peak HBM / GPU | 16.3 GB | 16.3 GB |

fp32 is higher at every depth (not a single-depth artifact), compounding to **+7.5% EAL**. 

## Tests

`TestBf16GradientPrecision` feeds identical bf16 logits to each loss and to an exact float64
reference, and asserts the gradients agree within 2%. On `main` it fails for every changed loss:

| | kl_div | rkl | tv | nla | lk_hybrid |
|---|---|---|---|---|---|
| bf16 gradient error on `main` | 8.1% | 9.3% | 23.2% | 23.1% | 23.0% |
| with this change | <0.2% | <0.2% | <0.2% | <0.2% | <0.2% |

`tests/unit`: 436 passed, 3 skipped. ruff clean.

## Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.

