### PR TITLE
[Data] Make the regen natural language transciption a faithful decode of token IDs

### DIFF
--- a/docs/cli/response_regeneration.md
+++ b/docs/cli/response_regeneration.md
@@ -140,10 +140,7 @@ Rows are pre-tokenized and ready for training: one row per target generation, ho
   "primary_id": "conv-abc",
   "input_ids": [151644, 872, ...],
   "loss_mask": [0, 0, ..., 1, 1],
-  "conversations": [
-    {"role": "user", "content": "What is the capital of France?"},
-    {"role": "assistant", "content": "The capital of France is Paris."}
-  ],
+  "text": "<|im_start|>user\nWhat is the capital of France?<|im_end|>\n<|im_start|>assistant\nThe capital of France is Paris.<|im_end|>",
   "metadata": {
     "idx": 0,
     "finish_reason": "stop",
@@ -159,7 +156,7 @@ Rows are pre-tokenized and ready for training: one row per target generation, ho
 - A conversation yields one row per target generation, each carrying the history before it. Generation `k`'s row is `{primary_id}_gen{k}`. A plain assistant turn is one generation; a turn that calls a tool is two or more (see [Tool calls](#tool-calls)).
 - `primary_id` is the conversation's stable id, used by `--resume`. The row `id` is generation-suffixed and never matches it.
 - `is_tool_call` marks a row whose generated tokens are a tool call rather than a final answer.
-- `conversations` is a human-readable twin of `input_ids` for review only. Training drops it.
+- `text` is a human-readable decode of `input_ids` (`tokenizer.decode`, special tokens kept) for review only — faithful to the tokens by construction. Training drops it.
 
 Rows are written only once a conversation finishes. A conversation that fails partway writes nothing to the output file and one row to a sibling error file instead (`--outfile out.jsonl` gives `out.errors.jsonl`), so `--resume` retries it whole:
 

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -9,11 +9,13 @@ import re
 import sys
 import time
 from collections import deque
-from typing import Any
+from collections.abc import Callable
+from typing import Any, cast
 
 import aiohttp
 from datasets import load_dataset
 from tqdm import tqdm
+from transformers import AutoTokenizer
 
 from speculators.data_generation.configs import DATASET_CONFIGS, DatasetConfig
 from speculators.data_generation.vllm_client import (
@@ -367,6 +369,24 @@ async def detect_model(endpoint: str) -> str:
         ) from e
 
 
+def build_detokenizer(model: str) -> Callable[[list[int]], str]:
+    """Return a decoder for the review-only ``text`` twin (see _sample_from_response).
+
+    Loads ``model``'s tokenizer so the twin is exactly ``decode(input_ids)``;
+    ``skip_special_tokens=False`` keeps the chat/control tokens (``<|im_start|>``,
+    ``<think>``, ``<|im_end|>``) visible. Pass a tokenizer path as ``--model``
+    (the checkpoint, not a ``--served-model-name`` alias).
+    """
+    print(f"Loading tokenizer: {model}")
+    tokenizer = AutoTokenizer.from_pretrained(model)
+
+    def detokenize(token_ids: list[int]) -> str:
+        # decode() is typed str | list[str]; a 1-D id list always yields str.
+        return cast("str", tokenizer.decode(token_ids, skip_special_tokens=False))
+
+    return detokenize
+
+
 # Transient statuses worth retrying: request timeout, conflict, too-early, and
 # rate limiting, plus all 5xx. Other non-2xx replies (e.g. 400/401/404) are
 # permanent config/client errors and fail fast.
@@ -434,7 +454,7 @@ def _tool_result_message(tool_call: dict, content: str) -> dict[str, Any]:
 def _sample_from_response(
     data: dict[str, Any],
     *,
-    prefix: list[dict[str, Any]],
+    detokenize: Callable[[list[int]], str],
     conv_id: str,
     sample_index: int,
     idx: int,
@@ -484,8 +504,10 @@ def _sample_from_response(
         "primary_id": conv_id,
         "input_ids": input_ids,
         "loss_mask": loss_mask,
-        # Review-only twin of input_ids; ignored by training.
-        "conversations": [*prefix, assistant_msg],
+        # Review-only decode of input_ids; ignored by training. Faithful to the
+        # tokens by construction -- system/user context, the template's <think>
+        # priming, and history with prior-turn reasoning already stripped.
+        "text": detokenize(input_ids),
         "metadata": {
             "idx": idx,
             "finish_reason": choice.get("finish_reason"),
@@ -507,6 +529,7 @@ async def regenerate_conversation(
     endpoint: str,
     sampling_params: dict[str, Any],
     samples: list[dict[str, Any]],
+    detokenize: Callable[[list[int]], str],
 ) -> bool:
     """Regenerate one conversation into per-generation boundary samples.
 
@@ -555,7 +578,7 @@ async def regenerate_conversation(
             data = await post_fn(payload)
             sample, assistant_msg, tool_calls = _sample_from_response(
                 data,
-                prefix=prefix,
+                detokenize=detokenize,
                 conv_id=conv_id,
                 sample_index=len(samples),
                 idx=item["idx"],
@@ -626,6 +649,7 @@ async def worker(
     endpoint: str,
     progress,
     stats: dict[str, Any],
+    detokenize: Callable[[list[int]], str],
 ):
     """Pull conversations off the queue and regenerate them into boundary rows.
 
@@ -664,6 +688,7 @@ async def worker(
                 endpoint=endpoint,
                 sampling_params=args.sampling_params,
                 samples=samples,
+                detokenize=detokenize,
             )
             # Written only after the conversation finishes -- a clean truncation
             # included, since rerunning it would truncate again. An exception
@@ -719,6 +744,9 @@ async def main():
         args.model = await detect_model(endpoint)
 
     print(f"Using model: {args.model}")
+
+    # Decoder for the review-only `text` twin; see build_detokenizer.
+    detokenize = build_detokenizer(args.model)
 
     # Get dataset configuration
     dataset_config = DATASET_CONFIGS[args.dataset]
@@ -793,6 +821,7 @@ async def main():
                         endpoint,
                         progress,
                         stats,
+                        detokenize,
                     )
                 )
                 for _ in range(args.concurrency)

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -496,6 +496,7 @@ def _run_worker(responses, tmp_path, stem):
             "http://x/v1/chat/completions",
             _NullProgress(),
             stats,
+            _detok,
         )
         return stats
 
@@ -581,6 +582,11 @@ def _response(
     }
 
 
+def _detok(token_ids):
+    """Test stand-in for ``tokenizer.decode`` -- deterministic and readable."""
+    return " ".join(str(t) for t in token_ids)
+
+
 def _fake_post(responses):
     """A post_fn returning canned responses in order and recording sent payloads."""
     sent = []
@@ -606,6 +612,7 @@ def _regen(
             endpoint=endpoint,
             sampling_params=sampling_params or {},
             samples=samples,
+            detokenize=_detok,
         )
     )
     return samples, truncated, sent
