### PR TITLE
ci(quality): run Quality workflow on release-* branches

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - "release-*"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Extend the `Quality` workflow's `push` trigger to include `release-*` branches, not just `main`, so direct pushes/merges into release branches (e.g. hotfixes) run quality checks.

## Test plan
- [ ] Confirm the `Quality` check runs on a push to a `release-*` branch after merge.