### PR TITLE
fix(test): increase dflash/peagle weekly regression timeouts to 45 min

### DIFF
--- a/tests/e2e/regression/test_training_only_acceptance.py
+++ b/tests/e2e/regression/test_training_only_acceptance.py
@@ -89,7 +89,7 @@ def test_dflash_qwen3_8b_sharegpt(tmp_path: Path, prompts: list[list[dict[str, s
             num_layers=3,
             online=False,
             log_freq=50,
-            timeout=30 * 60,  # 30 mins
+            timeout=45 * 60,  # 45 mins
         )
     final_checkpoint = str(save_path / str(epochs - 1))
     run_vllm_engine(
@@ -122,7 +122,7 @@ def test_peagle_qwen3_8b_sharegpt(tmp_path: Path, prompts: list[list[dict[str, s
             num_layers=4,
             online=False,
             log_freq=50,
-            timeout=30 * 60,  # 30 mins
+            timeout=45 * 60,  # 45 mins
             extra_train_args=[
                 "--no-norm-before-residual",
                 "--scheduler-type",


### PR DESCRIPTION
## Summary

- Increase training timeout from 30 min to 45 min for `test_dflash_qwen3_8b_sharegpt` and `test_peagle_qwen3_8b_sharegpt`

Fixes [INFERENG-9068](https://redhat.atlassian.net/browse/INFERENG-9068).

## Context

The 30-minute timeout was already tight — dflash training completed in ~28 min on the last passing weekly run (July 4, vLLM 0.24.0). Two PRs merged between July 9–13 added per-run overhead:

- **#749** (default sliding window for dflash/dspark) — changed attention defaults for all draft layers
- **#731** (torch.compile for `create_block_mask`) — improves steady-state mask build time but adds first-time compilation overhead

This pushed both dflash and peagle past the 30-min mark on the July 14 weekly run, causing `TimeoutExpired`.

45 minutes gives ~60% headroom over the ~28 min baseline and aligns with the 60-min timeout used by the MTP online test.

## Test plan

- [x] Verify only dflash/peagle timeouts changed (eagle3 kept at 30 min — unaffected by #731)
- [ ] Next weekly CI run validates the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)