### PR TITLE
Restore the --max-steps training flag

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -675,6 +675,7 @@ def main(cfg: TrainConfig):  # noqa: C901
         hidden_states_dtype=hidden_states_dtype,
         log_freq=args.log_freq,
         fsdp_shard=args.fsdp_shard,
+        max_steps=args.max_steps,
     )
     trainer = Trainer(draft_model, trainer_config, train_loader, val_loader)
 

--- a/src/speculators/train/config/schema.py
+++ b/src/speculators/train/config/schema.py
@@ -400,6 +400,12 @@ class TrainerArgs(_Group):
         "parameters are fully replicated (DDP-like). Enable when the model does not "
         "fit in a single GPU's memory.",
     )
+    max_steps: int | None = Field(
+        default=None,
+        ge=1,
+        description="Stop training after this many optimizer steps (counted across "
+        "epochs). Useful for quick smoke runs. Default: run all epochs to completion.",
+    )
 
     @field_validator("checkpoint_freq")
     @classmethod

--- a/tests/unit/train/test_cli_args.py
+++ b/tests/unit/train/test_cli_args.py
@@ -2,6 +2,8 @@
 
 import argparse
 
+import pytest
+
 from speculators.models.dflash.core import DFlashDraftModel
 from speculators.models.dspark.core import DSparkDraftModel
 from speculators.models.eagle3.core import Eagle3DraftModel
@@ -169,3 +171,23 @@ def test_no_norm_before_fc_flag(monkeypatch):
 def test_no_norm_output_flag(monkeypatch):
     args = _parse(monkeypatch, ["--no-norm-output"])
     assert args.norm_output is False
+
+
+# ---------------------------------------------------------------------------
+# --max-steps
+# ---------------------------------------------------------------------------
+
+
+def test_max_steps_default_is_none(monkeypatch):
+    args = _parse(monkeypatch, [])
+    assert args.max_steps is None
+
+
+def test_max_steps_explicit(monkeypatch):
+    args = _parse(monkeypatch, ["--max-steps", "15"])
+    assert args.max_steps == 15
+
+
+def test_max_steps_rejects_non_positive(monkeypatch):
+    with pytest.raises(SystemExit):
+        _parse(monkeypatch, ["--max-steps", "0"])


### PR DESCRIPTION
## Summary

The config-file-first CLI refactor (#841) moved every `scripts/train.py` flag into the typed schema but did not carry over **`--max-steps`**. `TrainerConfig.max_steps` and the training loop's early-stop check (`self.global_step >= self.config.max_steps`) still exist, but the flag was unreachable from the CLI and left unset in `main()`, so `max_steps` was effectively dead code — `--max-steps N` now errors with `unrecognized arguments: --max-steps`.

This restores it the schema-native way:

- Add a single `max_steps: int | None` `Field` (with `ge=1`) to `TrainerArgs` in `src/speculators/train/config/schema.py`, so the flag, type, `--help`, and validation are all derived from it automatically.
- Wire it into the `TrainerConfig` built in `main()` (`max_steps=args.max_steps`).

No behavior change to the training loop itself — it already honored `TrainerConfig.max_steps`; this just makes it reachable again.

## Test plan

- `python -m pytest tests/unit/train/test_cli_args.py tests/unit/train/config` — 88 passing (adds default/explicit/reject-non-positive cases for `--max-steps`).
- `make quality` (ruff + format + mypy) clean.
- Manual: `--max-steps 15` → `cfg.trainer.max_steps == 15`; omitted → `None`; `--max-steps 0` → clean config error; flag appears in `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
