### PR TITLE
fix(dflash): use conditional_torch_compile to avoid BiSheng IR error on Ascend NPU devices

### DIFF
--- a/examples/train/dflash_qwen3_8b_sharegpt_online_5k_npu.sh
+++ b/examples/train/dflash_qwen3_8b_sharegpt_online_5k_npu.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Online DFlash Training Script
+#
+# Runs the full online DFlash training pipeline: data preparation, vLLM server launch,
+# and training (with hidden states generated on-the-fly from the live server).
+#
+# Usage: Copy this script, modify the configuration variables below, then run:
+#   bash examples/train/dflash_qwen3_8b_sharegpt_online_10k_npu.sh
+#
+# For a detailed walkthrough, see 
+# https://docs.vllm.ai/projects/speculators/en/latest/user_guide/tutorials/train_dflash_online/
+
+### Example E2E run for DFlash Qwen3-8B on Ascend NPU device from ShareGPT ###
+
+# Note: With just 5k samples, the model performance will not be very good, however there
+# are enough samples to verify that the pipeline is working correctly and that the model
+# is learning something. This is a good sanity check when creating a drafter for a new
+# target model.
+
+# Experiments on 6x Ascend 910B 64GB NPUs, DP=2
+
+set -euo pipefail
+
+# ============ Configuration ============
+MODEL="Qwen/Qwen3-8B"
+DATASET="sharegpt"                # sharegpt, ultrachat, or path to custom data
+OUTPUT_DIR="./output/dflash_qwen3_8b_sharegpt"
+VLLM_PORT=8010
+MAX_SAMPLES=5000
+SEQ_LENGTH=8192
+EPOCHS=10
+LR=3e-4
+
+# DFlash-specific parameters
+SPECULATOR_TYPE="dflash"
+BLOCK_SIZE=8
+MAX_ANCHORS=1024
+NUM_LAYERS=5
+DRAFT_VOCAB_SIZE=32000
+TARGET_LAYER_IDS="2 18 33"  # Must match vLLM's eagle_aux_hidden_state_layer_ids
+
+# NPU assignments (online training needs separate NPUs for vLLM and training)
+VLLM_NPUS="0,1"
+TRAIN_NPUS="2,3"
+NUM_TRAIN_NPUS=2
+# =======================================
+
+# Step 1: Prepare data
+echo "=== Step 1: Preparing data ==="
+python scripts/prepare_data.py \
+    --model "$MODEL" \
+    --data "$DATASET" \
+    --output "$OUTPUT_DIR" \
+    --max-samples "$MAX_SAMPLES" \
+    --seq-length "$SEQ_LENGTH"
+
+# Step 2: Launch vLLM server in the background
+echo "=== Step 2: Launching vLLM server ==="
+ASCEND_RT_VISIBLE_DEVICES="$VLLM_NPUS" python scripts/launch_vllm.py "$MODEL" \
+    --target-layer-ids $TARGET_LAYER_IDS \
+    -- --data-parallel-size 2 --port "$VLLM_PORT" &
+VLLM_PID=$!
+
+# Ensure vLLM is cleaned up on exit
+cleanup() {
+    echo "Stopping vLLM server..."
+    kill "$VLLM_PID" 2>/dev/null || true
+    wait "$VLLM_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "Waiting for vLLM server to be ready..."
+until curl -sf "http://localhost:${VLLM_PORT}/health" > /dev/null 2>&1; do
+    sleep 2
+done
+echo "vLLM server ready."
+
+# Step 3: Train against the live vLLM server
+echo "=== Step 3: Training ==="
+ASCEND_RT_VISIBLE_DEVICES="$TRAIN_NPUS" torchrun \
+    --standalone --nproc_per_node "$NUM_TRAIN_NPUS" \
+    scripts/train.py \
+    --verifier-name-or-path "$MODEL" \
+    --data-path "$OUTPUT_DIR" \
+    --vllm-endpoint "http://localhost:${VLLM_PORT}/v1" \
+    --save-path "$OUTPUT_DIR/checkpoints" \
+    --draft-vocab-size "$DRAFT_VOCAB_SIZE" \
+    --epochs "$EPOCHS" \
+    --lr "$LR" \
+    --total-seq-len "$SEQ_LENGTH" \
+    --speculator-type "$SPECULATOR_TYPE" \
+    --block-size "$BLOCK_SIZE" \
+    --max-anchors "$MAX_ANCHORS" \
+    --num-layers "$NUM_LAYERS" \
+    --target-layer-ids $TARGET_LAYER_IDS \
+    --draft-attn-impl sdpa \
+    --on-missing generate \
+    --on-generate delete
+
+echo "Done. Checkpoints saved to $OUTPUT_DIR/checkpoints/"

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 # Compile so the mask builds block-sparse instead of materializing DFlash's huge
 # dense [Q, KV] grid every step. (No benefit for EAGLE3's small autoregressive mask.)
-_compiled_create_block_mask = torch.compile(create_block_mask)
+_compiled_create_block_mask = conditional_torch_compile(create_block_mask)
 
 
 @SpeculatorModel.register("dflash")


### PR DESCRIPTION
## Purpose
src/speculators/models/dflash/core.py
line 30: _compiled_create_block_mask = torch.compile(create_block_mask)
NVIDIA GPU → Inductor/Triton Backend; Ascend NPU → BiSheng Compiler Backend
The BiSheng Compiler cannot process the complex computation graph generated by create_block_mask (from torch.nn.attention.flex_attention), throwing an error: fail to run BiShengIR Pipeline.

use conditional_torch_compile(reuse existing interfaces) to avoid BiSheng IR error on Ascend NPU.
## Tests
work
## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
