### PR TITLE
test(e2e): fix flaky EAGLE-3 acceptance regression thresholds

### DIFF
--- a/tests/e2e/regression/test_eagle3_offline_acceptance.py
+++ b/tests/e2e/regression/test_eagle3_offline_acceptance.py
@@ -25,10 +25,15 @@ from tests.utils import requires_cadence
 
 @requires_cadence("nightly")
 @pytest.mark.parametrize(
-    ("model", "dataset", "acceptance_thresholds"),
+    ("model", "dataset", "acceptance_thresholds", "min_acceptance_length"),
     [
-        ("Qwen/Qwen3-8B", "sharegpt", [0.4, 0.1, 0.01]),
-        ("Qwen/Qwen3-VL-2B-Instruct", "sharegpt4v_coco", [0.4, 0.2, 0.04]),
+        # Per-position acceptance rates are high-variance at this eval size, so
+        # they are loose sanity floors set well below the observed run-to-run
+        # range (Qwen3-8B measured pos1 in 0.073-0.118 across identical-dep
+        # legs). `min_acceptance_length` is the primary, lower-variance gate
+        # (Qwen3-8B measured 1.54-1.65; 1.3 leaves ~0.24 headroom).
+        ("Qwen/Qwen3-8B", "sharegpt", [0.3, 0.04, 0.0], 1.3),
+        ("Qwen/Qwen3-VL-2B-Instruct", "sharegpt4v_coco", [0.4, 0.2, 0.04], None),
     ],
 )
 def test_offline_regression(
@@ -36,6 +41,7 @@ def test_offline_regression(
     model: str,
     dataset: str,
     acceptance_thresholds: list[float],
+    min_acceptance_length: float | None,
     prompts: list[list[dict[str, str]]],
 ):
     if dataset == "sharegpt4v_coco":
@@ -70,5 +76,6 @@ def test_offline_regression(
         epochs=3,
         prompts=prompts,
         acceptance_thresholds=acceptance_thresholds,
+        min_acceptance_length=min_acceptance_length,
         log_freq=50,
     )

--- a/tests/e2e/regression/test_eagle3_online_acceptance.py
+++ b/tests/e2e/regression/test_eagle3_online_acceptance.py
@@ -24,10 +24,15 @@ from tests.utils import requires_cadence
 
 @requires_cadence("nightly")
 @pytest.mark.parametrize(
-    ("model", "dataset", "acceptance_thresholds"),
+    ("model", "dataset", "acceptance_thresholds", "min_acceptance_length"),
     [
-        ("Qwen/Qwen3-8B", "sharegpt", [0.4, 0.1, 0.01]),
-        ("Qwen/Qwen3-VL-2B-Instruct", "sharegpt4v_coco", [0.4, 0.2, 0.04]),
+        # Per-position acceptance rates are high-variance at this eval size, so
+        # they are loose sanity floors set well below the observed run-to-run
+        # range (Qwen3-8B measured pos1 in 0.073-0.118 across identical-dep
+        # legs). `min_acceptance_length` is the primary, lower-variance gate
+        # (Qwen3-8B measured 1.54-1.65; 1.3 leaves ~0.24 headroom).
+        ("Qwen/Qwen3-8B", "sharegpt", [0.3, 0.04, 0.0], 1.3),
+        ("Qwen/Qwen3-VL-2B-Instruct", "sharegpt4v_coco", [0.4, 0.2, 0.04], None),
     ],
 )
 def test_online_regression(
@@ -35,6 +40,7 @@ def test_online_regression(
     model: str,
     dataset: str,
     acceptance_thresholds: list[float],
+    min_acceptance_length: float | None,
     prompts: list[list[dict[str, str]]],
 ):
     if dataset == "sharegpt4v_coco":
@@ -69,6 +75,7 @@ def test_online_regression(
         epochs=3,
         prompts=prompts,
         acceptance_thresholds=acceptance_thresholds,
+        min_acceptance_length=min_acceptance_length,
         log_freq=50,
         train_timeout=45 * 60,  # 45 mins
     )

--- a/tests/e2e/smoke/test_offline_training.py
+++ b/tests/e2e/smoke/test_offline_training.py
@@ -112,6 +112,7 @@ def run_offline_e2e(
     max_tokens: int = 50,
     ignore_eos: bool = True,
     acceptance_thresholds: list[float] | None = None,
+    min_acceptance_length: float | None = None,
     speculator_type: str = "eagle3",
     extra_train_args: list[str] | None = None,
     target_layer_ids: list[int] | None = None,
@@ -174,5 +175,6 @@ def run_offline_e2e(
             max_tokens=max_tokens,
             ignore_eos=ignore_eos,
             acceptance_thresholds=acceptance_thresholds,
+            min_acceptance_length=min_acceptance_length,
             **inference_kwargs,
         )

--- a/tests/e2e/smoke/test_online_training.py
+++ b/tests/e2e/smoke/test_online_training.py
@@ -79,6 +79,7 @@ def run_online_e2e(
     max_tokens: int = 50,
     ignore_eos: bool = True,
     acceptance_thresholds: list[float] | None = None,
+    min_acceptance_length: float | None = None,
     log_freq: int = 1,
     train_timeout: int = 30 * 60,  # 30 mins
 ):
@@ -126,5 +127,6 @@ def run_online_e2e(
             max_tokens=max_tokens,
             ignore_eos=ignore_eos,
             acceptance_thresholds=acceptance_thresholds,
+            min_acceptance_length=min_acceptance_length,
             **(vllm_kwargs or {}),
         )

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -368,6 +368,7 @@ def run_vllm_engine(
     max_tokens: int = 50,
     ignore_eos: bool = True,
     acceptance_thresholds: Iterable[float] | None = None,
+    min_acceptance_length: float | None = None,
     timeout: float | None = None,
 ):
     VLLM_PYTHON = os.environ.get("VLLM_PYTHON", sys.executable)
@@ -443,6 +444,10 @@ def run_vllm_engine(
         assert max_tokens > 100 or len(output_token_ids) == max_tokens
         assert all(isinstance(token, int) for token in output_token_ids)
 
+    # Per-position acceptance rates are high-variance at these small eval sizes
+    # (num_drafts is only ~50-100), so they serve as loose sanity floors. The
+    # primary regression gate is `min_acceptance_length` below, a lower-variance
+    # aggregate. See tests/e2e/regression for the thresholds and rationale.
     if acceptance_thresholds is not None:
         for i, thresholdi in enumerate(acceptance_thresholds):
             assert f"acceptance_at_token_{i}" in metrics_dict, (
@@ -452,3 +457,13 @@ def run_vllm_engine(
             assert acci >= thresholdi, (
                 f"Acceptance {acci} at token {i} is less than threshold {thresholdi}"
             )
+
+    if min_acceptance_length is not None:
+        assert "acceptance_length" in metrics_dict, (
+            "acceptance_length is not in metrics_dict"
+        )
+        acceptance_length = metrics_dict["acceptance_length"]
+        assert acceptance_length >= min_acceptance_length, (
+            f"Acceptance length {acceptance_length} is less than "
+            f"threshold {min_acceptance_length}"
+        )


### PR DESCRIPTION
## Purpose

The nightly `test_eagle3_offline_acceptance` / `test_eagle3_online_acceptance` regressions for `Qwen/Qwen3-8B` fail intermittently on the per-position acceptance thresholds. This is a **test-configuration + measurement-variance** problem, **not** a vLLM or transformers regression.

## Root cause (evidence)

From nightly runs [29298743272](https://github.com/neuralmagic/llm-compressor-testing/actions/runs/29298743272) (07-14) and [29381829610](https://github.com/neuralmagic/llm-compressor-testing/actions/runs/29381812961) (07-15), reading the actual `metrics_dict` from every eval:

| Leg | Python | transformers | vllm | offline acc@1 | online acc@1 |
|---|---|---|---|---|---|
| pinned | 3.10 | `5.13.1` | `0.25.1` | 0.112 ✅ | 0.073 ❌ |
| pinned | 3.11 | `5.13.1` | `0.25.1` | 0.074 ❌ | 0.118 ✅ |
| pinned | 3.13 | `5.13.1` | `0.25.1` | 0.104 ✅ | 0.097 ❌ |
| @main | 3.13 | `5.14.0.dev0` | `0.25.1` | 0.098 ❌ | 0.110 ✅ |

(torch `2.12.1+cu130` on all legs.) The "pinned" legs pass `transformers=''` in the workflow matrix, so they use the version vLLM 0.25.1 resolves (`5.13.1`); `vllm=''` resolves to the latest stable release (`0.25.1`).

- The **three pinned legs have byte-identical dependency sets** yet `acceptance_at_token_1` swings **0.073–0.118** (~47% spread), straddling the `0.1` bar so pass/fail is essentially random. That is variance, not a version effect.
- The **`transformers@main`** leg lands *mid-distribution* (higher than pinned 3.11's 0.074), so it is not a source of degradation.
- The `test_eagle3_conversion_acceptance` cases, which load **pretrained** heads, return **identical high** acceptance (`[0.827, 0.615, 0.462]`, …) on every leg — vLLM's EAGLE-3 spec-decode path is healthy and deterministic. Only the **freshly-trained** head (5000 samples / 3 epochs, `num_drafts ≈ 50–100`) is low-and-noisy.
- History: #463 already lowered the offline thresholds `[0.4, 0.1, 0.01] → [0.4, 0.07, 0.007]` for this exact flakiness; #495 inadvertently reverted them to `[0.4, 0.1, 0.01]` while adding multimodal parametrization (verified: `1bc3788~1` had `0.07`, `1bc3788` has `0.1`). The online test was never lowered.

## Description

`acceptance_length` is a far lower-variance aggregate (measured **1.54–1.65** across all legs, ~6% spread vs ~47% for per-position). This PR:

- Adds an optional `min_acceptance_length` check to `run_vllm_engine`, threaded through the offline/online e2e helpers.
- Gates the Qwen3-8B regression on `acceptance_length >= 1.3` (~0.24 headroom below the observed floor) as the primary, stable signal.
- Demotes the per-position rates to loose sanity floors (`[0.4, 0.1, 0.01] → [0.3, 0.04, 0.0]`) set well below the observed range.

Multimodal (`Qwen3-VL-2B`) per-position thresholds are left unchanged (COCO is skipped in CI, so there is no data to retune them).

**Follow-up (not in this PR):** the deeper flakiness driver is the tiny eval (`num_drafts ≈ 50–100`); enlarging it (more prompts / higher `max_tokens`) would make any per-position bar statistically meaningful.

## Tests

`tests/e2e/regression/test_eagle3_offline_acceptance.py` and `test_eagle3_online_acceptance.py` are nightly-cadence e2e tests (require GPU + HF access); they run in the `llm-compressor-testing` nightly. `make style` / `make quality` pass on the changed files.

E2E CI runs:
- Using transformers@main: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/29409073835
- Using stable versions of transformers/vllm: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/29409006763