### PR TITLE
fix(preprocessing): map unknown conversation roles to assistant

### DIFF
--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -33,6 +33,7 @@ __all__ = [
 
 log = PipelineLogger(__name__)
 
+_warned_roles: set[str] = set()
 
 ProcessorLike = PreTrainedTokenizerBase | ProcessorMixin
 
@@ -99,8 +100,11 @@ def _normalize_conversation(
         elif role == "tool":
             role = "tool"
         else:
-            log.warning(f"Unknown role '{role}', skipping turn")
-            continue
+            # Treat unknown roles (e.g. model names in on-policy data) as assistant.
+            if role not in _warned_roles:
+                _warned_roles.add(role)
+                log.warning(f"Mapping unknown role '{role}' → 'assistant'")
+            role = "assistant"
 
         # Build normalized turn with role and content
         normalized_turn = {"role": role, "content": content}

--- a/tests/integration/datagen/test_preprocessing.py
+++ b/tests/integration/datagen/test_preprocessing.py
@@ -80,18 +80,19 @@ def test_normalize_conversation_with_system():
 
 @pytest.mark.sanity
 def test_normalize_conversation_unknown_role():
-    """Test that unknown roles are skipped with warning."""
+    """Test that unknown roles are mapped to assistant."""
     conv = [
         {"role": "user", "content": "Hello"},
-        {"role": "unknown", "content": "Should be skipped"},
+        {"role": "laguna_s", "content": "On-policy response"},
         {"role": "assistant", "content": "Hi!"},
     ]
     result = _normalize_conversation(conv)
 
-    # Unknown role should be skipped
-    assert len(result) == 2
+    assert len(result) == 3
     assert result[0]["role"] == "user"
     assert result[1]["role"] == "assistant"
+    assert result[1]["content"] == "On-policy response"
+    assert result[2]["role"] == "assistant"
 
 
 @pytest.mark.sanity


### PR DESCRIPTION
## Summary
- Map unrecognized conversation roles to `assistant` instead of dropping turns in preprocessing
- On-policy datasets often use the model name as the role (e.g. `laguna_s` instead of `assistant`/`gpt`) — these turns were silently skipped, producing empty/broken training data
- Warns once per unknown role name to surface the mapping without log spam

## Test plan
- [ ] Run `prepare_data.py` on `RedHatAI/opb-laguna-s` dataset — verify all 1.4M rows process without dropped turns
- [ ] Verify single warning line for the `laguna_s` role mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)