### PR TITLE
fix(train): derive head_dim for verifiers that omit it from config

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -121,6 +121,11 @@ def create_transformer_layer_config(  # noqa: C901
         if num_attention_heads % num_key_value_heads != 0:
             num_key_value_heads = num_attention_heads
 
+    if head_dim is None:
+        # Verifiers like Qwen2 omit head_dim from their config; derive the
+        # implicit value so draft configs that require an int don't reject None.
+        head_dim = verifier_config.hidden_size // num_attention_heads
+
     if full_attention_indices and (
         min(full_attention_indices) < 0 or max(full_attention_indices) >= num_layers
     ):


### PR DESCRIPTION
Qwen2-style verifier configs (e.g. yuekai/cosyvoice2_llm) have no head_dim field, so create_transformer_layer_config passed head_dim=None into the draft transformer config. dflash/qwen3 draft configs validate head_dim as int and crash with "Field 'head_dim' expected int, got NoneType". Fall back to hidden_size // num_attention_heads.