### PR TITLE
docs: correct stale prose about the pre-tokenized on-policy path

### DIFF
--- a/docs/user_guide/tutorials/response_regeneration.md
+++ b/docs/user_guide/tutorials/response_regeneration.md
@@ -86,21 +86,19 @@ The output is a JSONL file with one pre-tokenized row per target generation. `lo
   "primary_id": "conv-abc",
   "input_ids": [151644, 872, ...],
   "loss_mask": [0, 0, ..., 1, 1],
-  "conversations": [
-    {"role": "user", "content": "What is the capital of France?"},
-    {"role": "assistant", "content": "The capital of France is Paris."}
-  ],
+  "text": "<|im_start|>user\nWhat is the capital of France?<|im_end|>\n<|im_start|>assistant\nThe capital of France is Paris.<|im_end|>",
   "metadata": {
     "idx": 0,
     "finish_reason": "stop",
     "is_tool_call": false,
     "usage": {...},
-    "endpoint": "http://127.0.0.1:8000/v1/chat/completions"
+    "endpoint": "http://127.0.0.1:8000/v1/chat/completions",
+    "sampling_params": {...}
   }
 }
 ```
 
-Each assistant turn produces at least one row — and more when the target calls a tool, since every call is its own generation — so expect more lines than input conversations. `conversations` is a review-only twin of `input_ids`; training drops it.
+Each assistant turn produces at least one row — and more when the target calls a tool, since every call is its own generation — so expect more lines than input conversations. `text` is the same tokens decoded back to a string (`tokenizer.decode`, special tokens kept), so reading it tells you exactly what `input_ids` holds. Training drops it.
 
 For multi-turn datasets, later turns include the regenerated history as context. For example, the second turn of the same conversation would be:
 
@@ -110,18 +108,14 @@ For multi-turn datasets, later turns include the regenerated history as context.
   "primary_id": "conv-abc",
   "input_ids": [151644, 872, ...],
   "loss_mask": [0, 0, ..., 1, 1],
-  "conversations": [
-    {"role": "user", "content": "What is the capital of France?"},
-    {"role": "assistant", "content": "The capital of France is Paris."},
-    {"role": "user", "content": "What about Germany?"},
-    {"role": "assistant", "content": "The capital of Germany is Berlin."}
-  ],
+  "text": "<|im_start|>user\nWhat is the capital of France?<|im_end|>\n<|im_start|>assistant\nThe capital of France is Paris.<|im_end|>\n<|im_start|>user\nWhat about Germany?<|im_end|>\n<|im_start|>assistant\nThe capital of Germany is Berlin.<|im_end|>",
   "metadata": {
     "idx": 0,
     "finish_reason": "stop",
     "is_tool_call": false,
     "usage": {...},
-    "endpoint": "http://127.0.0.1:8000/v1/chat/completions"
+    "endpoint": "http://127.0.0.1:8000/v1/chat/completions",
+    "sampling_params": {...}
   }
 }
 ```

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -7,6 +7,10 @@ This script processes an input dataset and:
 2. Produces a loss/assistant mask for each sample
 3. Records token frequency statistics
 
+Rows that already carry input_ids and loss_mask, as on-policy response
+regeneration emits, skip steps 1 and 2. They are truncated to --seq-length and
+filtered, but never re-tokenized or re-masked.
+
 The output of this script is:
 1. Processed dataset ready for online training or offline datagen in output_dir
 2. Token frequency statistics file at token_freq_path


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Two docs describe behaviour the code stopped having when on-policy regeneration started emitting pre-tokenized rows.

**1. The output row schema in the tutorial.** `scripts/response_regeneration/script.py:510` writes `"text"`, a decode of `input_ids`. The tutorial still shows `"conversations"`, a list of role/content messages, in both example rows, and its `metadata` blocks omit the `sampling_params` key the script emits. #808 made this change and updated `docs/cli/response_regeneration.md`, which is correct today; the tutorial was missed.

**2. The `prepare_data.py` module docstring.** It states the script applies a chat template and produces a loss mask, unconditionally. Since #729, rows carrying `input_ids` and `loss_mask` take the pre-tokenized branch at `preprocessing.py:648` and skip both steps -- they are truncated to `--seq-length` and filtered, nothing more. The docstring now notes the exception.

No code or behaviour change.

## Tests

Docs and one module docstring.

- `ruff check scripts/prepare_data.py` passes
- `ruff format --check scripts/prepare_data.py` passes
- `python -m mdformat --check docs/user_guide/tutorials/response_regeneration.md` passes

Field names verified against `script.py:500-519`; the pre-tokenized branch against `preprocessing.py:541` and `_passthrough_pretokenized` at `:499`.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.