### PR TITLE
add support for gemma3

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -169,6 +169,7 @@ def create_transformer_layer_config(  # noqa: C901
         "full_attention" if i in full_attention_indices else "sliding_attention"
         for i in range(num_layers)
     ]
+    has_sliding = "sliding_attention" in layer_types
 
     config = config_class(
         vocab_size=verifier_config.vocab_size,
@@ -183,8 +184,8 @@ def create_transformer_layer_config(  # noqa: C901
         rms_norm_eps=verifier_config.rms_norm_eps,
         head_dim=head_dim,
         tie_word_embeddings=False,
-        sliding_window=sliding_window,
-        use_sliding_window="sliding_attention" in layer_types,
+        sliding_window=sliding_window if has_sliding else None,
+        use_sliding_window=has_sliding,
         layer_types=layer_types,
     )
 
@@ -194,12 +195,16 @@ def create_transformer_layer_config(  # noqa: C901
             rope_params = deepcopy(verifier_config.rope_parameters)
             # Some verifiers (e.g. Laguna) use the nested per-layer-type rope format
             # {"full_attention": {...}, "sliding_attention": {...}} with no top-level
-            # "rope_theta". The llama-style draft uses a single rope, so collapse it to
-            # a flat default rope (preferring the sliding-attention theta).
+            # "rope_theta". The draft uses a single rope, so collapse it to the rope
+            # matching its attention mode.
             if isinstance(rope_params, dict) and "rope_theta" not in rope_params:
                 sub = (
-                    rope_params.get("sliding_attention")
-                    or rope_params.get("full_attention")
+                    rope_params.get(
+                        "sliding_attention" if has_sliding else "full_attention"
+                    )
+                    or rope_params.get(
+                        "full_attention" if has_sliding else "sliding_attention"
+                    )
                     or {}
                 )
                 if isinstance(sub, dict):

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -5,6 +5,7 @@ import torch
 from torch import nn
 from torch.nn.attention.flex_attention import create_block_mask, create_mask
 from transformers import PretrainedConfig
+from transformers.models.gemma3.modeling_gemma3 import Gemma3RMSNorm
 from transformers.models.qwen3.modeling_qwen3 import (
     Qwen3RMSNorm,
     Qwen3RotaryEmbedding,
@@ -106,7 +107,20 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             config.transformer_layer_config.hidden_size,
             eps=config.transformer_layer_config.rms_norm_eps,  # type: ignore[arg-type]
         )
-        self.verifier_norm = Qwen3RMSNorm(
+        verifier_architectures = (
+            config.speculators_config.verifier.architectures
+            if config.speculators_config is not None
+            else []
+        )
+        verifier_norm_cls = (
+            Gemma3RMSNorm
+            if any(
+                architecture.startswith("Gemma3")
+                for architecture in verifier_architectures
+            )
+            else Qwen3RMSNorm
+        )
+        self.verifier_norm = verifier_norm_cls(
             config.transformer_layer_config.hidden_size,
             eps=config.transformer_layer_config.rms_norm_eps,  # type: ignore[arg-type]
         )

--- a/tests/unit/models/test_dflash_targets.py
+++ b/tests/unit/models/test_dflash_targets.py
@@ -1,12 +1,18 @@
 import pytest
 import torch
-from transformers.models.qwen3.modeling_qwen3 import Qwen3Config
+from transformers.models.gemma3.modeling_gemma3 import Gemma3RMSNorm
+from transformers.models.qwen3.modeling_qwen3 import Qwen3Config, Qwen3RMSNorm
 
+from speculators.config import SpeculatorsConfig, VerifierConfig
 from speculators.models.dflash import DFlashSpeculatorConfig
 from speculators.models.dflash.core import DFlashDraftModel
+from speculators.proposals.greedy import GreedyTokenProposalConfig
 
 
-def _tiny_model(sample_from_anchor: bool) -> DFlashDraftModel:
+def _tiny_model(
+    sample_from_anchor: bool,
+    verifier_architectures: list[str] | None = None,
+) -> DFlashDraftModel:
     tl_config = Qwen3Config(
         hidden_size=16,
         intermediate_size=32,
@@ -17,6 +23,17 @@ def _tiny_model(sample_from_anchor: bool) -> DFlashDraftModel:
         vocab_size=64,
         _attn_implementation="eager",  # type: ignore[call-arg]
     )
+    verifier_kwargs = {}
+    if verifier_architectures is not None:
+        verifier_kwargs["speculators_config"] = SpeculatorsConfig(
+            algorithm="dflash",
+            proposal_methods=[GreedyTokenProposalConfig(speculative_tokens=3)],
+            default_proposal_method="greedy",
+            verifier=VerifierConfig(
+                name_or_path="dummy",
+                architectures=verifier_architectures,
+            ),
+        )
     config = DFlashSpeculatorConfig(
         transformer_layer_config=tl_config,
         draft_vocab_size=64,
@@ -24,11 +41,27 @@ def _tiny_model(sample_from_anchor: bool) -> DFlashDraftModel:
         aux_hidden_state_layer_ids=[0, 1],
         mask_token_id=0,
         sample_from_anchor=sample_from_anchor,
+        **verifier_kwargs,
     )
     model = DFlashDraftModel(config)
     torch.nn.init.normal_(model.verifier_lm_head.weight)
     torch.nn.init.ones_(model.verifier_norm.weight)
     return model.eval()
+
+
+@pytest.mark.parametrize(
+    ("verifier_architectures", "expected_norm_cls"),
+    [
+        (["Gemma3ForCausalLM"], Gemma3RMSNorm),
+        (["Qwen2ForCausalLM"], Qwen3RMSNorm),
+    ],
+)
+def test_verifier_norm_matches_verifier_architecture(
+    verifier_architectures,
+    expected_norm_cls,
+):
+    model = _tiny_model(False, verifier_architectures)
+    assert isinstance(model.verifier_norm, expected_norm_cls)
 
 
 @pytest.mark.parametrize("max_anchors", [5, 16])

--- a/tests/unit/train/test_rope_config.py
+++ b/tests/unit/train/test_rope_config.py
@@ -188,6 +188,33 @@ def test_non_mrope_model_has_no_mrope_section(patch_verifier):
     assert config.rope_parameters["rope_type"] == "llama3"
 
 
+def test_full_attention_uses_full_attention_rope(patch_verifier):
+    vc = _make_verifier_config(
+        rope_parameters={
+            "full_attention": {
+                "rope_type": "default",
+                "rope_theta": 1_000_000.0,
+            },
+            "sliding_attention": {
+                "rope_type": "default",
+                "rope_theta": 10_000.0,
+            },
+        }
+    )
+    patch_verifier(vc, "5.0.0")
+
+    config = _build(
+        draft_arch="qwen3",
+        full_attention_indices=[0],
+        sliding_window=1532,
+    )
+
+    assert config.layer_types == ["full_attention"]
+    assert config.sliding_window is None
+    assert config.use_sliding_window is False
+    assert config.rope_parameters["rope_theta"] == 1_000_000.0
+
+
 # ---------------------------------------------------------------------------
 # transformers < 5.0 (rope_scaling) path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Gemma3 has two things which are not supported:

1. Hybrid attention where some layers have sliding attention and some layers have full attention. If we are using sliding attention in the drafter, we probably want to pull the RoPE theta from the sliding attention layer.
2. Gemma3RMSNorm weights are +1 over Qwen3RMSNorm. I don't love how I did this, but given we explicitly load specify, I think this is the best way. Another way is loading the original model and then just keeping the norm from the model.

## Tests

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
