### PR TITLE
fix(test): reduce vLLM gpu_memory_utilization to avoid CUDA OOM in MTP regression

### DIFF
--- a/tests/e2e/regression/test_mtp_online_acceptance.py
+++ b/tests/e2e/regression/test_mtp_online_acceptance.py
@@ -47,5 +47,5 @@ def test_mtp_online_regression(
         acceptance_thresholds=[0.82, 0.65, 0.48],
         max_tokens=512,
         train_timeout=60 * 60,
-        gpu_memory_utilization=0.3,
+        gpu_memory_utilization=0.25,
     )


### PR DESCRIPTION
## Summary

- Reduces `gpu_memory_utilization` from `0.3` to `0.25` in `test_mtp_online_regression` to prevent CUDA launch failures caused by GPU memory pressure when running vLLM 0.25.1 alongside MTP training on a single H100

## Context

The weekly MTP online regression test fails with `cudaErrorLaunchFailure` after upgrading vLLM from 0.24.0 to 0.25.1. The test runs a vLLM server and training concurrently on the same GPU:

| | vLLM 0.24.0 (July 4, PASS) | vLLM 0.25.1 (July 14, FAIL) |
|---|---|---|
| vLLM memory | ~24 GB | ~24.9 GB |
| Training peak | ~55 GB | ~55.4 GB |
| Total peak | ~79 GB | **~80.3 GB** |
| Headroom | ~2.5 GB | **~1.2 GB** ❌ |

With 0.25.1's slightly higher memory footprint (CUDA graph profiling, model loading overhead), the combined usage peaks at 80.3/81.6 GB — insufficient for transient CUDA kernel allocations, causing an asynchronous launch failure that surfaces at `torch.cuda.synchronize()`.

Reducing `gpu_memory_utilization` from 0.3 to 0.25 saves ~4 GB of GPU memory for vLLM's KV cache, giving training ~5 GB of headroom. The vLLM server retains sufficient KV cache capacity (~60k tokens) for the hidden-state extraction workload.

## Test plan

- [x] Reproduced the CUDA launch failure with `gpu_memory_utilization=0.3` on vLLM 0.25.1 + single H100 (crashed at step ~57/146)
- [x] Verified test passes end-to-end with `gpu_memory_utilization=0.25` on vLLM 0.25.1 + single H100 (completed in 5m26s, all acceptance thresholds met: token_0=0.841≥0.82, token_1=0.674≥0.65, token_2=0.501≥0.48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)