### PR TITLE
fix(trainer): device-agnostic synchronize

### DIFF
--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -40,6 +40,14 @@ root_logger = logging.getLogger("speculators")
 metric_logger = logging.getLogger("speculators.metrics")
 
 
+def _synchronize_device() -> None:
+    """Device-agnostic synchronize: CUDA when available, otherwise NPU."""
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    elif hasattr(torch, "npu") and torch.npu.is_available():
+        torch.npu.synchronize()
+
+
 class _StepTimer:
     # Each mark()/now() forces a cuda.synchronize to capture true GPU time.
     # This serialises the CUDA pipeline, so profiled steps are slower; keep
@@ -54,7 +62,7 @@ class _StepTimer:
 
     def mark(self, name: str) -> None:
         if self.enabled:
-            torch.cuda.synchronize()
+            _synchronize_device()
             self._marks[name] = time.perf_counter()
 
     def mark_value(self, name: str, value: float) -> None:
@@ -64,7 +72,7 @@ class _StepTimer:
     def now(self) -> float | None:
         if not self.enabled:
             return None
-        torch.cuda.synchronize()
+        _synchronize_device()
         return time.perf_counter()
 
     def profile(self, num_tokens: int) -> dict[str, float] | None:

--- a/tests/unit/train/test_step_timer.py
+++ b/tests/unit/train/test_step_timer.py
@@ -1,8 +1,8 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from speculators.train.trainer import _StepTimer
+from speculators.train.trainer import _StepTimer, _synchronize_device
 
 
 def test_disabled_timer_returns_none():
@@ -16,7 +16,7 @@ def test_disabled_timer_returns_none():
     assert timer.profile(num_tokens=1024) is None
 
 
-@patch("speculators.train.trainer.torch.cuda.synchronize")
+@patch("speculators.train.trainer._synchronize_device")
 def test_enabled_timer_returns_profile(mock_sync):
     timer = _StepTimer(enabled=True)
 
@@ -79,7 +79,7 @@ def test_disabled_to_enabled_transition():
     timer.mark_value("start", t_before_fetch)
 
     with (
-        patch("speculators.train.trainer.torch.cuda.synchronize"),
+        patch("speculators.train.trainer._synchronize_device"),
         patch(
             "speculators.train.trainer.time.perf_counter",
             side_effect=[2.1, 2.4, 2.5, 2.6, 2.6],
@@ -106,7 +106,7 @@ def test_zero_step_ms_returns_zero_throughput():
     timer = _StepTimer(enabled=True)
     timer.mark_value("start", 1.0)
     with (
-        patch("speculators.train.trainer.torch.cuda.synchronize"),
+        patch("speculators.train.trainer._synchronize_device"),
         patch("speculators.train.trainer.time.perf_counter", return_value=1.0),
     ):
         timer.mark("fetch")
@@ -117,3 +117,36 @@ def test_zero_step_ms_returns_zero_throughput():
     assert profile is not None
     assert profile["tokens_per_s"] == 0.0
     assert profile["fetch_frac"] == 0.0
+
+
+def test_synchronize_device_uses_cuda_when_available():
+    """When CUDA is available, torch.cuda.synchronize is called."""
+    with (
+        patch("torch.cuda.is_available", return_value=True),
+        patch("torch.cuda.synchronize") as mock_cuda_sync,
+    ):
+        _synchronize_device()
+    mock_cuda_sync.assert_called_once()
+
+
+def test_synchronize_device_falls_back_to_npu():
+    """When CUDA is unavailable but NPU is, torch.npu.synchronize is called."""
+    mock_npu = MagicMock()
+    mock_npu.is_available.return_value = True
+    with (
+        patch("torch.cuda.is_available", return_value=False),
+        patch("torch.npu", mock_npu),
+    ):
+        _synchronize_device()
+    mock_npu.synchronize.assert_called_once()
+
+
+def test_synchronize_device_no_backend_available():
+    """When neither CUDA nor NPU is available, no synchronize is called."""
+    mock_npu = MagicMock()
+    mock_npu.is_available.return_value = False
+    with (
+        patch("torch.cuda.is_available", return_value=False),
+        patch("torch.npu", mock_npu),
+    ):
+        _synchronize_device()


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Replace hardcoded torch.cuda.synchronize() in _StepTimer with _synchronize_device(), which falls back to torch.npu.synchronize() on non-CUDA builds.

## Tests

Verified on the Ascend NPU 910B3.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
