### PR TITLE
refactor(tests): extract pipeline runners into scripts/

### DIFF
--- a/scripts/pipeline_runners.py
+++ b/scripts/pipeline_runners.py
@@ -1,3 +1,11 @@
+"""Subprocess runners for the sibling pipeline scripts.
+
+Each runner wraps one stage — data preparation, vLLM server launch, offline
+hidden-state generation, training, MTP stitching, and vLLM inference — building
+the argv and raising on a non-zero exit. Shared by the e2e tests and by sibling
+scripts, so the invocations are kept correct in one place.
+"""
+
 import json
 import os
 import subprocess
@@ -5,23 +13,18 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from collections.abc import Callable, Iterable
 from contextlib import contextmanager
-from functools import wraps
+from http import HTTPStatus
 from pathlib import Path
 from textwrap import indent
 
 from loguru import logger
-from PIL import Image
-
-from speculators.data_generation.preprocessing import load_raw_dataset
 
 __all__ = [
     "SCRIPTS_DIR",
     "VLLM_PYTHON",
     "launch_vllm_server",
     "launch_vllm_server_context",
-    "purge_newfiles",
     "run_data_generation_offline",
     "run_prepare_data",
     "run_stitch_mtp",
@@ -31,36 +34,8 @@ __all__ = [
     "wait_for_server",
 ]
 
-
-def purge_newfiles(fn: Callable[..., Path]):
-    """Decorator that turns a Path-returning function into a context manager.
-
-    On exit, deletes top-level files in the resolved directory whose mtime is
-    newer than when the wrapped function returned.  Does not recurse into
-    subdirectories.  This prevents generated artifacts (e.g. ``d2t.npy``,
-    ``t2d.npy`` potentially cached by ``train.py``) from persisting in
-    shared directories (such as the HF snapshot cache) between test runs.
-    """
-
-    @wraps(fn)
-    @contextmanager
-    def wrapper(*args, **kwargs):
-        path = fn(*args, **kwargs)
-        cutoff = time.time()
-        try:
-            yield path
-        finally:
-            if path.is_dir():
-                for f in path.iterdir():
-                    if f.is_file() and f.stat().st_mtime > cutoff:
-                        f.unlink()
-                        logger.info("Purged generated artifact: {}", f.name)
-
-    return wrapper
-
-
 VLLM_PYTHON = os.environ.get("VLLM_PYTHON", sys.executable)
-SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+SCRIPTS_DIR = Path(__file__).resolve().parent
 
 
 def wait_for_server(
@@ -87,7 +62,7 @@ def wait_for_server(
             )
         try:
             with urllib.request.urlopen(url, timeout=5) as resp:  # noqa: S310
-                if resp.status == 200:
+                if resp.status == HTTPStatus.OK:
                     return
         except (urllib.error.URLError, ConnectionError, OSError):
             pass
@@ -142,12 +117,7 @@ def launch_vllm_server(
         wait_for_server(port, process=process)
         logger.info("vLLM server ready on port {}", port)
     except Exception:
-        process.terminate()
-        try:
-            process.wait(timeout=30)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait()
+        stop_vllm_server(process)
         raise
 
     return process
@@ -174,25 +144,6 @@ def launch_vllm_server_context(*args, **kwargs):
         yield
     finally:
         stop_vllm_server(process)
-
-
-def setup_dummy_sharegpt4v_coco(coco_dir: Path):
-    """Enable ShareGPT4V to be used without downloading the actual COCO dataset."""
-    coco_dir.mkdir(parents=True, exist_ok=True)
-
-    dummy_image = Image.new("RGB", (256, 256))
-    dummy_image_path = coco_dir / "dummy.png"
-    dummy_image.save(dummy_image_path)
-
-    raw_dataset, normalize_fn = load_raw_dataset("sharegpt4v_coco")
-
-    # Use symlinks to avoid copying the image
-    for raw_path in raw_dataset["image"]:
-        image_path = coco_dir / raw_path.removeprefix("coco/")
-
-        if not image_path.exists():
-            image_path.parent.mkdir(parents=True, exist_ok=True)
-            image_path.symlink_to(dummy_image_path)
 
 
 def run_prepare_data(
@@ -222,7 +173,8 @@ def run_prepare_data(
     result = subprocess.run(  # noqa: S603
         cmd, check=False, timeout=timeout
     )
-    assert result.returncode == 0, "prepare_data.py failed"
+    if result.returncode != 0:
+        raise RuntimeError("prepare_data.py failed")
 
 
 def run_data_generation_offline(
@@ -259,9 +211,8 @@ def run_data_generation_offline(
     result = subprocess.run(  # noqa: S603
         datagen_cmd, stderr=subprocess.PIPE, text=True, check=False, timeout=timeout
     )
-    assert result.returncode == 0, (
-        f"data_generation_offline.py failed:\n{result.stderr}"
-    )
+    if result.returncode != 0:
+        raise RuntimeError(f"data_generation_offline.py failed:\n{result.stderr}")
 
 
 def run_training(
@@ -331,7 +282,8 @@ def run_training(
     result = subprocess.run(  # noqa: S603
         train_cmd, stderr=subprocess.PIPE, text=True, check=False, timeout=timeout
     )
-    assert result.returncode == 0, f"train.py failed:\n{result.stderr}"
+    if result.returncode != 0:
+        raise RuntimeError(f"train.py failed:\n{result.stderr}")
 
 
 def run_stitch_mtp(
@@ -352,12 +304,13 @@ def run_stitch_mtp(
     result = subprocess.run(  # noqa: S603
         cmd, capture_output=True, text=True, check=False, timeout=timeout
     )
-    assert result.returncode == 0, f"stitch_mtp.py failed:\n{result.stderr}"
+    if result.returncode != 0:
+        raise RuntimeError(f"stitch_mtp.py failed:\n{result.stderr}")
 
 
 def run_vllm_engine(
     model_path: str,
-    tmp_path: Path,
+    output_dir: Path,
     prompts: list[list[dict[str, str]]],
     max_model_len: int = 1024,
     gpu_memory_utilization: float = 0.8,
@@ -367,14 +320,16 @@ def run_vllm_engine(
     disable_compile_cache: bool = False,
     max_tokens: int = 50,
     ignore_eos: bool = True,
-    acceptance_thresholds: Iterable[float] | None = None,
     timeout: float | None = None,
-):
-    VLLM_PYTHON = os.environ.get("VLLM_PYTHON", sys.executable)
-    logger.info("vLLM Python executable: {}", VLLM_PYTHON)
+) -> dict:
+    """Serve a checkpoint in vLLM and return its outputs and metrics.
 
-    run_vllm_file = str(Path(__file__).with_name("run_vllm.py"))
-    results_file = str(tmp_path / "results.json")
+    Returns the parsed results of ``scripts/run_vllm.py``: ``outputs`` holds the
+    generated token IDs per prompt, and ``metrics`` holds the speculative-decoding
+    counters, including ``acceptance_length`` and ``acceptance_at_token_{i}``.
+    """
+    run_vllm_file = str(SCRIPTS_DIR / "run_vllm.py")
+    results_file = str(output_dir / "results.json")
 
     sampling_params_dict = {
         "temperature": 0,
@@ -406,13 +361,13 @@ def run_vllm_engine(
         "--results-file",
         results_file,
     ]
+    logger.info("vLLM Python executable: {}", VLLM_PYTHON)
     logger.info("run_vllm.py command:\n    {}", command)
 
-    # Set environment variables for subprocess
     env = os.environ.copy()
     if disable_compile_cache:
         env["VLLM_DISABLE_COMPILE_CACHE"] = "1"
-        logger.info("Disabling vLLM compile cache for this test")
+        logger.info("Disabling vLLM compile cache for this run")
 
     result = subprocess.run(  # noqa: S603
         command,
@@ -425,30 +380,15 @@ def run_vllm_engine(
     )
     logger.info("run_vllm.py output:\n{}", indent(result.stdout, "    "))
 
-    returncode = result.returncode
-    assert returncode == 0, (
-        f"run_vllm.py command exited with non-zero return code: {returncode}"
-    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"run_vllm.py command exited with non-zero return code: {result.returncode}"
+        )
 
     with Path(results_file).open(encoding="utf-8") as f:
         results_dict = json.load(f)
 
-    outputs_token_ids = results_dict["outputs"]
-    metrics_dict = results_dict["metrics"]
-    logger.info("outputs_token_ids: {}", outputs_token_ids)
-    logger.info("metrics_dict: {}", metrics_dict)
+    logger.info("outputs_token_ids: {}", results_dict["outputs"])
+    logger.info("metrics_dict: {}", results_dict["metrics"])
 
-    for output_token_ids in outputs_token_ids:
-        # If max_tokens is 100 or less, make sure the output length is max_tokens
-        assert max_tokens > 100 or len(output_token_ids) == max_tokens
-        assert all(isinstance(token, int) for token in output_token_ids)
-
-    if acceptance_thresholds is not None:
-        for i, thresholdi in enumerate(acceptance_thresholds):
-            assert f"acceptance_at_token_{i}" in metrics_dict, (
-                f"Acceptance at token {i} is not in metrics_dict"
-            )
-            acci = metrics_dict[f"acceptance_at_token_{i}"]
-            assert acci >= thresholdi, (
-                f"Acceptance {acci} at token {i} is less than threshold {thresholdi}"
-            )
+    return results_dict

--- a/scripts/run_vllm.py
+++ b/scripts/run_vllm.py
@@ -91,16 +91,16 @@ def extract_metrics(raw_metrics: list[Metric], total_num_output_tokens: int) -> 
     acceptance_counts: list[float] = []
     for metric in raw_metrics:
         if metric.name == "vllm:spec_decode_num_drafts":
-            assert isinstance(metric, Counter)
+            assert isinstance(metric, Counter)  # noqa: S101  # narrow the Metric union
             num_drafts += metric.value
         elif metric.name == "vllm:spec_decode_num_draft_tokens":
-            assert isinstance(metric, Counter)
+            assert isinstance(metric, Counter)  # noqa: S101
             num_draft_tokens += metric.value
         elif metric.name == "vllm:spec_decode_num_accepted_tokens":
-            assert isinstance(metric, Counter)
+            assert isinstance(metric, Counter)  # noqa: S101
             num_accepted_tokens += metric.value
         elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
-            assert isinstance(metric, Vector)
+            assert isinstance(metric, Vector)  # noqa: S101
             if len(acceptance_counts) < len(metric.values):
                 acceptance_counts = acceptance_counts + [0.0] * (
                     len(metric.values) - len(acceptance_counts)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 from packaging.version import Version
 
-from tests.e2e.utils import VLLM_PYTHON
+from scripts.pipeline_runners import VLLM_PYTHON
 
 
 @pytest.fixture

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,4 +1,16 @@
+import time
+from collections.abc import Callable, Iterable
+from contextlib import contextmanager
+from functools import wraps
+from pathlib import Path
+from typing import Any
+
 import pytest
+from loguru import logger
+from PIL import Image
+
+from scripts import pipeline_runners
+from speculators.data_generation.preprocessing import load_raw_dataset
 
 
 @pytest.fixture
@@ -16,3 +28,88 @@ def prompts():
         [{"role": "user", "content": "Explain how speculative decoding works"}],
         [{"role": "user", "content": "Code a transformer block function"}],
     ]
+
+
+def purge_newfiles(fn: Callable[..., Path]):
+    """Decorator that turns a Path-returning function into a context manager.
+
+    On exit, deletes top-level files in the resolved directory whose mtime is
+    newer than when the wrapped function returned.  Does not recurse into
+    subdirectories.  This prevents generated artifacts (e.g. ``d2t.npy``,
+    ``t2d.npy`` potentially cached by ``train.py``) from persisting in
+    shared directories (such as the HF snapshot cache) between test runs.
+    """
+
+    @wraps(fn)
+    @contextmanager
+    def wrapper(*args, **kwargs):
+        path = fn(*args, **kwargs)
+        cutoff = time.time()
+        try:
+            yield path
+        finally:
+            if path.is_dir():
+                for f in path.iterdir():
+                    if f.is_file() and f.stat().st_mtime > cutoff:
+                        f.unlink()
+                        logger.info("Purged generated artifact: {}", f.name)
+
+    return wrapper
+
+
+def setup_dummy_sharegpt4v_coco(coco_dir: Path):
+    """Enable ShareGPT4V to be used without downloading the actual COCO dataset."""
+    coco_dir.mkdir(parents=True, exist_ok=True)
+
+    dummy_image = Image.new("RGB", (256, 256))
+    dummy_image_path = coco_dir / "dummy.png"
+    dummy_image.save(dummy_image_path)
+
+    raw_dataset, normalize_fn = load_raw_dataset("sharegpt4v_coco")
+
+    # Use symlinks to avoid copying the image
+    for raw_path in raw_dataset["image"]:
+        image_path = coco_dir / raw_path.removeprefix("coco/")
+
+        if not image_path.exists():
+            image_path.parent.mkdir(parents=True, exist_ok=True)
+            image_path.symlink_to(dummy_image_path)
+
+
+def run_vllm_engine_and_assert(
+    model_path: str,
+    tmp_path: Path,
+    prompts: list[list[dict[str, str]]],
+    max_tokens: int = 50,
+    acceptance_thresholds: Iterable[float] | None = None,
+    **kwargs: Any,
+) -> None:
+    """Serve a checkpoint in vLLM, then assert on its outputs and acceptance rates.
+
+    Extra keyword arguments are forwarded to
+    :func:`scripts.pipeline_runners.run_vllm_engine`.
+    """
+    results_dict = pipeline_runners.run_vllm_engine(
+        model_path=model_path,
+        output_dir=tmp_path,
+        prompts=prompts,
+        max_tokens=max_tokens,
+        **kwargs,
+    )
+    outputs_token_ids = results_dict["outputs"]
+    metrics_dict = results_dict["metrics"]
+
+    for output_token_ids in outputs_token_ids:
+        # If max_tokens is 100 or less, make sure the output length is max_tokens
+        assert max_tokens > 100 or len(output_token_ids) == max_tokens
+        assert all(isinstance(token, int) for token in output_token_ids)
+
+    if acceptance_thresholds is not None:
+        for i, thresholdi in enumerate(acceptance_thresholds):
+            assert f"acceptance_at_token_{i}" in metrics_dict, (
+                f"Acceptance at token {i} is not in metrics_dict"
+            )
+            acci = metrics_dict[f"acceptance_at_token_{i}"]
+            assert acci >= thresholdi, (
+                f"Acceptance {acci} at token {i} is less than threshold {thresholdi}"
+            )

--- a/tests/e2e/regression/test_eagle3_conversion_acceptance.py
+++ b/tests/e2e/regression/test_eagle3_conversion_acceptance.py
@@ -1,7 +1,7 @@
 import pytest
 
 from speculators.convert.eagle.eagle3_converter import Eagle3Converter
-from tests.e2e.utils import run_vllm_engine
+from tests.e2e.conftest import run_vllm_engine_and_assert
 from tests.utils import requires_cadence
 
 
@@ -66,7 +66,7 @@ class TestEagle3vLLM:
             ]
 
         converter.convert(**convert_kwargs)
-        run_vllm_engine(
+        run_vllm_engine_and_assert(
             model_path=str(converted_path),
             tmp_path=tmp_path,
             enforce_eager=False,
@@ -96,7 +96,7 @@ class TestEagle3vLLM:
     def test_vllm_engine_eagle3(
         self, model_path, acceptance_thresholds, prompts, tmp_path
     ):
-        run_vllm_engine(
+        run_vllm_engine_and_assert(
             model_path=model_path,
             tmp_path=tmp_path,
             prompts=prompts,

--- a/tests/e2e/regression/test_eagle3_offline_acceptance.py
+++ b/tests/e2e/regression/test_eagle3_offline_acceptance.py
@@ -6,7 +6,7 @@ Exercises the full offline pipeline:
   3. Generate hidden states offline (scripts/data_generation_offline.py)
   4. Stop the vLLM server
   5. Train a draft model using pre-generated hidden states (scripts/train.py)
-  6. Validate the trained checkpoint via vLLM inference (run_vllm_engine)
+  6. Validate the trained checkpoint via vLLM inference (run_vllm_engine_and_assert)
 """
 
 from pathlib import Path

--- a/tests/e2e/regression/test_eagle3_online_acceptance.py
+++ b/tests/e2e/regression/test_eagle3_online_acceptance.py
@@ -5,7 +5,7 @@ docs/user_guide/tutorials/train_eagle3_online.md:
   1. Prepare data (scripts/prepare_data.py)
   2. Launch a vLLM server for hidden-state extraction (scripts/launch_vllm.py)
   3. Train a draft model against the live server (scripts/train.py)
-  4. Validate the trained checkpoint via vLLM inference (run_vllm_engine)
+  4. Validate the trained checkpoint via vLLM inference (run_vllm_engine_and_assert)
 """
 
 from pathlib import Path

--- a/tests/e2e/regression/test_training_only_acceptance.py
+++ b/tests/e2e/regression/test_training_only_acceptance.py
@@ -4,7 +4,8 @@ import pytest
 from huggingface_hub import snapshot_download
 from huggingface_hub.utils import LocalEntryNotFoundError
 
-from tests.e2e.utils import purge_newfiles, run_training, run_vllm_engine
+from scripts.pipeline_runners import run_training
+from tests.e2e.conftest import purge_newfiles, run_vllm_engine_and_assert
 from tests.utils import requires_cadence
 
 
@@ -59,7 +60,7 @@ def test_eagle3_qwen3_8b_sharegpt(tmp_path: Path, prompts: list[list[dict[str, s
             timeout=30 * 60,  # 30 mins
         )
     final_checkpoint = str(save_path / str(epochs - 1))
-    run_vllm_engine(
+    run_vllm_engine_and_assert(
         model_path=final_checkpoint,
         tmp_path=tmp_path,
         max_tokens=512,
@@ -92,7 +93,7 @@ def test_dflash_qwen3_8b_sharegpt(tmp_path: Path, prompts: list[list[dict[str, s
             timeout=30 * 60,  # 30 mins
         )
     final_checkpoint = str(save_path / str(epochs - 1))
-    run_vllm_engine(
+    run_vllm_engine_and_assert(
         model_path=final_checkpoint,
         tmp_path=tmp_path,
         max_tokens=512,
@@ -130,7 +131,7 @@ def test_peagle_qwen3_8b_sharegpt(tmp_path: Path, prompts: list[list[dict[str, s
             ],
         )
     final_checkpoint = str(save_path / str(epochs - 1))
-    run_vllm_engine(
+    run_vllm_engine_and_assert(
         model_path=final_checkpoint,
         tmp_path=tmp_path,
         max_tokens=512,

--- a/tests/e2e/smoke/test_mtp_conversion_roundtrip.py
+++ b/tests/e2e/smoke/test_mtp_conversion_roundtrip.py
@@ -22,7 +22,7 @@ from safetensors.torch import load_file
 from speculators import SpeculatorModel
 from speculators.convert.mtp import MTPConverter
 from tests.conftest import requires_cuda, requires_transformers_version
-from tests.e2e.utils import run_vllm_engine
+from tests.e2e.conftest import run_vllm_engine_and_assert
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +194,7 @@ def test_mtp_roundtrip(tmp_path: Path, seed):
     prompts = [
         [{"role": "user", "content": "Write a binary search function in python"}],
     ]
-    run_vllm_engine(
+    run_vllm_engine_and_assert(
         model_path=str(stitched_path),
         tmp_path=tmp_path,
         prompts=prompts,

--- a/tests/e2e/smoke/test_mtp_finetuning.py
+++ b/tests/e2e/smoke/test_mtp_finetuning.py
@@ -16,18 +16,18 @@ from pathlib import Path
 import pytest
 from huggingface_hub import hf_hub_download
 
+from scripts.pipeline_runners import (
+    launch_vllm_server_context,
+    run_prepare_data,
+    run_stitch_mtp,
+    run_training,
+)
 from tests.conftest import (
     requires_cuda,
     requires_transformers_version,
     requires_vllm_version,
 )
-from tests.e2e.utils import (
-    launch_vllm_server_context,
-    run_prepare_data,
-    run_stitch_mtp,
-    run_training,
-    run_vllm_engine,
-)
+from tests.e2e.conftest import run_vllm_engine_and_assert
 
 logger = logging.getLogger(__name__)
 
@@ -157,7 +157,7 @@ def run_mtp_finetuning_e2e(
         logger.info("Stitch complete: %s", stitched_path)
 
         logger.info("Running vLLM MTP inference on stitched checkpoint")
-        run_vllm_engine(
+        run_vllm_engine_and_assert(
             model_path=str(stitched_path),
             tmp_path=tmp_path,
             prompts=prompts,

--- a/tests/e2e/smoke/test_offline_training.py
+++ b/tests/e2e/smoke/test_offline_training.py
@@ -6,7 +6,7 @@ Exercises the full offline pipeline:
   3. Generate hidden states offline (scripts/data_generation_offline.py)
   4. Stop the vLLM server
   5. Train a draft model using pre-generated hidden states (scripts/train.py)
-  6. Validate the trained checkpoint via vLLM inference (run_vllm_engine)
+  6. Validate the trained checkpoint via vLLM inference (run_vllm_engine_and_assert)
 """
 
 from pathlib import Path
@@ -14,14 +14,13 @@ from typing import Any
 
 import pytest
 
-from tests.e2e.utils import (
+from scripts.pipeline_runners import (
     launch_vllm_server_context,
     run_data_generation_offline,
     run_prepare_data,
     run_training,
-    run_vllm_engine,
-    setup_dummy_sharegpt4v_coco,
 )
+from tests.e2e.conftest import run_vllm_engine_and_assert, setup_dummy_sharegpt4v_coco
 
 TEXT_MODEL = "Qwen/Qwen3-0.6B"
 MM_MODEL = "Qwen/Qwen3-VL-2B-Instruct"
@@ -166,7 +165,7 @@ def run_offline_e2e(
     if prompts is not None:
         checkpoint_path = str(save_path / "checkpoint_best")
         inference_kwargs = {**(vllm_kwargs or {}), "gpu_memory_utilization": 0.8}
-        run_vllm_engine(
+        run_vllm_engine_and_assert(
             model_path=checkpoint_path,
             tmp_path=tmp_path,
             prompts=prompts,

--- a/tests/e2e/smoke/test_online_training.py
+++ b/tests/e2e/smoke/test_online_training.py
@@ -5,7 +5,7 @@ docs/user_guide/tutorials/train_eagle3_online.md:
   1. Prepare data (scripts/prepare_data.py)
   2. Launch a vLLM server for hidden-state extraction (scripts/launch_vllm.py)
   3. Train a draft model against the live server (scripts/train.py)
-  4. Validate the trained checkpoint via vLLM inference (run_vllm_engine)
+  4. Validate the trained checkpoint via vLLM inference (run_vllm_engine_and_assert)
 """
 
 from pathlib import Path
@@ -13,13 +13,12 @@ from typing import Any
 
 import pytest
 
-from tests.e2e.utils import (
+from scripts.pipeline_runners import (
     launch_vllm_server_context,
     run_prepare_data,
     run_training,
-    run_vllm_engine,
-    setup_dummy_sharegpt4v_coco,
 )
+from tests.e2e.conftest import run_vllm_engine_and_assert, setup_dummy_sharegpt4v_coco
 
 TEXT_MODEL = "Qwen/Qwen3-0.6B"
 MM_MODEL = "Qwen/Qwen3-VL-2B-Instruct"
@@ -118,7 +117,7 @@ def run_online_e2e(
     # Step 3: Validate trained checkpoint with vLLM inference
     if prompts is not None:
         checkpoint_path = str(save_path / "checkpoint_best")
-        run_vllm_engine(
+        run_vllm_engine_and_assert(
             model_path=checkpoint_path,
             tmp_path=tmp_path,
             prompts=prompts,

--- a/tests/e2e/smoke/test_resume_optimizer.py
+++ b/tests/e2e/smoke/test_resume_optimizer.py
@@ -17,13 +17,13 @@ from pathlib import Path
 import pytest
 from loguru import logger
 
-from tests.conftest import requires_multi_gpu
-from tests.e2e.utils import (
+from scripts.pipeline_runners import (
     SCRIPTS_DIR,
     launch_vllm_server_context,
     run_data_generation_offline,
     run_prepare_data,
 )
+from tests.conftest import requires_multi_gpu
 
 MODEL = "Qwen/Qwen3-0.6B"
 VLLM_PORT = 8323

--- a/tests/e2e/smoke/test_training_only.py
+++ b/tests/e2e/smoke/test_training_only.py
@@ -10,7 +10,7 @@ from loguru import logger
 from speculators.train.vocab_mapping import (
     build_vocab_mappings_from_distribution,
 )
-from tests.e2e.utils import run_vllm_engine
+from tests.e2e.conftest import run_vllm_engine_and_assert
 
 
 class TestTrainvLLM:
@@ -102,4 +102,6 @@ class TestTrainvLLM:
 
         # 4. Run trained speculator in vLLM
         # TODO: is there a way to get the checkpoint folder directly?
-        run_vllm_engine(model_path=SAVE_PATH + "/0", tmp_path=tmp_path, prompts=prompts)
+        run_vllm_engine_and_assert(
+            model_path=SAVE_PATH + "/0", tmp_path=tmp_path, prompts=prompts
+        )


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

The e2e tests hold the runners for our pipeline scripts — data prep, vLLM launch, hidden-state generation, training, stitching. They live under tests, so nothing else can use them.

I'm building a mini-training A/B harness next. It needs to run the same pipeline and read the acceptance numbers back. It can't today: the runners aren't importable from outside tests, and the vLLM runner asserts its results instead of returning them.

## What changed

One behavior change: `run_vllm_engine` now returns its metrics instead of asserting them. The assertions move to a thin wrapper, `run_vllm_engine_and_assert`, so the tests behave the same. This is the reason for the PR.

Everything else is a move, shown as two renames:

- `tests/e2e/utils.py` → `scripts/pipeline_runners.py` — the runners
- `tests/e2e/run_vllm.py` → `scripts/run_vllm.py` — the standalone vLLM CLI

The test-only helpers (`purge_newfiles`, `setup_dummy_sharegpt4v_coco`, and the new `run_vllm_engine_and_assert`) move to `tests/e2e/conftest.py`. Nothing in `src/` changes.

## Why scripts, not the package

The runners shell out to the scripts folder, so they can't run from an installed wheel. Putting them in the package would also publish them as public API. Next to the scripts they drive, they just work, and both the tests and the new harness import them directly.

## Tests

- unit: 458 passed, 3 skipped
- make quality: clean
- e2e, offline eagle3 Qwen3-0.6B smoke test on one GPU: passed in 2:46. This runs the full pipeline — prepare, vLLM launch, hidden-state generation, training, inference — so it exercises every moved runner and the changed vLLM runner end to end.

CI runs unit and integration, not e2e, so the rest of the e2e suite does not run on this PR.

## Follow-up

Some tests still call the scripts by hand. For example:

```python
# a test today:
subprocess.run([sys.executable, "scripts/stitch_mtp.py", ckpt, verifier, "--output-path", out], ...)

# could just be:
run_stitch_mtp(ckpt, verifier, out)
```

These work and are untouched here, so nothing is broken. Switching them to the runners is an easy win. It is a separate PR because one of them needs a new distributed-training option first, and they are GPU tests.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
