### PR TITLE
Add eval reproducibility artifacts (RFC #880)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Speculators — Agent Guide
+
+## Provenance
+
+Both eval and vLLM-launch scripts write reproducibility artifacts so runs can be recreated later.
+
+- **Training** (`src/speculators/train/utils.py`): `save_train_command()` writes `train_command.txt` (timestamp, git SHA, world size, package versions, full argv) into the checkpoint directory.
+- **Eval** (`scripts/evaluate/evaluate.py`): `save_eval_provenance()` writes `eval_command.txt` (timestamp, git SHA, package versions, full argv) into the output directory.
+- **vLLM launch** (`scripts/launch_vllm.py`): `_save_vllm_provenance()` writes `vllm_command.txt`, `vllm.patch`, and `checkpoint_sha256.txt` into `--provenance-dir`.
+
+When publishing a model or eval results (HuggingFace, GitHub comments, etc.), always include the provenance artifacts (`train_command.txt`, `eval_command.txt`, `vllm_command.txt`, patches) so the run can be reproduced.

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -335,8 +335,8 @@ def run_benchmark(args: argparse.Namespace) -> None:
 
     if not (output_dir / "vllm_command.txt").exists():
         logger.info(
-            "Tip: pass --provenance-dir %s to launch_vllm.py "
-            "to capture vLLM launch artifacts here",
+            "Tip: launch_vllm.py saves provenance to vllm_<model>_<ts>/ "
+            "by default, or pass --provenance-dir %s to co-locate here",
             output_dir,
         )
 

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -23,10 +23,15 @@ Examples:
 from __future__ import annotations
 
 import argparse
+import importlib.metadata
 import json
 import logging
+import os
+import shlex
+import subprocess
 import sys
-from datetime import datetime
+import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from urllib.error import URLError
 from urllib.request import urlopen
@@ -88,6 +93,66 @@ def _fetch_model_name(target: str) -> str | None:
 
 def _sanitize_dir_name(name: str) -> str:
     return name.replace("/", "_").replace(" ", "_")
+
+
+def save_eval_provenance(output_dir: Path) -> None:
+    """Write ``eval_command.txt`` into *output_dir*.
+
+    Records the full command line, timestamp, and package versions so the
+    eval can be reproduced.  Best-effort — never blocks the eval on failure.
+    """
+    try:
+        try:
+            sha = (
+                subprocess.run(
+                    ["git", "rev-parse", "HEAD"],  # noqa: S607
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    check=False,
+                ).stdout.strip()
+                or "unknown"
+            )
+        except OSError:
+            sha = "unknown"
+
+        pkg_versions: list[str] = []
+        for pkg in (
+            "speculators",
+            "vllm",
+            "transformers",
+            "torch",
+            "compressed-tensors",
+        ):
+            try:
+                ver = importlib.metadata.version(pkg)
+            except importlib.metadata.PackageNotFoundError:
+                ver = "not installed"
+            pkg_versions.append(f"# {pkg}: {ver}")
+
+        header = "\n".join(
+            [
+                f"# Timestamp: {datetime.now(timezone.utc).isoformat()}",
+                f"# Git SHA: {sha}",
+                *pkg_versions,
+            ]
+        )
+        content = f"{header}\n{shlex.join(sys.argv)}\n"
+
+        dest = output_dir / "eval_command.txt"
+        fd, tmp = tempfile.mkstemp(
+            dir=output_dir, prefix=".eval_command_", suffix=".tmp"
+        )
+        tmp_path = Path(tmp)
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(content)
+            tmp_path.replace(dest)
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink()
+    except Exception:
+        logger.warning("Failed to save eval_command.txt", exc_info=True)
 
 
 def _require_metrics(metrics_url: str) -> list:
@@ -258,6 +323,8 @@ def run_benchmark(args: argparse.Namespace) -> None:
     artifacts_dir = output_dir / "artifacts"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 
+    save_eval_provenance(output_dir)
+
     acceptance_csv = None
     perf_csv = None
     all_max_tokens: dict[str, int] = {}
@@ -418,7 +485,6 @@ def main() -> None:
             "Required when --dataset is a speedbench/ spec."
         ),
     )
-
     args = parser.parse_args()
 
     if args.output_dir is None:

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -335,8 +335,8 @@ def run_benchmark(args: argparse.Namespace) -> None:
 
     if not (output_dir / "vllm_command.txt").exists():
         logger.info(
-            "Tip: launch_vllm.py saves provenance to vllm_<model>_<ts>/ "
-            "by default, or pass --provenance-dir %s to co-locate here",
+            "No vllm_command.txt found. To co-locate vLLM provenance "
+            "with eval results: launch_vllm.py --provenance-dir %s",
             output_dir,
         )
 

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -95,6 +95,50 @@ def _sanitize_dir_name(name: str) -> str:
     return name.replace("/", "_").replace(" ", "_")
 
 
