### PR TITLE
Preallocate collate buffer to avoid double copy

### DIFF
--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -10,7 +10,6 @@ from typing import Any, Literal, cast
 
 import openai
 import torch
-import torch.nn.functional as F  # noqa: N812
 from datasets import load_from_disk
 from torch.utils.data import Dataset
 
@@ -37,13 +36,6 @@ def list_files(path):
             datapath.append(file_path)
 
     return datapath
-
-
-def slice_and_pad_to_length(tensor, length):
-    sliced_tensor = tensor[:length]
-    padding = [0, 0] * sliced_tensor.dim()
-    padding[-1] = length - sliced_tensor.shape[0]
-    return F.pad(sliced_tensor, padding)
 
 
 def split_files(datapath: str, ratio: float = 0.9, seed: int = 0):
@@ -490,16 +482,23 @@ def create_collate_fn(
 
         collated_data = {}
         for key in batch[0]:  # type: ignore[union-attr]
-            # Concatenate the tensors along the seq (0th) dimension
-            collated_data[key] = torch.cat([b[key] for b in batch], dim=0)  # type: ignore[index]
-            # shape: [total_seq_len, ...]
-
-            if key != "lengths":
-                # Slice and pad on seq (0th) dimension to max_len
-                collated_data[key] = slice_and_pad_to_length(
-                    collated_data[key], max_len
-                ).unsqueeze(0)
-                # shape: [1, max_len, ...]
+            if key == "lengths":
+                collated_data[key] = torch.cat([b[key] for b in batch], dim=0)  # type: ignore[index]
+                continue
+            # Copy samples into a preallocated [max_len, ...] buffer, avoiding
+            # the two full-size intermediate copies of cat + pad
+            first = batch[0][key]  # type: ignore[index]
+            out = torch.zeros((max_len, *first.shape[1:]), dtype=first.dtype)
+            offset = 0
+            for b in batch:
+                tensor = b[key]  # type: ignore[index]
+                num_rows = min(tensor.shape[0], max_len - offset)
+                out[offset : offset + num_rows] = tensor[:num_rows]
+                offset += num_rows
+                if offset == max_len:
+                    break
+            collated_data[key] = out.unsqueeze(0)
+            # shape: [1, max_len, ...]
 
         # Include lengths until while they fit in max_len
         # The last included length is (if necessary) truncated

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -488,7 +488,9 @@ def create_collate_fn(
             # Copy samples into a preallocated [max_len, ...] buffer, avoiding
             # the two full-size intermediate copies of cat + pad
             first = batch[0][key]  # type: ignore[index]
-            out = torch.zeros((max_len, *first.shape[1:]), dtype=first.dtype)
+            out = torch.zeros(
+                (max_len, *first.shape[1:]), dtype=first.dtype, device=first.device
+            )
             offset = 0
             for b in batch:
                 tensor = b[key]  # type: ignore[index]


### PR DESCRIPTION
## Purpose

Speed up the training dataloader collate path. Each batch was assembled with `torch.cat` followed by `F.pad`, which materializes two full-size intermediate copies per key. Samples are now copied once into a preallocated `[max_len, ...]` buffer. Output is unchanged (verified `torch.equal` against the old implementation); the now-unused `slice_and_pad_to_length` is removed.

Micro-benchmark (8192 seq × 3×4096 hidden, 6 samples, median of 30 runs):

| | per batch | speedup |
| --- | --- | --- |
| before (cat + pad) | 10.33 ms | |
| after (preallocated buffer) | 7.92 ms | 1.30× |

## Tests

- `tests/unit/train/test_data.py`: 10 passed (covers collate basics and length truncation).
- `make quality` (ruff + mypy) passes.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
