### PR TITLE
refactor(loss): drop unused resolve_loss_fn

### DIFF
--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -427,31 +427,6 @@ _LOSS_FN_MAP: dict[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = 
 }
 
 
-def resolve_loss_fn(
-    name: str,
-) -> "Callable[[torch.Tensor, torch.Tensor], torch.Tensor]":
-    """Resolves a loss function given its abbreviated name.
-
-    Args:
-        name: ``"kl_div"`` for KL-divergence, ``"rkl"`` for reverse KL-divergence,
-            ``"jsd"`` for Jensen-Shannon divergence, ``"ce"`` for cross-entropy,
-            ``"tv"`` for total variation, ``"nla"`` for negative log-acceptance,
-            or ``"lk_hybrid"`` for the adaptive KL/TV blend.
-
-    Returns:
-        The corresponding loss function.
-
-    Raises:
-        ValueError: If *name* is not a recognised loss function.
-    """
-    if name not in _LOSS_FN_MAP:
-        raise ValueError(
-            f"Unknown loss function '{name}'. "
-            f"Choose from: {sorted(_LOSS_FN_MAP.keys())}"
-        )
-    return _LOSS_FN_MAP[name]
-
-
 def resolve_loss_config(spec: str) -> LossConfig:
     """Parse a loss spec into ``{name: (loss_fn, weight)}``.
 

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -16,7 +16,7 @@ from speculators.models.metrics import (
     loss_function,
     neg_log_acceptance_loss,
     nla_loss_fused_or_eager,
-    resolve_loss_fn,
+    resolve_loss_config,
     reverse_kl_div_loss,
     tv_loss,
     tv_loss_fused_or_eager,
@@ -120,8 +120,8 @@ class TestReverseKLDivLoss:
         )
 
     def test_resolve_rkl(self):
-        """resolve_loss_fn maps 'rkl' to reverse_kl_div_loss."""
-        assert resolve_loss_fn("rkl") is reverse_kl_div_loss
+        """resolve_loss_config wires 'rkl' to reverse_kl_div_loss."""
+        assert resolve_loss_config("rkl")["rkl"][0] is reverse_kl_div_loss
 
 
 class TestJSDivLoss:
@@ -171,8 +171,8 @@ class TestJSDivLoss:
         assert torch.allclose(out, expected, atol=1e-5)
 
     def test_resolve_jsd(self):
-        """resolve_loss_fn maps 'jsd' to js_div_loss."""
-        assert resolve_loss_fn("jsd") is js_div_loss
+        """resolve_loss_config wires 'jsd' to js_div_loss."""
+        assert resolve_loss_config("jsd")["jsd"][0] is js_div_loss
 
 
 class TestTVLoss:
@@ -199,8 +199,8 @@ class TestTVLoss:
         assert (out <= 1).all()
 
     def test_resolve_tv(self):
-        """resolve_loss_fn maps 'tv' to the fused-or-eager dispatcher."""
-        assert resolve_loss_fn("tv") is tv_loss_fused_or_eager
+        """resolve_loss_config wires 'tv' to the fused-or-eager dispatcher."""
+        assert resolve_loss_config("tv")["tv"][0] is tv_loss_fused_or_eager
 
     @pytest.mark.skipif(
         not torch.cuda.is_available(), reason="fused Triton loss requires CUDA"
@@ -271,8 +271,8 @@ class TestNegLogAcceptanceLoss:
         assert torch.isfinite(neg_log_acceptance_loss(logits, targets)).all()
 
     def test_resolve_nla(self):
-        """resolve_loss_fn maps 'nla' to the fused-or-eager dispatcher."""
-        assert resolve_loss_fn("nla") is nla_loss_fused_or_eager
+        """resolve_loss_config wires 'nla' to the fused-or-eager dispatcher."""
+        assert resolve_loss_config("nla")["nla"][0] is nla_loss_fused_or_eager
 
 
 class TestLKHybridLoss:
@@ -330,8 +330,8 @@ class TestLKHybridLoss:
         assert not torch.allclose(g_detached, g_nodetach, atol=1e-4)
 
     def test_resolve_lk_hybrid(self):
-        """resolve_loss_fn maps 'lk_hybrid' to lk_hybrid_loss."""
-        assert resolve_loss_fn("lk_hybrid") is lk_hybrid_loss
+        """resolve_loss_config wires 'lk_hybrid' to lk_hybrid_loss."""
+        assert resolve_loss_config("lk_hybrid")["lk_hybrid"][0] is lk_hybrid_loss
 
 
 class TestComputeAccuracySingleStep:


### PR DESCRIPTION
## Purpose

**Dead**: `resolve_loss_fn(name) -> _LOSS_FN_MAP[name]` has no callers.

**Actual**: production resolves losses through `resolve_loss_config`, and the dead fun isn't exported (`__init__` / `__all__` / docs). only the `test_resolve_*` tests used it. Drop it, and re-point those five tests at `resolve_loss_config`. No behavior change.

## Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
