### PR TITLE
fix(muon x dspark): Markov embedding should not use Muon

### DIFF
--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -55,6 +55,12 @@ class DSparkDraftModel(DFlashDraftModel):
             )
             self.confidence_head = ConfidenceHead(input_dim)
 
+        # These heads are attached after DFlash's __init__ has already run the weight
+        # init sweep, so without a second pass they keep raw torch defaults -- N(0, 1)
+        # for the Markov embedding. Modules the first pass covered are flagged and
+        # skipped, as are the NaN-filled verifier heads.
+        self.post_init()
+
     @classmethod
     def from_training_args(
         cls,

--- a/src/speculators/train/optimizers.py
+++ b/src/speculators/train/optimizers.py
@@ -16,7 +16,7 @@ import logging
 
 import torch
 from torch import Tensor
-from torch.nn import Module
+from torch.nn import Embedding, Module
 
 logger = logging.getLogger("speculators")
 
@@ -35,13 +35,24 @@ def split_named_params_for_muon(
     """Split a model's trainable parameters into Muon and AdamW groups.
 
     A parameter goes to Muon iff it requires gradients, is a 2D matrix with both
-    dimensions > 1, and is not an embedding or LM-head weight; everything else goes to
-    AdamW. Degenerate 2D weights (``[1, N]`` / ``[N, 1]`` vectors) route to AdamW --
-    Muon orthogonalizes matrices, not vectors, and crashes on them under FSDP2.
+    dimensions > 1, is not owned by an ``nn.Embedding``, and is not an LM-head weight;
+    everything else goes to AdamW. Degenerate 2D weights (``[1, N]`` / ``[N, 1]``
+    vectors) route to AdamW -- Muon orthogonalizes matrices, not vectors, and crashes
+    on them under FSDP2.
 
     :param model: The model whose parameters should be partitioned.
     :return: A ``(muon_params, adamw_params)`` tuple of named parameter lists.
     """
+    # Matched on the module, not the name: an embedding is a lookup table indexed by
+    # token id, so orthogonalizing it is meaningless whatever it happens to be called.
+    # DSpark's Markov head owns one (`markov_w1`) that no name hint would catch.
+    embedding_param_ids = {
+        id(param)
+        for module in model.modules()
+        if isinstance(module, Embedding)
+        for param in module.parameters(recurse=False)
+    }
+
     muon_params: list[tuple[str, Tensor]] = []
     adamw_params: list[tuple[str, Tensor]] = []
     for name, param in model.named_parameters():
@@ -50,6 +61,7 @@ def split_named_params_for_muon(
         if (
             param.ndim == _MATRIX_NDIM
             and min(param.shape) > 1  # exclude degenerate [1, N] / [N, 1] vectors
+            and id(param) not in embedding_param_ids
             and not any(hint in name for hint in _ADAMW_NAME_HINTS)
         ):
             muon_params.append((name, param))

--- a/tests/unit/models/test_dspark_model_definitions.py
+++ b/tests/unit/models/test_dspark_model_definitions.py
@@ -2,8 +2,13 @@
 
 import pytest
 import torch
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 
+from speculators import SpeculatorsConfig, VerifierConfig
+from speculators.models.dspark import DSparkSpeculatorConfig
+from speculators.models.dspark.core import DSparkDraftModel
 from speculators.models.dspark.model_definitions import ConfidenceHead, MarkovHead
+from speculators.proposals.greedy import GreedyTokenProposalConfig
 
 
 class TestMarkovHead:
@@ -73,3 +78,48 @@ class TestConfidenceHead:
         out = head(features)
         assert out.shape == (3, 4)
         assert torch.isfinite(out).all()
+
+
+def test_markov_head_is_covered_by_the_weight_init_sweep():
+    # The heads are attached after DFlash's __init__ has run the init sweep, so
+    # without a second pass the Markov embedding keeps nn.Embedding's N(0, 1)
+    # default -- ~50x the initializer_range every other draft matrix gets, landing
+    # as a large random bias directly on the draft logits.
+    transformer_config = Qwen3Config(
+        vocab_size=2048,
+        hidden_size=64,
+        intermediate_size=256,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=16,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-6,
+        tie_word_embeddings=False,
+    )
+    model = DSparkDraftModel(
+        DSparkSpeculatorConfig(
+            transformer_layer_config=transformer_config,
+            draft_vocab_size=512,
+            block_size=4,
+            aux_hidden_state_layer_ids=[0, 1, 2],
+            mask_token_id=0,
+            markov_rank=16,
+            markov_head_type="vanilla",
+            speculators_config=SpeculatorsConfig(
+                algorithm="dspark",
+                proposal_methods=[GreedyTokenProposalConfig(speculative_tokens=3)],
+                default_proposal_method="greedy",
+                verifier=VerifierConfig(
+                    name_or_path=None, architectures=["Qwen3ForCausalLM"]
+                ),
+            ),
+        )
+    )
+
+    # `fc` is a matrix the first sweep certainly covered; compare against it rather
+    # than hardcoding initializer_range.
+    reference = model.fc.weight.std().item()
+    assert model.markov_head.markov_w1.weight.std().item() == pytest.approx(
+        reference, rel=0.3
+    )

--- a/tests/unit/train/test_optimizers.py
+++ b/tests/unit/train/test_optimizers.py
@@ -1,0 +1,21 @@
+"""Tests for optimizer parameter partitioning."""
+
+from torch import nn
+
+from speculators.train.optimizers import split_named_params_for_muon
+
+
+def test_embeddings_route_to_adamw_regardless_of_name():
+    # Muon orthogonalizes a matrix as a linear map between feature spaces; an embedding
+    # is a lookup table indexed by token id, so the update is meaningless for it. The
+    # probe mirrors DSpark's Markov head, whose embedding no name hint would catch.
+    model = nn.Module()
+    model.markov_head = nn.Module()
+    model.markov_head.markov_w1 = nn.Embedding(512, 16)
+    model.proj = nn.Linear(16, 32, bias=False)
+
+    muon, adamw = split_named_params_for_muon(model)
+
+    assert "markov_head.markov_w1.weight" in {n for n, _ in adamw}
+    assert "markov_head.markov_w1.weight" not in {n for n, _ in muon}
+    assert "proj.weight" in {n for n, _ in muon}  # ordinary matrices still reach Muon


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Bug

Muon should not be used for Markov head, because Markov head is `nn.embedding`, and Muon should not be used for embedding. 

## Attempts: 

1. route Markov head to AdamW (not working)
2. change the post_init order to give Markov head good initialization. (not working)
3. fix the lr (running ablation now)

## Result

Qwen3-8B, 2000 conversations (6000 rows) Muon + DSpark

arm | routing | init | peak val EAL | Δ vs main | shipped | train EAL
-- | -- | -- | -- | -- | -- | --
nofix (main) | Muon | 1.0 | 1.1146 | — | 1.0784 | 4.6943
+route (844f895) | AdamW | 1.0 | 1.0445 | −0.0702 | 1.0041 | 4.2974
+init (51e30c7) | AdamW | 0.02 | 1.0943 | −0.0203 | 1.0589 | 4.3558

The two fixes make things worse than main.

## Next attempt

Give the embedding its own optimizer group rather than dumping it in the existing AdamW one: AdamW, but at lr 3e-3 / wd 0.1 — Muon's own values. That's #866 + the lr it should have had. T

