### PR TITLE
[DO NOT MERGE YET] fix(train): use spawn for DataLoader workers to avoid CUDA fork crash

### DIFF
--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -3,7 +3,7 @@ import math
 import os
 import random
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from os import PathLike
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -458,14 +458,28 @@ class SampleFileDataset(BaseDataset):
         )
 
 
-def create_collate_fn(
-    max_len: int,
-    hidden_size: int,
-    num_target_layers: int = 3,
-    dtype: torch.dtype = torch.bfloat16,
-    preprocess: Callable[[BatchType], BatchType] | None = None,
-):
-    def collate_fn(batch: list[BatchType | None]) -> BatchType:
+class CollateFn:
+    """Picklable collate function for use with ``multiprocessing_context='spawn'``."""
+
+    def __init__(
+        self,
+        max_len: int,
+        hidden_size: int,
+        num_target_layers: int = 3,
+        dtype: torch.dtype = torch.bfloat16,
+        preprocess: Callable[[BatchType], BatchType] | None = None,
+    ):
+        self.max_len = max_len
+        self.hidden_size = hidden_size
+        self.num_target_layers = num_target_layers
+        self.dtype = dtype
+        self.preprocess = preprocess
+
+    def __call__(self, batch: Sequence[BatchType | None]) -> BatchType:
+        max_len = self.max_len
+        dtype = self.dtype
+        preprocess = self.preprocess
+
         # Apply per-sample preprocessing and filter failed samples
         batch = [preprocess(b) if preprocess else b for b in batch if b is not None]
 
