### PR TITLE
fix(regen): count max_tokens truncations, not tool-pairing failures

### DIFF
--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -701,7 +701,9 @@ async def worker(
             out_fh.flush()
             if samples:
                 stats["ok"] += 1
-            if truncated:
+            if truncated or any(
+                s.get("metadata", {}).get("finish_reason") == "length" for s in samples
+            ):
                 stats["truncated"] += 1
         except Exception as e:  # noqa: BLE001
             # Failures go to a separate error file, not the training output.


### PR DESCRIPTION
## Purpose

- **Before (bug):** `truncated` counted only tool-call pairing failures, so a response cut off at `max_tokens` was never reflected — the count read `0` for every text dataset.
- **After (this PR):** `truncated` counts truncation of any kind — tool-pairing failures and `max_tokens` cut-offs (`finish_reason == "length"`) alike.

## Tests

`pytest tests/unit/scripts/test_response_regeneration.py` → 43 passed. Real run (gpt-oss-20b, 200 ultrachat convs, `--max-tokens 2048`): 35% of rows finished with `length`, previously reported as `0 truncated`.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
