### PR TITLE
fix(dflash): resolve quality failures and PR feedback for Laguna converter (clean)

### DIFF
--- a/src/speculators/convert/dflash/converter.py
+++ b/src/speculators/convert/dflash/converter.py
@@ -173,10 +173,19 @@ class DFlashConverter:
 
         for key, tensor in weights.items():
             if "qkv_proj" in key:
+                q_key = key.replace("qkv_proj", "q_proj")
+                k_key = key.replace("qkv_proj", "k_proj")
+                v_key = key.replace("qkv_proj", "v_proj")
+                for dest_key in (q_key, k_key, v_key):
+                    if dest_key in remapped or dest_key in weights:
+                        raise ValueError(
+                            f"Mixed fused and separate projections: "
+                            f"target key {dest_key} already exists."
+                        )
                 q, k, v = tensor.split([q_dim, kv_dim, kv_dim], dim=0)
-                remapped[key.replace("qkv_proj", "q_proj")] = q
-                remapped[key.replace("qkv_proj", "k_proj")] = k
-                remapped[key.replace("qkv_proj", "v_proj")] = v
+                remapped[q_key] = q
+                remapped[k_key] = k
+                remapped[v_key] = v
             elif ".g_proj." in key or key.startswith("aux_hidden_norms."):
                 dropped.append(key)
             elif key == "fc.weight":

--- a/tests/unit/convert/test_dflash_converter.py
+++ b/tests/unit/convert/test_dflash_converter.py
@@ -186,9 +186,7 @@ class TestRemapWeights:
 
         remapped = DFlashConverter()._remap_weights(weights, config, model)
         assert remapped["fc.weight"].shape[1] == model.fc.in_features
-        assert torch.equal(
-            remapped["fc.weight"], wide_fc[:, : model.fc.in_features]
-        )
+        assert torch.equal(remapped["fc.weight"], wide_fc[:, : model.fc.in_features])
 
     def test_passthrough_when_no_fused_qkv(self):
         config = _tiny_dflash_config()
@@ -204,6 +202,16 @@ class TestRemapWeights:
         remapped = DFlashConverter()._remap_weights(weights, config, model)
         assert "layers.0.self_attn.o_proj.weight" in remapped
         assert "norm.weight" in remapped
+
+    def test_rejects_mixed_fused_and_separate_projections(self):
+        config = _tiny_dflash_config()
+        model = DFlashDraftModel(config=config)
+        weights = self._make_fused_weights()
+        # Add a conflicting separate projection
+        weights["layers.0.self_attn.q_proj.weight"] = torch.randn(_Q_DIM, _HIDDEN)
+
+        with pytest.raises(ValueError, match="Mixed fused and separate projections"):
+            DFlashConverter()._remap_weights(weights, config, model)
 
 
 class TestSave:


### PR DESCRIPTION
This PR fixes the quality checks and implements the CodeRabbit review feedback for PR #922. It ensures mixed fused/separate projections raise a ValueError. (Replacing PR #941 which had merge conflicts).