### PR TITLE
docs(regen): document tool-call regeneration and its parsers

### DIFF
--- a/docs/user_guide/tutorials/response_regeneration.md
+++ b/docs/user_guide/tutorials/response_regeneration.md
@@ -48,6 +48,34 @@ For larger models, use data parallelism and/or tensor parallelism:
   --dataset magpie
 ```
 
+### Tool-Call Regeneration
+
+For tool-calling datasets (e.g. `hermes-fc`), pass the model's `--tool-call-parser` (and `--reasoning-parser`, for thinking models) so the server returns structured `tool_calls` and separated reasoning instead of plain text. Both are model-specific, so look them up in the model's [vLLM recipe](https://recipes.vllm.ai/):
+
+```bash
+# Qwen3
+./scripts/response_regeneration/run_all.sh \
+  --model "Qwen/Qwen3-8B" \
+  --tool-call-parser hermes --reasoning-parser qwen3 \
+  --dataset hermes-fc
+
+# Gemma 4
+./scripts/response_regeneration/run_all.sh \
+  --model "google/gemma-4-E2B-it" \
+  --tool-call-parser gemma4 --reasoning-parser gemma4 \
+  --dataset hermes-fc
+
+# gpt-oss (reasoning is parsed automatically)
+./scripts/response_regeneration/run_all.sh \
+  --model "openai/gpt-oss-20b" \
+  --tool-call-parser openai \
+  --dataset hermes-fc
+```
+
+This is **semi-on-policy** tool-call regeneration: the target regenerates the tool-call tokens on-policy, but tools are not executed. The *i*-th cached tool result from the source data is spliced positionally after the target's *i*-th regenerated call.
+
+**Limitation:** parallel tool calls are under development; the turn is currently truncated to the first call.
+
 ## Step 2: Verify the Output
 
 The output is a JSONL file with one pre-tokenized row per target generation. `loss_mask` is `0` over the prompt the target conditioned on and `1` over the tokens it generated, so training needs no further masking:


### PR DESCRIPTION
## Purpose

Add a Tool-Call Regeneration subsection to the response-regeneration tutorial (after Multi-GPU Configurations). It documents:

- the per-model `--tool-call-parser` / `--reasoning-parser` flags for Qwen3, Gemma 4, and gpt-oss, with values taken from the `vllm-project/recipes` source files (`models/Qwen/Qwen3-32B.yaml`, `models/Google/gemma-4-E2B-it.yaml`, `OpenAI/GPT-OSS.md`);
- that this is semi-on-policy: the target regenerates the tool-call tokens on-policy, but tools are not executed. The i-th cached tool result from the source data is spliced positionally after the target's i-th regenerated call;
- the limitation that a turn with parallel tool calls is truncated to the first call.

## Tests

Docs-only change. `mdformat --check docs/user_guide/tutorials/response_regeneration.md` passes.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
