### PR TITLE
fix(mtp): default to SDPA attention instead of eager

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -442,7 +442,7 @@ def build_draft_model(
             # _attn_implementation is never serialized by HF configs, so re-apply
             # the CLI selection before construction -- mirroring from_training_args.
             # MTP is skipped: its from_training_args never sets the field and its
-            # __init__ resolves its own default ("eager") when it is absent.
+            # __init__ resolves its own default ("sdpa") when it is absent.
             config = model_class.config_class.from_pretrained(args.from_pretrained)
             config.transformer_layer_config._attn_implementation = args.draft_attn_impl
             return model_class.from_pretrained(

--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -69,8 +69,9 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
     d2t: torch.Tensor | None
 
     def __init__(self, config: MTPSpeculatorConfig) -> None:
+        # SDPA, not eager — eager OOMs on long sequences (#886).
         if config.transformer_layer_config._attn_implementation is None:  # noqa: SLF001
-            config.transformer_layer_config._attn_implementation = "eager"  # noqa: SLF001
+            config.transformer_layer_config._attn_implementation = "sdpa"  # noqa: SLF001
         super().__init__(config=config)
         self._init_vocab(config)
         if self.use_draft_vocab:

--- a/tests/unit/models/test_mtp_attention.py
+++ b/tests/unit/models/test_mtp_attention.py
@@ -47,8 +47,15 @@ def test_packed_batch_attention_is_document_local(mtp_model, monkeypatch):
     assert isinstance(mask, torch.Tensor)  # dense mask path, not BlockMask/None
     # [batch, 1, q, kv]: broadcast over heads, so head 0 is authoritative
     assert mask.shape == (1, 1, n, n)
-    allow = mask[0, 0] == 0  # additive mask -> "may attend"
+    # bool mask (sdpa) vs float-additive mask (eager) — assert the invariant.
+    allow = mask[0, 0] if mask.dtype == torch.bool else mask[0, 0] == 0
     idx = torch.arange(n)
     doc = document_ids
     expected = (idx[:, None] >= idx[None, :]) & (doc[:, None] == doc[None, :])
     assert torch.equal(allow, expected)
+
+
+def test_default_attn_impl_is_sdpa_not_eager(mtp_model):
+    """MTP must default to SDPA, not eager — eager OOMs on long sequences (#886)."""
+    tlc = mtp_model.config.transformer_layer_config
+    assert tlc._attn_implementation == "sdpa"


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes #886.

`MTPDraftModel.__init__` defaults `_attn_implementation` to `"eager"` when unset, which is always the case on the training path. Eager materializes a `[1, heads, valid_len, valid_len]` score matrix per speculative step — at `total_seq_len=8192` on Qwen3.5-4B this pushes peak memory to **49.95 GiB**, OOMing when the co-resident vLLM datagen server holds ~20 GiB of the same 80 GiB H100.

This PR defaults MTP to `sdpa` instead. SDPA consumes the same dense mask from `create_causal_mask` and produces numerically identical output, while cutting peak memory to **38.08 GiB** (-24%). `simple_flex_attention` is not usable here — it expects a `BlockMask`, not a dense mask, and silently computes a different result.

## Tests

### Unit tests — 29/29 passed

```
python -m pytest tests/unit/models/test_mtp_attention.py tests/unit/models/test_mtp_model.py \
  tests/unit/models/test_mtp_config.py tests/unit/models/test_mtp_data.py \
  tests/unit/models/test_mtp_frozen_weights.py -v
========================= 29 passed in 99.33s =========================
```

Key assertions:
- `test_default_attn_impl_is_sdpa_not_eager` — pins the default so the regression cannot return
- `test_packed_batch_attention_is_document_local` — document-local masking preserved under SDPA's bool mask encoding

### Numerical equivalence — SDPA vs Eager

Tiny-model comparison (Qwen3.5 arch, `seq_len=128`):

| metric | result |
|---|---|
| Loss difference | `0.000000e+00` (bitwise identical) |
| Max logit diff (all 3 steps) | `7.8125e-03` (1 ULP in bf16) |

### Memory comparison at seq_len=8192

Tiny-model forward pass at the OOM-triggering sequence length:

| backend | peak memory |
|---|---|
| **SDPA** | **56.59 MiB** |
| Eager | 2,736.59 MiB |
| Saving | 2,680 MiB (97.9%) |

### Integration tests — 3/3 passed

```
python -m pytest tests/integration/models/test_model_forward.py -k "TestMTPParams" -v
========================= 3 passed in 2.14s =========================
```

### E2E regression test — PASSED

The previously-failing test now completes all 146/146 training steps without OOM:

```
CADENCE=weekly VLLM_PYTHON=vllm_venv/bin/python \
  pytest tests/e2e/regression/test_mtp_online_acceptance.py::test_mtp_online_regression -v
metrics_dict: {'acceptance_length': 3.051, 'acceptance_at_token_0': 0.859,
               'acceptance_at_token_1': 0.687, 'acceptance_at_token_2': 0.505}
========================= 1 passed in 626.19s (0:10:26) =========================
```

All acceptance thresholds met: 0.859 >= 0.82, 0.687 >= 0.65, 0.505 >= 0.48.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.