### PR TITLE
fix(regen): create parent dirs for --outfile before opening

### DIFF
--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -47,6 +47,16 @@ def _dataset_choice(name: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def ensure_parent_dirs(*paths: str) -> None:
+    """Create parent directories for output files.
+
+    open(..., "a") creates the file but not its parent directories.
+    """
+    for path in paths:
+        if parent := os.path.dirname(path):
+            os.makedirs(parent, exist_ok=True)
+
+
 def parse_args():
     """Parse command-line arguments for the script."""
     parser = argparse.ArgumentParser(
@@ -780,6 +790,8 @@ async def main():
     dataset = load_dataset(dataset_id, name=subset, split=split, streaming=True)
 
     queue: asyncio.Queue = asyncio.Queue(maxsize=args.concurrency * 4)
+
+    ensure_parent_dirs(args.outfile, error_outfile)
 
     timeout = aiohttp.ClientTimeout(total=None, sock_connect=90, sock_read=None)
     connector = aiohttp.TCPConnector(


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

`open(path, "a")` creates the file but not its parent directories, so the regen script crashes with `FileNotFoundError` when `--outfile` points into a missing directory (e.g. no `output/` on a fresh checkout) — and only *after* the vLLM server has finished starting up.                                                 
                                                                                               
Create the parent dirs (`os.makedirs(..., exist_ok=True)`) before opening. No behavior change when the directory already exists.

## Tests

Ran `scripts/response_regeneration/script.py` with `--outfile` pointing into a non-existent directory: reproduced the crash on main; with this fix the file is created and generation starts normally.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