@@ -475,7 +489,9 @@ def create_collate_fn(
             # Match the configured `dtype` so the placeholder doesn't crash
             # downstream layers loaded at a different precision (e.g. bf16
             # weights vs fp32 default placeholders).
-            empty = create_empty_sample(hidden_size, num_target_layers, dtype=dtype)
+            empty = create_empty_sample(
+                self.hidden_size, self.num_target_layers, dtype=dtype
+            )
             if preprocess:
                 empty = preprocess(empty)
             batch = [empty]
@@ -530,5 +546,3 @@ def create_collate_fn(
         collated_data["document_ids"] = document_ids
 
         return collated_data
-
-    return collate_fn

--- a/src/speculators/train/dataloader.py
+++ b/src/speculators/train/dataloader.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any, Literal
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+import os
+
 import torch
 from torch.utils.data import DataLoader
 
@@ -14,8 +16,8 @@ from hs_connectors import HiddenStatesTransfer
 from speculators.train.data import (
     ArrowDataset,
     BaseDataset,
+    CollateFn,
     SampleFileDataset,
-    create_collate_fn,
     split_files,
 )
 from speculators.train.distributed import get_dp_rank, get_dp_size
@@ -27,6 +29,27 @@ from speculators.train.noise_transforms import AddUniformNoise
 logger = logging.getLogger(__name__)
 
 BatchType = dict[str, Any]
+
+
+def _limit_worker_threads() -> None:
+    """Limit per-worker thread pools to avoid thread exhaustion.
+
+    With ``multiprocessing_context='spawn'``, each worker is a full process
+    that re-imports numpy (OpenBLAS) and torch, each creating thread pools
+    sized to the core count.  DataLoader workers only do I/O and tensor
+    slicing -- they don't benefit from intra-op parallelism.
+
+    The env vars must be set before numpy/torch are imported to take effect
+    on OpenBLAS/OMP.  Call this at the top of the training entry point,
+    before DataLoader construction.
+    """
+    os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+    os.environ.setdefault("OMP_NUM_THREADS", "1")
+    os.environ.setdefault("MKL_NUM_THREADS", "1")
+
+
+def _worker_init_fn(worker_id: int) -> None:  # noqa: ARG001
+    torch.set_num_threads(1)
 
 
 def _setup_dataloader(
@@ -51,7 +74,7 @@ def _setup_dataloader(
         num_workers=num_workers,
         prefetch_factor=prefetch_factor if use_workers else None,
         pin_memory=True,
-        collate_fn=create_collate_fn(
+        collate_fn=CollateFn(
             total_seq_len,
             hidden_size,
             num_target_layers=num_target_layers,
@@ -59,6 +82,8 @@ def _setup_dataloader(
             preprocess=preprocess,
         ),
         persistent_workers=use_workers,
+        multiprocessing_context="spawn" if use_workers else None,
+        worker_init_fn=_worker_init_fn if use_workers else None,
     )
 
 
@@ -90,6 +115,7 @@ def create_train_val_loaders(
     batches via scatter).  Reads DP/SP topology from
     :mod:`speculators.train.distributed`.
     """
+    _limit_worker_threads()
     noise_transform = AddUniformNoise(std=noise_std)
 
     if not (0.0 < train_data_ratio < 1.0):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,7 +18,7 @@ from speculators.models.mtp.core import MTPDraftModel
 from speculators.models.peagle.config import PEagleSpeculatorConfig
 from speculators.models.peagle.core import PEagleDraftModel
 from speculators.proposals.greedy import GreedyTokenProposalConfig
-from speculators.train.data import create_collate_fn
+from speculators.train.data import CollateFn
 
 # ---------------------------------------------------------------------------
 # Tiny verifier configs
@@ -315,7 +315,7 @@ def make_batch(
 ) -> dict[str, torch.Tensor]:
     """Collate a list of samples into a single batch using the real collate_fn.
 
-    Uses ``create_collate_fn`` from ``speculators.train.data`` to pack and pad
+    Uses ``CollateFn`` from ``speculators.train.data`` to pack and pad
     samples exactly the way the training pipeline does.
 
     Args:
@@ -330,7 +330,7 @@ def make_batch(
     Returns:
         Dict with keys matching model forward() signatures, all on ``device``.
     """
-    collate_fn = create_collate_fn(
+    collate_fn = CollateFn(
         max_len=max_len,
         hidden_size=hidden_size,
         num_target_layers=num_target_layers,

--- a/tests/unit/train/test_data.py
+++ b/tests/unit/train/test_data.py
@@ -10,8 +10,8 @@ from safetensors.torch import save_file
 from speculators.models.eagle3.data import shift_batch
 from speculators.train.data import (
     ArrowDataset,
+    CollateFn,
     SampleFileDataset,
-    create_collate_fn,
     standardize_data_v1,
 )
 
@@ -133,7 +133,7 @@ def test_collate_fn_basic():
     max_len = 10
     hidden_size = 1
     num_target_layers = 3
-    collate_fn = create_collate_fn(
+    collate_fn = CollateFn(
         max_len, hidden_size, num_target_layers=num_target_layers, dtype=torch.float32
     )
 
@@ -210,7 +210,7 @@ def test_collate_fn_basic():
 
 def test_collate_fn_casts_hidden_states_dtype():
     """Test that hidden-states keys are cast to the target dtype during collation."""
-    collate_fn = create_collate_fn(4, 1, dtype=torch.bfloat16)
+    collate_fn = CollateFn(4, 1, dtype=torch.bfloat16)
     batch = [
         {
             "input_ids": torch.tensor([0], dtype=torch.long),
@@ -234,7 +234,7 @@ def test_collate_fn_length_truncation():
     max_len = 11
     hidden_size = 8
     num_target_layers = 3
-    collate_fn = create_collate_fn(
+    collate_fn = CollateFn(
         max_len, hidden_size, num_target_layers=num_target_layers, dtype=torch.float32
     )
 


### PR DESCRIPTION
## Purpose

Fix CUDA fork-safety crash in DataLoader workers that surfaces on **PyTorch 2.13+**.

Resolves https://github.com/vllm-project/speculators/issues/887

### Background

Starting with PyTorch 2.13, `torch.multiprocessing` defaults to stricter CUDA fork-safety checks. Because the training loop initialises CUDA in the main process before DataLoader workers are created, the default `fork` start method causes workers to inherit a partially-initialised CUDA context. This manifests as:

```
RuntimeError: DataLoader worker (pid(s) …) exited unexpectedly
  …
  CUDA error: initialization error
  Exception raised from ExchangeDevice at …/c10/cuda/CUDAFunctions.cpp:274
```

Training completes and checkpoints are written correctly, but the worker crash causes the process to exit non-zero — failing CI tests and masking an otherwise successful run.

### Fix

Switch DataLoader workers from the default `fork` start method to `spawn`, which gives each worker a clean process without inherited CUDA state. This requires two supporting changes:

1. **Make the collate function picklable** — Replace the `create_collate_fn` closure with a `CollateFn` class. Closures cannot be pickled, and `spawn` workers need to pickle everything passed across the process boundary.

2. **Limit per-worker thread pools** — With `spawn`, each worker re-imports NumPy/PyTorch and creates full-sized thread pools (one per CPU core). DataLoader workers only do I/O and tensor slicing, so we cap `OPENBLAS_NUM_THREADS`, `OMP_NUM_THREADS`, `MKL_NUM_THREADS` to `1` before DataLoader construction, and set `torch.set_num_threads(1)` via `worker_init_fn`.

### Attribution

This fix is extracted from @fynnsu's Mooncake backend PR (https://github.com/vllm-project/speculators/pull/836), isolated here for independent review and faster merge.

## Tests

### Existing test suite

All existing unit tests that use the collate function have been updated to use `CollateFn` in place of `create_collate_fn`:

```
pytest tests/unit/train/test_data.py -v
```

### Integration / regression

Verified against the two failing test scenarios from #887:
- `test_eagle3_online_acceptance.py::test_online_regression[Qwen/Qwen3-8B-sharegpt-acceptance_thresholds0]`
- `smoke/test_online_training.py::test_online_smoke[Qwen/Qwen3-0.6B-sharegpt]`

Tested with both vllm stable `0.26.0` and nightly builds commit `5c7a7f9462`.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have reviewed the code in this PR to the best of my ability.
