### PR TITLE
Fix eager-path draft-token mask extension inverting additive mask semantics

### DIFF
--- a/src/speculators/models/eagle3/attention.py
+++ b/src/speculators/models/eagle3/attention.py
@@ -117,10 +117,16 @@ def extend_dense_mask_for_draft_tokens(mask: torch.Tensor, total_seq_len: int):
 
     Dense-mask equivalent of extend_mask_for_draft_tokens (which operates on
     BlockMask). Appends total_seq_len new KV columns where only position
-    (q, new_offset + q) is True — the same diagonal pattern.
+    (q, new_offset + q) is attended (the same diagonal pattern).
+
+    The appended block follows the input mask's semantics: 0 / -inf for an
+    additive float mask (the eager / SDPA path built by create_float_mask,
+    where 0 means attend and -inf blocked), and True/False (or 1/0) for a
+    boolean or integral mask.
 
     Args:
-        mask: Dense boolean mask of shape [1, 1, total_seq_len, kv_len].
+        mask: Dense boolean or additive float mask of shape
+            [1, 1, total_seq_len, kv_len].
         total_seq_len: Number of query positions (= original sequence length).
 
     Returns:
@@ -128,8 +134,13 @@ def extend_dense_mask_for_draft_tokens(mask: torch.Tensor, total_seq_len: int):
     """
     idx = torch.arange(total_seq_len, device=mask.device)
     diag = idx.unsqueeze(1) == idx.unsqueeze(0)
-    diag = diag.to(dtype=mask.dtype).unsqueeze(0).unsqueeze(0)
-    return torch.cat([mask, diag], dim=-1)
+    if mask.dtype.is_floating_point:
+        new_cols = torch.zeros(diag.shape, dtype=mask.dtype, device=mask.device)
+        new_cols.masked_fill_(~diag, float("-inf"))
+    else:
+        new_cols = diag.to(dtype=mask.dtype)
+    new_cols = new_cols.unsqueeze(0).unsqueeze(0)
+    return torch.cat([mask, new_cols], dim=-1)
 
 
 def block_mask_to_dense_attention_mask(

--- a/tests/unit/models/test_eagle3_attention.py
+++ b/tests/unit/models/test_eagle3_attention.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from torch.nn.attention.flex_attention import BlockMask, create_mask
 
+from speculators.models.attention import create_float_mask
 from speculators.models.eagle3.attention import (
     create_combined_mask_mod,
     extend_dense_mask_for_draft_tokens,
@@ -150,3 +151,47 @@ def test_extend_dense_mask_matches_block_mask():
         assert torch.equal(new_block.bool(), expected_diag), (
             f"New block at step {step} is not diagonal"
         )
+
+
+def test_extend_dense_float_mask_keeps_additive_semantics():
+    """The eager/SDPA path extends the additive float mask from
+    create_float_mask (0 = attend, -inf = blocked): appended draft-KV columns
+    must be 0 on the diagonal and -inf everywhere else, not a 1/0 block that
+    lets every query attend all previous-step draft tokens."""
+    total_seq_len = 8
+    document_ids = torch.zeros(total_seq_len, dtype=torch.long)
+    document_ids[total_seq_len // 2 :] = 1  # two packed documents
+    mask_mod = create_combined_mask_mod(document_ids, total_seq_len)
+
+    float_mask = create_float_mask(
+        mask_mod,
+        B=None,
+        H=None,
+        Q_LEN=total_seq_len,
+        KV_LEN=total_seq_len,
+        device="cpu",
+        dtype=torch.float32,
+    )
+    original = float_mask.clone()
+
+    for step in range(3):
+        float_mask = extend_dense_mask_for_draft_tokens(float_mask, total_seq_len)
+        assert float_mask.shape == (1, 1, total_seq_len, total_seq_len * (step + 2))
+        assert torch.equal(float_mask[..., :total_seq_len], original)
+
+        new_block = float_mask[0, 0, :, -total_seq_len:]
+        diag = torch.eye(total_seq_len, dtype=torch.bool)
+        assert torch.all(new_block[diag] == 0.0), "diagonal must stay attended (0)"
+        assert torch.all(torch.isneginf(new_block[~diag])), (
+            "off-diagonal draft-KV columns must be blocked (-inf)"
+        )
+
+
+def test_extend_dense_integral_mask_keeps_one_zero_diagonal():
+    """Integral (non-bool, non-float) masks keep the 1/0 diagonal block."""
+    total_seq_len = 4
+    mask = torch.ones(1, 1, total_seq_len, total_seq_len, dtype=torch.long)
+    extended = extend_dense_mask_for_draft_tokens(mask, total_seq_len)
+    new_block = extended[0, 0, :, -total_seq_len:]
+    assert new_block.dtype == torch.long
+    assert torch.equal(new_block, torch.eye(total_seq_len, dtype=torch.long))


### PR DESCRIPTION
## Problem

`extend_dense_mask_for_draft_tokens` appends a 1/0 diagonal block regardless of the input mask's semantics. The eager/SDPA path feeds it the additive float mask from `create_float_mask` (0 = attend, -inf = blocked), so on every TTT step >= 1 the appended draft-KV columns are 0.0 off-diagonal (fully attended) and +1.0 on the diagonal (a spurious score bias). Every query then attends all previous-step draft tokens across document boundaries and future positions, so training or validation with `draft_attn_impl="eager"` silently diverges from the flex-attention backend and learns from leaked context.

## Fix

The appended block now follows the input mask's semantics: 0 on the diagonal and -inf elsewhere for floating-point masks, and the previous True/False (or 1/0) diagonal for boolean and integral masks.

## Tests

`test_extend_dense_float_mask_keeps_additive_semantics` extends a two-document additive float mask over three steps and asserts the new columns are 0 on the diagonal and -inf off it (fails on main), plus `test_extend_dense_integral_mask_keeps_one_zero_diagonal` pins the integral-mask behavior. Existing boolean-mask tests are unchanged and pass.
