### PR TITLE
Enable FA4 Flex attention backend

### DIFF
--- a/.buildkite/gpu-tests/scripts/run-tests.sh
+++ b/.buildkite/gpu-tests/scripts/run-tests.sh
@@ -31,5 +31,12 @@ if [ -n "${TRANSFORMERS_VERSION:-}" ] && [ "${TRANSFORMERS_VERSION}" != "latest"
   uv pip install "transformers${TRANSFORMERS_VERSION}"
 fi
 
+# Install FA4 on Hopper+ GPUs (compute capability >= 9.0) so FA4 tests run.
+CC=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1 | tr -d '.')
+if [ "${CC:-0}" -ge 90 ]; then
+  echo "--- Installing flash-attn (FA4) for Hopper+ GPU"
+  uv pip install flash-attn --prerelease allow || echo "WARNING: flash-attn install failed, FA4 tests will be skipped"
+fi
+
 echo "+++ Running tests"
 python -m pytest -ra "tests/${TEST_TYPE}"

--- a/.buildkite/gpu-tests/scripts/run-tests.sh
+++ b/.buildkite/gpu-tests/scripts/run-tests.sh
@@ -35,7 +35,7 @@ fi
 CC=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1 | tr -d '.')
 if [ "${CC:-0}" -ge 90 ]; then
   echo "--- Installing flash-attn (FA4) for Hopper+ GPU"
-  uv pip install flash-attn --prerelease allow || echo "WARNING: flash-attn install failed, FA4 tests will be skipped"
+  uv pip install flash-attn-4 --prerelease allow || echo "WARNING: flash-attn install failed, FA4 tests will be skipped"
 fi
 
 echo "+++ Running tests"

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -20,6 +20,7 @@ from speculators.data_generation.vllm_client import (
     DEFAULT_REQUEST_TIMEOUT,
 )
 from speculators.model import SpeculatorModel
+from speculators.models.attention import configure_fa4
 from speculators.models.eagle3.data import shift_batch
 from speculators.models.eagle3.rotary_partial import install_partial_neox_rotary
 from speculators.models.metrics import resolve_loss_config
@@ -555,6 +556,8 @@ def main(args: argparse.Namespace):  # noqa: C901
             "Use bfloat16 instead, which provides the same memory savings with "
             "better numerical stability and no gradient scaling required."
         )
+
+    configure_fa4(args.fa4)
 
     if args.speculator_type == "mtp":
         if args.draft_attn_impl != "simple_flex_attention":
@@ -1157,6 +1160,15 @@ def parse_args():
         help="Attention implementation for draft layers. "
         "Use 'sdpa' or 'eager' for hardware that doesn't support flex attention."
         "Not supported for MTP.",
