### PR TITLE
fix(dspark): detach confidence head inputs to prevent gradient leakage

### DIFF
--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -172,14 +172,15 @@ class DSparkDraftModel(DFlashDraftModel):
             )
 
         if self.confidence_head is not None:
-            # confidence_head_with_markov requires markov_rank > 0 (enforced in
-            # __init__), so prev_emb is always set when the flag is on.
+            # Detach inputs so the confidence BCE loss only trains the
+            # confidence head itself, not the backbone or Markov head.
+            h_det = hidden_blocks.detach()
             if self.config.confidence_head_with_markov and prev_emb is not None:
                 conf_features = torch.cat(
-                    [hidden_blocks, prev_emb.to(hidden_blocks.dtype)], dim=-1
+                    [h_det, prev_emb.detach().to(h_det.dtype)], dim=-1
                 )
             else:
-                conf_features = hidden_blocks
+                conf_features = h_det
             confidence_logits = self.confidence_head(conf_features).reshape(
                 1, mask_tokens_size
             )


### PR DESCRIPTION
## Summary

Detach `hidden_blocks` and `prev_emb` before feeding them to the confidence head, so its BCE loss only trains the confidence head's own projection — not the backbone or Markov head.

Without `.detach()`, the confidence BCE gradients leak into the backbone transformer and Markov W1 embedding, pushing them toward acceptance-rate prediction instead of generation quality. This explains the A3 vs A4 regression in ablation #757 (1.96 vs 3.20 MAL).

## Test plan

- [x] `ruff check` passes
- [x] DSpark model definition tests pass (8/8)
- [x] Gradient flow test confirms detach blocks backprop without affecting the main loss path

🤖 Generated with [Claude Code](https://claude.com/claude-code)