### PR TITLE
fix(data): a chat template that rejects a row must not kill prepare-data

### DIFF
--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -588,7 +588,8 @@ def _preprocess_batch(
         except Exception as e:
             log.error(
                 f"Failed to process conversation {idx} "
-                f"(assistant_pattern={assistant_pattern is not None}): {e}"
+                f"(assistant_pattern={assistant_pattern is not None}): "
+                f"{type(e).__name__}: {e}"
             )
             continue
 

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -582,7 +582,10 @@ def _preprocess_batch(
                 tools=parsed_tools,
                 conv_idx=idx,
             )
-        except (TypeError, ValueError, KeyError, AttributeError, RuntimeError) as e:
+        # Templates reject rows they cannot render with arbitrary types -- Mistral
+        # and Gemma raise jinja2's TemplateError, which subclasses Exception
+        # directly. One unrenderable row must not kill the run.
+        except Exception as e:
             log.error(
                 f"Failed to process conversation {idx} "
                 f"(assistant_pattern={assistant_pattern is not None}): {e}"
@@ -903,8 +906,11 @@ def load_and_preprocess_dataset(
             assistant_pattern=assistant_pattern,
             minimum_valid_tokens=minimum_valid_tokens,
         )
-        if minimum_valid_tokens is not None:
-            log.info(f"Kept {len(preprocessed_dataset)} samples after filtering")
+        dropped = len(raw_dataset) - len(preprocessed_dataset)
+        if dropped:
+            log.warning(
+                f"Dropped {dropped}/{len(raw_dataset)} samples during preprocessing"
+            )
         processed_datasets.append(preprocessed_dataset)
 
     combined_dataset = concatenate_datasets(processed_datasets)

--- a/tests/integration/datagen/test_preprocessing.py
+++ b/tests/integration/datagen/test_preprocessing.py
@@ -616,6 +616,49 @@ def test_preprocess_batch_empty_conversations():
 
 
 @pytest.mark.sanity
+def test_preprocess_batch_skips_rows_a_strict_template_rejects():
+    """A template that rejects a role sequence must skip the row, not kill the run.
+
+    Mistral and Gemma templates validate role order and call ``raise_exception``,
+    which surfaces as ``jinja2.TemplateError``. Reproduced here with a minimal
+    strict template so the test needs no gated download.
+    """
+    processor = load_processor(TEXT_MODEL_REPO, trust_remote_code=True)
+    processor.chat_template = (
+        "{% for m in messages %}"
+        "{% if (m['role'] == 'user') != (loop.index0 % 2 == 0) %}"
+        "{{ raise_exception('roles must alternate user/assistant/...') }}"
+        "{% endif %}"
+        "{{ m['role'] }}: {{ m['content'] }}\n"
+        "{% endfor %}"
+    )
+
+    examples = {
+        "conversations": [
+            # Opens on an assistant turn, the shape sharegpt rows carry.
+            [
+                {"role": "assistant", "content": "Sure"},
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+            ],
+            [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+            ],
+        ]
+    }
+
+    results = _preprocess_batch(
+        examples, processor, max_length=512, assistant_pattern=r"assistant: (.*?)\n"
+    )
+
+    # The clean row survives, and survives usable -- proving the skip is selective
+    # rather than the batch collapsing.
+    assert len(results["input_ids"]) == 1
+    assert results["loss_mask"][0].sum() > 0
+
+
+@pytest.mark.sanity
 def test_preprocess_batch_invalid_conversation():
     """Test preprocessing batch with invalid conversations."""
     processor = load_processor(TEXT_MODEL_REPO, trust_remote_code=True)


### PR DESCRIPTION
## Purpose

`prepare-data` crashes on the `sharegpt` and `hermes-fc` presets when the target model is Mistral or Gemma. A single row the chat template can't render takes down the whole run.

Mistral and Gemma templates validate role order and call Jinja's `raise_exception`, which transformers surfaces as `jinja2.TemplateError`. That subclasses `Exception` directly, so it matched none of the types in `_preprocess_batch`'s hand-listed except tuple — the handler whose whole job is to log a bad conversation and continue. Llama/Qwen/Phi templates render any role sequence, so this stayed latent until Mistral support landed in #719.

### Repro

```python
from speculators.data_generation.preprocessing import _preprocess_batch, load_processor

proc = load_processor("mistralai/Mistral-7B-Instruct-v0.3")
_preprocess_batch(
    # A sharegpt row: opens on a `gpt` turn.
    {"conversations": [[{"role": "assistant", "content": "Sure"},
                        {"role": "user", "content": "Hello"}]]},
    proc, max_length=512, assistant_pattern=None,
)
# jinja2.exceptions.TemplateError: After the optional system message, conversation
# roles must alternate user/assistant/user/assistant/...
```

On `main` that traceback escapes and ends the run. On this branch the row is logged and skipped.

## Changes

- **`_preprocess_batch` catches `Exception`** for a row that fails to render. Enumerating the types third-party template code can raise is what broke here, and the list can't be completed: `trust_remote_code` templates raise anything, and transformers treats the template engine as swappable. `BLE001` is already ignored for this package, and `train/data.py:340` uses the same per-sample skip.
- **Dropped rows are reported unconditionally.** Previously the count only appeared under `--minimum-valid-tokens`, so silent loss was invisible. This is what makes the broad catch safe — you always learn that rows went missing.

## Impact

Measured on real Hub rows through the real Mistral v0.3 template:

| `prepare-data --data …` | before | after |
| --- | --- | --- |
| `sharegpt` | run dies | 47/60 kept, 13 skipped + logged |
| `hermes-fc` | run dies | 0/60 → clear "No samples remain after preprocessing" |
| `sharegpt` on Llama-3.1 | 60/60 | 60/60, unchanged |

**This does not make those presets work on Mistral — it stops the crash and makes the loss visible.** Two follow-ups, both out of scope here:

- `sharegpt` loses 34% of rows to a dangling leading `gpt` turn (138/400 sampled). Dropping that turn renders 400/400. That changes existing training data on permissive templates too, so it needs its own PR.
- `hermes-fc` needs structured `tool_calls` for Mistral's alternation check to skip the call turn — that's #750's path, not a preprocessing fix.

## Tests

- New `test_preprocess_batch_skips_rows_a_strict_template_rejects`. Uses a minimal strict template inline, so it needs no gated download. Fails on `main` with the production error; passes here.


## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.

Signed-off-by: Ranran Haoran Zhang <ranzhang@redhat.com>
