### PR TITLE
fix(mtp): pin static shapes for compiled MTP forward

### DIFF
--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -107,7 +107,16 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
         super().load_verifier_weights()
         del self.verifier_lm_head
 
-    @conditional_torch_compile
+    # Compile with static shapes (dynamic=False). The forward is written for a
+    # fixed per-call sequence length and is meant to recompile per shape. If
+    # dynamo's automatic-dynamic promotes seq_len to a symbol, inductor must reason
+    # about strides derived from
+    #   valid_len = seq_len - min(num_steps, max(0, seq_len - 2)) - 1  (below)
+    # and chokes on the resulting symbolic expression: torch 2.13 raises "Exponent
+    # must be non-negative" (safe_pow over a PowByNatural(_, -1) term from
+    # valid_len**2 / valid_len) and torch 2.12 raises CantSplit on the same stride.
+    # Pinning static shapes keeps seq_len concrete and sidesteps both.
+    @conditional_torch_compile(dynamic=False)
     def forward(
         self,
         input_ids: torch.Tensor,

--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -107,15 +107,7 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
         super().load_verifier_weights()
         del self.verifier_lm_head
 
-    # Compile with static shapes (dynamic=False). The forward is written for a
-    # fixed per-call sequence length and is meant to recompile per shape. If
-    # dynamo's automatic-dynamic promotes seq_len to a symbol, inductor must reason
-    # about strides derived from
-    #   valid_len = seq_len - min(num_steps, max(0, seq_len - 2)) - 1  (below)
-    # and chokes on the resulting symbolic expression: torch 2.13 raises "Exponent
-    # must be non-negative" (safe_pow over a PowByNatural(_, -1) term from
-    # valid_len**2 / valid_len) and torch 2.12 raises CantSplit on the same stride.
-    # Pinning static shapes keeps seq_len concrete and sidesteps both.
+    # requires `dynamic=False`. See #876
     @conditional_torch_compile(dynamic=False)
     def forward(
         self,


### PR DESCRIPTION
## Purpose

Fix a `torch.compile`/inductor crash in the MTP speculator forward that surfaces once torch 2.13 is allowed (the dependency bump on `updep` #869), and that is a latent fragility on torch 2.12 as well. This PR is scoped to MTP and branches from `main` so it can merge independently of the torch version bump.

### The bug

`MTPDraftModel.forward` is decorated with `@conditional_torch_compile` at **class-definition time**, so every `MTPDraftModel` instance shares one `torch.compile`/dynamo cache. When that cache observes two different sequence lengths (e.g. `tests/unit/models/test_mtp_model.py` uses `seq_len=10`, then `test_mtp_frozen_weights.py` uses `seq_len=32`), dynamo's **automatic-dynamic** promotes `seq_len` to a symbol.

Inductor then reasons about strides derived from:

```
valid_len = seq_len - min(num_steps, max(0, seq_len - 2)) - 1
```

and chokes on the resulting symbolic expression. The originating expression (captured via `TORCHDYNAMO_VERBOSE=1`):

```
Eq((s70 - Min(3, Max(0, s70-2)) - 1) * Mod(1, (...)/(s70 - Min(3, Max(0, s70-2)) - 1)), 0)
```

The numerator simplifies to `valid_len**2`, so the stride carries a `valid_len**2 / valid_len` = `PowByNatural(valid_len, -1)` term.

- **torch 2.13**: `value_ranges.pow_by_natural` -> `safe_pow(x, -1)` -> `ValueError: Exponent must be non-negative.`
- **torch 2.12**: `CantSplit: 1024*s70 - ... not divisible by ...` on the same stride.

So dynamic `seq_len` was never safely supported for this forward on any torch version — the existing comment already implies static shapes are required (*"keeps tensor shapes identical ... which torch.compile requires for stable codegen"*). torch 2.13 merely widened the set of shape sequences that crash, which is why the test now fails on the version bump.

### Why other torch versions "pass"

The full unit suite passes on torch 2.12.1 because the exact `(seq_len=10 -> seq_len=32)` sequence happens not to trip 2.12's codegen; a different sequence (e.g. `32 -> 48`) crashes 2.12 too with `CantSplit`. This is a robustness fix, not a 2.13-only workaround.

### The fix

Compile the MTP forward with `dynamic=False` so `seq_len` stays concrete and recompiles per shape, sidestepping both failures. Scoped to MTP only (`valid_len` is MTP-specific) — the shared `conditional_torch_compile` helper and the eagle3/dflash/peagle/dspark forwards are **unchanged**.

> Note: the underlying inductor behavior (`safe_pow` raising on a negative-exponent `PowByNatural` during value-range bounding) looks like an upstream torch fragility worth reporting separately; this PR is a self-contained workaround that aligns with the forward's documented static-shape contract.

## Tests

Environment: **torch 2.13.0+cu130**, transformers 5.14.1, 1x H100.

The previously-failing combination (model tests seq_len=10 pollute the shared compile cache, then the frozen-weights test at seq_len=32 hits automatic-dynamic):

```
$ pytest tests/unit/models/test_mtp_model.py tests/unit/models/test_mtp_frozen_weights.py -q
# before this fix:
FAILED tests/unit/models/test_mtp_frozen_weights.py::test_mtp_verifier_weights_frozen_after_from_pretrained
  - torch._inductor.exc.InductorError: ValueError: Exponent must be non-negative.
# with this fix:
6 passed, 14 warnings in 38.48s
```

Full model suite on torch 2.13:

```
$ pytest tests/unit/models/ -q
137 passed, 14 warnings in 47.10s
```

Also verified the same fix resolves the `CantSplit` variant on torch 2.12.1.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