+def _git_sha() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        return result.stdout.strip() or "unknown"
+    except OSError:
+        return "unknown"
+
+
+def _pkg_version(name: str) -> str:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return "not installed"
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    fd, tmp = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}_", suffix=".tmp"
+    )
+    tmp_path = Path(tmp)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        tmp_path.replace(path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+_TRACKED_PACKAGES = (
+    "speculators",
+    "vllm",
+    "transformers",
+    "torch",
+    "compressed-tensors",
+)
+
+
 def save_eval_provenance(output_dir: Path) -> None:
     """Write ``eval_command.txt`` into *output_dir*.
 
@@ -102,55 +146,19 @@ def save_eval_provenance(output_dir: Path) -> None:
     eval can be reproduced.  Best-effort — never blocks the eval on failure.
     """
     try:
-        try:
-            sha = (
-                subprocess.run(
-                    ["git", "rev-parse", "HEAD"],  # noqa: S607
-                    capture_output=True,
-                    text=True,
-                    timeout=5,
-                    check=False,
-                ).stdout.strip()
-                or "unknown"
-            )
-        except OSError:
-            sha = "unknown"
-
-        pkg_versions: list[str] = []
-        for pkg in (
-            "speculators",
-            "vllm",
-            "transformers",
-            "torch",
-            "compressed-tensors",
-        ):
-            try:
-                ver = importlib.metadata.version(pkg)
-            except importlib.metadata.PackageNotFoundError:
-                ver = "not installed"
-            pkg_versions.append(f"# {pkg}: {ver}")
-
+        sha = _git_sha()
+        versions = [f"# {p}: {_pkg_version(p)}" for p in _TRACKED_PACKAGES]
         header = "\n".join(
             [
                 f"# Timestamp: {datetime.now(timezone.utc).isoformat()}",
                 f"# Git SHA: {sha}",
-                *pkg_versions,
+                *versions,
             ]
         )
-        content = f"{header}\n{shlex.join(sys.argv)}\n"
-
-        dest = output_dir / "eval_command.txt"
-        fd, tmp = tempfile.mkstemp(
-            dir=output_dir, prefix=".eval_command_", suffix=".tmp"
+        _atomic_write(
+            output_dir / "eval_command.txt",
+            f"{header}\n{shlex.join(sys.argv)}\n",
         )
-        tmp_path = Path(tmp)
-        try:
-            with os.fdopen(fd, "w") as f:
-                f.write(content)
-            tmp_path.replace(dest)
-        finally:
-            if tmp_path.exists():
-                tmp_path.unlink()
     except Exception:
         logger.warning("Failed to save eval_command.txt", exc_info=True)
 

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -325,6 +325,13 @@ def run_benchmark(args: argparse.Namespace) -> None:
 
     save_eval_provenance(output_dir)
 
+    if not (output_dir / "vllm_command.txt").exists():
+        logger.info(
+            "Tip: pass --provenance-dir %s to launch_vllm.py "
+            "to capture vLLM launch artifacts here",
+            output_dir,
+        )
+
     acceptance_csv = None
     perf_csv = None
     all_max_tokens: dict[str, int] = {}

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -95,12 +95,28 @@ def _sanitize_dir_name(name: str) -> str:
     return name.replace("/", "_").replace(" ", "_")
 
 
+def _speculators_repo_root() -> str | None:
+    try:
+        import speculators  # noqa: PLC0415
+
+        d = os.path.realpath(os.path.dirname(speculators.__file__))
+        while d != os.path.dirname(d):
+            if os.path.isdir(os.path.join(d, ".git")):
+                return d
+            d = os.path.dirname(d)
+    except (ImportError, OSError):
+        pass
+    return None
+
+
 def _git_sha() -> str:
     try:
+        repo = _speculators_repo_root()
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],  # noqa: S607
             capture_output=True,
             text=True,
+            cwd=repo,
             timeout=5,
             check=False,
         )
@@ -117,9 +133,7 @@ def _pkg_version(name: str) -> str:
 
 
 def _atomic_write(path: Path, content: str) -> None:
-    fd, tmp = tempfile.mkstemp(
-        dir=path.parent, prefix=f".{path.name}_", suffix=".tmp"
-    )
+    fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}_", suffix=".tmp")
     tmp_path = Path(tmp)
     try:
         with os.fdopen(fd, "w") as f:

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -173,7 +173,7 @@ def save_eval_provenance(output_dir: Path) -> None:
             output_dir / "eval_command.txt",
             f"{header}\n{shlex.join(sys.argv)}\n",
         )
