### PR TITLE
fix(e2e): let callers override chunked prefill

### DIFF
--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -145,9 +145,13 @@ def main():
         *vllm_args,
     ]
 
-    disable_cp_arg = "--no-enable-chunked-prefill"
-    if disable_cp_arg not in cmd:
-        cmd.append(disable_cp_arg)
+    # Default off unless the caller already chose; hybrid mamba models need it on
+    # for vLLM's 'align' cache mode. vLLM treats '_' and '-' in flags as equivalent.
+    chunked_prefill_flags = ("--enable-chunked-prefill", "--no-enable-chunked-prefill")
+    if not any(
+        a.replace("_", "-").startswith(chunked_prefill_flags) for a in vllm_args
+    ):
+        cmd.append("--no-enable-chunked-prefill")
 
     print("Running command:")
     print(" ".join(cmd))

--- a/tests/e2e/smoke/test_mtp_finetuning.py
+++ b/tests/e2e/smoke/test_mtp_finetuning.py
@@ -53,6 +53,8 @@ def test_mtp_finetuning_smoke(
         lr=3e-4,
         prompts=prompts,
         enforce_eager=True,
+        # Qwen3.5 is hybrid mamba: 'align' cache mode requires chunked prefill.
+        enable_chunked_prefill=True,
     )
 
 
@@ -72,6 +74,7 @@ def run_mtp_finetuning_e2e(
     train_timeout: int = 30 * 60,
     gpu_memory_utilization: float = 0.5,
     enforce_eager: bool = False,
+    enable_chunked_prefill: bool | None = None,
 ):
     """Run MTP online finetuning E2E pipeline.
 
@@ -121,6 +124,7 @@ def run_mtp_finetuning_e2e(
         gpu_memory_utilization=gpu_memory_utilization,
         target_layer_ids=target_layer_ids,
         enforce_eager=enforce_eager,
+        enable_chunked_prefill=enable_chunked_prefill,
     ):
         run_training(
             model=verifier,

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -115,11 +115,14 @@ def launch_vllm_server(
     mooncake_master: str | None = None,
     mooncake_metadata_server: str | None = None,
     mooncake_protocol: str | None = None,
+    enable_chunked_prefill: bool | None = None,
 ) -> subprocess.Popen:
     """Launch a vLLM server configured for hidden-state extraction.
 
     Returns the server subprocess. Caller is responsible for stopping it
     via stop_vllm_server().
+
+    enable_chunked_prefill overrides the launch script's default of disabling it.
     """
     cmd = [
         VLLM_PYTHON,
@@ -152,6 +155,12 @@ def launch_vllm_server(
         str(gpu_memory_utilization),
         "--disable-uvicorn-access-log",
     ]
+    if enable_chunked_prefill is not None:
+        cmd.append(
+            "--enable-chunked-prefill"
+            if enable_chunked_prefill
+            else "--no-enable-chunked-prefill"
+        )
     logger.info("Starting vLLM server: {}", " ".join(cmd))
 
     process = subprocess.Popen(cmd)  # noqa: S603


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Fixes `test_mtp_finetuning_smoke` failing at vLLM server startup with:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for VllmConfig
  Assertion failed, Chunked prefill is required for mamba cache mode 'align'.
```

Upstream vLLM added a pydantic `VllmConfig` validation for mamba cache mode `align`
(`vllm/model_executor/models/config.py`). For hybrid mamba verifiers such as
`Qwen/Qwen3.5-0.8B`, vLLM auto-assigns `mamba_cache_mode='align'` whenever prefix
caching is enabled (the default), and align mode then asserts chunked prefill is on.

`scripts/launch_vllm.py` appended `--no-enable-chunked-prefill` whenever that exact
string was absent from the command. It did not recognize the opposite polarity, so a
caller passing `--enable-chunked-prefill` had it silently overridden and hit the
assert anyway.

This keeps chunked prefill disabled by default, but skips the injection when the
caller has already made a choice — matching either polarity and vLLM's underscore
spelling (vLLM normalizes `_` to `-` in flag names). `launch_vllm_server` gains an
`enable_chunked_prefill` passthrough and the MTP smoke test opts in.

Note the assert is not specific to vLLM nightly — stable 0.26.0 carries it too, so
this failure was reachable on both.

## Tests

`test_mtp_finetuning_smoke` on 1xH100, run against both a nightly and a stable vLLM:

```
CADENCE=weekly VLLM_PYTHON=<vllm-venv>/bin/python PATH=<vllm-venv>/bin:$PATH \
  pytest tests/e2e/smoke/test_mtp_finetuning.py -x -s
```

| vLLM | Result |
| --- | --- |
| nightly `0.10.1.dev11698+g62a86318d` | `1 passed in 252.47s (0:04:12)` |
| stable `0.26.0` | `1 passed in 345.98s (0:05:45)` |

Both runs went through the previously failing configuration — engine config logged
`enable_prefix_caching=True, enable_chunked_prefill=True` with mamba cache mode
`align`.

To confirm enabling chunked prefill does not perturb hidden-state extraction, nightly
was re-run in the pre-fix configuration (`--no-enable-chunked-prefill
--no-enable-prefix-caching`, which avoids the assert by keeping cache mode `none`).
Metrics were identical:

| | prefix caching | chunked prefill | drafts | draft tokens | accepted | acceptance length |
| --- | --- | --- | --- | --- | --- | --- |
| this PR | True | True | 131 | 393 | 16 | 1.1221374045801527 |
| pre-fix | False | False | 131 | 393 | 16 | 1.1221374045801527 |

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
