### PR TITLE
Add DFlash Qwen3-8B online training example for Ascend NPU devices

### DIFF
--- a/examples/train/dflash_qwen3_8b_sharegpt_online_5k_npu.sh
+++ b/examples/train/dflash_qwen3_8b_sharegpt_online_5k_npu.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Online DFlash Training Script
+#
+# Runs the full online DFlash training pipeline: data preparation, vLLM server launch,
+# and training (with hidden states generated on-the-fly from the live server).
+#
+# Usage: Copy this script, modify the configuration variables below, then run:
+#   bash examples/train/dflash_qwen3_8b_sharegpt_online_5k_npu.sh
+#
+# For a detailed walkthrough, see 
+# https://docs.vllm.ai/projects/speculators/en/latest/user_guide/tutorials/train_dflash_online/
+
+### Example E2E run for DFlash Qwen3-8B on Ascend NPU device from ShareGPT ###
+
+# Note: With just 5k samples, the model performance will not be very good, however there
+# are enough samples to verify that the pipeline is working correctly and that the model
+# is learning something. This is a good sanity check when creating a drafter for a new
+# target model.
+
+# Experiments on 6x Ascend 910B 64GB NPUs, DP=2
+
+set -euo pipefail
+
+# ============ Configuration ============
+MODEL="Qwen/Qwen3-8B"
+DATASET="sharegpt"                # sharegpt, ultrachat, or path to custom data
+OUTPUT_DIR="./output/dflash_qwen3_8b_sharegpt"
+VLLM_PORT=8010
+MAX_SAMPLES=5000
+SEQ_LENGTH=8192
+EPOCHS=10
+LR=3e-4
+
+# DFlash-specific parameters
+SPECULATOR_TYPE="dflash"
+BLOCK_SIZE=8
+MAX_ANCHORS=128
+NUM_LAYERS=5
+DRAFT_VOCAB_SIZE=32000
+TARGET_LAYER_IDS="2 18 33"  # Must match vLLM's eagle_aux_hidden_state_layer_ids
+
+# NPU assignments (online training needs separate NPUs for vLLM and training)
+VLLM_NPUS="0,1"
+TRAIN_NPUS="2,3,4,5"
+NUM_TRAIN_NPUS=4
+# =======================================
+
+# Step 1: Prepare data
+echo "=== Step 1: Preparing data ==="
+python scripts/prepare_data.py \
+    --model "$MODEL" \
+    --data "$DATASET" \
+    --output "$OUTPUT_DIR" \
+    --max-samples "$MAX_SAMPLES" \
+    --seq-length "$SEQ_LENGTH"
+
+# Step 2: Launch vLLM server in the background
+echo "=== Step 2: Launching vLLM server ==="
+ASCEND_RT_VISIBLE_DEVICES="$VLLM_NPUS" python scripts/launch_vllm.py "$MODEL" \
+    --target-layer-ids $TARGET_LAYER_IDS \
+    -- --data-parallel-size 2 --port "$VLLM_PORT" &
+VLLM_PID=$!
+
+# Ensure vLLM is cleaned up on exit
+cleanup() {
+    echo "Stopping vLLM server..."
+    kill "$VLLM_PID" 2>/dev/null || true
+    wait "$VLLM_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Waiting for vLLM server to be ready..."
+MAX_RETRY=60           # Max retry attempts for health check, 2s interval, total timeout 120s
+WAIT_SEC=2
+retry_cnt=0
+until curl -sf "http://localhost:${VLLM_PORT}/health" > /dev/null 2>&1; do
+    # Check if the background vLLM process has crashed and exited
+    if ! ps -p "$VLLM_PID" > /dev/null; then
+        echo "ERROR: vLLM background process PID $VLLM_PID exited unexpectedly, abort script"
+        exit 1
+    fi
+
+    retry_cnt=$((retry_cnt + 1))
+    if [ $retry_cnt -ge $MAX_RETRY ]; then
+        echo "ERROR: vLLM health check timeout after $MAX_RETRY retries (total $((MAX_RETRY * WAIT_SEC))s)"
+        exit 1
+    fi
+
+    echo "vLLM not ready yet, retry $retry_cnt/$MAX_RETRY, wait ${WAIT_SEC}s..."
+    sleep $WAIT_SEC
+done
+echo "vLLM server ready."
+
+# Step 3: Train against the live vLLM server
+echo "=== Step 3: Training ==="
+ASCEND_RT_VISIBLE_DEVICES="$TRAIN_NPUS" torchrun \
+    --nnodes 1 --nproc_per_node "$NUM_TRAIN_NPUS" \
+    scripts/train.py \
+    --verifier-name-or-path "$MODEL" \
+    --data-path "$OUTPUT_DIR" \
+    --vllm-endpoint "http://localhost:${VLLM_PORT}/v1" \
+    --save-path "$OUTPUT_DIR/checkpoints" \
+    --draft-vocab-size "$DRAFT_VOCAB_SIZE" \
+    --epochs "$EPOCHS" \
+    --lr "$LR" \
+    --total-seq-len "$SEQ_LENGTH" \
+    --speculator-type "$SPECULATOR_TYPE" \
+    --block-size "$BLOCK_SIZE" \
+    --max-anchors "$MAX_ANCHORS" \
+    --num-layers "$NUM_LAYERS" \
+    --target-layer-ids $TARGET_LAYER_IDS \
+    --draft-attn-impl sdpa \
+    --on-missing generate \
+    --on-generate delete
+
+echo "Done. Checkpoints saved to $OUTPUT_DIR/checkpoints/"


### PR DESCRIPTION
## Purpose
The official speculators examples are GPU-centric: they assume CUDA availability, use CUDA_VISIBLE_DEVICES, , and rely on the vllm-ascend backend for large models. There is no reference configuration or script for running DFlash on Ascend NPU with small dense models.
## Tests
<img width="5408" height="4787" alt="training_curves" src="https://github.com/user-attachments/assets/1c91c5ce-a9df-411c-830c-d4af5d43ea25" />

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