-    except Exception:
+    except OSError:
         logger.warning("Failed to save eval_command.txt", exc_info=True)
 
 

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -96,8 +96,8 @@ def parse_args():
         type=str,
         default=None,
         help=(
-            "Directory to write vllm_command.txt and vllm.patch for "
-            "eval reproducibility (e.g. the eval output directory)."
+            "Directory to write vllm_command.txt, vllm.patch, and "
+            "checkpoint_sha256.txt. Defaults to vllm_<model>_<timestamp>/."
         ),
     )
     parser.add_argument(
@@ -357,8 +357,11 @@ def main():
     print("Running command:")
     print(" ".join(cmd))
 
-    if args.provenance_dir:
-        _save_vllm_provenance(cmd, args.provenance_dir, args.model)
+    if not args.provenance_dir:
+        sanitized = args.model.replace("/", "_").replace(" ", "_")
+        ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        args.provenance_dir = f"vllm_{sanitized}_{ts}"
+    _save_vllm_provenance(cmd, args.provenance_dir, args.model)
 
     if not args.dry_run:
         os.execvp(cmd[0], cmd)  # noqa: S606

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -102,6 +102,17 @@ def parse_args():
         ),
     )
     parser.add_argument(
+        "--no-hash-checkpoints",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip SHA256 hashing of .safetensors files. Useful for large "
+            "checkpoints where hashing adds significant launch latency. "
+            "When set, checkpoint_sha256.txt records file sizes and "
+            "modification times instead."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the command that would be executed without running it",
@@ -223,7 +234,9 @@ def _save_vllm_patch(
     _atomic_write(os.path.join(provenance_dir, "vllm.patch"), content)
 
 
-def _save_checkpoint_sha256(provenance_dir: str, model: str) -> None:
+def _save_checkpoint_sha256(
+    provenance_dir: str, model: str, *, skip_hash: bool = False
+) -> None:
     dest = os.path.join(provenance_dir, "checkpoint_sha256.txt")
     model_path = os.path.expanduser(model)
     if not os.path.isdir(model_path):
@@ -235,19 +248,33 @@ def _save_checkpoint_sha256(provenance_dir: str, model: str) -> None:
     if not safetensors:
         _atomic_write(dest, f"# no .safetensors files in {model_path}\n")
         return
-    lines = [
-        f"{_sha256_file(os.path.join(model_path, name))}  {name}"
-        for name in safetensors
-    ]
-    _atomic_write(dest, "\n".join(lines) + "\n")
+    if skip_hash:
+        lines = []
+        for name in safetensors:
+            fp = os.path.join(model_path, name)
+            st = os.stat(fp)
+            lines.append(f"size={st.st_size}  mtime={st.st_mtime}  {name}")
+        header = "# hashing skipped (--no-hash-checkpoints)\n"
+        _atomic_write(dest, header + "\n".join(lines) + "\n")
+    else:
+        lines = [
+            f"{_sha256_file(os.path.join(model_path, name))}  {name}"
+            for name in safetensors
+        ]
+        _atomic_write(dest, "\n".join(lines) + "\n")
 
 
 # ---------------------------------------------------------------------------
 # Top-level entry point
 # ---------------------------------------------------------------------------
 
+
 def _save_vllm_provenance(
-    cmd: list[str], provenance_dir: str, model: str
+    cmd: list[str],
+    provenance_dir: str,
+    model: str,
+    *,
+    skip_hash: bool = False,
 ) -> None:
     """Write vllm_command.txt, vllm.patch, and checkpoint_sha256.txt.
 
@@ -260,9 +287,7 @@ def _save_vllm_provenance(
         return
 
     vllm_repo = _find_vllm_repo()
-    git_sha = _run_git(
-        ["git", "rev-parse", "HEAD"], vllm_repo or "."
-    ) or "unknown"
+    git_sha = _run_git(["git", "rev-parse", "HEAD"], vllm_repo or ".") or "unknown"
     diff = (
         _run_git(
             ["git", "diff", "HEAD"],
@@ -275,15 +300,34 @@ def _save_vllm_provenance(
     vllm_ver = _pkg_version("vllm")
 
     writers = [
-        ("vllm_command.txt", lambda: _save_vllm_command(
-            provenance_dir, cmd, git_sha, diff, vllm_ver,
-        )),
-        ("vllm.patch", lambda: _save_vllm_patch(
-            provenance_dir, vllm_repo, git_sha, diff, vllm_ver,
-        )),
-        ("checkpoint_sha256.txt", lambda: _save_checkpoint_sha256(
-            provenance_dir, model,
-        )),
+        (
+            "vllm_command.txt",
+            lambda: _save_vllm_command(
+                provenance_dir,
+                cmd,
+                git_sha,
+                diff,
+                vllm_ver,
+            ),
+        ),
+        (
+            "vllm.patch",
+            lambda: _save_vllm_patch(
+                provenance_dir,
+                vllm_repo,
+                git_sha,
+                diff,
+                vllm_ver,
+            ),
+        ),
+        (
+            "checkpoint_sha256.txt",
+            lambda: _save_checkpoint_sha256(
+                provenance_dir,
+                model,
+                skip_hash=skip_hash,
+            ),
+        ),
     ]
     for artifact, write in writers:
         try:
@@ -355,7 +399,12 @@ def main():
         sanitized = args.model.replace("/", "_").replace(" ", "_")
         ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         args.provenance_dir = f"vllm_{sanitized}_{ts}"
-    _save_vllm_provenance(cmd, args.provenance_dir, args.model)
+    _save_vllm_provenance(
+        cmd,
+        args.provenance_dir,
+        args.model,
+        skip_hash=args.no_hash_checkpoints,
+    )
 
     if not args.dry_run:
         os.execvp(cmd[0], cmd)  # noqa: S606

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -155,6 +155,13 @@ def _git_info(repo: str) -> tuple[str, str | None]:
     return sha, diff
 
 
+def _is_vllm_repo(path: str) -> bool:
+    """Check that *path* looks like the vllm source tree, not an unrelated repo."""
+    return os.path.isdir(os.path.join(path, ".git")) and os.path.isfile(
+        os.path.join(path, "vllm", "__init__.py")
+    )
+
+
 def _find_vllm_repo() -> str | None:
     """Find the vllm git checkout by walking up from the installed package."""
     try:
@@ -162,7 +169,7 @@ def _find_vllm_repo() -> str | None:
         if dist.files:
             d = str(dist._path.parent)
             while d != os.path.dirname(d):
-                if os.path.isdir(os.path.join(d, ".git")):
+                if _is_vllm_repo(d):
                     return d
                 d = os.path.dirname(d)
     except (importlib.metadata.PackageNotFoundError, AttributeError):
@@ -172,7 +179,7 @@ def _find_vllm_repo() -> str | None:
         os.path.expanduser("~/vllm"),
         "/workspace/vllm",
     ]:
-        if os.path.isdir(os.path.join(candidate, ".git")):
+        if _is_vllm_repo(candidate):
             return candidate
     return None
 
@@ -182,12 +189,20 @@ def _save_vllm_provenance(cmd: list[str], provenance_dir: str) -> None:
 
     Best-effort — failures are printed but never fatal.
     """
-    os.makedirs(provenance_dir, exist_ok=True)
+    try:
+        os.makedirs(provenance_dir, exist_ok=True)
+    except OSError as exc:
+        print(
+            f"Warning: could not create provenance dir: {exc}",
+            file=sys.stderr,
+        )
+        return
 
     vllm_repo = _find_vllm_repo()
     git_sha = "unknown"
+    diff: str | None = None
     if vllm_repo:
-        git_sha, _ = _git_info(vllm_repo)
+        git_sha, diff = _git_info(vllm_repo)
 
     try:
         vllm_ver = importlib.metadata.version("vllm")
@@ -197,10 +212,8 @@ def _save_vllm_provenance(cmd: list[str], provenance_dir: str) -> None:
     # --- vllm_command.txt ---
     try:
         sha_label = git_sha
-        if vllm_repo:
-            _, diff = _git_info(vllm_repo)
-            if diff:
-                sha_label += " (dirty)"
+        if diff:
+            sha_label += " (dirty)"
 
         ts = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
         header = "\n".join(
@@ -214,24 +227,31 @@ def _save_vllm_provenance(cmd: list[str], provenance_dir: str) -> None:
         content = f"{header}\n{shlex.join(cmd)}\n"
         _atomic_write(os.path.join(provenance_dir, "vllm_command.txt"), content)
     except OSError as exc:
-        print(f"Warning: could not save vllm_command.txt: {exc}", file=sys.stderr)
+        print(
+            f"Warning: could not save vllm_command.txt: {exc}",
+            file=sys.stderr,
+        )
 
     # --- vllm.patch ---
     try:
         if vllm_repo:
-            _, diff = _git_info(vllm_repo)
+            patch_content = f"# repo: {vllm_repo} ({git_sha})\n"
             if diff:
-                _atomic_write(
-                    os.path.join(provenance_dir, "vllm.patch"),
-                    f"# repo: {vllm_repo} ({git_sha})\n{diff}",
-                )
+                patch_content += diff
+            _atomic_write(
+                os.path.join(provenance_dir, "vllm.patch"),
+                patch_content,
+            )
         else:
             _atomic_write(
                 os.path.join(provenance_dir, "vllm.patch"),
                 f"# vllm {vllm_ver} (wheel install, no git repo found)\n",
             )
     except OSError as exc:
-        print(f"Warning: could not save vllm.patch: {exc}", file=sys.stderr)
+        print(
+            f"Warning: could not save vllm.patch: {exc}",
+            file=sys.stderr,
+        )
 
 
 def main():

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -1,7 +1,12 @@
 import argparse
+import datetime
+import importlib.metadata
 import json
 import os
+import shlex
+import subprocess
 import sys
+import tempfile
 import warnings
 
 try:
@@ -86,11 +91,147 @@ def parse_args():
         ),
     )
     parser.add_argument(
+        "--provenance-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory to write vllm_command.txt and vllm.patch for "
+            "eval reproducibility (e.g. the eval output directory)."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the command that would be executed without running it",
     )
     return parser.parse_known_args()
+
+
+def _atomic_write(path: str, content: str) -> None:
+    fd, tmp = tempfile.mkstemp(
+        dir=os.path.dirname(path),
+        prefix=f".{os.path.basename(path)}_",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp, path)
+    finally:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+
+
+def _git_info(repo: str) -> tuple[str, str | None]:
+    """Return ``(sha, diff)`` for a git repo.  *diff* is None on failure."""
+    try:
+        sha = (
+            subprocess.run(
+                ["git", "rev-parse", "HEAD"],  # noqa: S607
+                capture_output=True,
+                text=True,
+                cwd=repo,
+                timeout=5,
+                check=False,
+            ).stdout.strip()
+            or "unknown"
+        )
+    except OSError:
+        sha = "unknown"
+
+    try:
+        result = subprocess.run(
+            ["git", "diff", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            cwd=repo,
+            timeout=30,
+            check=False,
+        )
+        diff = result.stdout if result.returncode == 0 else None
+    except OSError:
+        diff = None
+
+    return sha, diff
+
+
+def _find_vllm_repo() -> str | None:
+    """Find the vllm git checkout by walking up from the installed package."""
+    try:
+        dist = importlib.metadata.distribution("vllm")
+        if dist.files:
+            d = str(dist._path.parent)
+            while d != os.path.dirname(d):
+                if os.path.isdir(os.path.join(d, ".git")):
+                    return d
+                d = os.path.dirname(d)
+    except (importlib.metadata.PackageNotFoundError, AttributeError):
+        pass
+
+    for candidate in [
+        os.path.expanduser("~/vllm"),
+        "/workspace/vllm",
+    ]:
+        if os.path.isdir(os.path.join(candidate, ".git")):
+            return candidate
+    return None
+
+
+def _save_vllm_provenance(cmd: list[str], provenance_dir: str) -> None:
+    """Write vllm_command.txt and vllm.patch to *provenance_dir*.
+
+    Best-effort — failures are printed but never fatal.
+    """
+    os.makedirs(provenance_dir, exist_ok=True)
+
+    vllm_repo = _find_vllm_repo()
+    git_sha = "unknown"
+    if vllm_repo:
+        git_sha, _ = _git_info(vllm_repo)
+
+    try:
+        vllm_ver = importlib.metadata.version("vllm")
+    except importlib.metadata.PackageNotFoundError:
+        vllm_ver = "unknown"
+
+    # --- vllm_command.txt ---
+    try:
+        sha_label = git_sha
+        if vllm_repo:
+            _, diff = _git_info(vllm_repo)
+            if diff:
+                sha_label += " (dirty)"
+
+        ts = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+        header = "\n".join(
+            [
+                f"# Timestamp: {ts}",
+                f"# Python: {sys.executable}",
+                f"# Git SHA: {sha_label}",
+                f"# vllm: {vllm_ver}",
+            ]
+        )
+        content = f"{header}\n{shlex.join(cmd)}\n"
+        _atomic_write(os.path.join(provenance_dir, "vllm_command.txt"), content)
+    except OSError as exc:
+        print(f"Warning: could not save vllm_command.txt: {exc}", file=sys.stderr)
+
+    # --- vllm.patch ---
+    try:
+        if vllm_repo:
+            _, diff = _git_info(vllm_repo)
+            if diff:
+                _atomic_write(
+                    os.path.join(provenance_dir, "vllm.patch"),
+                    f"# repo: {vllm_repo} ({git_sha})\n{diff}",
+                )
+        else:
+            _atomic_write(
+                os.path.join(provenance_dir, "vllm.patch"),
+                f"# vllm {vllm_ver} (wheel install, no git repo found)\n",
+            )
+    except OSError as exc:
+        print(f"Warning: could not save vllm.patch: {exc}", file=sys.stderr)
 
 
 def main():
@@ -151,6 +292,9 @@ def main():
 
     print("Running command:")
     print(" ".join(cmd))
+
+    if args.provenance_dir:
+        _save_vllm_provenance(cmd, args.provenance_dir)
 
     if not args.dry_run:
         os.execvp(cmd[0], cmd)  # noqa: S606

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -170,13 +170,6 @@ def _find_vllm_repo() -> str | None:
                 d = os.path.dirname(d)
     except (ModuleNotFoundError, ValueError):
         pass
-
-    for candidate in [
-        os.path.expanduser("~/vllm"),
-        "/workspace/vllm",
-    ]:
-        if _is_vllm_repo(candidate):
-            return candidate
     return None
 
 

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -2,6 +2,7 @@ import argparse
 import datetime
 import hashlib
 import importlib.metadata
+import importlib.util
 import json
 import os
 import shlex
@@ -160,14 +161,14 @@ def _is_vllm_repo(path: str) -> bool:
 def _find_vllm_repo() -> str | None:
     """Find the vllm git checkout by walking up from the installed package."""
     try:
-        dist = importlib.metadata.distribution("vllm")
-        if dist.files:
-            d = str(dist._path.parent)
+        spec = importlib.util.find_spec("vllm")
+        if spec and spec.origin:
+            d = os.path.dirname(spec.origin)
             while d != os.path.dirname(d):
                 if _is_vllm_repo(d):
                     return d
                 d = os.path.dirname(d)
-    except (importlib.metadata.PackageNotFoundError, AttributeError):
+    except (ModuleNotFoundError, ValueError):
         pass
 
     for candidate in [

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -1,5 +1,6 @@
 import argparse
 import datetime
+import hashlib
 import importlib.metadata
 import json
 import os
@@ -184,7 +185,43 @@ def _find_vllm_repo() -> str | None:
     return None
 
 
-def _save_vllm_provenance(cmd: list[str], provenance_dir: str) -> None:
+def _sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        while chunk := f.read(1 << 20):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _save_checkpoint_sha256(provenance_dir: str, model: str) -> None:
+    dest = os.path.join(provenance_dir, "checkpoint_sha256.txt")
+    try:
+        model_path = os.path.expanduser(model)
+        if os.path.isdir(model_path):
+            safetensors = sorted(
+                f for f in os.listdir(model_path) if f.endswith(".safetensors")
+            )
+            if safetensors:
+                lines = []
+                for name in safetensors:
+                    h = _sha256_file(os.path.join(model_path, name))
+                    lines.append(f"{h}  {name}")
+                _atomic_write(dest, "\n".join(lines) + "\n")
+            else:
+                _atomic_write(
+                    dest,
+                    f"# no .safetensors files in {model_path}\n",
+                )
+        else:
+            _atomic_write(dest, f"# model: {model} (not a local path)\n")
+    except OSError as exc:
+        print(
+            f"Warning: could not save checkpoint_sha256.txt: {exc}",
+            file=sys.stderr,
+        )
+
+
+def _save_vllm_provenance(cmd: list[str], provenance_dir: str, model: str) -> None:
     """Write vllm_command.txt and vllm.patch to *provenance_dir*.
 
     Best-effort — failures are printed but never fatal.
@@ -253,6 +290,8 @@ def _save_vllm_provenance(cmd: list[str], provenance_dir: str) -> None:
             file=sys.stderr,
         )
 
+    _save_checkpoint_sha256(provenance_dir, model)
+
 
 def main():
     args, vllm_args = parse_args()
@@ -314,7 +353,7 @@ def main():
     print(" ".join(cmd))
 
     if args.provenance_dir:
-        _save_vllm_provenance(cmd, args.provenance_dir)
+        _save_vllm_provenance(cmd, args.provenance_dir, args.model)
 
     if not args.dry_run:
         os.execvp(cmd[0], cmd)  # noqa: S606

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -108,6 +108,10 @@ def parse_args():
     return parser.parse_known_args()
 
 
+def _warn(msg: str) -> None:
+    print(f"Warning: {msg}", file=sys.stderr)
+
+
 def _atomic_write(path: str, content: str) -> None:
     fd, tmp = tempfile.mkstemp(
         dir=os.path.dirname(path),
@@ -123,37 +127,27 @@ def _atomic_write(path: str, content: str) -> None:
             os.unlink(tmp)
 
 
-def _git_info(repo: str) -> tuple[str, str | None]:
-    """Return ``(sha, diff)`` for a git repo.  *diff* is None on failure."""
+def _run_git(args: list[str], cwd: str, timeout: int = 5) -> str:
+    """Run a git command and return stdout, or empty string on failure."""
     try:
-        sha = (
-            subprocess.run(
-                ["git", "rev-parse", "HEAD"],  # noqa: S607
-                capture_output=True,
-                text=True,
-                cwd=repo,
-                timeout=5,
-                check=False,
-            ).stdout.strip()
-            or "unknown"
-        )
-    except OSError:
-        sha = "unknown"
-
-    try:
-        result = subprocess.run(
-            ["git", "diff", "HEAD"],  # noqa: S607
+        result = subprocess.run(  # noqa: S603
+            args,
             capture_output=True,
             text=True,
-            cwd=repo,
-            timeout=30,
+            cwd=cwd,
+            timeout=timeout,
             check=False,
         )
-        diff = result.stdout if result.returncode == 0 else None
+        return result.stdout.strip() if result.returncode == 0 else ""
     except OSError:
-        diff = None
+        return ""
 
-    return sha, diff
+
+def _pkg_version(name: str) -> str:
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
 
 
 def _is_vllm_repo(path: str) -> bool:
@@ -193,104 +187,115 @@ def _sha256_file(path: str) -> str:
     return h.hexdigest()
 
 
+# ---------------------------------------------------------------------------
+# Individual provenance writers — each is self-contained and best-effort.
+# ---------------------------------------------------------------------------
+
+
+def _save_vllm_command(
+    provenance_dir: str,
+    cmd: list[str],
+    git_sha: str,
+    diff: str,
+    vllm_ver: str,
+) -> None:
+    sha_label = f"{git_sha} (dirty)" if diff else git_sha
+    ts = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+    header = "\n".join(
+        [
+            f"# Timestamp: {ts}",
+            f"# Python: {sys.executable}",
+            f"# Git SHA: {sha_label}",
+            f"# vllm: {vllm_ver}",
+        ]
+    )
+    _atomic_write(
+        os.path.join(provenance_dir, "vllm_command.txt"),
+        f"{header}\n{shlex.join(cmd)}\n",
+    )
+
+
+def _save_vllm_patch(
+    provenance_dir: str,
+    vllm_repo: str | None,
+    git_sha: str,
+    diff: str,
+    vllm_ver: str,
+) -> None:
+    if vllm_repo:
+        content = f"# repo: {vllm_repo} ({git_sha})\n{diff}"
+    else:
+        content = f"# vllm {vllm_ver} (wheel install, no git repo found)\n"
+    _atomic_write(os.path.join(provenance_dir, "vllm.patch"), content)
+
+
 def _save_checkpoint_sha256(provenance_dir: str, model: str) -> None:
     dest = os.path.join(provenance_dir, "checkpoint_sha256.txt")
-    try:
-        model_path = os.path.expanduser(model)
-        if os.path.isdir(model_path):
-            safetensors = sorted(
-                f for f in os.listdir(model_path) if f.endswith(".safetensors")
-            )
-            if safetensors:
-                lines = []
-                for name in safetensors:
-                    h = _sha256_file(os.path.join(model_path, name))
-                    lines.append(f"{h}  {name}")
-                _atomic_write(dest, "\n".join(lines) + "\n")
-            else:
-                _atomic_write(
-                    dest,
-                    f"# no .safetensors files in {model_path}\n",
-                )
-        else:
-            _atomic_write(dest, f"# model: {model} (not a local path)\n")
-    except OSError as exc:
-        print(
-            f"Warning: could not save checkpoint_sha256.txt: {exc}",
-            file=sys.stderr,
-        )
+    model_path = os.path.expanduser(model)
+    if not os.path.isdir(model_path):
+        _atomic_write(dest, f"# model: {model} (not a local path)\n")
+        return
+    safetensors = sorted(
+        f for f in os.listdir(model_path) if f.endswith(".safetensors")
+    )
+    if not safetensors:
+        _atomic_write(dest, f"# no .safetensors files in {model_path}\n")
+        return
+    lines = [
+        f"{_sha256_file(os.path.join(model_path, name))}  {name}"
+        for name in safetensors
+    ]
+    _atomic_write(dest, "\n".join(lines) + "\n")
 
 
-def _save_vllm_provenance(cmd: list[str], provenance_dir: str, model: str) -> None:
-    """Write vllm_command.txt and vllm.patch to *provenance_dir*.
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
 
-    Best-effort — failures are printed but never fatal.
+def _save_vllm_provenance(
+    cmd: list[str], provenance_dir: str, model: str
+) -> None:
+    """Write vllm_command.txt, vllm.patch, and checkpoint_sha256.txt.
+
+    Best-effort — failures warn but never block the vLLM launch.
     """
     try:
         os.makedirs(provenance_dir, exist_ok=True)
     except OSError as exc:
-        print(
-            f"Warning: could not create provenance dir: {exc}",
-            file=sys.stderr,
-        )
+        _warn(f"could not create provenance dir: {exc}")
         return
 
     vllm_repo = _find_vllm_repo()
-    git_sha = "unknown"
-    diff: str | None = None
-    if vllm_repo:
-        git_sha, diff = _git_info(vllm_repo)
-
-    try:
-        vllm_ver = importlib.metadata.version("vllm")
-    except importlib.metadata.PackageNotFoundError:
-        vllm_ver = "unknown"
-
-    # --- vllm_command.txt ---
-    try:
-        sha_label = git_sha
-        if diff:
-            sha_label += " (dirty)"
-
-        ts = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
-        header = "\n".join(
-            [
-                f"# Timestamp: {ts}",
-                f"# Python: {sys.executable}",
-                f"# Git SHA: {sha_label}",
-                f"# vllm: {vllm_ver}",
-            ]
+    git_sha = _run_git(
+        ["git", "rev-parse", "HEAD"], vllm_repo or "."
+    ) or "unknown"
+    diff = (
+        _run_git(
+            ["git", "diff", "HEAD"],
+            vllm_repo or ".",
+            timeout=30,
         )
-        content = f"{header}\n{shlex.join(cmd)}\n"
-        _atomic_write(os.path.join(provenance_dir, "vllm_command.txt"), content)
-    except OSError as exc:
-        print(
-            f"Warning: could not save vllm_command.txt: {exc}",
-            file=sys.stderr,
-        )
+        if vllm_repo
+        else ""
+    )
+    vllm_ver = _pkg_version("vllm")
 
-    # --- vllm.patch ---
-    try:
-        if vllm_repo:
-            patch_content = f"# repo: {vllm_repo} ({git_sha})\n"
-            if diff:
-                patch_content += diff
-            _atomic_write(
-                os.path.join(provenance_dir, "vllm.patch"),
-                patch_content,
-            )
-        else:
-            _atomic_write(
-                os.path.join(provenance_dir, "vllm.patch"),
-                f"# vllm {vllm_ver} (wheel install, no git repo found)\n",
-            )
-    except OSError as exc:
-        print(
-            f"Warning: could not save vllm.patch: {exc}",
-            file=sys.stderr,
-        )
-
-    _save_checkpoint_sha256(provenance_dir, model)
+    writers = [
+        ("vllm_command.txt", lambda: _save_vllm_command(
+            provenance_dir, cmd, git_sha, diff, vllm_ver,
+        )),
+        ("vllm.patch", lambda: _save_vllm_patch(
+            provenance_dir, vllm_repo, git_sha, diff, vllm_ver,
+        )),
+        ("checkpoint_sha256.txt", lambda: _save_checkpoint_sha256(
+            provenance_dir, model,
+        )),
+    ]
+    for artifact, write in writers:
+        try:
+            write()
+        except Exception as exc:  # noqa: BLE001
+            _warn(f"could not save {artifact}: {exc}")
 
 
 def main():

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -163,7 +163,7 @@ def _find_vllm_repo() -> str | None:
     try:
         spec = importlib.util.find_spec("vllm")
         if spec and spec.origin:
-            d = os.path.dirname(spec.origin)
+            d = os.path.realpath(os.path.dirname(spec.origin))
             while d != os.path.dirname(d):
                 if _is_vllm_repo(d):
                     return d

--- a/src/speculators/train/utils.py
+++ b/src/speculators/train/utils.py
@@ -107,11 +107,22 @@ def save_train_command(save_path: str, argv: list[str] | None = None) -> None:
     it during resolution); it falls back to the live ``sys.argv`` when a caller has
     no recorded argv, so a direct call is unchanged.
     """
+    repo_root = None
+    try:
+        d = Path(__file__).resolve().parent
+        while d != d.parent:
+            if (d / ".git").is_dir():
+                repo_root = d
+                break
+            d = d.parent
+    except OSError:
+        pass
     try:
         sha = subprocess.run(
             ["git", "rev-parse", "HEAD"],  # noqa: S607
             capture_output=True,
             text=True,
+            cwd=repo_root,
             check=True,
         ).stdout.strip()
     except (OSError, subprocess.CalledProcessError):

--- a/tests/unit/scripts/test_eval_provenance.py
+++ b/tests/unit/scripts/test_eval_provenance.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts" / "evaluate"))
+
+
+from evaluate import (  # type: ignore[import-not-found]
+    _git_sha,
+    _speculators_repo_root,
+    save_eval_provenance,
+)
+
+
+class TestSpeculatorsRepoRoot:
+    def test_returns_string_when_found(self):
+        root = _speculators_repo_root()
+        if root is not None:
+            assert isinstance(root, str)
+            assert (Path(root) / ".git").is_dir()
+
+    def test_returns_none_when_import_fails(self):
+        with patch.dict(sys.modules, {"speculators": None}):
+            assert _speculators_repo_root() is None
+
+
+class TestGitSha:
+    def test_returns_hex_string(self):
+        sha = _git_sha()
+        is_valid_hex = len(sha) == 40 and all(c in "0123456789abcdef" for c in sha)
+        assert sha == "unknown" or is_valid_hex
+
+    def test_uses_speculators_repo_root(self):
+        with (
+            patch(
+                "evaluate._speculators_repo_root", return_value="/fake/repo"
+            ) as mock_root,
+            patch("evaluate.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value.stdout = "abc123\n"
+            mock_run.return_value.returncode = 0
+            _git_sha()
+            mock_root.assert_called_once()
+            _, kwargs = mock_run.call_args
+            assert kwargs["cwd"] == "/fake/repo"
+
+    def test_fallback_on_oserror(self):
+        with patch("evaluate.subprocess.run", side_effect=OSError("no git")):
+            assert _git_sha() == "unknown"
+
+
+class TestSaveEvalProvenance:
+    def test_creates_file(self, tmp_path: Path):
+        save_eval_provenance(tmp_path)
+        assert (tmp_path / "eval_command.txt").exists()
+
+    def test_contains_timestamp(self, tmp_path: Path):
+        save_eval_provenance(tmp_path)
+        content = (tmp_path / "eval_command.txt").read_text()
+        assert "# Timestamp:" in content
+
+    def test_contains_git_sha(self, tmp_path: Path):
+        save_eval_provenance(tmp_path)
+        content = (tmp_path / "eval_command.txt").read_text()
+        assert "# Git SHA:" in content
+
+    def test_contains_package_versions(self, tmp_path: Path):
+        save_eval_provenance(tmp_path)
+        content = (tmp_path / "eval_command.txt").read_text()
+        pkgs = ("speculators", "vllm", "transformers", "torch", "compressed-tensors")
+        for pkg in pkgs:
+            assert f"# {pkg}:" in content
+
+    def test_contains_sys_argv(self, tmp_path: Path):
+        argv = ["evaluate.py", "--target", "http://localhost:8000/v1"]
+        with patch.object(sys, "argv", argv):
+            save_eval_provenance(tmp_path)
+        content = (tmp_path / "eval_command.txt").read_text()
+        assert "evaluate.py --target" in content
+
+    def test_no_leftover_tmp_files(self, tmp_path: Path):
+        save_eval_provenance(tmp_path)
+        tmp_files = [
+            f for f in tmp_path.iterdir() if f.name.startswith(".eval_command")
+        ]
+        assert tmp_files == []
+
+    def test_best_effort_never_raises(self, tmp_path: Path):
+        with patch("evaluate._atomic_write", side_effect=RuntimeError("disk full")):
+            save_eval_provenance(tmp_path)
+
+    def test_overwrites_existing(self, tmp_path: Path):
+        (tmp_path / "eval_command.txt").write_text("old content")
+        save_eval_provenance(tmp_path)
+        content = (tmp_path / "eval_command.txt").read_text()
+        assert "old content" not in content
+        assert "# Timestamp:" in content

--- a/tests/unit/scripts/test_eval_provenance.py
+++ b/tests/unit/scripts/test_eval_provenance.py
@@ -19,7 +19,7 @@ class TestSpeculatorsRepoRoot:
         root = _speculators_repo_root()
         if root is not None:
             assert isinstance(root, str)
-            assert (Path(root) / ".git").is_dir()
+            assert (Path(root) / ".git").exists()
 
     def test_returns_none_when_import_fails(self):
         with patch.dict(sys.modules, {"speculators": None}):

--- a/tests/unit/scripts/test_eval_provenance.py
+++ b/tests/unit/scripts/test_eval_provenance.py
@@ -88,7 +88,7 @@ class TestSaveEvalProvenance:
         assert tmp_files == []
 
     def test_best_effort_never_raises(self, tmp_path: Path):
-        with patch("evaluate._atomic_write", side_effect=RuntimeError("disk full")):
+        with patch("evaluate._atomic_write", side_effect=OSError("disk full")):
             save_eval_provenance(tmp_path)
 
     def test_overwrites_existing(self, tmp_path: Path):

--- a/tests/unit/scripts/test_provenance_integration.py
+++ b/tests/unit/scripts/test_provenance_integration.py
@@ -1,0 +1,81 @@
+"""Integration test: run launch_vllm.py --dry-run and verify provenance artifacts."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[3] / "scripts"
+LAUNCH_VLLM = str(SCRIPTS_DIR / "launch_vllm.py")
+MODEL = "gpt2"
+
+
+@pytest.fixture
+def provenance_dir(tmp_path: Path) -> Path:
+    return tmp_path / "provenance"
+
+
+class TestLaunchVllmProvenance:
+    def _run(
+        self, provenance_dir: Path, *extra_args: str
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                LAUNCH_VLLM,
+                MODEL,
+                "--dry-run",
+                "--provenance-dir",
+                str(provenance_dir),
+                *extra_args,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+    def test_creates_all_provenance_files(self, provenance_dir: Path):
+        result = self._run(provenance_dir)
+        assert result.returncode == 0, result.stderr
+        assert (provenance_dir / "vllm_command.txt").exists()
+        assert (provenance_dir / "vllm.patch").exists()
+        assert (provenance_dir / "checkpoint_sha256.txt").exists()
+
+    def test_vllm_command_contains_metadata(self, provenance_dir: Path):
+        self._run(provenance_dir)
+        content = (provenance_dir / "vllm_command.txt").read_text()
+        assert "# Timestamp:" in content
+        assert "# Python:" in content
+        assert "# Git SHA:" in content
+        assert "# vllm:" in content
+        assert "vllm.entrypoints" in content
+
+    def test_checkpoint_sha256_remote_model(self, provenance_dir: Path):
+        self._run(provenance_dir)
+        content = (provenance_dir / "checkpoint_sha256.txt").read_text()
+        assert "not a local path" in content
+
+    def test_default_provenance_dir_created(self, tmp_path: Path):
+        result = subprocess.run(  # noqa: S603
+            [sys.executable, LAUNCH_VLLM, MODEL, "--dry-run"],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+            timeout=120,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        prov_dirs = [
+            d
+            for d in tmp_path.iterdir()
+            if d.is_dir() and d.name.startswith("vllm_gpt2_")
+        ]
+        assert len(prov_dirs) == 1
+        prov = prov_dirs[0]
+        assert (prov / "vllm_command.txt").exists()
+        assert (prov / "vllm.patch").exists()
+        assert (prov / "checkpoint_sha256.txt").exists()

--- a/tests/unit/scripts/test_vllm_provenance.py
+++ b/tests/unit/scripts/test_vllm_provenance.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+
+from launch_vllm import (  # type: ignore[import-not-found]
+    _find_vllm_repo,
+    _is_vllm_repo,
+    _save_checkpoint_sha256,
+    _save_vllm_command,
+    _save_vllm_patch,
+    _save_vllm_provenance,
+)
+
+
+class TestIsVllmRepo:
+    def test_returns_true_for_valid_repo(self, tmp_path: Path):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "vllm").mkdir()
+        (tmp_path / "vllm" / "__init__.py").touch()
+        assert _is_vllm_repo(str(tmp_path))
+
+    def test_returns_false_without_git(self, tmp_path: Path):
+        (tmp_path / "vllm").mkdir()
+        (tmp_path / "vllm" / "__init__.py").touch()
+        assert not _is_vllm_repo(str(tmp_path))
+
+    def test_returns_false_without_vllm_package(self, tmp_path: Path):
+        (tmp_path / ".git").mkdir()
+        assert not _is_vllm_repo(str(tmp_path))
+
+
+class TestFindVllmRepo:
+    def test_returns_string_or_none(self):
+        result = _find_vllm_repo()
+        assert result is None or isinstance(result, str)
+
+    def test_returns_none_when_vllm_not_importable(self):
+        with patch("launch_vllm.importlib.util.find_spec", return_value=None):
+            assert _find_vllm_repo() is None
+
+
+class TestSaveVllmCommand:
+    def test_creates_file(self, tmp_path: Path):
+        _save_vllm_command(
+            str(tmp_path),
+            ["python", "-m", "vllm", "serve", "model"],
+            "abc123",
+            "",
+            "0.1.0",
+        )
+        assert (tmp_path / "vllm_command.txt").exists()
+
+    def test_contains_metadata(self, tmp_path: Path):
+        _save_vllm_command(
+            str(tmp_path),
+            ["python", "-m", "vllm", "serve", "model"],
+            "abc123",
+            "",
+            "0.1.0",
+        )
+        content = (tmp_path / "vllm_command.txt").read_text()
+        assert "# Timestamp:" in content
+        assert "# Python:" in content
+        assert "# Git SHA: abc123" in content
+        assert "# vllm: 0.1.0" in content
+        assert "python -m vllm serve model" in content
+
+    def test_dirty_marker_when_diff_present(self, tmp_path: Path):
+        _save_vllm_command(str(tmp_path), ["cmd"], "abc123", "some diff", "0.1.0")
+        content = (tmp_path / "vllm_command.txt").read_text()
+        assert "abc123 (dirty)" in content
+
+    def test_no_dirty_marker_when_clean(self, tmp_path: Path):
+        _save_vllm_command(str(tmp_path), ["cmd"], "abc123", "", "0.1.0")
+        content = (tmp_path / "vllm_command.txt").read_text()
+        assert "(dirty)" not in content
+
+
+class TestSaveVllmPatch:
+    def test_records_repo_and_diff(self, tmp_path: Path):
+        _save_vllm_patch(
+            str(tmp_path), "/path/to/vllm", "abc123", "diff content", "0.1.0"
+        )
+        content = (tmp_path / "vllm.patch").read_text()
+        assert "# repo: /path/to/vllm (abc123)" in content
+        assert "diff content" in content
+
+    def test_header_only_for_clean_checkout(self, tmp_path: Path):
+        _save_vllm_patch(str(tmp_path), "/path/to/vllm", "abc123", "", "0.1.0")
+        content = (tmp_path / "vllm.patch").read_text()
+        assert "# repo: /path/to/vllm (abc123)" in content
+
+    def test_wheel_install_fallback(self, tmp_path: Path):
+        _save_vllm_patch(str(tmp_path), None, "unknown", "", "0.5.0")
+        content = (tmp_path / "vllm.patch").read_text()
+        assert "wheel install" in content
+        assert "0.5.0" in content
+
+
+class TestSaveCheckpointSha256:
+    def test_remote_model(self, tmp_path: Path):
+        _save_checkpoint_sha256(str(tmp_path), "org/model-name")
+        content = (tmp_path / "checkpoint_sha256.txt").read_text()
+        assert "not a local path" in content
+
+    def test_local_model_with_safetensors(self, tmp_path: Path):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "model.safetensors").write_bytes(b"fake weights")
+        _save_checkpoint_sha256(str(tmp_path), str(model_dir))
+        content = (tmp_path / "checkpoint_sha256.txt").read_text()
+        assert "model.safetensors" in content
+        assert len(content.split("  ")[0]) == 64  # SHA256 hex length
+
+    def test_no_safetensors(self, tmp_path: Path):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text("{}")
+        _save_checkpoint_sha256(str(tmp_path), str(model_dir))
+        content = (tmp_path / "checkpoint_sha256.txt").read_text()
+        assert "no .safetensors files" in content
+
+    def test_skip_hash_records_size_and_mtime(self, tmp_path: Path):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "model.safetensors").write_bytes(b"fake weights")
+        _save_checkpoint_sha256(str(tmp_path), str(model_dir), skip_hash=True)
+        content = (tmp_path / "checkpoint_sha256.txt").read_text()
+        assert "# hashing skipped (--no-hash-checkpoints)" in content
+        assert "size=" in content
+        assert "mtime=" in content
+        assert "model.safetensors" in content
+
+    def test_skip_hash_does_not_contain_sha256(self, tmp_path: Path):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "model.safetensors").write_bytes(b"fake weights")
+        _save_checkpoint_sha256(str(tmp_path), str(model_dir), skip_hash=True)
+        content = (tmp_path / "checkpoint_sha256.txt").read_text()
+        data_lines = [line for line in content.splitlines() if not line.startswith("#")]
+        for line in data_lines:
+            assert line.startswith("size=")
+
+    def test_multiple_safetensors_sorted(self, tmp_path: Path):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        for name in ("c.safetensors", "a.safetensors", "b.safetensors"):
+            (model_dir / name).write_bytes(b"data")
+        _save_checkpoint_sha256(str(tmp_path), str(model_dir))
+        content = (tmp_path / "checkpoint_sha256.txt").read_text()
+        names = [line.split("  ")[1] for line in content.strip().splitlines()]
+        assert names == ["a.safetensors", "b.safetensors", "c.safetensors"]
+
+
+class TestSaveVllmProvenance:
+    def test_creates_all_artifacts(self, tmp_path: Path):
+        prov_dir = tmp_path / "provenance"
+        _save_vllm_provenance(["python", "serve"], str(prov_dir), "org/model")
+        assert (prov_dir / "vllm_command.txt").exists()
+        assert (prov_dir / "vllm.patch").exists()
+        assert (prov_dir / "checkpoint_sha256.txt").exists()
+
+    def test_creates_provenance_dir(self, tmp_path: Path):
+        prov_dir = tmp_path / "nested" / "provenance"
+        _save_vllm_provenance(["cmd"], str(prov_dir), "org/model")
+        assert prov_dir.is_dir()
+
+    def test_bad_dir_warns_and_returns(self, tmp_path: Path, capsys):
+        _save_vllm_provenance(["cmd"], "/dev/null/impossible", "org/model")
+        captured = capsys.readouterr()
+        assert "Warning:" in captured.err
+
+    def test_skip_hash_propagated(self, tmp_path: Path):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "weights.safetensors").write_bytes(b"data")
+        prov_dir = tmp_path / "prov"
+        _save_vllm_provenance(["cmd"], str(prov_dir), str(model_dir), skip_hash=True)
+        content = (prov_dir / "checkpoint_sha256.txt").read_text()
+        assert "hashing skipped" in content
+
+    def test_individual_writer_failure_does_not_block_others(self, tmp_path: Path):
+        prov_dir = tmp_path / "prov"
+        with patch("launch_vllm._save_vllm_command", side_effect=RuntimeError("boom")):
+            _save_vllm_provenance(["cmd"], str(prov_dir), "org/model")
+        assert not (prov_dir / "vllm_command.txt").exists()
+        assert (prov_dir / "vllm.patch").exists()
+        assert (prov_dir / "checkpoint_sha256.txt").exists()


