### PR TITLE
fix(dspark): loss mask off-by-one

### DIFF
--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -413,7 +413,14 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         logits = self.lm_head(hidden)
         # shape: [1, num_anchors*block_size, vocab_size]
 
-        aligned_loss_mask = loss_mask.clone()[:, anchored_block_indices]
+        # The mask must gate the token a slot predicts, not the slot's own
+        # position. select_anchors' tail exclusion keeps the shift in range.
+        mask_indices = (
+            anchored_block_indices + 1
+            if self.config.sample_from_anchor
+            else anchored_block_indices
+        )
+        aligned_loss_mask = loss_mask.clone()[:, mask_indices]
         # shape: [1, num_anchors*block_size]
 
         # zero out any padded anchor blocks

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -135,6 +135,7 @@ def make_dflash_model(
     draft_vocab_size: int = 64,
     block_size: int = 4,
     draft_attn_impl: str | None = None,
+    sample_from_anchor: bool = False,
     device: str = "cuda:0",
     dtype: torch.dtype = torch.bfloat16,
 ) -> DFlashDraftModel:
@@ -146,6 +147,7 @@ def make_dflash_model(
         transformer_layer_config=transformer_config,
         draft_vocab_size=draft_vocab_size,
         block_size=block_size,
+        sample_from_anchor=sample_from_anchor,
         aux_hidden_state_layer_ids=[0, 1, 2],
         mask_token_id=0,
         speculators_config=SpeculatorsConfig(

--- a/tests/integration/models/test_model_forward.py
+++ b/tests/integration/models/test_model_forward.py
@@ -248,6 +248,31 @@ class TestVocabBoundary:
 
 @requires_cuda
 class TestDFlashParams:
+    def test_loss_mask_gates_the_predicted_token(self):
+        # sample_from_anchor=True (DSpark's default) supervises slot j on token
+        # a+j+1, so gating it on loss_mask[a+j] trains the slot past a turn's
+        # last content token on the separator that follows it.
+        model = make_dflash_model(sample_from_anchor=True, draft_attn_impl="eager")
+        samples = _make_samples([MAX_LEN])
+        batch = make_batch(max_len=MAX_LEN, samples=samples, hidden_size=HIDDEN_SIZE)
+        batch["loss_mask"] = torch.zeros_like(batch["loss_mask"])
+        batch["loss_mask"][0, 8:40] = 1  # one assistant turn, boundary at 40
+
+        *_, aligned_loss_mask, anchored_block_indices = model._backbone_forward(
+            hidden_states=batch["hidden_states"],
+            input_ids=batch["input_ids"],
+            loss_mask=batch["loss_mask"],
+            verifier_last_hidden_states=batch["verifier_last_hidden_states"],
+            document_ids=batch["document_ids"],
+            position_ids=batch["position_ids"],
+            max_anchors=8,
+        )
+
+        supervised = aligned_loss_mask[0].bool()
+        predicted_is_supervised = batch["loss_mask"][0][anchored_block_indices + 1]
+        assert supervised.any(), "no slot was supervised; the probe proves nothing"
+        assert predicted_is_supervised[supervised].all()
+
     @pytest.mark.parametrize("block_size", [2, 4, 8])
     def test_varying_block_size(self, block_size):
         model = make_dflash_model(block_size=block_size)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Affects `sample_from_anchor=True`, DSpark's default. DFlash defaults to False and is unchanged.


A draft slot was gated by the loss mask at its own position instead of at the token it predicts. A hidden state at position *i* yields the distribution over token *i+1*, so the mask has to be read one position ahead.

Assistant turn at positions 8-39, `block_size=4`, anchor `a=37`:

```
slot j             0    1    2    3
position a+j      37   38   39   40
predicts token    38   39   40   41
is it content?   yes  yes   no   no     <- turn ends at 39

before           [1,   1,   1,   0]     <- loss_mask[a+j]
after            [1,   1,   0,   0]     <- loss_mask[a+j+1]
                            ^ trained on the turn separator
```

```python
# before
aligned_loss_mask = loss_mask.clone()[:, anchored_block_indices]

# after
mask_indices = (
    anchored_block_indices + 1
    if self.config.sample_from_anchor
    else anchored_block_indices
)
aligned_loss_mask = loss_mask.clone()[:, mask_indices]
```

The two indices only disagree where the mask changes, so this is confined to turn boundaries — 0.47% of supervised slots at 200-token turns, 5.7% at 20-token turns, always over-supervision.


## Tests

One test: every slot the model marks trainable must be predicting a supervised token. Red with the fix reverted, green with it — the failure is the bug stated directly, `loss_mask` sampled at each trained slot's predicted token, which should be all ones.

```
E  assert tensor(False)
E   + where ... = tensor([1., 1., 1., ..., 1., 1., 0.]).all
```

```
pytest tests/integration/models/test_model_forward.py::TestDFlashParams -q   19 passed
pytest tests/unit/models -q                                                 137 passed
```

`ruff check` and `ruff format --check` pass.

Note for reviewers: this mask also feeds `full_acc`, `eal`, `accept_rate` and the confidence-head target, so acceptance numbers will shift slightly. That is the correction, not a regression.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
