### PR TITLE
Fuse hidden states dtype cast into collate copy

### DIFF
--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -175,12 +175,6 @@ class BaseDataset(Dataset):
         #  "loss_mask": [seq_len],
         # }
 
-        # Convert hidden states to the correct dtype
-        data = {
-            k: v.to(self.hidden_states_dtype) if "hidden_states" in k else v
-            for k, v in data.items()
-        }
-
         # Add lengths tensor
         seq_len = data["input_ids"].shape[0]
         data["lengths"] = torch.tensor([seq_len], dtype=torch.long)
@@ -485,11 +479,11 @@ def create_collate_fn(
             if key == "lengths":
                 collated_data[key] = torch.cat([b[key] for b in batch], dim=0)  # type: ignore[index]
                 continue
-            # Copy samples into a preallocated [max_len, ...] buffer, avoiding
-            # the two full-size intermediate copies of cat + pad
+            # one copy per sample: preallocated buffer, hidden states cast during write
             first = batch[0][key]  # type: ignore[index]
+            buffer_dtype = dtype if "hidden_states" in key else first.dtype
             out = torch.zeros(
-                (max_len, *first.shape[1:]), dtype=first.dtype, device=first.device
+                (max_len, *first.shape[1:]), dtype=buffer_dtype, device=first.device
             )
             offset = 0
             for b in batch:

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -10,7 +10,6 @@ from typing import Any, Literal, cast
 
 import openai
 import torch
-import torch.nn.functional as F  # noqa: N812
 from datasets import load_from_disk
 from torch.utils.data import Dataset
 
@@ -37,13 +36,6 @@ def list_files(path):
             datapath.append(file_path)
 
     return datapath
-
-
-def slice_and_pad_to_length(tensor, length):
-    sliced_tensor = tensor[:length]
-    padding = [0, 0] * sliced_tensor.dim()
-    padding[-1] = length - sliced_tensor.shape[0]
-    return F.pad(sliced_tensor, padding)
 
 
 def split_files(datapath: str, ratio: float = 0.9, seed: int = 0):
@@ -490,16 +482,23 @@ def create_collate_fn(
 
         collated_data = {}
         for key in batch[0]:  # type: ignore[union-attr]
-            # Concatenate the tensors along the seq (0th) dimension
-            collated_data[key] = torch.cat([b[key] for b in batch], dim=0)  # type: ignore[index]
-            # shape: [total_seq_len, ...]
-
-            if key != "lengths":
-                # Slice and pad on seq (0th) dimension to max_len
-                collated_data[key] = slice_and_pad_to_length(
-                    collated_data[key], max_len
-                ).unsqueeze(0)
-                # shape: [1, max_len, ...]
+            if key == "lengths":
+                collated_data[key] = torch.cat([b[key] for b in batch], dim=0)  # type: ignore[index]
+                continue
+            # Copy samples into a preallocated [max_len, ...] buffer, avoiding
+            # the two full-size intermediate copies of cat + pad
+            first = batch[0][key]  # type: ignore[index]
+            out = torch.zeros((max_len, *first.shape[1:]), dtype=first.dtype)
+            offset = 0
+            for b in batch:
+                tensor = b[key]  # type: ignore[index]
+                num_rows = min(tensor.shape[0], max_len - offset)
+                out[offset : offset + num_rows] = tensor[:num_rows]
+                offset += num_rows
+                if offset == max_len:
+                    break
+            collated_data[key] = out.unsqueeze(0)
+            # shape: [1, max_len, ...]
 
         # Include lengths until while they fit in max_len
         # The last included length is (if necessary) truncated

--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -488,7 +488,9 @@ def create_collate_fn(
             # Copy samples into a preallocated [max_len, ...] buffer, avoiding
             # the two full-size intermediate copies of cat + pad
             first = batch[0][key]  # type: ignore[index]
-            out = torch.zeros((max_len, *first.shape[1:]), dtype=first.dtype)
+            out = torch.zeros(
+                (max_len, *first.shape[1:]), dtype=first.dtype, device=first.device
+            )
             offset = 0
             for b in batch:
                 tensor = b[key]  # type: ignore[index]

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -134,7 +134,7 @@ def test_collate_fn_basic():
     hidden_size = 1
     num_target_layers = 3
     collate_fn = create_collate_fn(
-        max_len, hidden_size, num_target_layers=num_target_layers
+        max_len, hidden_size, num_target_layers=num_target_layers, dtype=torch.float32
     )
 
     batch = [
@@ -208,13 +208,34 @@ def test_collate_fn_basic():
         )
 
 
+def test_collate_fn_casts_hidden_states_dtype():
+    """Test that hidden-states keys are cast to the target dtype during collation."""
+    collate_fn = create_collate_fn(4, 1, dtype=torch.bfloat16)
+    batch = [
+        {
+            "input_ids": torch.tensor([0], dtype=torch.long),
+            "hidden_states": torch.ones(1, 3, dtype=torch.float32),
+            "verifier_last_hidden_states": torch.ones(1, 1, dtype=torch.float32),
+            "loss_mask": torch.ones(1, dtype=torch.long),
+            "lengths": torch.tensor([1], dtype=torch.long),
+            "position_ids": torch.tensor([0], dtype=torch.long),
+        }
+    ]
+
+    collated = collate_fn(batch)
+
+    assert collated["hidden_states"].dtype == torch.bfloat16
+    assert collated["verifier_last_hidden_states"].dtype == torch.bfloat16
+    assert collated["input_ids"].dtype == torch.long
+
+
 def test_collate_fn_length_truncation():
     """Test that lengths are truncated when they exceed max_len."""
     max_len = 11
     hidden_size = 8
     num_target_layers = 3
     collate_fn = create_collate_fn(
-        max_len, hidden_size, num_target_layers=num_target_layers
+        max_len, hidden_size, num_target_layers=num_target_layers, dtype=torch.float32
     )
 
     batch = [
@@ -257,9 +278,8 @@ def test_collate_fn_length_truncation():
 
 
 def test_dataset_getitem_v1_format(tmp_path: Path):
-    """Test dataset __getitem__ with v1 data format and dtype conversion."""
+    """Test dataset __getitem__ with v1 data format."""
 
-    output_dtype = torch.float64
     file_dtype = torch.float32
 
     # Create v1 format data
@@ -343,7 +363,7 @@ def test_dataset_getitem_v1_format(tmp_path: Path):
                 [7.0, 7.1, 17.0, 17.1, 27.0, 27.1],
                 [8.0, 8.1, 18.0, 18.1, 28.0, 28.1],
             ],
-            dtype=output_dtype,
+            dtype=file_dtype,
         ),
         "verifier_last_hidden_states": torch.tensor(
             [
@@ -357,7 +377,7 @@ def test_dataset_getitem_v1_format(tmp_path: Path):
                 [38.0, 38.1],
                 [39.0, 39.1],
             ],
-            dtype=output_dtype,
+            dtype=file_dtype,
         ),
         "loss_mask": torch.tensor([0, 1, 1, 1, 1, 1, 1, 1, 1], dtype=torch.long),
         "lengths": torch.tensor([9], dtype=torch.long),
@@ -368,7 +388,7 @@ def test_dataset_getitem_v1_format(tmp_path: Path):
     torch.save(data, file_path)
 
     dataset = SampleFileDataset(
-        max_len=12, file_list=[str(file_path)], hidden_states_dtype=output_dtype
+        max_len=12, file_list=[str(file_path)], hidden_states_dtype=file_dtype
     )
 
     raw_item = dataset[0]


### PR DESCRIPTION
## Purpose

Based on #815. Datasets converted hidden states to the training dtype with a per-sample `.to()`, a full-size copy on top of the collate copy. The collate buffer is now created in the target dtype directly, so the cast happens during the single buffer write.

Micro-benchmark (fp32 data → bf16 training, 8192 seq × 3×4096 hidden, 6 samples, median of 30 runs):

| | per batch | speedup |
| --- | --- | --- |
| before (`.to()` per sample + collate) | 15.79 ms | |
| after (cast in collate) | 11.41 ms | 1.38× |

Outputs are identical (`torch.equal`). When data is already in the training dtype, `.to()` was a no-op, so nothing changes.

## Tests

- New `test_collate_fn_casts_hidden_states_dtype`; `tests/unit/train/test_data.py`: 11 passed.
- `make quality` (ruff + mypy) passes.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
