### PR TITLE
feat(#880): add reproducibility artifacts to eval runs and checkpoints

### DIFF
--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -258,6 +258,29 @@ def run_benchmark(args: argparse.Namespace) -> None:
     artifacts_dir = output_dir / "artifacts"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 
+    from datetime import timezone
+    import shlex
+    from speculators.utils.provenance import (
+        get_git_sha,
+        get_package_root,
+        get_package_versions,
+    )
+
+    speculators_root = get_package_root("speculators") or Path.cwd()
+    sha = get_git_sha(speculators_root)
+    pkg_versions = get_package_versions(
+        ["speculators", "vllm", "transformers", "torch", "compressed-tensors"]
+    )
+    header = "\n".join(
+        [
+            f"# Timestamp: {datetime.now(timezone.utc).isoformat()}",
+            f"# Git SHA: {sha}",
+            *pkg_versions,
+        ]
+    )
+    with (artifacts_dir / "eval_command.txt").open("w") as f:
+        f.write(f"{header}\n{shlex.join(sys.argv)}\n")
+
     acceptance_csv = None
     perf_csv = None
     all_max_tokens: dict[str, int] = {}

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -86,6 +86,17 @@ def parse_args():
         ),
     )
     parser.add_argument(
+        "--provenance-dir",
+        type=str,
+        default=None,
+        help="Directory to save provenance artifacts (vllm_command.txt, vllm.patch, checkpoint_sha256.txt).",
+    )
+    parser.add_argument(
+        "--no-hash-checkpoints",
+        action="store_true",
+        help="Skip hashing the .safetensors checkpoints in the provenance directory.",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the command that would be executed without running it",
@@ -151,6 +162,53 @@ def main():
 
     print("Running command:")
     print(" ".join(cmd))
+
+    import datetime
+    import shlex
+    from pathlib import Path
+    from speculators.utils.provenance import (
+        get_git_sha,
+        get_git_diff,
+        get_package_root,
+        get_package_versions,
+        hash_safetensors,
+        write_atomic,
+    )
+
+    prov_dir = args.provenance_dir
+    if not prov_dir:
+        safe_model = args.model.replace("/", "_")
+        ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d_%H%M%S")
+        prov_dir = f"vllm_{safe_model}_{ts}"
+    prov_path = Path(prov_dir)
+
+    spec_root = get_package_root("speculators") or Path.cwd()
+    vllm_root = get_package_root("vllm")
+    
+    spec_sha = get_git_sha(spec_root)
+    versions = get_package_versions(["vllm"])
+    vllm_ver = versions[0] if versions else "unknown"
+
+    vllm_cmd_header = "\n".join([
+        f"# Timestamp: {datetime.datetime.now(datetime.timezone.utc).isoformat()}",
+        f"# Python: {sys.executable}",
+        f"# Speculators Git SHA: {spec_sha}",
+        f"{vllm_ver}",
+    ])
+    vllm_cmd_content = f"{vllm_cmd_header}\n{shlex.join(cmd)}\n"
+    write_atomic(prov_path, "vllm_command.txt", vllm_cmd_content)
+
+    if vllm_root and (vllm_root.parent / ".git").exists():
+        vllm_repo = vllm_root.parent
+        diff = get_git_diff(vllm_repo)
+        patch_header = f"# repo: {vllm_repo} ({get_git_sha(vllm_repo)})"
+        write_atomic(prov_path, "vllm.patch", f"{patch_header}\n{diff}\n")
+    else:
+        write_atomic(prov_path, "vllm.patch", f"# Installed from wheel or non-git source\n{vllm_ver}\n")
+
+    if not args.no_hash_checkpoints:
+        hashes = hash_safetensors(args.model)
+        write_atomic(prov_path, "checkpoint_sha256.txt", hashes + "\n")
 
     if not args.dry_run:
         os.execvp(cmd[0], cmd)  # noqa: S606

--- a/src/speculators/train/utils.py
+++ b/src/speculators/train/utils.py
@@ -107,23 +107,20 @@ def save_train_command(save_path: str, argv: list[str] | None = None) -> None:
     it during resolution); it falls back to the live ``sys.argv`` when a caller has
     no recorded argv, so a direct call is unchanged.
     """
-    try:
-        sha = subprocess.run(
-            ["git", "rev-parse", "HEAD"],  # noqa: S607
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout.strip()
-    except (OSError, subprocess.CalledProcessError):
-        sha = "unknown"
+    from speculators.utils.provenance import (
+        get_git_diff,
+        get_git_sha,
+        get_package_root,
+        get_package_versions,
+        write_atomic,
+    )
 
-    pkg_versions: list[str] = []
-    for pkg in ("speculators", "vllm", "transformers", "torch", "compressed-tensors"):
-        try:
-            ver = importlib.metadata.version(pkg)
-        except importlib.metadata.PackageNotFoundError:
-            ver = "not installed"
-        pkg_versions.append(f"# {pkg}: {ver}")
+    speculators_root = get_package_root("speculators") or Path.cwd()
+    sha = get_git_sha(speculators_root)
+
+    pkg_versions = get_package_versions(
+        ["speculators", "vllm", "transformers", "torch", "compressed-tensors"]
+    )
 
     header = "\n".join(
         [
@@ -136,15 +133,8 @@ def save_train_command(save_path: str, argv: list[str] | None = None) -> None:
 
     command = shlex.join(argv or sys.argv)
     content = f"{header}\n{command}\n"
+    write_atomic(save_path, "train_command.txt", content)
 
-    path = Path(save_path)
-    path.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=save_path, prefix=".train_command_", suffix=".tmp")
-    tmp_path = Path(tmp)
-    try:
-        with os.fdopen(fd, "w") as f:
-            f.write(content)
-        tmp_path.replace(path / "train_command.txt")
-    finally:
-        if tmp_path.exists():
-            tmp_path.unlink()
+    diff = get_git_diff(speculators_root)
+    if diff:
+        write_atomic(save_path, "speculators.patch", diff)

--- a/src/speculators/utils/provenance.py
+++ b/src/speculators/utils/provenance.py
@@ -1,0 +1,91 @@
+import hashlib
+import importlib.metadata
+import logging
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+def get_git_sha(repo_root: str | Path) -> str:
+    """Get the current git SHA of the repository."""
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=str(repo_root),
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+def get_git_diff(repo_root: str | Path) -> str:
+    """Get the uncommitted git diff of the repository."""
+    try:
+        return subprocess.run(
+            ["git", "diff", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=str(repo_root),
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return ""
+
+def get_package_versions(packages: list[str]) -> list[str]:
+    """Get version strings for the given packages."""
+    pkg_versions: list[str] = []
+    for pkg in packages:
+        try:
+            ver = importlib.metadata.version(pkg)
+        except importlib.metadata.PackageNotFoundError:
+            ver = "not installed"
+        pkg_versions.append(f"# {pkg}: {ver}")
+    return pkg_versions
+
+def hash_safetensors(model_dir: str | Path) -> str:
+    """Compute SHA256 hashes of all .safetensors files in a directory."""
+    path = Path(model_dir)
+    if not path.exists() or not path.is_dir():
+        return f"# {model_dir} is a remote reference or not a local directory."
+    
+    safetensors_files = sorted(path.rglob("*.safetensors"))
+    if not safetensors_files:
+        return f"# No .safetensors files found in {model_dir}"
+
+    hashes = []
+    for f in safetensors_files:
+        sha256 = hashlib.sha256()
+        with open(f, "rb") as file_obj:
+            while chunk := file_obj.read(8192):
+                sha256.update(chunk)
+        hashes.append(f"{sha256.hexdigest()}  {f.relative_to(path)}")
+    return "\n".join(hashes)
+
+def write_atomic(save_path: str | Path, filename: str, content: str) -> None:
+    """Write content to save_path/filename atomically."""
+    path = Path(save_path)
+    path.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=save_path, prefix=f".{filename}_", suffix=".tmp")
+    tmp_path = Path(tmp)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        tmp_path.replace(path / filename)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+def get_package_root(package_name: str) -> Optional[Path]:
+    """Return the source root directory of a package if it exists."""
+    try:
+        import importlib
+        pkg = importlib.import_module(package_name)
+        if hasattr(pkg, "__file__") and pkg.__file__:
+            return Path(pkg.__file__).parent
+    except ImportError:
+        pass
+    return None


### PR DESCRIPTION
Implements the reproducibility artifacts RFC (#880) to save exact eval commands, vLLM launch metadata, safetensors SHA256 hashes, and uncommitted git diffs.

Closes #880.