### PR TITLE
Revert "[BUG FIX] Detach dspark outputs before feeding them into the confidence head"

### DIFF
--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -176,11 +176,10 @@ class DSparkDraftModel(DFlashDraftModel):
             # __init__), so prev_emb is always set when the flag is on.
             if self.config.confidence_head_with_markov and prev_emb is not None:
                 conf_features = torch.cat(
-                    [hidden_blocks.detach(), prev_emb.detach().to(hidden_blocks.dtype)],
-                    dim=-1,
+                    [hidden_blocks, prev_emb.to(hidden_blocks.dtype)], dim=-1
                 )
             else:
-                conf_features = hidden_blocks.detach()
+                conf_features = hidden_blocks
             confidence_logits = self.confidence_head(conf_features).reshape(
                 1, mask_tokens_size
             )


### PR DESCRIPTION
Reverts vllm-project/speculators#848