### PR TITLE
chore(evaluate): upgrade guidellm from 0.6.0 to 0.7.1

### DIFF
--- a/docs/user_guide/tutorials/evaluating_performance.md
+++ b/docs/user_guide/tutorials/evaluating_performance.md
@@ -39,7 +39,8 @@ Both `throughput` and `sweep` share the same options:
   --gen-len-rate N           Request rate for gen-len estimation (default: 128)
   --sweep-rate N             Number of sweep rate points (default: 10)
   --gen-kwargs JSON          Generation kwargs, e.g. '{"temperature":0.6}'
-  --data-column-mapper JSON  Column mapping for guidellm (default: '{"text_column":"prompt"}')
+  --data-column-mapper TEXT  Column mapping for guidellm in typed key=value format
+                             (default: kind=generative_column_mapper,column_mappings.text_column=prompt)
 ```
 
 ## SPEED-Bench

--- a/examples/evaluate/example_qwen3_8b_dflash_humaneval.sh
+++ b/examples/evaluate/example_qwen3_8b_dflash_humaneval.sh
@@ -65,6 +65,7 @@ echo "=== Step 2: Running acceptance rate evaluation ==="
 python "$SCRIPT_DIR/evaluate.py" \
     --target "${SERVER_URL}/v1" \
     --dataset "$DATASET" \
+    --data-column-mapper "kind=generative_column_mapper,column_mappings.text_column=prompt" \
     throughput \
     --subsets "HumanEval" \
     --max-requests 80

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -35,10 +35,10 @@ from perf_utils import (
     BASE_CSV_COLUMNS,
     CsvWriter,
     acceptance_csv_columns,
-    build_backend_args,
     check_dependencies,
     extract_spec_decode_metrics,
     fetch_metrics,
+    parse_gen_kwargs,
     parse_gen_len_results,
     parse_prometheus_metrics,
     parse_sweep_results,
@@ -57,13 +57,17 @@ DEFAULT_MAX_CONCURRENCY = 128
 DEFAULT_MAX_REQUESTS = 200
 DEFAULT_GEN_LEN_RATE = 128
 DEFAULT_SWEEP_RATE = 10
-DEFAULT_DATA_COLUMN_MAPPER = '{"text_column":"prompt"}'
+DEFAULT_DATA_COLUMN_MAPPER = (
+    "kind=generative_column_mapper,column_mappings.text_column=prompt"
+)
 
 # ---------------------------------------------------------------------------
 # SPEED-Bench constants
 # ---------------------------------------------------------------------------
 
-_SPEEDBENCH_COLUMN_MAPPER = '{"text_column":"turns"}'
+_SPEEDBENCH_COLUMN_MAPPER = (
+    "kind=generative_column_mapper,column_mappings.text_column=turns"
+)
 
 
 def _fetch_model_name(target: str) -> str | None:
@@ -182,7 +186,8 @@ def _run_subset(
             rate=args.gen_len_rate,
             max_requests=None,
             output_path=gen_len_output,
-            backend_args=build_backend_args(args.gen_kwargs, 4096),
+            max_tokens=4096,
+            gen_kwargs=parse_gen_kwargs(args.gen_kwargs),
         )
         mapping = parse_gen_len_results(
             [gen_len_output],
@@ -202,7 +207,8 @@ def _run_subset(
         profile=profile,
         max_requests=args.max_requests,
         output_path=run_output,
-        backend_args=build_backend_args(args.gen_kwargs, max_tokens),
+        max_tokens=max_tokens,
+        gen_kwargs=parse_gen_kwargs(args.gen_kwargs),
     )
     current = _require_metrics(metrics_url)
 
@@ -400,7 +406,8 @@ def main() -> None:
     parser.add_argument(
         "--data-column-mapper",
         default=DEFAULT_DATA_COLUMN_MAPPER,
-        help=f"Column mapping for guidellm (default: {DEFAULT_DATA_COLUMN_MAPPER})",
+        help="Column mapping for guidellm in typed key=value format"
+        f" (default: {DEFAULT_DATA_COLUMN_MAPPER})",
     )
     parser.add_argument(
         "--speedbench-data-dir",

--- a/scripts/evaluate/perf_utils.py
+++ b/scripts/evaluate/perf_utils.py
@@ -6,7 +6,6 @@ import csv
 import json
 import logging
 import math
-import os
 import re
 import shutil
 import statistics
@@ -152,7 +151,7 @@ def _load_json(
     with filepath.open() as f:
         data = json.load(f)
 
-    subset = Path(data["args"]["data_args"][0]["data_files"]).stem
+    subset = Path(data["config"]["spec"]["data"][0]["load_kwargs"]["data_files"]).stem
     points: list[tuple[float, float]] = []
     for bench in data.get("benchmarks", []):
         if bench.get("config", {}).get("strategy", {}).get("type_") != "constant":
@@ -248,7 +247,7 @@ def parse_gen_len_file(filepath: Path) -> dict:
     if not successful:
         raise ValueError(f"No successful requests found in {filepath}")
 
-    output_tokens = [r["output_tokens"] for r in successful]
+    output_tokens = [r["output_metrics"]["text_tokens"] for r in successful]
     median = statistics.median(output_tokens)
 
     return {
@@ -518,17 +517,14 @@ def check_dependencies() -> None:
         sys.exit(1)
 
 
-def build_backend_args(gen_kwargs: str, max_tokens: int) -> str:
-    if gen_kwargs:
-        try:
-            body = json.loads(gen_kwargs)
-        except json.JSONDecodeError as e:
-            msg = f"Invalid JSON in --gen-kwargs: {gen_kwargs!r}: {e}"
-            raise ValueError(msg) from e
-    else:
-        body = {}
-    body["max_tokens"] = max_tokens
-    return json.dumps({"extras": {"body": body}})
+def parse_gen_kwargs(gen_kwargs: str) -> dict:
+    if not gen_kwargs:
+        return {}
+    try:
+        return json.loads(gen_kwargs)
+    except json.JSONDecodeError as e:
+        msg = f"Invalid JSON in --gen-kwargs: {gen_kwargs!r}: {e}"
+        raise ValueError(msg) from e
 
 
 def fetch_metrics(metrics_url: str, retries: int = 3, delay: float = 2.0) -> str | None:
@@ -559,33 +555,31 @@ def run_guidellm(
     max_requests: int | None,
     max_concurrency: int,
     output_path: Path,
-    backend_args: str,
+    max_tokens: int,
+    gen_kwargs: dict | None = None,
 ) -> None:
-    cmd = [
-        "guidellm",
-        "benchmark",
-        "--target",
-        target,
-        "--data",
-        dataset,
-        "--data-column-mapper",
-        data_column_mapper,
-        "--profile",
-        profile,
-        "--rate",
-        str(rate),
-        "--output-path",
-        str(output_path),
-        "--backend-args",
-        backend_args,
-    ]
-    # When subset is given, filter to that file within the HF dataset.
-    # When subset is None the dataset IS the file (e.g. a local JSONL).
-    if subset is not None:
-        cmd.extend(["--data-args", json.dumps({"data_files": f"{subset}.jsonl"})])
-    if max_requests is not None:
-        cmd.extend(["--max-requests", str(max_requests)])
+    backend = f"kind=openai_http,target={target},max_tokens={max_tokens}"
+    for k, v in (gen_kwargs or {}).items():
+        backend += f",extras.body.{k}={v}"
+    cmd = ["guidellm", "run", "--backend", backend]
 
-    env = os.environ.copy()
-    env["GUIDELLM__MAX_CONCURRENCY"] = str(max_concurrency)
-    subprocess.run(cmd, check=True, env=env)  # noqa: S603
+    if subset is not None:
+        data = f"kind=huggingface,source={dataset}"
+        data += f",load_kwargs.data_files={subset}.jsonl"
+    else:
+        data = f"kind=json_file,path={dataset}"
+    cmd.extend(["--data", data])
+
+    cmd.extend(["--data-column-mapper", data_column_mapper])
+
+    profile_str = f"kind={profile},max_concurrency={max_concurrency}"
+    if profile == "sweep":
+        profile_str += f",sweep_size={rate}"
+    cmd.extend(["--profile", profile_str])
+
+    if max_requests is not None:
+        cmd.extend(["--constraint", f"kind=max_requests,count={max_requests}"])
+
+    cmd.extend(["--output", f"kind=json,path={output_path}"])
+
+    subprocess.run(cmd, check=True)  # noqa: S603

--- a/scripts/evaluate/requirements.txt
+++ b/scripts/evaluate/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies for performance benchmarking with guidellm
 vllm>=0.12.0
-guidellm>=0.7.1
+guidellm~=0.7.1
 
 # Visualization dependencies
 matplotlib

--- a/scripts/evaluate/requirements.txt
+++ b/scripts/evaluate/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies for performance benchmarking with guidellm
 vllm>=0.12.0
-guidellm==0.6.0
+guidellm>=0.7.1
 
 # Visualization dependencies
 matplotlib

--- a/tests/unit/scripts/test_perf_utils.py
+++ b/tests/unit/scripts/test_perf_utils.py
@@ -1,0 +1,363 @@
+"""Tests for scripts/evaluate/perf_utils.py.
+
+Covers the changed code paths from the guidellm 0.6→0.7 upgrade:
+  - parse_gen_kwargs (replaced build_backend_args)
+  - run_guidellm CLI command construction
+  - _load_json (new JSON output structure)
+  - parse_gen_len_file (new request stats structure)
+  - parse_sweep_file (unchanged, regression guard)
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_SCRIPT_DIR = Path(__file__).resolve().parents[3] / "scripts" / "evaluate"
+_PERF_UTILS_PATH = _SCRIPT_DIR / "perf_utils.py"
+
+
+@pytest.fixture(scope="module")
+def perf_utils():
+    spec = importlib.util.spec_from_file_location(
+        "perf_utils", _PERF_UTILS_PATH, submodule_search_locations=[]
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    prev = sys.modules.get("perf_utils")
+    sys.modules["perf_utils"] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        if prev is None:
+            sys.modules.pop("perf_utils", None)
+        else:
+            sys.modules["perf_utils"] = prev
+        raise
+    return module
+
+
+# ---------------------------------------------------------------------------
+# parse_gen_kwargs
+# ---------------------------------------------------------------------------
+
+
+class TestParseGenKwargs:
+    def test_empty_string(self, perf_utils):
+        assert perf_utils.parse_gen_kwargs("") == {}
+
+    def test_valid_json(self, perf_utils):
+        result = perf_utils.parse_gen_kwargs('{"temperature": 0.6, "top_p": 0.9}')
+        assert result == {"temperature": 0.6, "top_p": 0.9}
+
+    def test_invalid_json_raises(self, perf_utils):
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            perf_utils.parse_gen_kwargs("{bad json}")
+
+
+# ---------------------------------------------------------------------------
+# run_guidellm — command construction
+# ---------------------------------------------------------------------------
+
+
+class TestRunGuidellm:
+    def _capture_cmd(self, perf_utils, **kwargs):
+        defaults = {
+            "target": "http://localhost:8000/v1",
+            "dataset": "RedHatAI/speculator_benchmarks",
+            "subset": "qa",
+            "data_column_mapper": (
+                "kind=generative_column_mapper,column_mappings.text_column=prompt"
+            ),
+            "profile": "sweep",
+            "rate": 10,
+            "max_requests": 200,
+            "max_concurrency": 128,
+            "output_path": Path("/tmp/out.json"),
+            "max_tokens": 4096,
+            "gen_kwargs": None,
+        }
+        defaults.update(kwargs)
+        with patch("subprocess.run") as mock_run:
+            perf_utils.run_guidellm(**defaults)
+            return mock_run.call_args[0][0]
+
+    def test_subcommand_is_run(self, perf_utils):
+        cmd = self._capture_cmd(perf_utils)
+        assert cmd[0] == "guidellm"
+        assert cmd[1] == "run"
+
+    def test_backend_flag(self, perf_utils):
+        cmd = self._capture_cmd(perf_utils)
+        idx = cmd.index("--backend")
+        backend = cmd[idx + 1]
+        assert "kind=openai_http" in backend
+        assert "target=http://localhost:8000/v1" in backend
+        assert "max_tokens=4096" in backend
+
+    def test_backend_gen_kwargs(self, perf_utils):
+        cmd = self._capture_cmd(perf_utils, gen_kwargs={"temperature": 0.6})
+        idx = cmd.index("--backend")
+        backend = cmd[idx + 1]
+        assert "extras.body.temperature=0.6" in backend
+
+    def test_data_huggingface_with_subset(self, perf_utils):
+        cmd = self._capture_cmd(perf_utils, subset="qa")
+        idx = cmd.index("--data")
+        data = cmd[idx + 1]
+        assert "kind=huggingface" in data
+        assert "source=RedHatAI/speculator_benchmarks" in data
+        assert "load_kwargs.data_files=qa.jsonl" in data
+
+    def test_data_local_file_without_subset(self, perf_utils):
+        cmd = self._capture_cmd(
+            perf_utils,
+            subset=None,
+            dataset="/tmp/local.jsonl",
+        )
+        idx = cmd.index("--data")
+        data = cmd[idx + 1]
+        assert "kind=json_file" in data
+        assert "path=/tmp/local.jsonl" in data
+
+    def test_profile_sweep(self, perf_utils):
+        cmd = self._capture_cmd(perf_utils, profile="sweep", rate=10)
+        idx = cmd.index("--profile")
+        profile = cmd[idx + 1]
+        assert "kind=sweep" in profile
+        assert "sweep_size=10" in profile
+        assert "max_concurrency=128" in profile
+
+    def test_profile_throughput_no_sweep_size(self, perf_utils):
+        cmd = self._capture_cmd(perf_utils, profile="throughput", rate=128)
+        idx = cmd.index("--profile")
+        profile = cmd[idx + 1]
+        assert "kind=throughput" in profile
+        assert "sweep_size" not in profile
+
+    def test_constraint_max_requests(self, perf_utils):
+        cmd = self._capture_cmd(perf_utils, max_requests=200)
+        idx = cmd.index("--constraint")
+        constraint = cmd[idx + 1]
+        assert "kind=max_requests" in constraint
+        assert "count=200" in constraint
+
+    def test_no_constraint_when_max_requests_none(self, perf_utils):
+        cmd = self._capture_cmd(perf_utils, max_requests=None)
+        assert "--constraint" not in cmd
+
+    def test_output_flag(self, perf_utils):
+        cmd = self._capture_cmd(perf_utils, output_path=Path("/tmp/out.json"))
+        idx = cmd.index("--output")
+        output = cmd[idx + 1]
+        assert "kind=json" in output
+        assert "path=/tmp/out.json" in output
+
+
+# ---------------------------------------------------------------------------
+# _load_json — JSON output parsing
+# ---------------------------------------------------------------------------
+
+
+def _make_benchmark_json(
+    subset_file="qa.jsonl",
+    strategy_type="constant",
+    rps_mean=50.0,
+    latency_median=0.1,
+):
+    return {
+        "config": {
+            "spec": {
+                "data": [
+                    {
+                        "kind": "huggingface",
+                        "source": "RedHatAI/speculator_benchmarks",
+                        "load_kwargs": {"data_files": subset_file},
+                    }
+                ]
+            }
+        },
+        "benchmarks": [
+            {
+                "config": {
+                    "strategy": {"type_": strategy_type, "rate": 50.0},
+                },
+                "metrics": {
+                    "requests_per_second": {
+                        "successful": {"mean": rps_mean},
+                    },
+                    "request_latency": {
+                        "successful": {"median": latency_median},
+                    },
+                    "inter_token_latency_ms": {
+                        "successful": {"median": 5.0},
+                    },
+                    "time_to_first_token_ms": {
+                        "successful": {"median": 20.0},
+                    },
+                    "output_tokens_per_second": {
+                        "successful": {"median": 100.0},
+                    },
+                },
+            }
+        ],
+    }
+
+
+class TestLoadJson:
+    def test_extracts_subset_from_data_config(self, perf_utils, tmp_path):
+        data = _make_benchmark_json(subset_file="HumanEval.jsonl")
+        fp = tmp_path / "bench.json"
+        fp.write_text(json.dumps(data))
+        result = perf_utils._load_json(fp, "latency")
+        assert "HumanEval" in result
+
+    def test_extracts_latency_points(self, perf_utils, tmp_path):
+        data = _make_benchmark_json(rps_mean=50.0, latency_median=0.1)
+        fp = tmp_path / "bench.json"
+        fp.write_text(json.dumps(data))
+        result = perf_utils._load_json(fp, "latency")
+        assert result["qa"] == [(50.0, 0.1)]
+
+    def test_skips_non_constant_strategies(self, perf_utils, tmp_path):
+        data = _make_benchmark_json(strategy_type="throughput")
+        fp = tmp_path / "bench.json"
+        fp.write_text(json.dumps(data))
+        result = perf_utils._load_json(fp, "latency")
+        assert result == {}
+
+    def test_multiple_benchmarks_sorted(self, perf_utils, tmp_path):
+        data = _make_benchmark_json()
+        data["benchmarks"].append(
+            {
+                "config": {"strategy": {"type_": "constant", "rate": 100.0}},
+                "metrics": {
+                    "requests_per_second": {"successful": {"mean": 20.0}},
+                    "request_latency": {"successful": {"median": 0.2}},
+                },
+            }
+        )
+        fp = tmp_path / "bench.json"
+        fp.write_text(json.dumps(data))
+        result = perf_utils._load_json(fp, "latency")
+        points = result["qa"]
+        assert points == [(20.0, 0.2), (50.0, 0.1)]
+
+
+# ---------------------------------------------------------------------------
+# parse_gen_len_file — request stats parsing
+# ---------------------------------------------------------------------------
+
+
+def _make_gen_len_json(output_token_counts):
+    return {
+        "benchmarks": [
+            {
+                "requests": {
+                    "successful": [
+                        {"output_metrics": {"text_tokens": n}}
+                        for n in output_token_counts
+                    ]
+                }
+            }
+        ]
+    }
+
+
+class TestParseGenLenFile:
+    def test_basic_stats(self, perf_utils, tmp_path):
+        fp = tmp_path / "gen_len.json"
+        fp.write_text(json.dumps(_make_gen_len_json([100, 200, 300])))
+        result = perf_utils.parse_gen_len_file(fp)
+        assert result["count"] == 3
+        assert result["median"] == 200
+        assert result["min"] == 100
+        assert result["max"] == 300
+
+    def test_max_tokens_power_of_two(self, perf_utils, tmp_path):
+        fp = tmp_path / "gen_len.json"
+        fp.write_text(json.dumps(_make_gen_len_json([100, 200, 300])))
+        result = perf_utils.parse_gen_len_file(fp)
+        assert result["max_tokens"] == 256  # 2^ceil(log2(200))
+
+    def test_no_benchmarks_raises(self, perf_utils, tmp_path):
+        fp = tmp_path / "gen_len.json"
+        fp.write_text(json.dumps({"benchmarks": []}))
+        with pytest.raises(ValueError, match="No benchmarks"):
+            perf_utils.parse_gen_len_file(fp)
+
+    def test_no_successful_requests_raises(self, perf_utils, tmp_path):
+        fp = tmp_path / "gen_len.json"
+        fp.write_text(json.dumps({"benchmarks": [{"requests": {"successful": []}}]}))
+        with pytest.raises(ValueError, match="No successful requests"):
+            perf_utils.parse_gen_len_file(fp)
+
+
+# ---------------------------------------------------------------------------
+# parse_sweep_file — regression guard (unchanged logic)
+# ---------------------------------------------------------------------------
+
+
+def _make_sweep_json(subset_name="qa"):
+    return {
+        "benchmarks": [
+            {
+                "config": {
+                    "strategy": {"type_": "constant", "rate": 10.0},
+                },
+                "metrics": {
+                    "requests_per_second": {
+                        "successful": {"median": 9.5},
+                    },
+                    "request_latency": {
+                        "successful": {"median": 0.15},
+                    },
+                    "inter_token_latency_ms": {
+                        "successful": {"median": 4.2},
+                    },
+                    "time_to_first_token_ms": {
+                        "successful": {"median": 18.0},
+                    },
+                    "output_tokens_per_second": {
+                        "successful": {"median": 95.0},
+                    },
+                    "output_tokens": {
+                        "successful": {"sum": 50000},
+                    },
+                },
+            },
+            {
+                "config": {
+                    "strategy": {"type_": "throughput"},
+                },
+                "metrics": {},
+            },
+        ],
+    }
+
+
+class TestParseSweepFile:
+    def test_extracts_constant_rows(self, perf_utils, tmp_path):
+        fp = tmp_path / "sweep_qa.json"
+        fp.write_text(json.dumps(_make_sweep_json()))
+        rows = perf_utils.parse_sweep_file(fp)
+        assert len(rows) == 1
+        assert rows[0]["strategy"] == "constant"
+        assert rows[0]["target_rate"] == 10.0
+
+    def test_skips_throughput_strategy(self, perf_utils, tmp_path):
+        fp = tmp_path / "sweep_qa.json"
+        fp.write_text(json.dumps(_make_sweep_json()))
+        rows = perf_utils.parse_sweep_file(fp)
+        strategies = [r["strategy"] for r in rows]
+        assert "throughput" not in strategies
+
+    def test_subset_from_filename(self, perf_utils, tmp_path):
+        fp = tmp_path / "sweep_HumanEval.json"
+        fp.write_text(json.dumps(_make_sweep_json()))
+        rows = perf_utils.parse_sweep_file(fp)
+        assert rows[0]["subset"] == "HumanEval"


### PR DESCRIPTION
## Summary

- Upgrade `guidellm` from pinned `==0.6.0` to `>=0.7.1` (3 releases behind, same vllm-project org)
- Adapt `run_guidellm()` CLI invocation to 0.7.x syntax: `benchmark` → `run`, typed `key=value` flags for `--backend`, `--data`, `--profile`, `--constraint`, `--output`
- Update JSON output parsers (`_load_json`, `parse_gen_len_file`) for new top-level structure (`config.spec.data` instead of `args.data_args`) and request stats (`output_metrics.text_tokens` instead of `output_tokens`)
- Replace `build_backend_args()` with `parse_gen_kwargs()` — backend args are now folded into the `--backend` flag
- Update `--data-column-mapper` default to guidellm 0.7.x typed format
- Add 24 unit tests covering all changed code paths (verified they fail against old code)

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] 24 unit tests pass (`pytest tests/unit/scripts/test_perf_utils.py --noconftest`)
- [x] Tests verified to fail against pre-upgrade code, confirming change-path coverage
- [ ] Run `python evaluate.py throughput --target <server>/v1 --subsets HumanEval` against a live vLLM server to verify end-to-end CLI construction and output parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)