@@ -698,7 +705,7 @@ def test_sample_from_response_rejects_empty_and_missing_token_ids():
     with pytest.raises(ValueError, match="empty assistant generation"):
         regen._sample_from_response(
             _response(prompt_token_ids=[1], token_ids=[2], content=None),
-            prefix=[],
+            detokenize=_detok,
             conv_id="c",
             sample_index=0,
             idx=0,
@@ -713,7 +720,7 @@ def test_sample_from_response_rejects_empty_and_missing_token_ids():
     with pytest.raises(ValueError, match="return_token_ids"):
         regen._sample_from_response(
             bad,
-            prefix=[],
+            detokenize=_detok,
             conv_id="c",
             sample_index=0,
             idx=0,


### PR DESCRIPTION
## Purpose

Regeneration saves each row as token IDs (`input_ids`/`loss_mask`) so training does not re-tokenize. For human review it also saved a natural-language twin, but that `conversations` twin was rebuilt from message dicts and was not faithful to the token IDs. It is review-only, so training is unaffected (training consumes `input_ids`/`loss_mask` and drops this field).

Fix: save the plain `text` = `tokenizer.decode(input_ids)` instead, which is faithful by construction.

Example (`text` of a 3-turn row):

```
<|im_start|>user
More verbose and details<|im_end|>
<|im_start|>assistant
I'd be glad to provide a more verbose and detailed response!...
<|im_end|>
<|im_start|>user
Explain it more in that style<|im_end|>
<|im_start|>assistant
Since you didn't specify a particular subject...
<|im_end|>
<|im_start|>user
double the length<|im_end|>
<|im_start|>assistant
<think>
Here's a thinking process: ...
</think>
...answer...<|im_end|>
```

## Tests

`pytest tests/unit/scripts/test_response_regeneration.py`: 43 passed. ruff and mypy clean.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
