### PR TITLE
fix(trainer): device-agnostic synchronize and DSKIP_VAL

### DIFF
--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import time
 import warnings
 from pathlib import Path
@@ -40,6 +41,14 @@ root_logger = logging.getLogger("speculators")
 metric_logger = logging.getLogger("speculators.metrics")
 
 
+def _synchronize_device() -> None:
+    """Device-agnostic synchronize: CUDA when available, otherwise NPU."""
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    elif hasattr(torch, "npu") and torch.npu.is_available():
+        torch.npu.synchronize()
+
+
 class _StepTimer:
     # Each mark()/now() forces a cuda.synchronize to capture true GPU time.
     # This serialises the CUDA pipeline, so profiled steps are slower; keep
@@ -54,7 +63,7 @@ class _StepTimer:
 
     def mark(self, name: str) -> None:
         if self.enabled:
-            torch.cuda.synchronize()
+            _synchronize_device()
             self._marks[name] = time.perf_counter()
 
     def mark_value(self, name: str, value: float) -> None:
@@ -64,7 +73,7 @@ class _StepTimer:
     def now(self) -> float | None:
         if not self.enabled:
             return None
-        torch.cuda.synchronize()
+        _synchronize_device()
         return time.perf_counter()
 
     def profile(self, num_tokens: int) -> dict[str, float] | None:
@@ -631,7 +640,13 @@ class Trainer:
 
             val_metrics = None
 
-            if self.val_loader is None:
+            if os.environ.get("DSKIP_VAL"):
+                # Skip validation (e.g. unstable generation on some verifiers).
+                # Checkpoints and train/* metrics are still saved.
+                root_logger.warning(
+                    f"DSKIP_VAL set; skipping validation epoch {epoch + 1}/{n_epochs}"
+                )
+            elif self.val_loader is None:
                 root_logger.warning("No val loader, skipping validation epoch")
             else:
                 root_logger.info(f"Validation epoch {epoch + 1}/{n_epochs} started")

--- a/tests/unit/train/test_step_timer.py
+++ b/tests/unit/train/test_step_timer.py
@@ -16,7 +16,7 @@ def test_disabled_timer_returns_none():
     assert timer.profile(num_tokens=1024) is None
 
 
-@patch("speculators.train.trainer.torch.cuda.synchronize")
+@patch("speculators.train.trainer._synchronize_device")
 def test_enabled_timer_returns_profile(mock_sync):
     timer = _StepTimer(enabled=True)
 
@@ -79,7 +79,7 @@ def test_disabled_to_enabled_transition():
     timer.mark_value("start", t_before_fetch)
 
     with (
-        patch("speculators.train.trainer.torch.cuda.synchronize"),
+        patch("speculators.train.trainer._synchronize_device"),
         patch(
             "speculators.train.trainer.time.perf_counter",
             side_effect=[2.1, 2.4, 2.5, 2.6, 2.6],
@@ -106,7 +106,7 @@ def test_zero_step_ms_returns_zero_throughput():
     timer = _StepTimer(enabled=True)
     timer.mark_value("start", 1.0)
     with (
-        patch("speculators.train.trainer.torch.cuda.synchronize"),
+        patch("speculators.train.trainer._synchronize_device"),
         patch("speculators.train.trainer.time.perf_counter", return_value=1.0),
     ):
         timer.mark("fetch")


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Replace hardcoded torch.cuda.synchronize() in _StepTimer with _synchronize_device(), which falls back to torch.npu.synchronize() on non-CUDA builds. Add DSKIP_VAL env var to skip validation when generation is unstable; checkpoints and train/* metrics are still saved.

## Tests

Verified on Ascend NPU 910B3.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
