### PR TITLE
Count only evaluable positions in the conditional accuracy denominator

### DIFF
--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -32,15 +32,27 @@ def compute_accuracy_single_step(
         counts suitable for distributed reduction before computing ratios.
     """
     correct = pred_ids == target_ids
-    cond_total = torch.tensor(correct.numel(), dtype=torch.float, device=correct.device)
+    eval_mask = loss_mask.to(torch.bool) if loss_mask is not None else None
+    cond_total = None
     if prev_correct is not None:
-        cond_total = prev_correct.sum().float()
+        # The conditional denominator counts positions that are both still in
+        # play and evaluable at this step. Counting prev_correct alone would
+        # include positions the numerator can never reach once the caller's
+        # shifted loss_mask zeroes them (biasing cond accuracy low).
+        cond_mask = (
+            prev_correct
+            if eval_mask is None
+            else torch.logical_and(prev_correct, eval_mask)
+        )
+        cond_total = cond_mask.sum().float()
         correct = torch.logical_and(prev_correct, correct, out=prev_correct)
-    if loss_mask is not None:
-        correct = torch.masked_select(correct, loss_mask.to(torch.bool))
+    if eval_mask is not None:
+        correct = torch.masked_select(correct, eval_mask)
 
     correct_sum = correct.float().sum()
     full_total = torch.tensor(correct.numel(), dtype=torch.float, device=correct.device)
+    if cond_total is None:
+        cond_total = full_total.clone()
 
     return correct_sum, full_total, correct_sum.clone(), cond_total
 

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -447,3 +447,35 @@ class TestBf16GradientPrecision:
 
         rel_err = ((actual - exact).norm() / exact.norm()).item()
         assert rel_err < 0.02, f"{loss_fn.__name__} bf16 gradient error {rel_err:.1%}"
+
+
+class TestComputeAccuracySingleStepMasked:
+    def test_cond_total_counts_only_evaluable_positions(self):
+        """The eagle3 caller offsets loss_mask (ttt_step:) against prev_correct
+        (:-ttt_step), so a position can be prev-correct yet not evaluable. The
+        conditional denominator must count prev_correct AND loss_mask, or the
+        numerator can never reach the extra positions and cond_acc biases low."""
+        pred = torch.tensor([[1, 2, 3, 4]])
+        tgt = torch.tensor([[1, 2, 3, 4]])  # all correct at this step
+        prev_correct = torch.tensor([[True, True, True, False]])
+        loss_mask = torch.tensor([[1, 1, 0, 1]])  # position 2 not evaluable
+
+        full_correct, full_total, cond_correct, cond_total = (
+            compute_accuracy_single_step(pred, tgt, loss_mask, prev_correct)
+        )
+        # Evaluable positions: 0, 1, 3. Prev-correct among them: 0, 1.
+        assert full_total.item() == pytest.approx(3, abs=1e-4)
+        assert full_correct.item() == pytest.approx(2, abs=1e-4)
+        assert cond_correct.item() == pytest.approx(2, abs=1e-4)
+        # Buggy behavior counted prev_correct.sum() == 3 here.
+        assert cond_total.item() == pytest.approx(2, abs=1e-4)
+
+    def test_masked_no_prev_correct_uses_masked_denominator(self):
+        pred = torch.tensor([[1, 2, 9, 9]])
+        tgt = torch.tensor([[1, 2, 3, 4]])
+        loss_mask = torch.tensor([[1, 1, 1, 0]])
+        _, full_total, _, cond_total = compute_accuracy_single_step(
+            pred, tgt, loss_mask, prev_correct=None
+        )
+        assert full_total.item() == pytest.approx(3, abs=1e-4)
+        assert cond_total.item() == pytest.approx(3, abs=1e-4)


### PR DESCRIPTION
## Problem

For eagle3 TTT steps >= 1, the caller slices `loss_mask[:, ttt_step:]` against `prev_correct[:, :-ttt_step]`, so a position can be prev-correct yet not evaluable at this step. `compute_accuracy_single_step` counted the conditional denominator from `prev_correct` alone, before the loss mask applies, while the numerator is loss-masked, so `cond_acc_1/2` are systematically biased low at every assistant-span boundary.

## Fix

The conditional denominator now counts positions that are both prev-correct and inside the loss mask, snapshotted before the in-place `logical_and` update. With `prev_correct=None` and a mask, the denominator is now the masked count for the same reason (previously the unmasked numel). Note for dashboards: logged `cond_acc_*` values step-change across this fix by design.

## Tests

New unit tests pin the masked denominator with and without `prev_correct` (both fail on main); the existing unmasked chain test is unchanged and passes.
