### PR TITLE
Add timing metrics to offline data generation pipeline

### DIFF
--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -275,7 +275,6 @@ async def worker(  # noqa: C901
                 ) from e
         else:
             stats["ok"] += 1
-            stats["requests"] += 1
             stats["total_vllm_s"] += vllm_s
             stats["total_write_s"] += write_s
             logger.debug(
@@ -289,7 +288,7 @@ async def worker(  # noqa: C901
         finally:
             elapsed = time.perf_counter() - stats["start_time"]
             postfix = {"ok": stats["ok"], "err": stats["errors"]}
-            if elapsed > 0 and stats["requests"] > 0:
+            if elapsed > 0 and stats["ok"] > 0:
                 postfix["rps"] = f"{stats['requests'] / elapsed:.1f}"
                 postfix["vllm"] = (
                     f"{stats['total_vllm_s'] / stats['requests'] * 1000:.0f}ms"
@@ -375,7 +374,6 @@ async def generate_and_save_hidden_states(args, dataset):
     stats: dict[str, Any] = {
         "ok": 0,
         "errors": 0,
-        "requests": 0,
         "total_vllm_s": 0.0,
         "total_write_s": 0.0,
         "start_time": time.perf_counter(),
@@ -426,14 +424,14 @@ async def generate_and_save_hidden_states(args, dataset):
             await _shutdown_workers(workers, queue, cancel_event)
 
     elapsed = time.perf_counter() - stats["start_time"]
-    if stats["requests"] > 0:
+    if stats["ok"] > 0:
         logger.info(
             "Timing: %.1fs elapsed, %.1f samples/s, "
             "avg vLLM request %.0f ms, avg file write %.0f ms",
             elapsed,
-            stats["requests"] / elapsed if elapsed > 0 else 0,
-            stats["total_vllm_s"] / stats["requests"] * 1000,
-            stats["total_write_s"] / stats["requests"] * 1000,
+            stats["ok"] / elapsed if elapsed > 0 else 0,
+            stats["total_vllm_s"] / stats["ok"] * 1000,
+            stats["total_write_s"] / stats["ok"] * 1000,
         )
 
     num_saved = len(to_process) - len(skipped_indices)

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -289,12 +289,10 @@ async def worker(  # noqa: C901
             elapsed = time.perf_counter() - stats["start_time"]
             postfix = {"ok": stats["ok"], "err": stats["errors"]}
             if elapsed > 0 and stats["ok"] > 0:
-                postfix["rps"] = f"{stats['requests'] / elapsed:.1f}"
-                postfix["vllm"] = (
-                    f"{stats['total_vllm_s'] / stats['requests'] * 1000:.0f}ms"
-                )
+                postfix["rps"] = f"{stats['ok'] / elapsed:.1f}"
+                postfix["vllm"] = f"{stats['total_vllm_s'] / stats['ok'] * 1000:.0f}ms"
                 postfix["write"] = (
-                    f"{stats['total_write_s'] / stats['requests'] * 1000:.0f}ms"
+                    f"{stats['total_write_s'] / stats['ok'] * 1000:.0f}ms"
                 )
             pbar.set_postfix(postfix, refresh=False)
             pbar.update(1)

--- a/scripts/data_generation_offline.py
+++ b/scripts/data_generation_offline.py
@@ -18,6 +18,7 @@ import logging
 import os
 import shutil
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -207,6 +208,7 @@ async def worker(  # noqa: C901
     skipped_indices: list[int],
     cancel_event: asyncio.Event,
     failure_tracker: _FailureTracker | None,
+    stats: dict[str, Any],
 ):
     """Worker that pulls items from queue and sends them to the vLLM endpoint."""
     while True:
@@ -226,6 +228,7 @@ async def worker(  # noqa: C901
 
         try:
             async with vllm_semaphore:  # Limit number of active generate calls
+                t_vllm = time.perf_counter()
                 hidden_states_path = await generate_hidden_states_async(
                     client,
                     model,
@@ -233,14 +236,17 @@ async def worker(  # noqa: C901
                     timeout=request_timeout,
                     max_retries=max_retries,
                 )
+                vllm_s = time.perf_counter() - t_vllm
             lock_path = hidden_states_path + ".lock"
             if Path(lock_path).exists():  # noqa: ASYNC240
                 await wait_for_lock_async(lock_path)
 
             async with write_semaphore:  # Limit number of active disk writes
+                t_write = time.perf_counter()
                 await asyncio.to_thread(
                     shutil.move, hidden_states_path, target_hidden_states_path
                 )
+                write_s = time.perf_counter() - t_write
                 if validate_outputs:
 
                     def _load_and_check(
@@ -260,6 +266,7 @@ async def worker(  # noqa: C901
                 os._exit(1)
             logger.warning("Skipping sample %d due to error: %s", idx, e)
             skipped_indices.append(idx)
+            stats["errors"] += 1
             if failure_tracker is not None and failure_tracker.record_failure():
                 cancel_event.set()
                 raise RuntimeError(
@@ -267,9 +274,30 @@ async def worker(  # noqa: C901
                     "errored out. The vLLM server may be unreachable."
                 ) from e
         else:
+            stats["ok"] += 1
+            stats["requests"] += 1
+            stats["total_vllm_s"] += vllm_s
+            stats["total_write_s"] += write_s
+            logger.debug(
+                "Sample %d: vLLM %.0f ms, write %.0f ms",
+                idx,
+                vllm_s * 1000,
+                write_s * 1000,
+            )
             if failure_tracker is not None:
                 failure_tracker.record_success()
         finally:
+            elapsed = time.perf_counter() - stats["start_time"]
+            postfix = {"ok": stats["ok"], "err": stats["errors"]}
+            if elapsed > 0 and stats["requests"] > 0:
+                postfix["rps"] = f"{stats['requests'] / elapsed:.1f}"
+                postfix["vllm"] = (
+                    f"{stats['total_vllm_s'] / stats['requests'] * 1000:.0f}ms"
+                )
+                postfix["write"] = (
+                    f"{stats['total_write_s'] / stats['requests'] * 1000:.0f}ms"
+                )
+            pbar.set_postfix(postfix, refresh=False)
             pbar.update(1)
             queue.task_done()
 
@@ -344,6 +372,14 @@ async def generate_and_save_hidden_states(args, dataset):
 
     skipped_indices: list[int] = []
     cancel_event = asyncio.Event()
+    stats: dict[str, Any] = {
+        "ok": 0,
+        "errors": 0,
+        "requests": 0,
+        "total_vllm_s": 0.0,
+        "total_write_s": 0.0,
+        "start_time": time.perf_counter(),
+    }
 
     max_consec = args.max_consecutive_errors
     if max_consec is None:
@@ -380,6 +416,7 @@ async def generate_and_save_hidden_states(args, dataset):
                         skipped_indices,
                         cancel_event,
                         failure_tracker,
+                        stats,
                     )
                 )
                 for _ in range(args.concurrency * 2)
@@ -387,6 +424,17 @@ async def generate_and_save_hidden_states(args, dataset):
 
             await _feed_queue(to_process, dataset, queue, cancel_event)
             await _shutdown_workers(workers, queue, cancel_event)
+
+    elapsed = time.perf_counter() - stats["start_time"]
+    if stats["requests"] > 0:
+        logger.info(
+            "Timing: %.1fs elapsed, %.1f samples/s, "
+            "avg vLLM request %.0f ms, avg file write %.0f ms",
+            elapsed,
+            stats["requests"] / elapsed if elapsed > 0 else 0,
+            stats["total_vllm_s"] / stats["requests"] * 1000,
+            stats["total_write_s"] / stats["requests"] * 1000,
+        )
 
     num_saved = len(to_process) - len(skipped_indices)
     logger.info(f"Saved {num_saved} new data points to {args.output}")


### PR DESCRIPTION
## Summary
- Instruments the offline data generation script with performance timing using `time.perf_counter()`
- Times each `generate_hidden_states_async()` call (vLLM request latency) and each `shutil.move()` call (file write latency) independently
- Adds live throughput to tqdm postfix (`rps` = samples/s, `vllm` = avg request ms, `write` = avg write ms)
- Logs a final timing summary with aggregate stats after pipeline completion
- Uses plain logging + tqdm (not `speculators.metrics`), per the approach agreed in [#717](https://github.com/vllm-project/speculators/issues/717)

Companion to the response regeneration timing PR (#803). Both address [INFERENG-8704](https://redhat.atlassian.net/browse/INFERENG-8704).

## Test plan
- [x] Existing unit tests pass (`tests/unit/data_generation/test_offline.py` — 18 tests)
- [x] `ruff check` and `ruff format` pass
- [ ] Manual run against a vLLM endpoint to verify tqdm postfix and final summary output

🤖 Generated with [Claude Code](https://claude.com/claude-code)