### PR TITLE
Save and load optimizer state at full precision in checkpoints

### DIFF
--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -312,9 +312,9 @@ class SingleGPUCheckpointer(BaseCheckpointer):
 
     def load_optimizer_state_dict(
         self,
-        model: PreTrainedModel,
+        model: PreTrainedModel,  # noqa: ARG002 (BaseCheckpointer signature)
         optimizer: OptimizerOrList,
-        float_dtype: torch.dtype | None = None,
+        float_dtype: torch.dtype | None = None,  # noqa: ARG002 (unused: no cast)
     ):
         device = get_current_device()
         loaded = torch.load(
@@ -324,12 +324,12 @@ class SingleGPUCheckpointer(BaseCheckpointer):
         )
         optimizers = _as_list(optimizer)
         loaded_list = loaded if isinstance(loaded, list) else [loaded]
-        raw_model = (
-            model.module if isinstance(model, DistributedDataParallel) else model
-        )
-        dtype = float_dtype or raw_model.dtype
+        # Load without a dtype cast: Optimizer.load_state_dict aligns per-param
+        # float state with the param dtype itself and keeps "step" untouched.
+        # Casting here would re-quantize fp32 moments and step counters to the
+        # model dtype (e.g. bf16), undoing the full-precision save.
         for opt, state_dict in zip(optimizers, loaded_list, strict=True):
-            opt.load_state_dict(convert_float_dtype(state_dict, dtype))
+            opt.load_state_dict(state_dict)
 
     @_rank0_only
     def save_checkpoint(
@@ -347,9 +347,11 @@ class SingleGPUCheckpointer(BaseCheckpointer):
         patch_config_dtype(self.path / str(epoch) / "config.json", float_dtype)
 
         optimizers = _as_list(optimizer)
-        state_dicts = [
-            convert_float_dtype(opt.state_dict(), float_dtype) for opt in optimizers
-        ]
+        # Optimizer state is saved at full precision on purpose: casting to
+        # bf16 quantizes the Adam moments and rounds the step counters (bf16
+        # has an 8-bit mantissa, so any step count above 256 is no longer
+        # exact), which corrupts resumed runs.
+        state_dicts = [opt.state_dict() for opt in optimizers]
         # Preserve the legacy single-optimizer format when there is only one.
         payload = state_dicts[0] if len(state_dicts) == 1 else state_dicts
         torch.save(payload, self.optimizer_path(epoch))
@@ -381,7 +383,7 @@ class DistributedCheckpointer(BaseCheckpointer):
         self,
         model,
         optimizer: OptimizerOrList,
-        float_dtype: torch.dtype | None = None,
+        float_dtype: torch.dtype | None = None,  # noqa: ARG002 (unused: no cast)
     ):
         optimizers = _as_list(optimizer)
         full_state_dict = torch.load(
@@ -390,10 +392,9 @@ class DistributedCheckpointer(BaseCheckpointer):
             weights_only=True,
             map_location="cpu",
         )
-        full_state_dict = convert_float_dtype(
-            full_state_dict, float_dtype or model.dtype
-        )
-
+        # No dtype cast here: casting would re-quantize the fp32-saved Adam
+        # moments and step counters to the model dtype (e.g. bf16), undoing
+        # the full-precision save.
         set_optimizer_state_dict(
             model,
             optimizers,
@@ -401,7 +402,8 @@ class DistributedCheckpointer(BaseCheckpointer):
             options=StateDictOptions(full_state_dict=True, broadcast_from_rank0=True),
         )
 
-        # Cast step counters back to float32
+        # Cast step counters back to float32 (repairs legacy checkpoints that
+        # were saved with bf16-converted optimizer state).
         for opt in optimizers:
             for state in opt.state.values():
                 if "step" in state and isinstance(state["step"], torch.Tensor):
@@ -426,7 +428,8 @@ class DistributedCheckpointer(BaseCheckpointer):
             _as_list(optimizer),
             options=StateDictOptions(full_state_dict=True, cpu_offload=True),
         )
