### PR TITLE
Batch val metric reduction to one sync per epoch

### DIFF
--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -522,8 +522,6 @@ class Trainer:
         if self.rank == 0:
             val_loader = tqdm(val_loader, desc=f"Epoch {epoch}")  # type: ignore[assignment]
 
-        # Accumulate metrics on device and reduce/sync once per epoch to avoid
-        # per-batch, per-metric all_reduce and .item() GPU syncs.
         accumulated: dict[str, torch.Tensor] = {}
         num_batches = len(val_loader)
         for batch in val_loader:

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -522,7 +522,9 @@ class Trainer:
         if self.rank == 0:
             val_loader = tqdm(val_loader, desc=f"Epoch {epoch}")  # type: ignore[assignment]
 
-        val_metrics: dict[str, float] = {}
+        # Accumulate metrics on device and reduce/sync once per epoch to avoid
+        # per-batch, per-metric all_reduce and .item() GPU syncs.
+        accumulated: dict[str, torch.Tensor] = {}
         num_batches = len(val_loader)
         for batch in val_loader:
             gpu_batch = {
@@ -539,12 +541,16 @@ class Trainer:
                     **gpu_batch, **(self.config.val_call_kwargs or {})
                 )
 
-            if self.is_distributed:
-                for m in metrics.values():
-                    dist.all_reduce(m, op=dist.ReduceOp.SUM)
-
             for k, v in metrics.items():
-                val_metrics[k] = val_metrics.get(k, 0.0) + v.item()
+                acc = accumulated.get(k)
+                accumulated[k] = v.float() if acc is None else acc + v.float()
+
+        val_metrics: dict[str, float] = {}
+        if accumulated:
+            stacked = torch.stack(list(accumulated.values()))
+            if self.is_distributed:
+                dist.all_reduce(stacked, op=dist.ReduceOp.SUM)
+            val_metrics = dict(zip(accumulated, stacked.tolist(), strict=True))
 
         world_size = dist.get_world_size() if self.is_distributed else 1
         val_metrics = {k: v / num_batches for k, v in val_metrics.items()}


### PR DESCRIPTION
## Purpose

The val loop issued one `all_reduce` and one `.item()` GPU sync per metric per batch. Accumulate metrics on device and reduce/sync once per epoch instead. Metric values are unchanged.

Benchmark on Modal, driving `Trainer.val_epoch` with a stub model (200 batches × 15 metrics, median of 5 rounds):

| setup | before | after | speedup |
| --- | --- | --- | --- |
| 1× L4 | 389.6 ms | 364.2 ms | 1.07× |
| 2× L4 (NCCL) | 642.5 ms | 439.8 ms | 1.46× |

## Tests

- Benchmark asserts old and new implementations produce identical metrics.
- `make quality` passes; trainer unit tests pass.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
