### PR TITLE
[BUG FIX] Detach dspark outputs before feeding them into the confidence head

### DIFF
--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -176,10 +176,11 @@ class DSparkDraftModel(DFlashDraftModel):
             # __init__), so prev_emb is always set when the flag is on.
             if self.config.confidence_head_with_markov and prev_emb is not None:
                 conf_features = torch.cat(
-                    [hidden_blocks, prev_emb.to(hidden_blocks.dtype)], dim=-1
+                    [hidden_blocks.detach(), prev_emb.detach().to(hidden_blocks.dtype)],
+                    dim=-1,
                 )
             else:
-                conf_features = hidden_blocks
+                conf_features = hidden_blocks.detach()
             confidence_logits = self.confidence_head(conf_features).reshape(
                 1, mask_tokens_size
             )


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Based on #757, it seems like enabling the DSpark confidence head affects the training of the drafter which should not be the case. 

It looks like we're not detaching the gradients before feeding the hidden states into the conf head. This pr fixes that. 

## Tests

Will run ablation tests. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
