### PR TITLE
Add loss functions page

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -4,6 +4,7 @@ nav:
           - user_guide/index.md
           - Getting Started: user_guide/getting_started.md
           - Features: user_guide/features.md
+          - Loss Functions: user_guide/loss_functions.md
           - Algorithms:
                 - user_guide/algorithms/index.md
                 - Eagle3: user_guide/algorithms/eagle3.md

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -14,5 +14,6 @@ Speculators provides a comprehensive framework for:
 
 - [Getting Started](getting_started.md) - Start here if you're new to Speculators
 - [Features](features.md) - Detailed documentation on core features
+- [Loss Functions](loss_functions.md) - Training losses available via `--loss-fn`
 - [Algorithms](algorithms/index.md) - Overview of supported algorithms
 - [Tutorials](tutorials/index.md) - Step-by-step guides

--- a/docs/user_guide/loss_functions.md
+++ b/docs/user_guide/loss_functions.md
@@ -20,7 +20,7 @@ python scripts/train.py ... --loss-fn kl_div
 | `nla`       | Negative log-acceptance, `-log(alpha)` | TV's target with a `1 / alpha` gradient boost, so it trains from a cold start. |
 | `lk_hybrid` | Adaptive KL/TV blend                   | `lambda * KL + (1 - lambda) * TV` with `lambda = exp(-3 * alpha)`, detached.   |
 
-`tv` and `nla` use a fused Triton kernel on CUDA/ROCm and fall back to eager PyTorch elsewhere.
+`tv` and `nla` use a fused Triton kernel on CUDA devices when it is available, and fall back to eager PyTorch otherwise.
 
 ## Choosing a Loss
 
@@ -30,7 +30,7 @@ python scripts/train.py ... --loss-fn kl_div
 
 ## Weighted Combinations
 
-Pass a JSON dict to train on a weighted sum of several losses. Each term is logged separately as `{name}_loss`.
+Pass a JSON dict to train on a weighted sum of several losses. Weights are used as provided and are not normalized. Each term is also logged separately as `{name}_loss`, before its weight is applied.
 
 ```bash
 python scripts/train.py ... --loss-fn '{"ce": 0.1, "tv": 0.9}'

--- a/docs/user_guide/loss_functions.md
+++ b/docs/user_guide/loss_functions.md
@@ -1,0 +1,42 @@
+# Loss Functions
+
+The training loss controls what the draft model is optimized for. Select it with `--loss-fn` in [`train.py`](../cli/train.md), which accepts either a single loss name or a JSON dict for a weighted combination. It applies to Eagle-3, P-EAGLE, DFlash, and DSpark. MTP uses its own multi-step cross-entropy loss and ignores this flag.
+
+```bash
+python scripts/train.py ... --loss-fn kl_div
+```
+
+## Available Losses
+
+`p` is the target distribution, `q` the draft distribution, and `alpha = sum_v min(p_v, q_v)` the distributional overlap, which equals the acceptance rate of speculative decoding.
+
+| Name        | Objective                              | Notes                                                                          |
+| ----------- | -------------------------------------- | ------------------------------------------------------------------------------ |
+| `kl_div`    | Forward KL, target to draft            | Default. Mass-covering: penalizes the draft for missing target mass.           |
+| `rkl`       | Reverse KL, draft to target            | Mode-seeking: the draft concentrates on the target's dominant modes.           |
+| `jsd`       | Jensen-Shannon divergence              | Symmetric, bounded by `log 2`. Balances forward and reverse KL.                |
+| `ce`        | Cross-entropy against `argmax p`       | Hard labels from the target. Required by `--per-position-loss-weight dpace`.   |
+| `tv`        | Total variation, `1 - alpha`           | Optimizes the acceptance rate directly. Gradients vanish when overlap is low.  |
+| `nla`       | Negative log-acceptance, `-log(alpha)` | TV's target with a `1 / alpha` gradient boost, so it trains from a cold start. |
+| `lk_hybrid` | Adaptive KL/TV blend                   | `lambda * KL + (1 - lambda) * TV` with `lambda = exp(-3 * alpha)`, detached.   |
+
+`tv` and `nla` use a fused Triton kernel on CUDA/ROCm and fall back to eager PyTorch elsewhere.
+
+## Choosing a Loss
+
+- Start with `kl_div`. It is the default and the best-tested option.
+- To optimize acceptance rate directly, use `lk_hybrid` or `nla`. Plain `tv` has the same objective but weak gradients early in training.
+- Use `ce` when you want hard-label supervision or D-PACE position weighting.
+
+## Weighted Combinations
+
+Pass a JSON dict to train on a weighted sum of several losses. Each term is logged separately as `{name}_loss`.
+
+```bash
+python scripts/train.py ... --loss-fn '{"ce": 0.1, "tv": 0.9}'
+```
+
+## References
+
+- Lin, "Divergence measures based on the Shannon entropy" (1991) -- Jensen-Shannon divergence
+- Samarin et al., ["LK Losses: Direct Acceptance Rate Optimization for Speculative Decoding"](https://arxiv.org/abs/2602.23881) -- `nla` and `lk_hybrid`


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

`--loss-fn` accepts seven losses and JSON weighted combinations, but nothing in the docs explains what they optimize or when to pick one. Adds a User Guide page, sourced from `src/speculators/models/metrics.py`.

- **Available Losses** -- one table row per loss
  - `kl_div` (default), `rkl`, `jsd`, `ce`, `tv`, `nla`, `lk_hybrid`
  - notes the fused Triton path for `tv` / `nla`
- **Choosing a Loss** -- three bullets: default, acceptance-rate optimization, hard labels / D-PACE
- **Weighted Combinations** -- the JSON dict syntax and per-term logging
- **References** -- JSD (Lin 1991) and LK Losses (arXiv 2602.23881)
- Wired into `docs/.nav.yml` and the User Guide index

## Tests

Docs-only. `mdformat --check` passes.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
