### PR TITLE
refactor: replace torch.cuda.synchronize() with device-agnostic torch.accelerator.synchronize()

### DIFF
--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -54,10 +54,7 @@ class _StepTimer:
 
     def mark(self, name: str) -> None:
         if self.enabled:
-            if hasattr(torch, "accelerator"):
-                torch.accelerator.synchronize()
-            else:
-                torch.cuda.synchronize()
+            torch.accelerator.synchronize()
             self._marks[name] = time.perf_counter()
 
     def mark_value(self, name: str, value: float) -> None:
@@ -67,10 +64,7 @@ class _StepTimer:
     def now(self) -> float | None:
         if not self.enabled:
             return None
-        if hasattr(torch, "accelerator"):
-            torch.accelerator.synchronize()
-        else:
-            torch.cuda.synchronize()
+        torch.accelerator.synchronize()
         return time.perf_counter()
 
     def profile(self, num_tokens: int) -> dict[str, float] | None:

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -41,7 +41,7 @@ metric_logger = logging.getLogger("speculators.metrics")
 
 
 class _StepTimer:
-    # Each mark()/now() forces a cuda.synchronize to capture true GPU time.
+    # Each mark()/now() forces an accelerator.synchronize to capture true GPU time.
     # This serialises the CUDA pipeline, so profiled steps are slower; keep
     # log_freq > 1 in perf-sensitive runs.
     def __init__(self, enabled: bool = False):

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -54,7 +54,10 @@ class _StepTimer:
 
     def mark(self, name: str) -> None:
         if self.enabled:
-            torch.cuda.synchronize()
+            if hasattr(torch, "accelerator"):
+                torch.accelerator.synchronize()
+            else:
+                torch.cuda.synchronize()
             self._marks[name] = time.perf_counter()
 
     def mark_value(self, name: str, value: float) -> None:
@@ -64,7 +67,10 @@ class _StepTimer:
     def now(self) -> float | None:
         if not self.enabled:
             return None
-        torch.cuda.synchronize()
+        if hasattr(torch, "accelerator"):
+            torch.accelerator.synchronize()
+        else:
+            torch.cuda.synchronize()
         return time.perf_counter()
 
     def profile(self, num_tokens: int) -> dict[str, float] | None:

--- a/tests/unit/train/test_step_timer.py
+++ b/tests/unit/train/test_step_timer.py
@@ -16,7 +16,7 @@ def test_disabled_timer_returns_none():
     assert timer.profile(num_tokens=1024) is None
 
 
-@patch("speculators.train.trainer.torch.cuda.synchronize")
+@patch("speculators.train.trainer.torch.accelerator.synchronize")
 def test_enabled_timer_returns_profile(mock_sync):
     timer = _StepTimer(enabled=True)
 
@@ -79,7 +79,7 @@ def test_disabled_to_enabled_transition():
     timer.mark_value("start", t_before_fetch)
 
     with (
-        patch("speculators.train.trainer.torch.cuda.synchronize"),
+        patch("speculators.train.trainer.torch.accelerator.synchronize"),
         patch(
             "speculators.train.trainer.time.perf_counter",
             side_effect=[2.1, 2.4, 2.5, 2.6, 2.6],
@@ -106,7 +106,7 @@ def test_zero_step_ms_returns_zero_throughput():
     timer = _StepTimer(enabled=True)
     timer.mark_value("start", 1.0)
     with (
-        patch("speculators.train.trainer.torch.cuda.synchronize"),
+        patch("speculators.train.trainer.torch.accelerator.synchronize"),
         patch("speculators.train.trainer.time.perf_counter", return_value=1.0),
     ):
         timer.mark("fetch")


### PR DESCRIPTION
## Purpose
This PR replaces torch.cuda.synchronize() calls with PyTorch hardware-agnostic unified accelerator API torch.accelerator.synchronize(). A version fallback wrapper is added to maintain compatibility with PyTorch versions below 2.5, eliminating hard-coded CUDA dependencies and enabling native support for heterogeneous accelerators such as NPU and XPU.

## Tests
tested on cuda GPU environment and Ascend NPU evironment

## Checklist
I have filled in:
- [ Y] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ Y] The test plan/results, such as providing test command and pasting the results.
- [Y ] I (a human) have written or reviewed the code in this pr to the best of my ability.
