### PR TITLE
refactor(dead code): drop the vLLM/torch standalone_compile workaround

### DIFF
--- a/tests/e2e/run_vllm.py
+++ b/tests/e2e/run_vllm.py
@@ -1,60 +1,9 @@
 import argparse
-import importlib
 import json
-import types
 from pathlib import Path
 
-
-def _workaround_vllm_torch210() -> None:
-    """Patch torch 2.10.0 / vLLM nightly incompatibility before loading vLLM.
-
-    In torch 2.10.0, ``torch._inductor`` exposes ``standalone_compile`` as a
-    wrapper function that shadows the submodule of the same name.  vLLM nightly
-    patches ``torch._inductor.standalone_compile.FakeTensorMode`` via
-    ``unittest.mock.patch``, but ``mock`` resolves the dotted path through
-    ``getattr``, landing on the wrapper function rather than the module.
-    Functions have no ``FakeTensorMode`` attribute, so ``mock`` raises
-    ``AttributeError`` and vLLM fails to start.
-
-    Fix: replace the attribute with a callable subclass of the actual submodule
-    so that ``mock.patch`` patches ``FakeTensorMode`` in the correct module
-    namespace (which the submodule reads at runtime via ``LOAD_GLOBAL``) while
-    callers that invoke ``standalone_compile(graph, ...)`` still reach the
-    original wrapper via ``__call__``.
-
-    Upstream issue: https://github.com/pytorch/pytorch/issues/176562
-    """
-    try:
-        import torch._inductor as _ti  # noqa: PLC0415
-    except ImportError:
-        return
-
-    sc_fn = getattr(_ti, "standalone_compile", None)
-    if not callable(sc_fn) or hasattr(sc_fn, "FakeTensorMode"):
-        return  # not affected or already patched
-
-    try:
-        sc_mod = importlib.import_module("torch._inductor.standalone_compile")
-    except ImportError:
-        return
-
-    if not hasattr(sc_mod, "FakeTensorMode"):
-        return  # unexpected module layout — leave untouched
-
-    class _CallableModule(types.ModuleType):
-        def __call__(self, *args, **kwargs):
-            return sc_fn(*args, **kwargs)  # type: ignore[misc]
-
-    sc_mod.__class__ = _CallableModule
-    _ti.standalone_compile = sc_mod  # type: ignore[assignment]
-
-
-# Apply the workaround before importing vLLM: the fix must be in place before
-# vLLM's compilation backend resolves torch._inductor.standalone_compile.
-_workaround_vllm_torch210()
-
-from vllm import LLM, SamplingParams  # type: ignore[import-not-found]  # noqa: E402
-from vllm.v1.metrics.reader import Counter, Metric, Vector  # noqa: E402
+from vllm import LLM, SamplingParams  # type: ignore[import-not-found]
+from vllm.v1.metrics.reader import Counter, Metric, Vector
 
 
 def parse_args():


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

`tests/e2e/run_vllm.py` monkeypatches `torch._inductor.standalone_compile` before importing vLLM, so that vLLM's `mock.patch` of `standalone_compile.FakeTensorMode` resolves to the module instead of torch's wrapper function.

vLLM fixed this on its side in [vllm-project/vllm#37158](https://github.com/vllm-project/vllm/pull/37158) (v0.19.0+) by patching `sys.modules["torch._inductor.standalone_compile"]` directly. The workaround has nothing left to do.

It is not dead code — torch still shadows `standalone_compile` (checked on 2.11.0 and 2.12.1), so the patch still fires and mutates torch internals on every run. Deleting it removes a live monkeypatch.

This makes the e2e suite require vLLM ≥ 0.19.0. The MTP e2e tests already gate at `requires_vllm_version("0.22.0")`, so it costs nothing.

## Changes

Delete `_workaround_vllm_torch210()` and its call, plus the `importlib` / `types` imports it owned. The two vLLM imports return to the top of the file, so their `# noqa: E402` goes too (`RUF100` fails otherwise). That is the whole `+2`.

One file, +2 / −53.

## Tests

all pass. Nothing broken. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