+    )
+    parser.add_argument(
+        "--fa4",
+        type=str,
+        default="auto",
+        choices=["auto", "on", "off"],
+        help="FA4 (FlashAttention-4) backend for flex attention. "
+        "'auto' (default) enables FA4 when Hopper+ GPU and flash_attn.cute are "
+        "available. 'on' forces FA4 (errors if unavailable). 'off' disables FA4.",
     )
     # P-EAGLE specific parameters
     parser.add_argument(

--- a/src/speculators/models/attention.py
+++ b/src/speculators/models/attention.py
@@ -4,7 +4,11 @@ This module contains attention functions and utilities shared across different
 speculator architectures (EAGLE3, DFlash, etc.) to avoid code duplication.
 """
 
+import importlib.util
+import logging
 from collections.abc import Callable
+from functools import lru_cache
+from typing import Literal
 
 import torch
 from torch.nn.attention.flex_attention import (
@@ -15,6 +19,47 @@ from torch.nn.attention.flex_attention import (
     create_mask as _create_mask,
 )
 from transformers.modeling_utils import AttentionInterface
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def fa4_is_available() -> bool:
+    """Check whether the FA4 (FlashAttention-4) backend can be used.
+
+    Requires both Hopper+ GPU (compute capability >= 9.0) and the
+    ``flash_attn.cute`` CuTeDSL kernels to be installed.
+    """
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    if (major, minor) < (9, 0):
+        return False
+    return importlib.util.find_spec("flash_attn.cute") is not None
+
+
+_fa4_mode: Literal["auto", "on", "off"] = "auto"
+
+
+def configure_fa4(mode: Literal["auto", "on", "off"] = "auto") -> None:
+    """Set the FA4 backend policy.
+
+    * ``"auto"`` (default): use FA4 when :func:`fa4_is_available` is True.
+    * ``"on"``: always request FA4 (errors at compile time if unavailable).
+    * ``"off"``: never use FA4, always use the default Triton backend.
+    """
+    global _fa4_mode  # noqa: PLW0603
+    _fa4_mode = mode
+    enabled = mode == "on" or (mode == "auto" and fa4_is_available())
+    logger.info("FA4 flex-attention backend: mode=%s, enabled=%s", mode, enabled)
+
+
+def _should_use_fa4() -> bool:
+    if _fa4_mode == "on":
+        return True
+    if _fa4_mode == "off":
+        return False
+    return fa4_is_available()
 
 
 def flex_attention_forward(
@@ -52,6 +97,8 @@ def flex_attention_forward(
     key = key.contiguous()
     value = value.contiguous()
 
+    kernel_options = {"BACKEND": "FLASH"} if _should_use_fa4() else None
+
     flex_attention_output = flex_attention(
         query,
         key,
@@ -60,6 +107,7 @@ def flex_attention_forward(
         block_mask=attention_mask,
         enable_gqa=enable_gqa,
         scale=scaling,
+        kernel_options=kernel_options,  # type: ignore[arg-type]
     )
     attention_output: torch.Tensor = flex_attention_output
     attention_output = attention_output.transpose(1, 2).contiguous()

--- a/src/speculators/models/attention.py
+++ b/src/speculators/models/attention.py
@@ -35,7 +35,10 @@ def fa4_is_available() -> bool:
     major, minor = torch.cuda.get_device_capability()
     if (major, minor) < (9, 0):
         return False
-    return importlib.util.find_spec("flash_attn.cute") is not None
+    try:
+        return importlib.util.find_spec("flash_attn.cute") is not None
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return False
 
 
 _fa4_mode: Literal["auto", "on", "off"] = "auto"

--- a/tests/unit/models/test_attention.py
+++ b/tests/unit/models/test_attention.py
@@ -1,0 +1,86 @@
+"""Tests for the FA4 (FlashAttention-4) flex attention backend."""
+
+import pytest
+import torch
+from torch.nn.attention.flex_attention import create_block_mask
+
+from speculators.models.attention import (
+    _should_use_fa4,
+    configure_fa4,
+    fa4_is_available,
+    flex_attention_forward,
+)
+from tests.conftest import requires_cuda
+
+requires_fa4 = pytest.mark.skipif(not fa4_is_available(), reason="FA4 not available")
+
+
+@requires_cuda
+@requires_fa4
+class TestFA4ForwardPass:
+    """Run flex_attention_forward with the FA4 backend on real hardware."""
+
+    @pytest.fixture(autouse=True)
+    def _enable_fa4(self):
+        configure_fa4("on")
+        yield
+        configure_fa4("auto")
+
+    def _make_inputs(self, batch, heads_q, heads_kv, seq_len, head_dim):
+        q = torch.randn(
+            batch, heads_q, seq_len, head_dim, device="cuda", dtype=torch.bfloat16
+        )
+        k = torch.randn(
+            batch, heads_kv, seq_len, head_dim, device="cuda", dtype=torch.bfloat16
+        )
+        v = torch.randn(
+            batch, heads_kv, seq_len, head_dim, device="cuda", dtype=torch.bfloat16
+        )
+
+        def causal(b, h, q_idx, kv_idx):
+            return q_idx >= kv_idx
+
+        mask = create_block_mask(
+            causal, B=batch, H=None, Q_LEN=seq_len, KV_LEN=seq_len, device="cuda"
+        )
+        return q, k, v, mask
+
+    def test_basic_forward(self):
+        assert _should_use_fa4()
+        q, k, v, mask = self._make_inputs(
+            batch=2, heads_q=8, heads_kv=8, seq_len=128, head_dim=64
+        )
+        out, weights = flex_attention_forward(
+            module=torch.nn.Identity(), query=q, key=k, value=v, attention_mask=mask
+        )
+        assert out.shape == (2, 128, 8, 64)
+        assert weights is None
+        assert out.isfinite().all()
+
+    def test_gqa(self):
+        q, k, v, mask = self._make_inputs(
+            batch=2, heads_q=8, heads_kv=2, seq_len=128, head_dim=64
+        )
+        out, _ = flex_attention_forward(
+            module=torch.nn.Identity(), query=q, key=k, value=v, attention_mask=mask
+        )
+        assert out.shape == (2, 128, 8, 64)
+        assert out.isfinite().all()
+
+    def test_matches_triton_backend(self):
+        """FA4 and Triton backends should produce close results."""
+        q, k, v, mask = self._make_inputs(
+            batch=2, heads_q=8, heads_kv=8, seq_len=128, head_dim=64
+        )
+
+        configure_fa4("on")
+        fa4_out, _ = flex_attention_forward(
+            module=torch.nn.Identity(), query=q, key=k, value=v, attention_mask=mask
+        )
+
+        configure_fa4("off")
+        triton_out, _ = flex_attention_forward(
+            module=torch.nn.Identity(), query=q, key=k, value=v, attention_mask=mask
+        )
+
+        torch.testing.assert_close(fa4_out, triton_out, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
Pytorch added support for an Flash Attention 4 backend to Flex Attention which has much better performance on Hopper and Blackwell gpus: https://pytorch.org/blog/flexattention-flashattention-4-fast-and-flexible/


Requires manually installing fa4 first:

```
uv pip install flash-attn-4 --prerelease allow
```
or
```
uv pip install "flash-attn-4[cu13]" --prerelease allow
```

Note: this is experimental. 

By default, if the flash attention package is available and we're using a Hopper or newer gpu, this backend will get used. You can also explicitly enable/disable it with `--fa4 on` or `--fa4 off`

## Tests

I've added some explicit tests for FA4 on the Hopper runners. I've also updated the buildkite pipeline to install FA4 so that the tests will run. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
