### PR TITLE
[Clarification] Rename launch_vllm.py -> launch_vllm_hidden_states.py

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -35,7 +35,7 @@ nav:
           - cli/index.md
           - prepare_data.py: cli/prepare_data.md
           - data_generation_offline.py: cli/data_generation_offline.md
-          - launch_vllm.py: cli/launch_vllm.md
+          - launch_vllm_hidden_states.py: cli/launch_vllm_hidden_states.md
           - train.py: cli/train.md
           - response_regeneration: cli/response_regeneration.md
     - Community:

--- a/docs/cli/data_generation_offline.md
+++ b/docs/cli/data_generation_offline.md
@@ -23,7 +23,7 @@ python scripts/data_generation_offline.py \
 
 ### Model Arguments
 
-- **`--endpoint`** (str, default: `http://localhost:8000/v1`) The address of the vLLM instance to use for hidden states generation. The vLLM instance must be configured for hidden states extraction (see [launch_vllm.py](launch_vllm.md)).
+- **`--endpoint`** (str, default: `http://localhost:8000/v1`) The address of the vLLM instance to use for hidden states generation. The vLLM instance must be configured for hidden states extraction (see [launch_vllm_hidden_states.py](launch_vllm_hidden_states.md)).
 
 - **`--model`** (str, default: `None`) HuggingFace model ID or local path for the target model. Used for verification only - the model is auto-detected from the vLLM endpoint.
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -10,7 +10,7 @@ Speculators provides the following CLI scripts for different stages of the specu
 | ---------------------------- | ------------------------------------------------------------ | --------------------------------------- |
 | `prepare_data.py`            | Preprocess and tokenize datasets for training                | [→ Details](prepare_data.md)            |
 | `data_generation_offline.py` | Generate hidden states offline using vLLM                    | [→ Details](data_generation_offline.md) |
-| `launch_vllm.py`             | Launch vLLM server configured for hidden states extraction   | [→ Details](launch_vllm.md)             |
+| `launch_vllm_hidden_states.py`             | Launch vLLM server configured for hidden states extraction   | [→ Details](launch_vllm_hidden_states.md)             |
 | `train.py`                   | Train speculator models with online or offline hidden states | [→ Details](train.md)                   |
 | `response_regeneration/`     | Regenerate dataset responses using a vLLM-served model       | [→ Details](response_regeneration.md)   |
 
@@ -26,14 +26,14 @@ flowchart TD
 
     subgraph offline ["Offline Pipeline"]
         B["prepare_data.py\nTokenize & format dataset"]
-        C["launch_vllm.py\nStart vLLM server"]
+        C["launch_vllm_hidden_states.py\nStart vLLM server"]
         D["data_generation_offline.py\nExtract hidden states from verifier and cache to disk"]
         E["train.py \nTrain draft model on saved hidden states"]
     end
 
     subgraph online ["Online Pipeline"]
         F["prepare_data.py\nTokenize & format dataset"]
-        G["launch_vllm.py\nStart vLLM server"]
+        G["launch_vllm_hidden_states.py\nStart vLLM server"]
         H["train.py \nExtract hidden states & train in one step"]
     end
 
@@ -44,8 +44,8 @@ flowchart TD
 
     click B "prepare_data/" _self
     click F "prepare_data/" _self
-    click C "launch_vllm/" _self
-    click G "launch_vllm/" _self
+    click C "launch_vllm_hidden_states/" _self
+    click G "launch_vllm_hidden_states/" _self
     click D "data_generation_offline/" _self
     click E "train/" _self
     click A "response_regeneration/" _self

--- a/docs/cli/launch_vllm_hidden_states.md
+++ b/docs/cli/launch_vllm_hidden_states.md
@@ -1,11 +1,13 @@
-# launch_vllm.py
+# launch_vllm_hidden_states.py
 
 Launches a vLLM server configured for hidden states extraction, used for online training or offline hidden states generation.
+
+Every request writes hidden-state tensors to `--hidden-states-path`; for a plain server (e.g. response regeneration) use `vllm serve`.
 
 ## Basic Usage
 
 ```bash
-python scripts/launch_vllm.py meta-llama/Llama-3.1-8B-Instruct 
+python scripts/launch_vllm_hidden_states.py meta-llama/Llama-3.1-8B-Instruct 
 ```
 
 ## Arguments
