### PR TITLE
[Bug fixing][Eagle3] Always teacher-force TTT tokens; remove --use-off-policy-tokens

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -148,8 +148,6 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 ### Eagle3-Specific Arguments
 
-- **`--use-off-policy-tokens`** (flag) Use off-policy tokens during training (required for [regenerated data](response_regeneration.md)).
-
 - **`--norm-before-residual` / `--no-norm-before-residual`** (flag, default: `True`) Toggle normalization before residual connections.
 
 - **`--embed-requires-grad` / `--no-embed-requires-grad`** (flag, default: `False`) Whether to train embedding layer weights.

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1036,12 +1036,6 @@ def parse_args():
         default=False,
         help="Sets cuda to deterministic mode. This may impact performance.",
     )
-    parser.add_argument(
-        "--use-off-policy-tokens",
-        action="store_true",
-        default=False,
-        help="Use off-policy tokens during training (required for regenerated data)",
-    )
     # Model hyperparameters
     parser.add_argument(
         "--norm-before-residual",

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -196,7 +196,6 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
         | None = None,  # shape: [1, total_seq_len, hidden_size]
         ttt_steps: int = 3,
         ttt_step_loss_decay: float = 1.0,
-        use_off_policy_tokens: bool = False,
         loss_config: LossConfig | None = None,
         **kwargs,
     ):
@@ -318,26 +317,21 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
             input_ids = torch.argmax(logits, dim=-1)
             draft_tokens.append(input_ids.detach().clone())
             # shape: [1, total_seq_len]
-            # Use d2t to map draft tokens to verifier tokens.
-            # Must be in verifier vocabulary space because we use the full verifier
-            # vocabulary in the embedding.
-            if self.d2t is not None:
-                input_ids = input_ids + self.d2t[input_ids]  # type: ignore[index]
 
-            if use_off_policy_tokens:
-                # Overwrite input_ids with ground truth tokens
-                # shift input_ids by 1 to the left and pad with 0
-                # note: inputs_ids no longer line up with verifier_last_hidden_states
-                # the draft logits generated from the padded tokens are ignored
-                # and sliced out for loss calculation
-                input_ids = torch.cat(
-                    [
-                        original_input_ids[:, 1 + ttt_step :],
-                        original_input_ids.new_zeros(1, 1 + ttt_step),
-                    ],
-                    dim=-1,
-                )
-                # shape: [1, total_seq_len]
+            # Teacher forcing: feed the ground-truth tokens (already in the verifier
+            # vocabulary) into the next TTT step instead of the draft's own
+            # predictions. Shift left by 1 + ttt_step and right-pad with 0; the padded
+            # positions produce logits that no longer line up with
+            # verifier_last_hidden_states and are sliced out of the loss (see
+            # align_for_step).
+            input_ids = torch.cat(
+                [
+                    original_input_ids[:, 1 + ttt_step :],
+                    original_input_ids.new_zeros(1, 1 + ttt_step),
+                ],
+                dim=-1,
+            )
+            # shape: [1, total_seq_len]
 
             if self._attn_impl == "simple_flex_attention":
                 if full_attn_mask is not None:
@@ -436,13 +430,11 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
         """
         loss_config = resolve_loss_config(kwargs["loss_fn"])
         train_kwargs = {
-            "use_off_policy_tokens": kwargs["use_off_policy_tokens"],
             "ttt_steps": kwargs["ttt_steps"],
             "ttt_step_loss_decay": kwargs["ttt_step_loss_decay"],
             "loss_config": loss_config,
         }
         val_kwargs = {
-            "use_off_policy_tokens": False,
             "ttt_steps": kwargs["ttt_steps"],
             "ttt_step_loss_decay": kwargs["ttt_step_loss_decay"],
             "loss_config": loss_config,


### PR DESCRIPTION
## Summary

Eagle3 training simulates multi-step drafting ("training-time test", TTT). This PR removes the `--use-off-policy-tokens` flag and its default code path so that Eagle3 **always teacher-forces the ground-truth token** in the TTT loop.

## Mechanism

Each TTT step feeds the draft two things to predict the next token: the draft's **own hidden state**, carried forward from the previous step, and a **token embedding**. The hidden-state recursion — the part that mirrors what the draft does at inference — runs in every case and is untouched here.

The flag only chose the **token** source:

- old default: the draft's own argmax prediction;
- flag on: the ground-truth token from the data.

Where the draft predicts correctly the two are identical; they differ only at positions where it mispredicts.

## Why always teacher-force, and why deleting the alternative is safe

- **Consistent objective.** The training label at each position is the verifier's next-token distribution, computed over the **ground-truth prefix**. Teacher forcing feeds that same ground-truth prefix, so the draft's input and its label always agree. Feeding the draft's own token feeds a prefix the label was never computed for — an inconsistent target exactly where the draft is wrong.
- **Nothing lost at inference.** A mispredicted draft token is rejected by the verifier and truncates the draft chain, so training the draft to continue from its own mistake gains nothing at serving time.

So the removed path only ever added an inconsistent — and at best neutral — training target. Teacher forcing is the right default.

## Changes

- `eagle3/core.py`: teacher-force unconditionally in the TTT loop; drop the now-dead draft→verifier (`d2t`) remap that only applied to the self-token feed; remove the `use_off_policy_tokens` parameter.
- `eagle3/core.py`: drop it from the train/val trainer kwargs — validation now matches training.
- `scripts/train.py`, `docs/cli/train.md`: remove the CLI flag and its doc entry.

## Note

This changes the **default** training behavior (previously the draft's own tokens were fed by default). No config, checkpoint, or data-format changes. Scripts that passed `--use-off-policy-tokens` should drop the flag.

Verified: `tests/unit/train/test_cli_args.py` green (20 passed), module imports, ruff clean.
