### PR TITLE
fix(data-gen): make MM continue_final_message model-aware

### DIFF
--- a/src/speculators/data_generation/vllm_client.py
+++ b/src/speculators/data_generation/vllm_client.py
@@ -165,6 +165,21 @@ def wait_for_lock(lock_path, timeout=10.0, poll_interval=0.1):
     os.remove(lock_path)
 
 
+# Models whose chat template appends a trailing EOS on a *closed* final turn that
+# ``input_ids`` omits; open the turn for them to keep prompt_token_ids == input_ids.
+# Interim name heuristic — see ADR 0005 for the model-independent fix.
+_OPEN_FINAL_TURN_MODEL_MARKERS = ("mistral",)
+
+
+def _continue_final_message_for(model: str) -> bool:
+    """Whether to leave the final assistant turn open when re-rendering the MM
+    chat prompt. Default False (closed, reproducing ``input_ids``); True for
+    Mistral, whose template adds a spurious EOS on close. See ADR 0005."""
+    # Basename match so the ``mistralai/`` org prefix doesn't sweep in siblings.
+    name = model.rsplit("/", 1)[-1].lower()
+    return any(marker in name for marker in _OPEN_FINAL_TURN_MODEL_MARKERS)
+
+
 @with_retries
 async def generate_hidden_states_async(
     client: openai.AsyncClient,
@@ -202,7 +217,8 @@ async def generate_hidden_states_async(
             max_tokens=1,
             extra_body={
                 "add_generation_prompt": False,
-                "continue_final_message": True,
+                # Re-render to match the stored ``input_ids`` (model-dependent).
+                "continue_final_message": _continue_final_message_for(model),
                 "return_token_ids": True,
             },
             timeout=timeout,
@@ -248,7 +264,8 @@ def generate_hidden_states(
             max_tokens=1,
             extra_body={
                 "add_generation_prompt": False,
-                "continue_final_message": True,
+                # Re-render to match the stored ``input_ids`` (model-dependent).
+                "continue_final_message": _continue_final_message_for(model),
                 "return_token_ids": True,
             },
             timeout=timeout,

--- a/src/speculators/data_generation/vllm_client.py
+++ b/src/speculators/data_generation/vllm_client.py
@@ -167,14 +167,13 @@ def wait_for_lock(lock_path, timeout=10.0, poll_interval=0.1):
 
 # Models whose chat template appends a trailing EOS on a *closed* final turn that
 # ``input_ids`` omits; open the turn for them to keep prompt_token_ids == input_ids.
-# Interim name heuristic — see ADR 0005 for the model-independent fix.
 _OPEN_FINAL_TURN_MODEL_MARKERS = ("mistral",)
 
 
 def _continue_final_message_for(model: str) -> bool:
     """Whether to leave the final assistant turn open when re-rendering the MM
     chat prompt. Default False (closed, reproducing ``input_ids``); True for
-    Mistral, whose template adds a spurious EOS on close. See ADR 0005."""
+    Mistral, whose template adds a spurious EOS on close."""
     # Basename match so the ``mistralai/`` org prefix doesn't sweep in siblings.
     name = model.rsplit("/", 1)[-1].lower()
     return any(marker in name for marker in _OPEN_FINAL_TURN_MODEL_MARKERS)


### PR DESCRIPTION
## Purpose

Fix `Prompt token IDs mismatch` in offline hidden-state extraction for
`Qwen/Qwen3-VL-2B-Instruct` (eagle3, `sharegpt4v_coco`).

`extract_output` asserts the server-echoed `prompt_token_ids` equals the stored `input_ids`
(the sequence hidden states and the loss mask align to). The text path satisfies this natively
(Completions echoes pre-tokenized ids); the **multimodal** path uses the Chat endpoint and
re-renders the prompt server-side, so the final assistant turn's terminator must match.

This is **not** a vLLM change — `continue_final_message` is a long-standing passthrough to HF
`apply_chat_template`. The regression came from #719, which set `continue_final_message=True`
**globally** on the MM chat request to fix Mistral (whose template appends a spurious EOS on a
closed turn). Qwen3-VL needs the opposite:

| Model | `input_ids` final tokens | Closed render (`False`) | Correct flag |
|-------|--------------------------|-------------------------|--------------|
| **Qwen3-VL** | `… <\|im_end\|> \n` | matches | `False` |
| **Mistral** | (no trailing EOS) | appends spurious EOS | `True` |

**This PR** selects the flag per model: default `False` (closed turn, reproduces `input_ids`
for Qwen and the general case), `True` for Mistral only (matched on model basename). The `prompt_token_ids == input_ids` assertion is left untouched.

**Interim fix.** The value is chosen by a model-name heuristic, which re-encodes a
model-independent invariant (*the request must reproduce `prepare_data`'s `input_ids`*) as
per-name knowledge. Candidate proper fixes:

1. Share `prepare_data`'s render flags as a single source of truth (same flags → same tokens).
2. Pick the flag per-sample: render client-side both ways, choose whichever reproduces `input_ids`.

Both of which will be bigger changes.
We'll discuss and implement the model-independent fix as part of the **Q3 Roadmap** see the [Q3 Roadmap RFC](https://github.com/vllm-project/speculators/issues/781).


## Tests

The failing test now passes

```bash
(speculators) ➜  speculators git:(main) ✗ PYTHONPATH=$PWD/hs_connectors/src CUDA_VISIBLE_DEVICES=7 \
  python -m pytest -q \
  "tests/e2e/smoke/test_offline_training.py::test_offline_smoke[Qwen/Qwen3-VL-2B-Instruct-sharegpt4v_coco-eagle3-extra_train_args1-None]"
.
.
.
2026-07-18 09:20:28.644 | INFO     | tests.e2e.utils:run_vllm_engine:438 - outputs_token_ids: [[8420, 594, 264, 7868, 2711, 729, 304, 13027, 429, 4278, 448, 264, 10615, 1140, 1447, 73594, 12669, 198, 750, 7868, 10716, 10939, 11, 2169, 982, 262, 3190, 262, 25001, 7868, 2711, 389, 264, 10615, 1334, 311, 1477, 279, 2169, 897, 624, 1066, 262, 17693, 510, 286, 2890, 320, 1607, 1648], [334, 8327, 22160, 47116, 334, 374, 264, 14762, 1483, 304, 6366, 17646, 323, 15473, 11, 7945, 304, 3070, 31615, 7600, 11320, 97219, 311, 7269, 5068, 553, 3070, 34698, 287, 323, 20045, 369, 3853, 11221, 334, 1573, 807, 525, 7225, 3881, 13, 1084, 374, 16626, 1483, 304, 3070, 411, 8668, 23810], [2, 62379, 8362, 5712, 271, 8420, 594, 264, 4583, 8129, 315, 264, 62379, 2504, 11, 892, 374, 264, 15811, 4752, 2504, 304, 62379, 77235, 1447, 73594, 12669, 198, 474, 7834, 198, 474, 7834, 19900, 438, 10883, 198, 474, 7834, 19900, 63261, 438, 434, 271, 1040, 62379, 4713, 33478, 26958, 982]]
2026-07-18 09:20:28.644 | INFO     | tests.e2e.utils:run_vllm_engine:439 - metrics_dict: {'total_num_output_tokens': 150, 'num_drafts': 139, 'num_draft_tokens': 417, 'num_accepted_tokens': 8, 'acceptance_length': 1.0575539568345325, 'acceptance_at_token_0': 0.05755395683453238, 'acceptance_at_token_1': 0.0, 'acceptance_at_token_2': 0.0}
PASSED

======================================================================== warnings summary ========================================================================
.venv/lib/python3.13/site-packages/torch/jit/_script.py:365: 14 warnings
  /home/rahul-tuli/speculators/.venv/lib/python3.13/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== 1 passed, 14 warnings in 306.44s (0:05:06) ===========================================================
```

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