@@ -42,7 +44,7 @@ See [vLLM CLI documentation](https://docs.vllm.ai/en/latest/cli/) for full list 
 ## Full Example
 
 ```bash
-python scripts/launch_vllm.py \
+python scripts/launch_vllm_hidden_states.py \
   meta-llama/Llama-3.1-70B-Instruct \
   --hidden-states-path /data/hidden_states \
   --target-layer-ids 5 20 40 80 \

--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -218,7 +218,7 @@ All speculator types (except `mtp`) use sliding window attention on all draft la
 
 ```bash
 # First, start vLLM server
-python scripts/launch_vllm.py \
+python scripts/launch_vllm_hidden_states.py \
   meta-llama/Llama-3.1-8B-Instruct \
   -- --port 8000
 

--- a/docs/user_guide/tutorials/train_dflash_online.md
+++ b/docs/user_guide/tutorials/train_dflash_online.md
@@ -75,13 +75,13 @@ output/dflash_qwen3_8b_sharegpt/
 
 ## Step 2: Launch vLLM Server
 
-During training, the drafter model takes internal hidden states from the verifier model as input. We use vLLM to serve the verifier and extract these hidden states. The `launch_vllm.py` script is a lightweight wrapper that sets up the right CLI arguments for vLLM to enable hidden state extraction.
+During training, the drafter model takes internal hidden states from the verifier model as input. We use vLLM to serve the verifier and extract these hidden states. The `launch_vllm_hidden_states.py` script is a lightweight wrapper that sets up the right CLI arguments for vLLM to enable hidden state extraction.
 
 For DFlash, you must explicitly specify which target layers to extract hidden states from using `--target-layer-ids`:
 
 ```bash
 # in vLLM venv
-CUDA_VISIBLE_DEVICES=0,1 python scripts/launch_vllm.py Qwen/Qwen3-8B \
+CUDA_VISIBLE_DEVICES=0,1 python scripts/launch_vllm_hidden_states.py Qwen/Qwen3-8B \
   --target-layer-ids 2 18 33 \
   -- --data-parallel-size 2 --port 8000
 ```
@@ -101,7 +101,7 @@ INFO:     Waiting for application startup.
 INFO:     Application startup complete
 ```
 
-**Note:** The `--target-layer-ids` must match what you pass to the training step. These specify which intermediate layers of the target model provide hidden states to the DFlash drafter. For more information on usage, please see the [launch_vllm.py cli reference](/cli/launch_vllm.md).
+**Note:** The `--target-layer-ids` must match what you pass to the training step. These specify which intermediate layers of the target model provide hidden states to the DFlash drafter. For more information on usage, please see the [launch_vllm_hidden_states.py cli reference](/cli/launch_vllm_hidden_states.md).
 
 ## Step 3: Start Training
 

--- a/docs/user_guide/tutorials/train_eagle3_offline.md
+++ b/docs/user_guide/tutorials/train_eagle3_offline.md
@@ -72,17 +72,17 @@ output/
 
 ## Step 2: Launch vLLM Server
 
-During training, the drafter model takes internal hidden states from the verifier model as input. We use vLLM to serve the verifier and extract these hidden states. The `launch_vllm.py` script is a lightweight wrapper that sets up the right CLI arguments for vLLM to enable hidden state extraction.
+During training, the drafter model takes internal hidden states from the verifier model as input. We use vLLM to serve the verifier and extract these hidden states. The `launch_vllm_hidden_states.py` script is a lightweight wrapper that sets up the right CLI arguments for vLLM to enable hidden state extraction.
 
 ```bash
 # in vLLM venv
 # For 8B model - use data parallelism
-CUDA_VISIBLE_DEVICES=0,1 python scripts/launch_vllm.py \
+CUDA_VISIBLE_DEVICES=0,1 python scripts/launch_vllm_hidden_states.py \
   meta-llama/Llama-3.1-8B-Instruct \
   -- --data-parallel-size 2 --port 8000
 
 # For 70B model - combine tensor parallelism and data parallelism
-CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python scripts/launch_vllm.py \
+CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python scripts/launch_vllm_hidden_states.py \
   meta-llama/Llama-3.3-70B-Instruct \
   -- --tensor-parallel-size 4 --data-parallel-size 2 --port 8000
 ```
@@ -102,7 +102,7 @@ INFO:     Waiting for application startup.
 INFO:     Application startup complete
 ```
 
-**Note:** This stage is also when you must decide which layer ids to extract from vLLM. For Eagle-3, if you don't pass in `--target-layer-ids`, this script will use sensible default values. For more information on usage, please see the [launch_vllm.py cli reference](/cli/launch_vllm.md).
+**Note:** This stage is also when you must decide which layer ids to extract from vLLM. For Eagle-3, if you don't pass in `--target-layer-ids`, this script will use sensible default values. For more information on usage, please see the [launch_vllm_hidden_states.py cli reference](/cli/launch_vllm_hidden_states.md).
 
 ## Step 3: Generate Hidden States Offline
 
@@ -151,7 +151,7 @@ output/hidden_states/
 
 ```bash
 # 8 GPUs with DP=8
-python scripts/launch_vllm.py model -- --data-parallel-size 8
+python scripts/launch_vllm_hidden_states.py model -- --data-parallel-size 8
 ```
 
 **Use multiple nodes:**

--- a/docs/user_guide/tutorials/train_eagle3_online.md
+++ b/docs/user_guide/tutorials/train_eagle3_online.md
@@ -72,16 +72,16 @@ output/
 
 ## Step 2: Launch vLLM Server
 
-During training, the drafter model takes internal hidden states from the verifier model as input. We use vLLM to serve the verifier and extract these hidden states. The `launch_vllm.py` script is a lightweight wrapper that sets up the right CLI arguments for vLLM to enable hidden state extraction.
+During training, the drafter model takes internal hidden states from the verifier model as input. We use vLLM to serve the verifier and extract these hidden states. The `launch_vllm_hidden_states.py` script is a lightweight wrapper that sets up the right CLI arguments for vLLM to enable hidden state extraction.
 
 ```bash
 # in vLLM venv
 
 # Single GPU
-python scripts/launch_vllm.py Qwen/Qwen3-8B
+python scripts/launch_vllm_hidden_states.py Qwen/Qwen3-8B
 
 # Multiple GPUs with data parallelism (recommended)
-CUDA_VISIBLE_DEVICES=0,1 python scripts/launch_vllm.py \
+CUDA_VISIBLE_DEVICES=0,1 python scripts/launch_vllm_hidden_states.py \
   Qwen/Qwen3-8B -- --data-parallel-size 2 --port 8000
 ```
 
@@ -100,7 +100,7 @@ INFO:     Waiting for application startup.
 INFO:     Application startup complete
 ```
 
-**Note:** This stage is also when you must decide which layer ids to extract from vLLM. For Eagle-3, if you don't pass in `--target-layer-ids`, this script will use sensible default values. For more information on usage, please see the [launch_vllm.py cli reference](/cli/launch_vllm.md).
+**Note:** This stage is also when you must decide which layer ids to extract from vLLM. For Eagle-3, if you don't pass in `--target-layer-ids`, this script will use sensible default values. For more information on usage, please see the [launch_vllm_hidden_states.py cli reference](/cli/launch_vllm_hidden_states.md).
 
 ## Step 3: Start Training
 
@@ -233,13 +233,13 @@ vLLM: CUDA out of memory
 
 ```bash
 # Increase GPU memory utilization
-python scripts/launch_vllm.py model -- --gpu-memory-utilization 0.95
+python scripts/launch_vllm_hidden_states.py model -- --gpu-memory-utilization 0.95
 
 # Reduce max model length
-python scripts/launch_vllm.py model -- --max-model-len 4096
+python scripts/launch_vllm_hidden_states.py model -- --max-model-len 4096
 
 # Use more GPUs
-python scripts/launch_vllm.py model -- --tensor-parallel-size 2
+python scripts/launch_vllm_hidden_states.py model -- --tensor-parallel-size 2
 ```
 
 ### Issue: Training Loss Not Decreasing
@@ -273,7 +273,7 @@ python scripts/launch_vllm.py model -- --tensor-parallel-size 2
 
 **Solutions:**
 
-1. **Redistribute GPUs between training and datagen processes:** If possible, increase the number of gpus assigned to vLLM datagen (i.e. the `launch_vllm.py` step) and reduce the number used during training. Inconsistent training performance typically means the training process is stuck waiting for new data samples to be generated.
+1. **Redistribute GPUs between training and datagen processes:** If possible, increase the number of gpus assigned to vLLM datagen (i.e. the `launch_vllm_hidden_states.py` step) and reduce the number used during training. Inconsistent training performance typically means the training process is stuck waiting for new data samples to be generated.
 
 2. **Consider switching to offline training:** Offline training pre-generates the hidden states for all samples and caches them on disk. Then during training the samples can just be loaded directly. If gpu resources are limited, this can be a better approach as it allows you to assign all gpus to data gen and then all to training.
 

--- a/docs/user_guide/tutorials/train_mtp_online.md
+++ b/docs/user_guide/tutorials/train_mtp_online.md
@@ -84,7 +84,7 @@ Start vLLM to serve the verifier for hidden state extraction. The server stays r
 
 ```bash
 # in vLLM venv
-CUDA_VISIBLE_DEVICES=0 python scripts/launch_vllm.py \
+CUDA_VISIBLE_DEVICES=0 python scripts/launch_vllm_hidden_states.py \
   Qwen/Qwen3.5-9B \
   --target-layer-ids 32 \
   -- --port 8000
@@ -105,7 +105,7 @@ INFO:     Waiting for application startup.
 INFO:     Application startup complete
 ```
 
-**Note:** For more information on usage, please see the [launch_vllm.py cli reference](/cli/launch_vllm.md).
+**Note:** For more information on usage, please see the [launch_vllm_hidden_states.py cli reference](/cli/launch_vllm_hidden_states.md).
 
 ## Step 3: Train Against the Live vLLM Server
 

--- a/docs/user_guide/tutorials/train_peagle_offline.md
+++ b/docs/user_guide/tutorials/train_peagle_offline.md
@@ -73,11 +73,11 @@ output/peagle_qwen3_8b_sharegpt/
 
 ## Step 2: Launch vLLM Server
 
-During training, the drafter model takes internal hidden states from the verifier model as input. We use vLLM to serve the verifier and extract these hidden states. The `launch_vllm.py` script is a lightweight wrapper that sets up the right CLI arguments for vLLM to enable hidden state extraction.
+During training, the drafter model takes internal hidden states from the verifier model as input. We use vLLM to serve the verifier and extract these hidden states. The `launch_vllm_hidden_states.py` script is a lightweight wrapper that sets up the right CLI arguments for vLLM to enable hidden state extraction.
 
 ```bash
 # in vLLM venv
-CUDA_VISIBLE_DEVICES=0,1 python scripts/launch_vllm.py Qwen/Qwen3-8B \
+CUDA_VISIBLE_DEVICES=0,1 python scripts/launch_vllm_hidden_states.py Qwen/Qwen3-8B \
   --hidden-states-path ./output/peagle_qwen3_8b_sharegpt/hidden_states \
   -- --data-parallel-size 2 --port 8000
 ```
@@ -97,7 +97,7 @@ INFO:     Waiting for application startup.
 INFO:     Application startup complete
 ```
 
-**Note:** For more information on usage, please see the [launch_vllm.py cli reference](/cli/launch_vllm.md).
+**Note:** For more information on usage, please see the [launch_vllm_hidden_states.py cli reference](/cli/launch_vllm_hidden_states.md).
 
 ## Step 3: Generate Hidden States Offline
 
@@ -146,7 +146,7 @@ output/peagle_qwen3_8b_sharegpt/hidden_states/
 
 ```bash
 # 8 GPUs with DP=8
-python scripts/launch_vllm.py model -- --data-parallel-size 8
+python scripts/launch_vllm_hidden_states.py model -- --data-parallel-size 8
 ```
 
 ### Resuming Interrupted Generation

--- a/examples/train/dflash_qwen3_8b_sharegpt_online_5k.sh
+++ b/examples/train/dflash_qwen3_8b_sharegpt_online_5k.sh
@@ -72,7 +72,7 @@ python scripts/prepare_data.py \
 
 # Step 2: Launch vLLM server in the background
 echo "=== Step 2: Launching vLLM server ==="
-CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm.py "$MODEL" \
+CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm_hidden_states.py "$MODEL" \
     --target-layer-ids $TARGET_LAYER_IDS \
     -- --data-parallel-size 2 --port "$VLLM_PORT" &
 VLLM_PID=$!

--- a/examples/train/dspark_qwen3_0_6b_sharegpt_online.sh
+++ b/examples/train/dspark_qwen3_0_6b_sharegpt_online.sh
@@ -62,7 +62,7 @@ python scripts/prepare_data.py \
 
 # Step 2: Launch vLLM server in the background
 echo "=== Step 2: Launching vLLM server ==="
-CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm.py "$MODEL" \
+CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm_hidden_states.py "$MODEL" \
     --target-layer-ids $TARGET_LAYER_IDS \
     -- --port "$VLLM_PORT" &
 VLLM_PID=$!

--- a/examples/train/eagle3_llama3_8b_ultrachat_offline_5k.sh
+++ b/examples/train/eagle3_llama3_8b_ultrachat_offline_5k.sh
@@ -64,7 +64,7 @@ python scripts/prepare_data.py \
 
 # Step 2: Launch vLLM server in the background
 echo "=== Step 2: Launching vLLM server ==="
-CUDA_VISIBLE_DEVICES="$GPUS" python scripts/launch_vllm.py "$MODEL" \
+CUDA_VISIBLE_DEVICES="$GPUS" python scripts/launch_vllm_hidden_states.py "$MODEL" \
     -- --data-parallel-size 2 --port "$VLLM_PORT" --gpu-memory-utilization 0.85 &
 VLLM_PID=$!
 

--- a/examples/train/eagle3_qwen3_8b_sharegpt_online_5k.sh
+++ b/examples/train/eagle3_qwen3_8b_sharegpt_online_5k.sh
@@ -62,7 +62,7 @@ python scripts/prepare_data.py \
 
 # Step 2: Launch vLLM server in the background
 echo "=== Step 2: Launching vLLM server ==="
-CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm.py "$MODEL" \
+CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm_hidden_states.py "$MODEL" \
     -- --data-parallel-size 2 --port "$VLLM_PORT" --gpu-memory-utilization 0.85 &
 VLLM_PID=$!
 

--- a/examples/train/mtp_qwen3_5_9b_gsm8k_online.sh
+++ b/examples/train/mtp_qwen3_5_9b_gsm8k_online.sh
@@ -72,7 +72,7 @@ python scripts/prepare_data.py \
 
 # Step 2: Launch vLLM server in the background
 echo "=== Step 2: Launching vLLM server ==="
-CUDA_VISIBLE_DEVICES="$VLLM_GPU" python scripts/launch_vllm.py "$MODEL" \
+CUDA_VISIBLE_DEVICES="$VLLM_GPU" python scripts/launch_vllm_hidden_states.py "$MODEL" \
     --target-layer-ids 32 \
     -- --port "$VLLM_PORT" &
 VLLM_PID=$!

--- a/examples/train/peagle_qwen3_8b_sharegpt_online_5k.sh
+++ b/examples/train/peagle_qwen3_8b_sharegpt_online_5k.sh
@@ -67,7 +67,7 @@ python scripts/prepare_data.py \
 
 # Step 2: Launch vLLM server in the background
 echo "=== Step 2: Launching vLLM server ==="
-CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm.py "$MODEL" \
+CUDA_VISIBLE_DEVICES="$VLLM_GPUS" python scripts/launch_vllm_hidden_states.py "$MODEL" \
     --hidden-states-path "$OUTPUT_DIR/hidden_states" \
     -- --data-parallel-size 2 --port "$VLLM_PORT" --gpu-memory-utilization 0.85 &
 VLLM_PID=$!

--- a/hs_connectors/src/hs_connectors/transfer.py
+++ b/hs_connectors/src/hs_connectors/transfer.py
@@ -65,7 +65,7 @@ class HiddenStatesBackend(ABC):
 
     Each backend registers itself via ``@HiddenStatesBackend.register(name)``
     and implements these four static hooks so that scripts (``train.py``,
-    ``launch_vllm.py``) can discover and configure backends without hardcoding.
+    ``launch_vllm_hidden_states.py``) can discover and configure backends without hardcoding.
     """
 
     registry: ClassVar[dict[str, type[HiddenStatesBackend]]] = {}
@@ -94,7 +94,7 @@ class HiddenStatesBackend(ABC):
     @staticmethod
     @abstractmethod
     def add_launch_args(parser: argparse.ArgumentParser) -> None:
-        """Add backend-specific CLI arguments to ``launch_vllm.py``."""
+        """Add backend-specific CLI arguments to ``launch_vllm_hidden_states.py``."""
         ...
 
     @staticmethod

--- a/scripts/launch_vllm_hidden_states.py
+++ b/scripts/launch_vllm_hidden_states.py
@@ -1,3 +1,5 @@
+"""Launch vLLM as a hidden-states producer for speculator training-data generation."""
+
 import argparse
 import json
 import os
@@ -46,7 +48,7 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Launch vLLM for hidden states extraction",
         usage=(
-            "launch_vllm.py [-h] MODEL [--hidden-states-backend BACKEND] "
+            "launch_vllm_hidden_states.py [-h] MODEL [--hidden-states-backend BACKEND] "
             "[--target-layer-ids TARGET_LAYER_IDS [TARGET_LAYER_IDS ...]] -- *VLLM_ARGS"
         ),
     )

--- a/tests/e2e/regression/test_eagle3_offline_acceptance.py
+++ b/tests/e2e/regression/test_eagle3_offline_acceptance.py
@@ -2,7 +2,7 @@
 
 Exercises the full offline pipeline:
   1. Prepare data (scripts/prepare_data.py)
-  2. Launch a vLLM server for hidden-state extraction (scripts/launch_vllm.py)
+  2. Launch a vLLM server for hidden-state extraction (scripts/launch_vllm_hidden_states.py)
   3. Generate hidden states offline (scripts/data_generation_offline.py)
   4. Stop the vLLM server
   5. Train a draft model using pre-generated hidden states (scripts/train.py)

--- a/tests/e2e/regression/test_eagle3_online_acceptance.py
+++ b/tests/e2e/regression/test_eagle3_online_acceptance.py
@@ -3,7 +3,7 @@
 Exercises the full pipeline documented in
 docs/user_guide/tutorials/train_eagle3_online.md:
   1. Prepare data (scripts/prepare_data.py)
-  2. Launch a vLLM server for hidden-state extraction (scripts/launch_vllm.py)
+  2. Launch a vLLM server for hidden-state extraction (scripts/launch_vllm_hidden_states.py)
   3. Train a draft model against the live server (scripts/train.py)
   4. Validate the trained checkpoint via vLLM inference (run_vllm_engine)
 """