### PR DESCRIPTION
## Summary
- **`evaluate.py`**: writes `eval_command.txt` (timestamp, git SHA, package versions, full command) into the eval output directory at the start of each run.
- **`launch_vllm.py`**: always writes three provenance artifacts to `vllm_<model>_<timestamp>/` (overridable with `--provenance-dir`):
  - `vllm_command.txt` — full launch command + metadata (timestamp, python path, git SHA w/ dirty marker, vllm version)
  - `vllm.patch` — git diff of the vllm checkout (header-only for clean checkouts, version note for wheel installs)
  - `checkpoint_sha256.txt` — SHA256 of all `.safetensors` files for local checkpoints, or model name for HF hub models

Closes #880

## Test plan
- [ ] `make quality` passes
- [ ] Run `launch_vllm.py <model>` and verify `vllm_<model>_<ts>/` is created with `vllm_command.txt`, `vllm.patch`, and `checkpoint_sha256.txt`
- [ ] Run `launch_vllm.py <model> --provenance-dir /tmp/custom` and verify artifacts land in `/tmp/custom/`
- [ ] Run eval and verify `eval_command.txt` appears in output dir
- [ ] Test with wheel-installed vllm (no git repo) — `vllm.patch` should contain version note
- [ ] Test with HF hub model — `checkpoint_sha256.txt` should contain model name

🤖 Generated with [Claude Code](https://claude.com/claude-code)