-        optimizer_state_dict = convert_float_dtype(optimizer_state_dict, float_dtype)
+        # Optimizer state stays at full precision (see SingleGPUCheckpointer):
+        # bf16 would quantize the Adam moments and round the step counters.
 
         if get_rank() == 0:
             # Only rank 0 saves the checkpoint

--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -331,6 +331,15 @@ class SingleGPUCheckpointer(BaseCheckpointer):
         for opt, state_dict in zip(optimizers, loaded_list, strict=True):
             opt.load_state_dict(state_dict)
 
+        # Cast step counters back to float32 (repairs legacy checkpoints that
+        # were saved with bf16-converted optimizer state). The non-capturable
+        # loader returns "step" in its saved dtype, so a bf16 counter would keep
+        # rounding its in-place increments and corrupt bias correction.
+        for opt in optimizers:
+            for state in opt.state.values():
+                if "step" in state and isinstance(state["step"], torch.Tensor):
+                    state["step"] = state["step"].float()
+
     @_rank0_only
     def save_checkpoint(
         self,

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -347,9 +347,13 @@ def test_optimizer_state_round_trips_at_full_precision(tmp_path):
     restored = resumed_optimizer.state_dict()
     for param_id, state in reference["state"].items():
         restored_state = restored["state"][param_id]
-        assert torch.equal(restored_state["step"], state["step"])
+        # load_optimizer_state_dict maps onto the current accelerator, so on a GPU
+        # host the restored tensors live on cuda while the reference is on cpu.
+        # Compare on cpu: this test is about dtype and value, not placement.
+        assert torch.equal(restored_state["step"].cpu(), state["step"].cpu())
         for key in ("exp_avg", "exp_avg_sq"):
-            assert torch.equal(restored_state[key], state[key])
+            assert restored_state[key].dtype == state[key].dtype
+            assert torch.equal(restored_state[key].cpu(), state[key].cpu())
 
 
 def test_legacy_bf16_optimizer_step_is_restored_to_float32(tmp_path):

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -350,3 +350,31 @@ def test_optimizer_state_round_trips_at_full_precision(tmp_path):
         assert torch.equal(restored_state["step"], state["step"])
         for key in ("exp_avg", "exp_avg_sq"):
             assert torch.equal(restored_state[key], state[key])
+
+
+def test_legacy_bf16_optimizer_step_is_restored_to_float32(tmp_path):
+    """A checkpoint written by the previous bf16 save path stores "step" in
+    bf16. The non-capturable loader keeps that dtype, so in-place increments
+    would round once the count is large. The load path must repair it."""
+    model = _TinyOptimModel()
+    optimizer = _stepped_optimizer(model)
+
+    checkpointer = SingleGPUCheckpointer(tmp_path)
+    checkpointer.save_checkpoint(model, optimizer, epoch=0)
+
+    # Rewrite the saved file the way the old bf16-casting save path would have.
+    legacy = torch.load(
+        checkpointer.optimizer_path(0), weights_only=True, map_location="cpu"
+    )
+    for state in legacy["state"].values():
+        state["step"] = state["step"].to(torch.bfloat16)
+    torch.save(legacy, checkpointer.optimizer_path(0))
+
+    resumed_model = _TinyOptimModel()
+    resumed_optimizer = torch.optim.AdamW(resumed_model.parameters(), lr=1e-3)
+    SingleGPUCheckpointer(tmp_path).load_optimizer_state_dict(
+        resumed_model, resumed_optimizer
+    )
+
+    for state in resumed_optimizer.state.values():
+        assert state["step"].dtype == torch.float32

--- a/tests/unit/train/test_checkpoint.py
+++ b/tests/unit/train/test_checkpoint.py
@@ -288,3 +288,65 @@ def test_graceful_shutdown_saves_interrupted_checkpoint(
     trainer.run_training()
 
     assert "interrupted" in saved_labels
+
+
+class _TinyOptimModel(torch.nn.Module):
+    """Duck-typed stand-in for a PreTrainedModel: save_pretrained + dtype."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(4, 4)
+
+    @property
+    def dtype(self):
+        return next(self.parameters()).dtype
+
+    def save_pretrained(self, save_directory, state_dict=None, **kwargs):
+        Path(save_directory).mkdir(parents=True, exist_ok=True)
+
+
+def _stepped_optimizer(model):
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    model.linear.weight.grad = torch.randn_like(model.linear.weight)
+    model.linear.bias.grad = torch.randn_like(model.linear.bias)
+    optimizer.step()
+    # Simulate a long run: bf16 would round 10001 to a multiple of 64.
+    for state in optimizer.state.values():
+        if isinstance(state.get("step"), torch.Tensor):
+            state["step"] = state["step"] + 10000.0
+    return optimizer
+
+
+def test_optimizer_state_round_trips_at_full_precision(tmp_path):
+    """Optimizer state must survive save + load without dtype degradation:
+    bf16 casts quantize the Adam moments and round the step counters (bf16 has
+    an 8-bit mantissa, so step counts above 256 are no longer exact)."""
+    model = _TinyOptimModel()
+    optimizer = _stepped_optimizer(model)
+    reference = optimizer.state_dict()
+
+    checkpointer = SingleGPUCheckpointer(tmp_path)
+    checkpointer.save_checkpoint(model, optimizer, epoch=0)
+
+    saved = torch.load(
+        checkpointer.optimizer_path(0), weights_only=True, map_location="cpu"
+    )
+    for param_id, state in reference["state"].items():
+        saved_state = saved["state"][param_id]
+        assert torch.equal(saved_state["step"], state["step"])
+        for key in ("exp_avg", "exp_avg_sq"):
+            assert saved_state[key].dtype == torch.float32
+            assert torch.equal(saved_state[key], state[key])
+
+    # Load path: a fresh checkpointer resumes from the saved epoch and must
+    # restore the state exactly, without casting to the model dtype.
+    resumed_model = _TinyOptimModel()
+    resumed_optimizer = torch.optim.AdamW(resumed_model.parameters(), lr=1e-3)
+    resumed_checkpointer = SingleGPUCheckpointer(tmp_path)
+    resumed_checkpointer.load_optimizer_state_dict(resumed_model, resumed_optimizer)
+    restored = resumed_optimizer.state_dict()
+    for param_id, state in reference["state"].items():
+        restored_state = restored["state"][param_id]
+        assert torch.equal(restored_state["step"], state["step"])
+        for key in ("exp_avg", "exp_avg_sq"):
+            assert torch.equal(restored_state[key], state[key])


### PR DESCRIPTION
## Problem

Checkpointing converts the entire optimizer state dict to bf16 (the default `float_dtype`), including the AdamW `exp_avg`/`exp_avg_sq` moments and the float `step` counters. bf16 has an 8-bit mantissa: any step count above 256 rounds (10000 rounds to a multiple of 64), and the second moments lose their low bits, so resumed runs use wrong bias correction and quantized moments, visibly deviating from an uninterrupted run. Both `SingleGPUCheckpointer` and `DistributedCheckpointer` are affected, and the load paths re-applied the same cast (to the model dtype), so bf16 models were re-quantized even when the file was fine.

## Fix

Optimizer state is saved and loaded without any dtype conversion. `Optimizer.load_state_dict` already aligns per-param float state with the param dtype and leaves `step` untouched; the distributed loader's step-to-float32 repair loop is kept for legacy bf16-saved checkpoints. Model weights still save as bf16 as before.

Note on scope: this changes what new checkpoints contain (optimizer state roughly doubles in size, fp32 instead of bf16) while remaining able to load old bf16-saved files. Flagging it here since it touches the checkpoint save/load path; happy to adjust if you prefer an opt-in flag.

## Tests

A round-trip unit test in `test_checkpoint.py` steps AdamW past step 10000, saves, reloads through the checkpointer, and asserts the step counters and moments are bit-exact fp32. Fails on main.
