### PR TITLE
Add AGENTS.md with vLLM launch instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Speculators Agent Instructions
+
+## Launching vLLM
+
+- **For training** (hidden state extraction): always use `scripts/launch_vllm.py`. Never use `python -m vllm.entrypoints.openai.api_server` directly — it misses `--speculative_config` and `--kv_transfer_config` which are required for hidden state extraction.
+- **For eval**: launch vLLM directly with `--spec-model` and `--spec-tokens` (e.g. `python -m vllm.entrypoints.openai.api_server --model <target> --spec-model <checkpoint> --spec-tokens <N>`).


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` at the repo root with instructions for AI coding agents on how to correctly launch vLLM
- **Training**: always use `scripts/launch_vllm.py` (configures `--speculative_config` and `--kv_transfer_config` for hidden state extraction)
- **Eval**: launch vLLM directly with `--spec-model` and `--spec-tokens`

## Test plan
- [ ] Verify the file renders correctly on GitHub
- [ ] Confirm AI agents pick up the instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)