### PR TITLE
fix(dflash): use conditional_torch_compile to avoid BiSheng IR error on Ascend NPU devices

### DIFF
--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 # Compile so the mask builds block-sparse instead of materializing DFlash's huge
 # dense [Q, KV] grid every step. (No benefit for EAGLE3's small autoregressive mask.)
-_compiled_create_block_mask = torch.compile(create_block_mask)
+_compiled_create_block_mask = conditional_torch_compile(create_block_mask)
 
 
 @SpeculatorModel.register("dflash")


### PR DESCRIPTION
src/speculators/models/dflash/core.py  
line 30:  _compiled_create_block_mask = torch.compile(create_block_mask)
NVIDIA GPU → Inductor/Triton Backend; Ascend NPU → BiSheng Compiler Backend
The BiSheng Compiler cannot process the complex computation graph generated by create_block_mask (from torch.nn.attention.flex_attention), throwing an error: fail to run BiShengIR Pipeline


## Purpose
use conditional_torch_compile(reuse existing interfaces) to avoid BiSheng IR error on Ascend NPU. 

## Tests
work
## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
