### PR TITLE
Add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,41 @@
+# See https://help.github.com/articles/about-codeowners/
+# for more info about CODEOWNERS file
+
+/src/speculators/ @fynnsu @shanjiaz @rahul-tuli @orestis-z
+/src/speculators/convert/ @shanjiaz @fynnsu @rahul-tuli
+/src/speculators/convert/mtp/ @rahul-tuli @fynnsu
+/src/speculators/convert/eagle/ @shanjiaz @fynnsu
+/src/speculators/data_generation/ @shanjiaz @fynnsu @rahul-tuli
+/src/speculators/models/ @fynnsu @shanjiaz @rahul-tuli @orestis-z
+/src/speculators/models/mtp/ @rahul-tuli @fynnsu
+/src/speculators/models/peagle/ @orestis-z @shanjiaz
+/src/speculators/models/eagle3/ @fynnsu @shanjiaz @orestis-z
+/src/speculators/models/dflash/ @fynnsu @shanjiaz @orestis-z
+/src/speculators/train/ @fynnsu @shanjiaz
+
+/tests/ @fynnsu @shanjiaz @rahul-tuli @orestis-z
+/tests/unit/convert/ @shanjiaz @rahul-tuli @fynnsu
+/tests/unit/models/ @fynnsu @rahul-tuli @shanjiaz
+/tests/unit/train/ @fynnsu @shanjiaz
+/tests/integration/ @fynnsu @shanjiaz @orestis-z
+/tests/e2e/ @shanjiaz @fynnsu @rahul-tuli
+/tests/e2e/regression/ @shanjiaz @fynnsu @rahul-tuli @dsikka
+/tests/e2e/smoke/ @shanjiaz @rahul-tuli @dsikka
+
+/scripts/ @fynnsu @shanjiaz @rahul-tuli @orestis-z
+
+/hs_connectors/ @fynnsu @shanjiaz
+
+/.buildkite/ @dsikka @dhuangnm @deepak-kumar-neu
+
+/.github/ @dsikka @fynnsu @shanjiaz
+
+/README.md @dsikka @fynnsu @shanjiaz @rahul-tuli
+/CONTRIBUTING.md @dsikka @fynnsu @shanjiaz @rahul-tuli
+/CODE_OF_CONDUCT.md @dsikka @fynnsu @shanjiaz @rahul-tuli
+/Makefile @dsikka @fynnsu @shanjiaz @rahul-tuli
+/mkdocs.yml @dsikka @fynnsu @shanjiaz @rahul-tuli
+/pyproject.toml @dsikka @fynnsu @shanjiaz @rahul-tuli
+/setup.py @dsikka @fynnsu @shanjiaz @rahul-tuli
+/.coderabbit.yaml @dsikka @fynnsu @shanjiaz @rahul-tuli
+


### PR DESCRIPTION
Adds .github/CODEOWNERS to define review ownership. GitHub uses last-match-wins: the most specific matching path decides reviewers, not a union of all matches. The file is ordered broad → specific accordingly.

Hierarchy:

  1. Package-wide defaults — `/src/speculators/`,`/tests/`, `/scripts/` owned by all core maintainers (@fynnsu @shanjiaz @rahul-tuli @orestis-z), acting as a
  catch-all.
  2. Subsystem overrides — convert/, data_generation/, train/ narrow to whoever owns that subsystem.
  3. Algorithm-specific overrides — convert/mtp/, convert/eagle/, models/mtp/, models/peagle/, models/eagle3/, models/dflash/ route to the individual
  method's owner(s), overriding both subsystem and package-wide rules.
  4. Tests mirror source — `/tests/` follows the same pattern, with e2e/regression/ and e2e/smoke/ also adding @dsikka.
  5. Infra/process files — `.buildkite/`, `.github/`, and root config/docs (README.md, pyproject.toml, etc.) owned separately by @dsikka plus relevant
  maintainers.

Example: a PR touching src/speculators/models/mtp/layer.py matches three rules — `/src/speculators/` (line 4),
`/src/speculators/models/` (line 9), and `/src/speculators/models/mtp/` (line 10) — but only the last, most specific match
applies, so reviewers are @rahul-tuli @fynnsu, not the full set of four maintainers.