### PR TITLE
fix a ddp ckpt bug

### DIFF
--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -390,8 +390,13 @@ class DistributedCheckpointer(BaseCheckpointer):
             weights_only=True,
             map_location="cpu",
         )
+
+        if isinstance(model, DistributedDataParallel):
+            model_dtype = model.module.dtype
+        else:
+            model_dtype = model.dtype
         full_state_dict = convert_float_dtype(
-            full_state_dict, float_dtype or model.dtype
+            full_state_dict, float_dtype or model_dtype
         )
 
         set_optimizer_state_dict(

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -324,8 +324,7 @@ class Trainer:
         self.model.to(self.local_rank)  # type: ignore[arg-type]
 
         if load_checkpoint:
-            if dist.get_rank() == 0:
-                self.checkpointer.load_model_state_dict(self.model)
+            self.checkpointer.load_model_state_dict(self.model)
         else:
             # Fresh init: broadcast rank 0's random initialization to all ranks
             for param in self.model.parameters():


### PR DESCRIPTION
When using ddp, ckpt is not resumed correctly. Only rank0 loads ckpt, which caused DDP is not initialized properly.
<img width="950" height="438" alt="image" src="https://github.com/user-attachments/assets/21ea331e-54cc-4314-8a08-fa28a3877ade" />

The relevant code is as follows, only rank0 loaded ckpt
<img width="703" height="263" alt="image" src="https://github.com/user-attachments/assets/4d08bb89-bf27-41c7-8a18-6b2f528332cd" />


