### PR TITLE
passing explicit split to fix guidellm 0.7.1

### DIFF
--- a/scripts/evaluate/perf_utils.py
+++ b/scripts/evaluate/perf_utils.py
@@ -565,7 +565,7 @@ def run_guidellm(
 
     if subset is not None:
         data = f"kind=huggingface,source={dataset}"
-        data += f",load_kwargs.data_files={subset}.jsonl"
+        data += f",load_kwargs.data_files={subset}.jsonl,load_kwargs.split=train"
     else:
         data = f"kind=json_file,path={dataset}"
     cmd.extend(["--data", data])


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
Fix guidellm HuggingFace data loading by adding explicit split=train to load_kwargs. Without this, guidellm 0.7.x receives a DatasetDict instead of a Dataset, causing benchmark runs to fail.

## Tests
Run python evaluate.py throughput --target <server>/v1 --subsets HumanEval against a live vLLM server to verify the fix

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