--- a/tests/e2e/smoke/test_offline_training.py
+++ b/tests/e2e/smoke/test_offline_training.py
@@ -2,7 +2,7 @@
 
 Exercises the full offline pipeline:
   1. Prepare data (scripts/prepare_data.py)
-  2. Launch a vLLM server for hidden-state extraction (scripts/launch_vllm.py)
+  2. Launch a vLLM server for hidden-state extraction (scripts/launch_vllm_hidden_states.py)
   3. Generate hidden states offline (scripts/data_generation_offline.py)
   4. Stop the vLLM server
   5. Train a draft model using pre-generated hidden states (scripts/train.py)

--- a/tests/e2e/smoke/test_online_training.py
+++ b/tests/e2e/smoke/test_online_training.py
@@ -3,7 +3,7 @@
 Exercises the full pipeline documented in
 docs/user_guide/tutorials/train_eagle3_online.md:
   1. Prepare data (scripts/prepare_data.py)
-  2. Launch a vLLM server for hidden-state extraction (scripts/launch_vllm.py)
+  2. Launch a vLLM server for hidden-state extraction (scripts/launch_vllm_hidden_states.py)
   3. Train a draft model against the live server (scripts/train.py)
   4. Validate the trained checkpoint via vLLM inference (run_vllm_engine)
 """

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -113,7 +113,7 @@ def launch_vllm_server(
     """
     cmd = [
         VLLM_PYTHON,
-        str(SCRIPTS_DIR / "launch_vllm.py"),
+        str(SCRIPTS_DIR / "launch_vllm_hidden_states.py"),
         model,
         "--hidden-states-path",
         str(hidden_states_path),


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose


**TLDR**: `scripts/launch_vllm.py` is slow because it always producing hidden states. So the name should not be generic. 

`scripts/launch_vllm.py` always configures vLLM as a hidden-states producer (writes tensors to `--hidden-states-path` on every request), but its generic name reads like a plain-server launcher. So it gets reached for in workflows that only want `vllm serve` (e.g. response regeneration). 

Rename it to `launch_vllm_hidden_states.py`, update all references, and add a one-line module docstring plus a one-sentence CLI-ref note. Pure rename + reference updates; no behavior change.

## Tests

- `git grep 'launch_vllm\.py'` / `launch_vllm.md` / `launch_vllm/` → all empty.


## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
