### PR TITLE
[Kimi-k2.5] fix(regen): carry the target's reasoning into the regenerated history

### DIFF
--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -472,6 +472,8 @@ def _sample_from_response(
     message = choice["message"]
     content = message.get("content")
     tool_calls = message.get("tool_calls")
+    # Older vLLM builds returned this as `reasoning_content`.
+    reasoning = message.get("reasoning") or message.get("reasoning_content")
 
     # A tool call legitimately has empty content; only a wholly empty generation
     # corrupts the next prefix and must fail the conversation.
@@ -487,8 +489,7 @@ def _sample_from_response(
 
     input_ids, loss_mask = build_boundary_sample(prompt_token_ids, completion_token_ids)
     if tool_calls:
-        # History keeps the parsed call; any generated <think> is supervised in
-        # this row's completion tokens, not re-rendered.
+        # History keeps the parsed call, not the raw text it was parsed from.
         assistant_msg = {
             "role": "assistant",
             "content": content or "",
@@ -496,6 +497,10 @@ def _sample_from_response(
         }
     else:
         assistant_msg = {"role": "assistant", "content": content}
+    if reasoning:
+        # Templates re-render a turn's reasoning from this field. Kimi K2.5 has no
+        # <think>-in-content fallback, so dropping it changes the next prompt.
+        assistant_msg["reasoning_content"] = reasoning
 
     sample = {
         "id": f"{conv_id}_gen{sample_index}",

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -566,13 +566,23 @@ def _tool_call(call_id="call_1", name="get_weather", arguments='{"city": "Tokyo"
 
 
 def _response(
-    *, prompt_token_ids, token_ids, content=None, tool_calls=None, finish="stop"
+    *,
+    prompt_token_ids,
+    token_ids,
+    content=None,
+    tool_calls=None,
+    finish="stop",
+    reasoning=None,
 ):
     """A vLLM chat-completion response with ``return_token_ids`` populated."""
     return {
         "choices": [
             {
-                "message": {"content": content, "tool_calls": tool_calls},
+                "message": {
+                    "content": content,
+                    "tool_calls": tool_calls,
+                    "reasoning": reasoning,
+                },
                 "finish_reason": finish,
                 "token_ids": token_ids,
             }
@@ -727,6 +737,31 @@ def test_sample_from_response_rejects_empty_and_missing_token_ids():
             endpoint="ep",
             sampling_params={},
         )
+
+
+def test_reasoning_is_carried_into_the_tool_call_history():
+    # Kimi K2.5 preserves reasoning for exactly the in-flight tool loop and reads
+    # it only from this field, so dropping it silently changes the next prompt.
+    _, assistant_msg, _ = regen._sample_from_response(
+        _response(
+            prompt_token_ids=[1, 2],
+            token_ids=[3],
+            tool_calls=[_tool_call()],
+            reasoning="Need the weather tool.",
+        ),
+        detokenize=_detok,
+        conv_id="c",
+        sample_index=0,
+        idx=0,
+        endpoint="ep",
+        sampling_params={},
+    )
+    assert assistant_msg == {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [_tool_call()],
+        "reasoning_content": "Need the weather tool.",
+    }
 
 
 # --- the tool-call loop: splice, truncate, and the unchanged plain path ---


### PR DESCRIPTION
<!-- markdownlint-disable -->
## Warning!! This PR is from static code analysis, not tested end2end on kimi2.5!
## Purpose

On-policy regeneration appends each reply to the running prefix as `content` alone, dropping the `reasoning` the server just parsed out. Chat templates read that field to decide whether a turn's reasoning is re-rendered into the next prompt, so every turn after the first was conditioned on a prefix serving would not produce.

Take a two-step tool call on Kimi K2.5. The target reasons, calls `get_weather`, and the second request has to re-render that call as history:

```jsonc
// what regen sends back for turn 2
{"role": "assistant", "content": "", "tool_calls": [{"id": "call_1", ...}]}
```

```text
// before -- the reasoning behind the call is gone
<|im_assistant|>assistant<|im_middle|><think></think><|tool_calls_section_begin|>...

// after -- it survives, as it does when serving
<|im_assistant|>assistant<|im_middle|><think>Need the weather tool for Tokyo.</think><|tool_calls_section_begin|>...
```

Kimi K2.5 preserves reasoning for exactly the in-flight tool loop and reads it only from `reasoning_content` -- no fallback. Qwen3 hid the bug because its template splits `<think>` back out of `content` when the field is missing, so the same defect is invisible there and silent here.

This forwards the field. It reads either response spelling (current vLLM answers with `reasoning`, older builds used `reasoning_content`) and sends the older one, which current vLLM normalizes and older builds pass through untouched. Without `--reasoning-parser` there is no field on the response, nothing is carried, and behaviour is unchanged.

## Tests

One test, on the tool-call path -- the branch where a real template actually loses the data.

Red without the source change, green with it:

```
E  assert {"role": "assistant", "content": "", "tool_calls": [...]}
        == {"role": "assistant", "content": "", "tool_calls": [...],
            "reasoning_content": "Need the weather tool."}
```

```
pytest tests/unit/scripts/test_response_regeneration.py -q
44 passed
```

`ruff check`, `ruff format --check`, and `mypy --check-untyped-defs` (174 files) all pass.

Not yet verified end to end against a live thinking model -- the round trip is traced through vLLM's request normalization and template rendering, but no two-turn request has been run to watch the field survive. Draft until that is done.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
