### PR TITLE
fix(train): DSpark + FSDP2 + Muon crash

### DIFF
--- a/src/speculators/train/optimizers.py
+++ b/src/speculators/train/optimizers.py
@@ -34,8 +34,10 @@ def split_named_params_for_muon(
 ) -> tuple[list[tuple[str, Tensor]], list[tuple[str, Tensor]]]:
     """Split a model's trainable parameters into Muon and AdamW groups.
 
-    A parameter goes to the Muon group iff it requires gradients, is 2D, and is not an
-    embedding or LM-head weight. All other trainable parameters go to the AdamW group.
+    A parameter goes to Muon iff it requires gradients, is a 2D matrix with both
+    dimensions > 1, and is not an embedding or LM-head weight; everything else goes to
+    AdamW. Degenerate 2D weights (``[1, N]`` / ``[N, 1]`` vectors) route to AdamW --
+    Muon orthogonalizes matrices, not vectors, and crashes on them under FSDP2.
 
     :param model: The model whose parameters should be partitioned.
     :return: A ``(muon_params, adamw_params)`` tuple of named parameter lists.
@@ -45,8 +47,10 @@ def split_named_params_for_muon(
     for name, param in model.named_parameters():
         if not param.requires_grad:
             continue
-        if param.ndim == _MATRIX_NDIM and not any(
-            hint in name for hint in _ADAMW_NAME_HINTS
+        if (
+            param.ndim == _MATRIX_NDIM
+            and min(param.shape) > 1  # exclude degenerate [1, N] / [N, 1] vectors
+            and not any(hint in name for hint in _ADAMW_NAME_HINTS)
         ):
             muon_params.append((name, param))
         else:


### PR DESCRIPTION
<!-- markdownlint-disable -->


## Issue

FSDP2 + Muon + DSpark crashed. (see repro below for the exact setting)

The new default DDP + Muon + DSpark is fine. Eagle3, DFlash are fine in both paths. 

## Root cause

This is a pytorch edge case bug. I think it's not worth fixing upstream. 

## Fix

* option 1 (this PR): extend the Muon/AdamW classifier: DSpark's confidence head should use AdamW. Then no crash. 

* option 2: delete fsdp path. The new default DDP is bug free

**Recommend option 2, close this PR and delete the FSDP path.** Because with the patch, FSDP and DDP will use different optimizer for different parameters. FSDP is an overkill for small drafter training, it's buggy and it's no longer the default anyway.

<details close>
<summary>long version</summary>

## Root cause long version

Training a speculator that has a scalar-prediction head — e.g. DSpark's confidence head, `nn.Linear(dim, 1)`, whose weight is `[1, N]` — with `--optimizer muon --fsdp-shard` crashes at the first optimizer step with `RuntimeError: aten.add_.Tensor: in-place operations that require placement changes are not supported ... placement (Shard(dim=0),)`.

The root cause is a **PyTorch × FSDP2 × Muon** interaction, not speculators itself: `torch.optim.Muon` orthogonalizes each weight via Newton-Schulz, but for a degenerate `[1, N]` (rank-1) param under FSDP2 the orthogonalized update comes back `Replicate` while the sharded param is `Shard(0)`, and Muon's in-place `param.add_(update)` cannot reconcile the placement change. It only triggers under `--fsdp-shard`; the **default DDP path is unaffected**, because DDP keeps params replicated and they never become `DTensor`s.

## Fix


The fix extends the Muon-eligibility guard in `split_named_params_for_muon` with `min(param.shape) > 1`, so a `[1, N]` / `[N, 1]` vector routes to AdamW — where it belongs, since Muon orthogonalizes matrices, not vectors. One-line change; the model then trains normally.


## Suggestion

Separately, we'd suggest **removing the `--fsdp-shard` path** altogether: param-sharding is overkill for the small draft models speculators trains (the training-memory bottleneck is activations + the loss region, not params, so FSDP saves ~nothing here), *and* it is the only path that hits this class of bug. The default DDP already covers the real use case.

</details>

## Repro

Qwen3-8B + DSpark + FSDP2 + Muon

```bash
python scripts/prepare_data.py --model Qwen/Qwen3-8B --data sharegpt \
  --max-samples 32 --seq-length 2048 --output ./repro/data

CUDA_VISIBLE_DEVICES=0 python scripts/launch_vllm.py Qwen/Qwen3-8B \
  --target-layer-ids 2 18 33 -- --data-parallel-size 1 --port 8000 &
until curl -sf localhost:8000/health >/dev/null; do sleep 2; done

CUDA_VISIBLE_DEVICES=1,2 torchrun --standalone --nproc_per_node 2 scripts/train.py \
  --verifier-name-or-path Qwen/Qwen3-8B --data-path ./repro/data \
  --vllm-endpoint http://localhost:8000/v1 --on-missing generate \
  --speculator-type dspark --markov-rank 256 --confidence-head-alpha 1.0 \
  --draft-vocab-size 32000 --total-seq-len 2048 --epochs 1 \
  --optimizer muon --fsdp-shard --save-path ./repro/ckpt
```

- **`main`**: `Muon optimizer: 11 2D params via Muon` → `RuntimeError: aten.add_.Tensor ... Shard(dim=0)` (crash).
- **this branch**: `Muon optimizer: 10 2D params via Muon` (the `[1, N]` head moved to AdamW) → trains, no crash.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
