### PR TITLE
fix(dspark): initialize and optimize the Markov lookup embedding as an embedding

### DIFF
--- a/src/speculators/models/dspark/model_definitions.py
+++ b/src/speculators/models/dspark/model_definitions.py
@@ -33,6 +33,7 @@ class MarkovHead(nn.Module):
         self.head_type = head_type
         self.markov_rank = markov_rank
         self.markov_w1 = nn.Embedding(verifier_vocab_size, markov_rank)
+        nn.init.normal_(self.markov_w1.weight, std=0.01)
         self.markov_w2 = nn.Linear(markov_rank, draft_vocab_size, bias=False)
         if head_type == "gated":
             self.gate_proj = nn.Linear(hidden_size + markov_rank, markov_rank)

--- a/src/speculators/train/optimizers.py
+++ b/src/speculators/train/optimizers.py
@@ -21,9 +21,9 @@ from torch.nn import Module
 logger = logging.getLogger("speculators")
 
 # Names of parameters that are 2D but should still be optimized with AdamW rather than
-# Muon, following the convention from Keller Jordan's Muon (embeddings and the output
-# head are excluded from the orthogonalized update).
-_ADAMW_NAME_HINTS = ("embed_tokens", "lm_head")
+# Muon, following the convention from Keller Jordan's Muon (embeddings, the Markov
+# lookup embedding, and the output head are excluded from the orthogonalized update).
+_ADAMW_NAME_HINTS = ("embed_tokens", "lm_head", "markov_w1")
 
 # Muon only orthogonalizes 2D weight matrices.
 _MATRIX_NDIM = 2

--- a/src/speculators/train/optimizers.py
+++ b/src/speculators/train/optimizers.py
@@ -21,9 +21,16 @@ from torch.nn import Module
 logger = logging.getLogger("speculators")
 
 # Names of parameters that are 2D but should still be optimized with AdamW rather than
-# Muon, following the convention from Keller Jordan's Muon (embeddings and the output
-# head and embedding-like codebooks are excluded from the orthogonalized update).
-_ADAMW_NAME_HINTS = ("embed_tokens", "lm_head", "codebook")
+# Muon, following the convention from Keller Jordan's Muon (embeddings, embedding-like
+# codebooks, Markov vocabulary factors, and output heads are excluded from the
+# orthogonalized update).
+_ADAMW_NAME_HINTS = (
+    "embed_tokens",
+    "lm_head",
+    "codebook",
+    "markov_w1",
+    "markov_w2",
+)
 
 # Muon only orthogonalizes 2D weight matrices.
 _MATRIX_NDIM = 2
@@ -35,10 +42,10 @@ def split_named_params_for_muon(
     """Split a model's trainable parameters into Muon and AdamW groups.
 
     A parameter goes to Muon iff it requires gradients, is a 2D matrix with both
-    dimensions > 1, and is not an embedding, codebook, or LM-head weight; everything
-    else goes to AdamW. Degenerate 2D weights (``[1, N]`` / ``[N, 1]`` vectors) route
-    to AdamW -- Muon orthogonalizes matrices, not vectors, and crashes on them under
-    FSDP2.
+    dimensions > 1, and is not an embedding, codebook, or vocabulary-output weight;
+    everything else goes to AdamW. Degenerate 2D weights (``[1, N]`` / ``[N, 1]``
+    vectors) route to AdamW -- Muon orthogonalizes matrices, not vectors, and crashes
+    on them under FSDP2.
 
     :param model: The model whose parameters should be partitioned.
     :return: A ``(muon_params, adamw_params)`` tuple of named parameter lists.

--- a/tests/unit/models/test_dspark_model_definitions.py
+++ b/tests/unit/models/test_dspark_model_definitions.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from speculators.models.dspark.model_definitions import ConfidenceHead, MarkovHead
+from speculators.train.optimizers import split_named_params_for_muon
 
 
 class TestMarkovHead:
@@ -45,6 +46,25 @@ class TestMarkovHead:
             prev_token_ids=torch.tensor([[2]]), hidden_states=hidden
         )
         assert not torch.allclose(bias_a, bias_b)
+
+    def test_lookup_embedding_has_small_initialization(self):
+        head = self._head("vanilla")
+
+        assert head.markov_w1.weight.std().item() == pytest.approx(0.01, rel=0.2)
+
+    def test_vocab_factors_use_adamw_under_muon_optimizer(self):
+        head = self._head("gated")
+
+        muon, adamw = split_named_params_for_muon(head)
+        muon_names = {name for name, _ in muon}
+        adamw_names = {name for name, _ in adamw}
+
+        assert muon_names == {"gate_proj.weight"}
+        assert adamw_names == {
+            "markov_w1.weight",
+            "markov_w2.weight",
+            "gate_proj.bias",
+        }
 
     def test_invalid_rank_raises(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Change the way we init the markov head and switch it to using the Adam optimizer. These should be better defaults for the embedding layer. 

## Tests

Not extensively validated, and change is primarily theoretical. More experimentation to follow. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>