### PR TITLE
perf(dflash): sort sampled anchors for contiguous flex-attention blocks

### DIFF
--- a/src/speculators/models/dflash/utils.py
+++ b/src/speculators/models/dflash/utils.py
@@ -59,7 +59,9 @@ def select_anchors(
     torch._check(k >= 0)  # noqa: SLF001
 
     perm = torch.randperm(valid_indices.numel(), device=loss_mask.device)
-    anchors[:k] = torch.gather(valid_indices, 0, perm[:k])
+    # Contiguous anchors let flex attention use dense (fast) blocks instead of
+    # scattered all-partial (slow) ones; the order never affects the loss.
+    anchors[:k] = torch.sort(torch.gather(valid_indices, 0, perm[:k])).values
     anchor_valid[:k] = True
 
     return anchors, anchor_valid

--- a/tests/unit/models/test_dflash_utils.py
+++ b/tests/unit/models/test_dflash_utils.py
@@ -1,8 +1,11 @@
-"""Unit tests for get_base_indices_for_anchored_blocks."""
+"""Unit tests for get_base_indices_for_anchored_blocks and select_anchors."""
 
 import torch
 
-from speculators.models.dflash.utils import get_base_indices_for_anchored_blocks
+from speculators.models.dflash.utils import (
+    get_base_indices_for_anchored_blocks,
+    select_anchors,
+)
 
 
 class TestGetBaseIndicesForAnchoredBlocks:
@@ -43,3 +46,14 @@ class TestGetBaseIndicesForAnchoredBlocks:
         anchor_positions = torch.tensor([[2.0, 5.0]])
         result = get_base_indices_for_anchored_blocks(anchor_positions, block_size=2)
         assert result.dtype == torch.long
+
+
+class TestSelectAnchors:
+    def test_sampled_anchors_are_sorted(self):
+        # Anchors are returned sorted by position so the draft blocks form
+        # contiguous flex-attention blocks (fast path) instead of scattered ones.
+        torch.manual_seed(0)
+        loss_mask = torch.ones(1, 64)
+        anchors, anchor_valid = select_anchors(loss_mask, num_anchors=8, block_size=4)
+        selected = anchors[anchor_valid]
+        assert torch.equal(selected, torch.sort(selected).values)


### PR DESCRIPTION
## Purpose

**Training a DFlash draft is ~3x slower than EAGLE3 for the same setup.** 

On 10 epochs of 2k conversations, with the same dataset, loss, sequence length and a single draft layer:

- **EAGLE3: 1.3 h**
- **DFlash: 3.7 h**
- **DFlash: 2.1 h** (This PR, projected from 1 epoch e2e bench)

The cost is in the draft attention: `select_anchors` samples anchor positions with `torch.randperm` and returns them in **random order**. Each anchor seeds a draft block that attends to the context *before* that anchor, so with anchors shuffled, adjacent query blocks reference scattered key ranges and the flex-attention block mask degenerates into all-**partial** (slow) blocks — the kernel re-evaluates the mask element-by-element instead of skipping whole blocks.

This PR **sorts the sampled anchors by position** (one line in `select_anchors`). Neighbouring blocks then share overlapping prefixes, so the block mask becomes mostly **full** (fast) blocks. Only the order changes — the sampled set is identical and the per-block loss is order-invariant, so training dynamics are unchanged. `select_anchors` is shared with DSpark, where it is equally safe (its Markov head is sequential *within* a block, not across anchors).

Isolated micro-benchmark of the attention pass (flex-attention fwd+bwd, bf16, packed 8192 seq, sliding-window 2048):

### Micro-bench

| attention pass | ms/iter | vs Eagle3 |
|---|---|---|
| Eagle3 (one TTT step) | 4.86 | 1× |
| DFlash (main), random anchors | 211 | 43× |
| DFlash (this PR), sorted anchors | 30 | 6.2× |

Sorting recovers ~86% of DFlash's attention time (7× on the pass). 

### E2E-bench

| variant | steady-state s/step | total wall (1 epoch, ~545 steps) |
|---|--:|--:|
| before (main)        | 2.58 | 1645 s |
| after  (#823 sorted) | 1.50 |  995 s |

**Speedup: 1.72x per step (−42%), 1.65x wall.**

## Tests

Added `TestSelectAnchors::test_sampled_anchors_are_sorted`, asserting the sampled anchors are returned sorted by position.



## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
