### PR TITLE
feat(training): support ModelOpt W4A16 NVFP4 verifier LM heads

### DIFF
--- a/src/speculators/model.py
+++ b/src/speculators/model.py
@@ -146,10 +146,25 @@ class DraftVocabMixin(nn.Module):
         if hasattr(self, "verifier_norm"):
             weights_to_load.append("model.norm.weight")
 
-        verifier_weights = load_model_layers(
-            weights_to_load,
-            verifier_config.name_or_path,
-        )
+        lm_head_rows: dict[str, torch.Tensor] | None = None
+        if self.use_draft_vocab:
+            if self.t2d is None or not torch.any(self.t2d).item():  # type: ignore[arg-type]
+                raise ValueError(
+                    "t2d tensor hasn't been set. Please call "
+                    "`.load_vocab_mappings(t2d, d2t)` before `.load_verifier_weights()`"
+                )
+            lm_head_rows = {"lm_head.weight": self.t2d.detach().cpu()}
+        if lm_head_rows is None:
+            verifier_weights = load_model_layers(
+                weights_to_load,
+                verifier_config.name_or_path,
+            )
+        else:
+            verifier_weights = load_model_layers(
+                weights_to_load,
+                verifier_config.name_or_path,
+                row_indices=lm_head_rows,
+            )
 
         embed_tokens_weight = verifier_weights["embed_tokens.weight"]
         lm_head_weight = verifier_weights.get("lm_head.weight", embed_tokens_weight)
@@ -159,14 +174,21 @@ class DraftVocabMixin(nn.Module):
             self.embed_tokens.load_state_dict({"weight": embed_tokens_weight})
 
         if self.use_draft_vocab:
-            if self.t2d is None or not torch.any(self.t2d).item():  # type: ignore[arg-type]
+            # An absent LM head falls back to the full embedding tensor. An
+            # explicit dense or quantized LM head was already row-selected by
+            # load_model_layers to avoid materializing unused vocabulary rows.
+            if lm_head_weight.shape[0] == self.verifier_vocab_size:
+                lm_head_weight = lm_head_weight[
+                    self.t2d.to(  # type: ignore[union-attr,index]
+                        device=lm_head_weight.device, dtype=torch.bool
+                    ),
+                    :,
+                ]
+            elif lm_head_weight.shape[0] != self.draft_vocab_size:
                 raise ValueError(
-                    "t2d tensor hasn't been set. Please call "
-                    "`.load_vocab_mappings(t2d, d2t)` before `.load_verifier_weights()`"
+                    f"Loaded LM head has {lm_head_weight.shape[0]} rows, expected "
+                    f"{self.draft_vocab_size} selected draft-vocabulary rows."
                 )
