### PR TITLE
fix: Fix Markov bigram prev_token_ids alignment for sample_from_anchor default mode in DSpark draft model

### DIFF
--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -144,10 +144,18 @@ class DSparkDraftModel(DFlashDraftModel):
         mask_tokens_size = num_blocks * block
         # Ground-truth block tokens (verifier vocab); position 0 is the anchor.
         block_tokens = input_ids[0, anchored_block_indices].view(num_blocks, block)
-        # prev_token_ids[:, k] is the token preceding draft position k within the block.
-        prev_token_ids = torch.cat(
-            [block_tokens[:, :1], block_tokens[:, :-1]], dim=1
-        )  # [num_blocks, block]
+        if self.config.sample_from_anchor:
+            # With sample_from_anchor=True (DSpark default), slot k predicts
+            # token p+k+1 and the inference Markov chain conditions slot k's
+            # bias on the token at the previous position p+k.
+            prev_token_ids = block_tokens
+        else:
+            # With sample_from_anchor=False (Dflash default), slot k predicts
+            # token p+k, so the previous token within the block is
+            # block_tokens[:, k-1] (shifted).
+            prev_token_ids = torch.cat(
+                [block_tokens[:, :1], block_tokens[:, :-1]], dim=1
+            )  # [num_blocks, block]
         hidden_blocks = hidden.view(num_blocks, block, -1)
 
         confidence_logits = None


### PR DESCRIPTION

## Purpose
Adjust prev_token_ids construction logic for DSpark Markov bigram bias by adding a conditional branch on sample_from_anchor:
1. Use raw block_tokens as prev_token_ids for the default sample_from_anchor=True (DSpart default) to match autoregressive draft generation chain
2. Keep the original shifted concat logic only for sample_from_anchor=False (Dflash default) workflows
3. Add detailed inline comments explaining bigram dependency rules for each sampling mode
Resolves mismatched context fed into Markov head logit bias during standard speculative inference without breaking legacy training paths. All downstream tensor shapes remain unchanged.

## Tests
1. We train the speculators model to overfit using a single training sample, then perform tests via vllm serve and vllm bench, achieving a high acceptance length.
----------------Speculative Decoding----------------
Acceptance rate (%):          80.51
Acceptance length:            7.44
Drafts:                       1700
Draft tokens:                 13600
Accepted tokens:              10950
Per-position acceptance (%):
  Position 0:                 100.00
  Position 1:                 94.12
  Position 2:                 82.94
  Position 3:                 82.94
  Position 4:                 71.18
  Position 5:                 71.18
  Position 6:                 71.18
  Position 7:                 70.59

2. Training was conducted for 2 epochs on the 7k dataset, followed by vLLM serve and vLLM bench test. The measured metrics (Acceceptance lenght, etc) from training, validation, and vLLM benchmark are consistent.

## Checklist
I have filled in:
- [Y ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ Y] The test plan/results, such as providing test command and pasting the results.
- [ Y] I (a human) have written or reviewed the code in this pr to the best of my ability.