-            lm_head_weight = lm_head_weight[
-                self.t2d.to(device=lm_head_weight.device, dtype=torch.bool), :  # type: ignore[union-attr,index]
-            ]
 
         if self.lm_head.weight.isnan().any():
             self.lm_head.load_state_dict(

--- a/src/speculators/utils/loading.py
+++ b/src/speculators/utils/loading.py
@@ -14,6 +14,11 @@ _WEIGHT_ALIASES: dict[str, list[str]] = {
     "model.norm.weight": ["norm.weight"],
 }
 
+_MODELOPT_QUANT_CONFIG = "hf_quant_config.json"
+_W4A16_NVFP4 = "W4A16_NVFP4"
+_NVFP4_GROUP_SIZE = 16
+_MATRIX_DIMENSIONS = 2
+
 
 def _resolve_key(name: str, weight_map: dict[str, str]) -> str | None:
     """Try exact match, then suffix match, then known aliases."""
@@ -80,16 +85,24 @@ def list_checkpoint_keys(checkpoint_dir: str | Path) -> list[str]:
 
 
 def load_model_layers(
-    layer_names: list[str], model_path: str
+    layer_names: list[str],
+    model_path: str,
+    *,
+    row_indices: dict[str, torch.Tensor] | None = None,
 ) -> dict[str, torch.Tensor]:
     """
     Load one or more named tensors from a HF repo using safetensors shards.
-    Supports both exact keys and suffix pattern matching.
+    Supports both exact keys and suffix pattern matching. Packed ModelOpt
+    W4A16 NVFP4 weights are materialized to BF16 when their checkpoint metadata
+    declares the verified unswizzled layout.
 
     :param layer_names: list of tensor names or suffix patterns to load, e.g.
     ["model.embed_tokens.weight", "lm_head.weight"]
     :param model_path: either a local directory of huggingface model
     containing model.safetensors.index
+    :param row_indices: optional mapping from a requested layer name to a boolean
+    mask or integer indices applied along its first dimension. Row-shaped NVFP4
+    metadata is selected before dequantization to bound peak memory.
     :return: dict mapping input names/patterns to loaded tensors
     """
     # download the index file or build weight map for single-file models
@@ -132,8 +145,251 @@ def load_model_layers(
         shard_path = _resolve_file(model_path, shard_file)
         with safe_open(shard_path, framework="pt", device="cpu") as f:
             for name, key in name_key_pairs:
-                out[name] = f.get_tensor(key)
+                tensor = f.get_tensor(key)
+                selector = (row_indices or {}).get(name)
+                if tensor.dtype == torch.uint8:
+                    out[name] = _materialize_modelopt_w4a16_nvfp4_weight(
+                        tensor,
+                        key=key,
+                        model_path=model_path,
+                        weight_map=weight_map,
+                        row_indices=selector,
+                    )
+                else:
+                    out[name] = _select_rows(tensor, selector, name)
     return out
+
+
+def _select_rows(
+    tensor: torch.Tensor,
+    row_indices: torch.Tensor | None,
+    name: str,
+) -> torch.Tensor:
+    """Apply a validated CPU row selector without changing its order."""
+    if row_indices is None:
+        return tensor
+    if tensor.ndim == 0:
+        raise ValueError(f"Row indexing is invalid for scalar tensor '{name}'.")
+
+    selector = row_indices.detach().to(device="cpu")
+    if selector.ndim != 1:
+        raise ValueError(
+            f"Row selector for '{name}' must be 1-D, got {tuple(selector.shape)}."
+        )
+    if selector.dtype == torch.bool:
+        if selector.numel() != tensor.shape[0]:
+            raise ValueError(
+                f"Boolean row selector for '{name}' has shape "
+                f"{tuple(selector.shape)}, expected ({tensor.shape[0]},)."
+            )
+    elif selector.dtype in {torch.int32, torch.int64}:
+        if selector.numel() and (
+            selector.min().item() < 0 or selector.max().item() >= tensor.shape[0]
+        ):
+            raise IndexError(
+                f"Row selector for '{name}' contains an index outside "
+                f"[0, {tensor.shape[0]})."
+            )
+    else:
+        raise TypeError(
+            f"Row selector for '{name}' must be boolean or integer, "
+            f"got {selector.dtype}."
+        )
+    return tensor[selector]
+
+
+def _load_checkpoint_tensor(
+    model_path: str,
+    weight_map: dict[str, str],
+    key: str,
+) -> torch.Tensor:
+    """Load one exact checkpoint key from its mapped safetensors shard."""
+    shard_path = _resolve_file(model_path, weight_map[key])
+    with safe_open(shard_path, framework="pt", device="cpu") as f:
+        return f.get_tensor(key)
+
+
+def _modelopt_layer_quantization(
+    model_path: str,
+    weight_key: str,
+) -> dict[str, Any]:
+    """Return the unambiguous ModelOpt quantized-layer entry for a weight."""
+    try:
+        config_path = _resolve_file(model_path, _MODELOPT_QUANT_CONFIG)
+    except (FileNotFoundError, EntryNotFoundError) as error:
+        raise ValueError(
+            f"Packed uint8 tensor '{weight_key}' requires "
+            f"{_MODELOPT_QUANT_CONFIG} to identify its quantization format."
+        ) from error
+
+    with config_path.open() as config_file:
+        config = json.load(config_file)
+    producer = config.get("producer", {})
+    producer_name = producer.get("name") if isinstance(producer, dict) else None
+    if not isinstance(producer_name, str) or producer_name.lower() != "modelopt":
+        raise ValueError(
+            f"Packed uint8 tensor '{weight_key}' requires a ModelOpt-produced "
+            f"{_MODELOPT_QUANT_CONFIG}, got producer {producer_name!r}."
+        )
+    quantization = config.get("quantization", {})
+    quantized_layers = quantization.get("quantized_layers", {})
+    if not isinstance(quantized_layers, dict):
+        raise ValueError(
+            f"Invalid {_MODELOPT_QUANT_CONFIG}: 'quantized_layers' must be a mapping."
+        )
+
+    layer_name = weight_key.removesuffix(".weight")
+    matches = [
+        entry
+        for name, entry in quantized_layers.items()
+        if name == layer_name
+        or layer_name.endswith(f".{name}")
+        or name.endswith(f".{layer_name}")
+    ]
+    if len(matches) != 1 or not isinstance(matches[0], dict):
+        raise ValueError(
+            f"Packed uint8 tensor '{weight_key}' must have exactly one matching "
+            f"entry in {_MODELOPT_QUANT_CONFIG}; found {len(matches)}."
+        )
+    return matches[0]
+
+
+def _materialize_modelopt_w4a16_nvfp4_weight(
+    packed_weight: torch.Tensor,
+    *,
+    key: str,
+    model_path: str,
+    weight_map: dict[str, str],
+    row_indices: torch.Tensor | None,
+) -> torch.Tensor:
+    """Materialize the verified unswizzled ModelOpt W4A16 NVFP4 layout.
+
+    The layout stores two E2M1 values in each byte, one row-major E4M3 scale per
+    16 input elements, and one scalar FP32 global scale. W4A16 does not quantize
+    activations, so a dense frozen projection retains input-gradient semantics.
+    """
+    if not key.endswith(".weight"):
+        raise ValueError(
+            f"Unsupported packed uint8 tensor '{key}': expected a weight tensor."
+        )
+
+    layer_quantization = _modelopt_layer_quantization(model_path, key)
+    quant_algo = layer_quantization.get("quant_algo")
+    group_size = layer_quantization.get("group_size")
+    if quant_algo != _W4A16_NVFP4 or group_size != _NVFP4_GROUP_SIZE:
+        raise ValueError(
+            f"Packed uint8 tensor '{key}' uses quant_algo={quant_algo!r}, "
+            f"group_size={group_size!r}; only the verified unswizzled "
+            f"{_W4A16_NVFP4} group-size {_NVFP4_GROUP_SIZE} layout is supported."
+        )
+
+    prefix = key.removesuffix(".weight")
+    scale_key = f"{prefix}.weight_scale"
+    global_scale_key = f"{prefix}.weight_scale_2"
+    missing = [
+        scale_name
+        for scale_name in (scale_key, global_scale_key)
+        if scale_name not in weight_map
+    ]
+    if missing:
+        raise ValueError(
+            f"Packed uint8 tensor '{key}' is missing ModelOpt NVFP4 metadata {missing}."
+        )
+
+    block_scales = _load_checkpoint_tensor(model_path, weight_map, scale_key)
+    global_scale = _load_checkpoint_tensor(model_path, weight_map, global_scale_key)
+    if (
+        packed_weight.ndim != _MATRIX_DIMENSIONS
+        or block_scales.ndim != _MATRIX_DIMENSIONS
+    ):
+        raise ValueError(
+            f"ModelOpt NVFP4 '{key}' expects 2-D weight/scales, got "
+            f"{tuple(packed_weight.shape)} and {tuple(block_scales.shape)}."
+        )
+    if block_scales.dtype != torch.float8_e4m3fn:
+        raise ValueError(
+            f"ModelOpt NVFP4 '{scale_key}' must use float8_e4m3fn, got "
+            f"{block_scales.dtype}."
+        )
+    if global_scale.dtype != torch.float32 or global_scale.ndim != 0:
+        raise ValueError(
+            f"ModelOpt NVFP4 '{global_scale_key}' must be a scalar float32, got "
+            f"dtype {global_scale.dtype} and shape {tuple(global_scale.shape)}."
+        )
+    if block_scales.shape[0] != packed_weight.shape[0]:
+        raise ValueError(
+            f"ModelOpt NVFP4 '{key}' row mismatch: weight has "
+            f"{packed_weight.shape[0]}, scales have {block_scales.shape[0]}."
+        )
+
+    hidden_size = packed_weight.shape[1] * 2
+    expected_scale_columns = hidden_size // _NVFP4_GROUP_SIZE
+    if (
+        hidden_size % _NVFP4_GROUP_SIZE
+        or block_scales.shape[1] != expected_scale_columns
+    ):
+        raise ValueError(
+            f"ModelOpt NVFP4 '{key}' has incompatible packed/scales shapes: "
+            f"{tuple(packed_weight.shape)} and {tuple(block_scales.shape)}."
+        )
+
+    # Apply the selector to every row-shaped input before allocating the dense
+    # output. The global scale is scalar and intentionally remains unchanged.
+    packed_weight = _select_rows(packed_weight, row_indices, key)
+    block_scales = _select_rows(block_scales, row_indices, scale_key)
+
+    logger.info(
+        "Materializing unswizzled ModelOpt W4A16 NVFP4 tensor '{}' as BF16 with "
+        "shape ({}, {}).",
+        key,
+        packed_weight.shape[0],
+        hidden_size,
+    )
+    return _dequantize_unswizzled_nvfp4(
+        packed_weight,
+        block_scales,
+        global_scale,
+    )
+
+
+def _dequantize_unswizzled_nvfp4(
+    packed_weight: torch.Tensor,
+    block_scales: torch.Tensor,
+    global_scale: torch.Tensor,
+    *,
+    chunk_rows: int = 1024,
+) -> torch.Tensor:
+    """CPU, row-chunked equivalent of vLLM's unswizzled NVFP4 dequantizer."""
+    if chunk_rows <= 0:
+        raise ValueError(f"chunk_rows must be positive, got {chunk_rows}.")
+    rows, packed_hidden_size = packed_weight.shape
+    hidden_size = packed_hidden_size * 2
+    output = torch.empty((rows, hidden_size), dtype=torch.bfloat16)
+    e2m1 = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+        dtype=torch.float32,
+    )
+    global_scale_f32 = global_scale.to(torch.float32)
+
+    for start in range(0, rows, chunk_rows):
+        end = min(start + chunk_rows, rows)
+        packed = packed_weight[start:end]
+        low = packed & 0x0F
+        high = (packed >> 4) & 0x0F
+        nibbles = torch.stack((low, high), dim=-1).reshape(end - start, hidden_size)
+        magnitudes = e2m1[(nibbles & 0x07).to(torch.long)]
+        signs = torch.where((nibbles & 0x08) != 0, -1.0, 1.0)
+        values = (magnitudes * signs).reshape(
+            end - start,
+            hidden_size // _NVFP4_GROUP_SIZE,
+            _NVFP4_GROUP_SIZE,
+        )
+        scales = block_scales[start:end].to(torch.float32) * global_scale_f32
+        output[start:end] = (values * scales.unsqueeze(-1)).reshape(
+            end - start, hidden_size
+        )
+
+    return output
 
 
 def _resolve_file(model_path: str, file_name: str) -> Path:

--- a/tests/unit/models/test_modelopt_verifier_weights.py
+++ b/tests/unit/models/test_modelopt_verifier_weights.py
@@ -1,0 +1,109 @@
+"""Tests for loading ModelOpt NVFP4 verifier-owned projections."""
+
+import json
+
+import pytest
+import torch
+from safetensors.torch import save_file
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+
+from speculators import SpeculatorsConfig, VerifierConfig
+from speculators.models.dflash import DFlashDraftModel, DFlashSpeculatorConfig
+from speculators.proposals.greedy import GreedyTokenProposalConfig
+from speculators.utils.loading import _dequantize_unswizzled_nvfp4
+
+
+def _write_verifier(path) -> dict[str, torch.Tensor]:
+    vocab_size = 4
+    hidden_size = 32
+    nibbles = (
+        torch.arange(vocab_size * hidden_size, dtype=torch.uint8).reshape(
+            vocab_size, hidden_size
+        )
+        % 16
+    )
+    tensors = {
+        "model.embed_tokens.weight": torch.randn(
+            vocab_size, hidden_size, dtype=torch.bfloat16
+        ),
+        "lm_head.weight": nibbles[:, 0::2] | (nibbles[:, 1::2] << 4),
+        "lm_head.weight_scale": torch.tensor(
+            [[1.0, 2.0], [2.0, 1.0], [0.5, 1.5], [1.5, 0.5]]
+        ).to(torch.float8_e4m3fn),
+        "lm_head.weight_scale_2": torch.tensor(0.5, dtype=torch.float32),
+        "model.norm.weight": torch.ones(hidden_size, dtype=torch.bfloat16),
+    }
+    shard_name = "model.safetensors"
+    save_file(tensors, path / shard_name)
+    (path / "hf_quant_config.json").write_text(
+        json.dumps(
+            {
+                "producer": {"name": "modelopt"},
+                "quantization": {
+                    "quant_algo": "MIXED_PRECISION",
+                    "quantized_layers": {
+                        "lm_head": {
+                            "quant_algo": "W4A16_NVFP4",
+                            "group_size": 16,
+                        }
+                    },
+                },
+            }
+        )
+    )
+    return tensors
+
+
+@pytest.mark.smoke
+def test_reduced_vocab_nvfp4_projection_is_frozen_and_backpropagates(tmp_path):
+    tensors = _write_verifier(tmp_path)
+    transformer_config = Qwen3Config(
+        vocab_size=4,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        max_position_embeddings=32,
+        layer_types=["full_attention"],
+        _attn_implementation="eager",
+    )
+    config = DFlashSpeculatorConfig(
+        transformer_layer_config=transformer_config,
+        draft_vocab_size=2,
+        block_size=2,
+        aux_hidden_state_layer_ids=[0],
+        mask_token_id=0,
+        speculators_config=SpeculatorsConfig(
+            algorithm="dflash",
+            proposal_methods=[GreedyTokenProposalConfig(speculative_tokens=1)],
+            default_proposal_method="greedy",
+            verifier=VerifierConfig(
+                name_or_path=str(tmp_path),
+                architectures=["Qwen3ForCausalLM"],
+            ),
+        ),
+    )
+    model = DFlashDraftModel(config)
+    selector = torch.tensor([True, False, True, False])
+    model.load_vocab_mappings(selector, torch.tensor([0, 2]))
+    model.load_verifier_weights()
+
+    expected = _dequantize_unswizzled_nvfp4(
+        tensors["lm_head.weight"],
+        tensors["lm_head.weight_scale"],
+        tensors["lm_head.weight_scale_2"],
+    )[selector]
+    assert torch.equal(model.lm_head.weight, expected)
+    assert torch.equal(model.verifier_lm_head.weight, expected)
+    assert model.lm_head.weight.requires_grad is False
+    assert model.verifier_lm_head.weight.requires_grad is False
+
+    hidden_states = torch.randn(3, 32, requires_grad=True)
+    model.lm_head(hidden_states).float().square().mean().backward()
+
+    assert hidden_states.grad is not None
+    assert torch.isfinite(hidden_states.grad).all()
+    assert model.lm_head.weight.grad is None
+    assert model.verifier_lm_head.weight.grad is None

--- a/tests/unit/utils/test_loading.py
+++ b/tests/unit/utils/test_loading.py
@@ -2,11 +2,15 @@
 Unit tests for the loading module in the Speculators library.
 """
 
+import json
+
 import pytest
 import torch
+from safetensors.torch import save_file
 from transformers import AutoModelForCausalLM
 
 from speculators.utils.loading import (
+    _dequantize_unswizzled_nvfp4,
     _resolve_file,
     _resolve_key,
     is_config_only_dir,
@@ -16,6 +20,69 @@ from speculators.utils.loading import (
 # Test model from HuggingFace
 TEST_MODEL_REPO = "nm-testing/tiny-testing-random-weights"
 SMALL_MODEL_REPO = "nm-testing/tinysmokellama-3.2"
+
+
+def _nvfp4_tensors(rows: int = 4, groups: int = 2) -> dict[str, torch.Tensor]:
+    hidden_size = groups * 16
+    nibbles = (
+        torch.arange(rows * hidden_size, dtype=torch.uint8).reshape(rows, hidden_size)
+        % 16
+    )
+    packed = nibbles[:, 0::2] | (nibbles[:, 1::2] << 4)
+    scales = torch.arange(1, rows * groups + 1, dtype=torch.float32).reshape(
+        rows, groups
+    )
+    return {
+        "lm_head.weight": packed,
+        "lm_head.weight_scale": scales.to(torch.float8_e4m3fn),
+        "lm_head.weight_scale_2": torch.tensor(0.5, dtype=torch.float32),
+    }
+
+
+def _write_nvfp4_checkpoint(
+    path,
+    *,
+    tensors: dict[str, torch.Tensor] | None = None,
+    quant_algo: str = "W4A16_NVFP4",
+    group_size: int = 16,
+    write_quant_config: bool = True,
+) -> None:
+    tensors = tensors or _nvfp4_tensors()
+    shard_name = "model-00001-of-00001.safetensors"
+    save_file(tensors, path / shard_name)
+    (path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": dict.fromkeys(tensors, shard_name)})
+    )
+    if write_quant_config:
+        (path / "hf_quant_config.json").write_text(
+            json.dumps(
+                {
+                    "producer": {"name": "modelopt"},
+                    "quantization": {
+                        "quant_algo": "MIXED_PRECISION",
+                        "quantized_layers": {
+                            "lm_head": {
+                                "quant_algo": quant_algo,
+                                "group_size": group_size,
+                            }
+                        },
+                    },
+                }
+            )
+        )
+
+
+def _reference_nvfp4(tensors: dict[str, torch.Tensor]) -> torch.Tensor:
+    packed = tensors["lm_head.weight"]
+    low = packed & 0x0F
+    high = (packed >> 4) & 0x0F
+    nibbles = torch.stack((low, high), dim=-1).flatten(start_dim=1)
+    e2m1 = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
+    values = e2m1[(nibbles & 0x07).long()]
+    values *= torch.where((nibbles & 0x08) != 0, -1.0, 1.0)
+    scales = tensors["lm_head.weight_scale"].float().repeat_interleave(16, dim=1)
+    return (values * scales * tensors["lm_head.weight_scale_2"]).to(torch.bfloat16)
+
 
 # is_config_only_dir Tests
 
@@ -210,3 +277,203 @@ def test_load_model_layers_matches_full_model():
         assert torch.equal(util_tensor, model_tensor), (
             f"Tensor values don't match for {layer_name}"
         )
+
+
+@pytest.mark.smoke
+def test_load_model_layers_materializes_modelopt_w4a16_nvfp4(tmp_path):
+    tensors = _nvfp4_tensors()
+    _write_nvfp4_checkpoint(tmp_path, tensors=tensors)
+
+    loaded = load_model_layers(["lm_head.weight"], str(tmp_path))["lm_head.weight"]
+
+    assert loaded.dtype == torch.bfloat16
+    assert torch.equal(loaded, _reference_nvfp4(tensors))
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "selector",
+    [
+        torch.tensor([True, False, False, True]),
+        torch.tensor([3, 1], dtype=torch.int64),
+    ],
+)
+def test_nvfp4_select_then_dequantize_matches_dequantize_then_select(
+    tmp_path, selector
+):
+    tensors = _nvfp4_tensors()
+    _write_nvfp4_checkpoint(tmp_path, tensors=tensors)
+
+    selected = load_model_layers(
+        ["lm_head.weight"],
+        str(tmp_path),
+        row_indices={"lm_head.weight": selector},
+    )["lm_head.weight"]
+    full = load_model_layers(["lm_head.weight"], str(tmp_path))["lm_head.weight"]
+
+    assert torch.equal(selected, full[selector])
+
+
+@pytest.mark.smoke
+def test_load_model_layers_selects_dense_rows(tmp_path):
+    weight = torch.arange(24, dtype=torch.bfloat16).reshape(4, 6)
+    save_file({"lm_head.weight": weight}, tmp_path / "model.safetensors")
+    selector = torch.tensor([2, 0], dtype=torch.int64)
+
+    selected = load_model_layers(
+        ["lm_head.weight"],
+        str(tmp_path),
+        row_indices={"lm_head.weight": selector},
+    )["lm_head.weight"]
+
+    assert torch.equal(selected, weight[selector])
+
+
+@pytest.mark.smoke
+def test_packed_weight_requires_modelopt_quant_config(tmp_path):
+    _write_nvfp4_checkpoint(tmp_path, write_quant_config=False)
+
+    with pytest.raises(ValueError, match="requires hf_quant_config.json"):
+        load_model_layers(["lm_head.weight"], str(tmp_path))
+
+
+@pytest.mark.smoke
+def test_packed_weight_rejects_non_modelopt_producer(tmp_path):
+    _write_nvfp4_checkpoint(tmp_path)
+    config_path = tmp_path / "hf_quant_config.json"
+    config = json.loads(config_path.read_text())
+    config["producer"]["name"] = "unknown"
+    config_path.write_text(json.dumps(config))
+
+    with pytest.raises(ValueError, match="requires a ModelOpt-produced"):
+        load_model_layers(["lm_head.weight"], str(tmp_path))
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("quant_algo", "group_size"),
+    [("FP8", 16), ("W4A16_NVFP4", 32)],
+)
+def test_packed_weight_rejects_unsupported_quantization(
+    tmp_path, quant_algo, group_size
+):
+    _write_nvfp4_checkpoint(tmp_path, quant_algo=quant_algo, group_size=group_size)
+
+    with pytest.raises(ValueError, match="only the verified unswizzled"):
+        load_model_layers(["lm_head.weight"], str(tmp_path))
+
+
+@pytest.mark.smoke
+def test_nvfp4_rejects_missing_scales(tmp_path):
+    tensors = _nvfp4_tensors()
+    del tensors["lm_head.weight_scale_2"]
+    _write_nvfp4_checkpoint(tmp_path, tensors=tensors)
+
+    with pytest.raises(ValueError, match="missing ModelOpt NVFP4 metadata"):
+        load_model_layers(["lm_head.weight"], str(tmp_path))
+
+
+@pytest.mark.smoke
+def test_nvfp4_rejects_non_matrix_packed_weight(tmp_path):
+    tensors = _nvfp4_tensors()
+    tensors["lm_head.weight"] = torch.zeros(16, dtype=torch.uint8)
+    _write_nvfp4_checkpoint(tmp_path, tensors=tensors)
+
+    with pytest.raises(ValueError, match="expects 2-D weight/scales"):
+        load_model_layers(["lm_head.weight"], str(tmp_path))
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    ("tensor_name", "replacement", "match"),
+    [
+        (
+            "lm_head.weight_scale",
+            torch.ones((4, 2), dtype=torch.float32),
+            "must use float8_e4m3fn",
+        ),
+        (
+            "lm_head.weight_scale_2",
+            torch.tensor(0.5, dtype=torch.bfloat16),
+            "must be a scalar float32",
+        ),
+        (
+            "lm_head.weight_scale_2",
+            torch.ones(1, dtype=torch.float32),
+            "must be a scalar float32",
+        ),
+        (
+            "lm_head.weight_scale",
+            torch.ones((3, 2), dtype=torch.float8_e4m3fn),
+            "row mismatch",
+        ),
+        (
+            "lm_head.weight_scale",
+            torch.ones((4, 1), dtype=torch.float8_e4m3fn),
+            "incompatible packed/scales shapes",
+        ),
+        (
+            "lm_head.weight_scale",
+            torch.ones(8, dtype=torch.float8_e4m3fn),
+            "expects 2-D weight/scales",
+        ),
+    ],
+)
+def test_nvfp4_rejects_invalid_scale_layout(tmp_path, tensor_name, replacement, match):
+    tensors = _nvfp4_tensors()
+    tensors[tensor_name] = replacement
+    _write_nvfp4_checkpoint(tmp_path, tensors=tensors)
+
+    with pytest.raises(ValueError, match=match):
+        load_model_layers(["lm_head.weight"], str(tmp_path))
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "selector",
+    [
+        torch.tensor([[True, False, True, False]]),
+        torch.tensor([True, False]),
+        torch.tensor([4], dtype=torch.int64),
+        torch.tensor([0.0]),
+    ],
+)
+def test_load_model_layers_rejects_invalid_row_selector(tmp_path, selector):
+    _write_nvfp4_checkpoint(tmp_path)
+
+    with pytest.raises((IndexError, TypeError, ValueError)):
+        load_model_layers(
+            ["lm_head.weight"],
+            str(tmp_path),
+            row_indices={"lm_head.weight": selector},
+        )
+
+
+@pytest.mark.smoke
+def test_dequantize_unswizzled_nvfp4_matches_vllm_when_available():
+    try:
+        from vllm.model_executor.layers.quantization.utils.nvfp4_emulation_utils import (  # noqa: E501, PLC0415
+            dequantize_to_dtype,
+        )
+    except (ImportError, RuntimeError) as error:
+        pytest.skip(f"vLLM NVFP4 helper is unavailable: {error}")
+    if not torch.cuda.is_available():
+        pytest.skip("vLLM's NVFP4 parity helper requires CUDA tensors")
+
+    tensors = _nvfp4_tensors(rows=3, groups=4)
+    actual = _dequantize_unswizzled_nvfp4(
+        tensors["lm_head.weight"],
+        tensors["lm_head.weight_scale"],
+        tensors["lm_head.weight_scale_2"],
+        chunk_rows=2,
+    )
+    expected = dequantize_to_dtype(
+        tensors["lm_head.weight"].cuda(),
+        tensors["lm_head.weight_scale"].cuda(),
+        tensors["lm_head.weight_scale_2"].cuda(),
+        torch.bfloat16,
+        block_size=16,
+        swizzle=False,
+    ).cpu()
+
+    assert torch.equal(actual, expected)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Allow Speculators training to load verifier LM heads directly from ModelOpt `W4A16_NVFP4` checkpoints.

ModelOpt stores the LM head as packed FP4 weights plus per-group and global scales, while Speculators currently expects a dense floating-point `lm_head.weight`.

This PR:

- detects and validates the supported ModelOpt `W4A16_NVFP4` representation;
- materializes the packed LM head once as a frozen BF16 projection for training;
- preserves reduced-vocabulary row selection before dequantization;
- keeps the existing dense BF16/FP16 verifier path unchanged; and
- does not add vLLM as a runtime dependency.

The materialized projection remains frozen while gradients continue to flow through it to draft hidden states.

## Tests

```bash
PYTHONPATH=src pytest -q -m smoke \
  tests/unit/utils/test_loading.py \
  tests/unit/models/test_modelopt_verifier_weights.py
```

Result:

```
33 passed, 4 deselected
```

Additional validation:

relevant offline unit subset: 89 passed, 15 deselected;
ruff format --check and ruff check: passed;
mypy --check-untyped-defs: passed;
verified synthetic dequantization parity with vLLM for swizzle=False;
verified reduced-vocabulary select-before-dequantization parity;
successfully materialized and reloaded the full Qwen3.6-27B NVFP4 LM head;
successfully ran a DSpark forward/backward pass with finite draft gradients and no verifier-projection gradients.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [ ] I (a human) have written or reviewed the code in this pr to the best of my ability.