### PR TITLE
docs(examples): add multi-node Kimi-K3 DSpark training example

### DIFF
--- a/examples/train/kimi_k3_dspark/README.md
+++ b/examples/train/kimi_k3_dspark/README.md
@@ -1,8 +1,6 @@
 # Kimi-K3 DSpark training (multi-node, online extraction)
 
-Kimi-K3 does not fit on a single node, so this example keeps hidden-state
-extraction and draft training on disjoint node groups and streams hidden states
-between them through a Mooncake store:
+Kimi-K3 does not fit on a single node, so this example keeps hidden-state extraction and draft training on disjoint node groups and streams hidden states between them through a Mooncake store:
 
 ```text
 extraction (2 nodes)                 training (1 node)
@@ -11,21 +9,13 @@ Kimi-K3 vLLM TP8 + expert parallel -> torchrun DSpark DDP, 4 ranks
                   Mooncake streaming store
 ```
 
-This is a worked example for one 4-GPU-per-node NVL72 rack, not a portable
-harness. Values are hardcoded so the commands stay readable; adapt them rather
-than configuring them.
+This is a worked example for one 4-GPU-per-node NVL72 rack, not a portable harness. Values are hardcoded so the commands stay readable; adapt them rather than configuring them.
 
-`k3_draft_layer_config.json` is the draft **decoder** config and nothing else — a plain
-`Qwen3Config` that `--draft-config` loads as the speculator's
-`transformer_layer_config`. Everything above the decoder (block size, vocab
-size, mask token, target layers, the Markov and confidence heads) is set by the
-flags in `launch_train_node.sh`, not by this file.
+`k3_draft_layer_config.json` is the draft **decoder** config and nothing else — a plain `Qwen3Config` that `--draft-config` loads as the speculator's `transformer_layer_config`. Everything above the decoder (block size, vocab size, mask token, target layers, the Markov and confidence heads) is set by the flags in `launch_train_node.sh`, not by this file.
 
 ## Requirements
 
-- Two environments: one with vLLM plus `hs_connectors` and
-  `mooncake-transfer-engine` (extraction), one with `speculators` plus
-  `mooncake-transfer-engine` (training).
+- Two environments: one with vLLM plus `hs_connectors` and `mooncake-transfer-engine` (extraction), one with `speculators` plus `mooncake-transfer-engine` (training).
 - Verifier weights at `/mnt/shared/weights/kimi-k3`, or set `MODEL_PATH`.
 
 ## The components
@@ -37,8 +27,7 @@ SOURCE_JSONL=/path/to/data.jsonl \
   sbatch --export=ALL,SOURCE_JSONL examples/train/kimi_k3_dspark/prepare_data.sbatch
 ```
 
-Writes the Arrow dataset, token frequencies, and vocabulary mapping to
-`runs/kimi_k3_dspark/data`. Everything below expects it to exist.
+Writes the Arrow dataset, token frequencies, and vocabulary mapping to `runs/kimi_k3_dspark/data`. Everything below expects it to exist.
 
 ### 2. Mooncake master
 
@@ -56,9 +45,7 @@ NODE_RANK=0 EXTRACT_ADDR=<head-fabric-ip> MOONCAKE_MASTER=<host>:50051 \
   bash examples/train/kimi_k3_dspark/launch_extractor_node.sh
 ```
 
-`NODE_RANK=0` on the head, `1` on the other; `EXTRACT_ADDR` is the head's fabric
-IP on both. Rank 1 runs `--headless`. Wait for `/health` on port 8000 before
-starting training.
+`NODE_RANK=0` on the head, `1` on the other; `EXTRACT_ADDR` is the head's fabric IP on both. Rank 1 runs `--headless`. Wait for `/health` on port 8000 before starting training.
 
 ### 4. Trainer
 
@@ -67,15 +54,11 @@ MOONCAKE_MASTER=<host>:50051 VLLM_ENDPOINT=http://<head-fabric-ip>:8000/v1 \
   bash examples/train/kimi_k3_dspark/launch_train_node.sh
 ```
 
-Add `MAX_STEPS=20` for a smoke run. Other useful overrides: `MODEL_PATH`,
-`DATA_DIR`, `RUN_NAME`, `TRAIN_LOGGER=''` to disable W&B.
+Add `MAX_STEPS=20` for a smoke run. Other useful overrides: `MODEL_PATH`, `DATA_DIR`, `RUN_NAME`, `TRAIN_LOGGER=''` to disable W&B.
 
 ## Running all four under Slurm
 
-`run.sbatch` does exactly the above on a 3-node allocation: nodes 0-1 extract,
-node 2 trains, the Mooncake master shares node 0. It resolves the extractor
-head's fabric address, waits for `/health`, then launches training, and stops
-the extractors and master when training exits.
+`run.sbatch` does exactly the above on a 3-node allocation: nodes 0-1 extract, node 2 trains, the Mooncake master shares node 0. It resolves the extractor head's fabric address, waits for `/health`, then launches training, and stops the extractors and master when training exits.
 
 ```bash
 sbatch examples/train/kimi_k3_dspark/run.sbatch
@@ -83,13 +66,6 @@ sbatch examples/train/kimi_k3_dspark/run.sbatch
 
 Logs and checkpoints land in `runs/kimi_k3_dspark/<run-name>/`.
 
-
 ## Integrity and failure handling
 
-Every Mooncake sample carries a versioned shape/dtype/CRC32 manifest. The
-producer rejects non-finite tensors before publication; the consumer verifies
-checksum and finiteness before training. Invalid round trips are regenerated
-twice, independently of the HTTP retry budget. An exhausted sample is dropped;
-if that leaves a rank with no valid samples it runs a locally empty zero-loss
-batch and still participates in DDP. Twenty consecutive failed round trips in
-one worker trip a synchronized circuit breaker.
+Every Mooncake sample carries a versioned shape/dtype/CRC32 manifest. The producer rejects non-finite tensors before publication; the consumer verifies checksum and finiteness before training. Invalid round trips are regenerated twice, independently of the HTTP retry budget. An exhausted sample is dropped; if that leaves a rank with no valid samples it runs a locally empty zero-loss batch and still participates in DDP. Twenty consecutive failed round trips in one worker trip a synchronized circuit breaker.

--- a/examples/train/kimi_k3_dspark/README.md
+++ b/examples/train/kimi_k3_dspark/README.md
@@ -42,6 +42,7 @@ mooncake_master --rpc_port 50051 --metrics_port 9003 \
 
 ```bash
 NODE_RANK=0 EXTRACT_ADDR=<head-fabric-ip> MOONCAKE_MASTER=<host>:50051 \
+  FABRIC_SUBNET=<subnet-prefix> \
   bash examples/train/kimi_k3_dspark/launch_extractor_node.sh
 ```
 
@@ -51,17 +52,18 @@ NODE_RANK=0 EXTRACT_ADDR=<head-fabric-ip> MOONCAKE_MASTER=<host>:50051 \
 
 ```bash
 MOONCAKE_MASTER=<host>:50051 VLLM_ENDPOINT=http://<head-fabric-ip>:8000/v1 \
+  FABRIC_SUBNET=<subnet-prefix> \
   bash examples/train/kimi_k3_dspark/launch_train_node.sh
 ```
 
-Add `MAX_STEPS=20` for a smoke run. Other useful overrides: `MODEL_PATH`, `DATA_DIR`, `RUN_NAME`, `TRAIN_LOGGER=''` to disable W&B.
+Add `MAX_STEPS=20` for a smoke run. Other useful overrides: `MODEL_PATH`, `DATA_DIR`, `RUN_NAME`.
 
 ## Running all four under Slurm
 
 `run.sbatch` does exactly the above on a 3-node allocation: nodes 0-1 extract, node 2 trains, the Mooncake master shares node 0. It resolves the extractor head's fabric address, waits for `/health`, then launches training, and stops the extractors and master when training exits.
 
 ```bash
-sbatch examples/train/kimi_k3_dspark/run.sbatch
+FABRIC_SUBNET=<subnet-prefix> sbatch --export=ALL examples/train/kimi_k3_dspark/run.sbatch
 ```
 
 Logs and checkpoints land in `runs/kimi_k3_dspark/<run-name>/`.

--- a/examples/train/kimi_k3_dspark/README.md
+++ b/examples/train/kimi_k3_dspark/README.md
@@ -1,0 +1,95 @@
+# Kimi-K3 DSpark training (multi-node, online extraction)
+
+Kimi-K3 does not fit on a single node, so this example keeps hidden-state
+extraction and draft training on disjoint node groups and streams hidden states
+between them through a Mooncake store:
+
+```text
+extraction (2 nodes)                 training (1 node)
+Kimi-K3 vLLM TP8 + expert parallel -> torchrun DSpark DDP, 4 ranks
+                 \                    /
+                  Mooncake streaming store
+```
+
+This is a worked example for one 4-GPU-per-node NVL72 rack, not a portable
+harness. Values are hardcoded so the commands stay readable; adapt them rather
+than configuring them.
+
+`k3_draft_layer_config.json` is the draft **decoder** config and nothing else — a plain
+`Qwen3Config` that `--draft-config` loads as the speculator's
+`transformer_layer_config`. Everything above the decoder (block size, vocab
+size, mask token, target layers, the Markov and confidence heads) is set by the
+flags in `launch_train_node.sh`, not by this file.
+
+## Requirements
+
+- Two environments: one with vLLM plus `hs_connectors` and
+  `mooncake-transfer-engine` (extraction), one with `speculators` plus
+  `mooncake-transfer-engine` (training).
+- Verifier weights at `/mnt/shared/weights/kimi-k3`, or set `MODEL_PATH`.
+
+## The components
+
+### 1. Prepare data
+
+```bash
+SOURCE_JSONL=/path/to/data.jsonl \
+  sbatch --export=ALL,SOURCE_JSONL examples/train/kimi_k3_dspark/prepare_data.sbatch
+```
+
+Writes the Arrow dataset, token frequencies, and vocabulary mapping to
+`runs/kimi_k3_dspark/data`. Everything below expects it to exist.
+
+### 2. Mooncake master
+
+One per run, anywhere both groups can reach:
+
+```bash
+mooncake_master --rpc_port 50051 --metrics_port 9003 \
+  --rpc_thread_num 8 --enable_disk_eviction=false --logtostderr=true
+```
+
+### 3. Extractor (both nodes of the TP8 pair)
+
+```bash
+NODE_RANK=0 EXTRACT_ADDR=<head-fabric-ip> MOONCAKE_MASTER=<host>:50051 \
+  bash examples/train/kimi_k3_dspark/launch_extractor_node.sh
+```
+
+`NODE_RANK=0` on the head, `1` on the other; `EXTRACT_ADDR` is the head's fabric
+IP on both. Rank 1 runs `--headless`. Wait for `/health` on port 8000 before
+starting training.
+
+### 4. Trainer
+
+```bash
+MOONCAKE_MASTER=<host>:50051 VLLM_ENDPOINT=http://<head-fabric-ip>:8000/v1 \
+  bash examples/train/kimi_k3_dspark/launch_train_node.sh
+```
+
+Add `MAX_STEPS=20` for a smoke run. Other useful overrides: `MODEL_PATH`,
+`DATA_DIR`, `RUN_NAME`, `TRAIN_LOGGER=''` to disable W&B.
+
+## Running all four under Slurm
+
+`run.sbatch` does exactly the above on a 3-node allocation: nodes 0-1 extract,
+node 2 trains, the Mooncake master shares node 0. It resolves the extractor
+head's fabric address, waits for `/health`, then launches training, and stops
+the extractors and master when training exits.
+
+```bash
+sbatch examples/train/kimi_k3_dspark/run.sbatch
+```
+
+Logs and checkpoints land in `runs/kimi_k3_dspark/<run-name>/`.
+
+
+## Integrity and failure handling
+
+Every Mooncake sample carries a versioned shape/dtype/CRC32 manifest. The
+producer rejects non-finite tensors before publication; the consumer verifies
+checksum and finiteness before training. Invalid round trips are regenerated
+twice, independently of the HTTP retry budget. An exhausted sample is dropped;
+if that leaves a rank with no valid samples it runs a locally empty zero-loss
+batch and still participates in DDP. Twenty consecutive failed round trips in
+one worker trip a synchronized circuit breaker.

--- a/examples/train/kimi_k3_dspark/k3_draft_layer_config.json
+++ b/examples/train/kimi_k3_dspark/k3_draft_layer_config.json
@@ -1,0 +1,36 @@
+{
+  "model_type": "qwen3",
+  "num_hidden_layers": 5,
+  "hidden_size": 7168,
+  "intermediate_size": 14336,
+  "num_attention_heads": 96,
+  "num_key_value_heads": 16,
+  "head_dim": 64,
+  "hidden_act": "silu",
+  "vocab_size": 163840,
+  "max_position_embeddings": 1048576,
+  "layer_types": [
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention",
+    "sliding_attention"
+  ],
+  "use_sliding_window": true,
+  "sliding_window": 2048,
+  "max_window_layers": 28,
+  "attention_bias": false,
+  "attention_dropout": 0.0,
+  "rms_norm_eps": 1e-05,
+  "rope_parameters": {
+    "rope_type": "default",
+    "rope_theta": 10000.0
+  },
+  "initializer_range": 0.02,
+  "tie_word_embeddings": false,
+  "use_cache": true,
+  "bos_token_id": 163584,
+  "eos_token_id": 163586,
+  "pad_token_id": 163839,
+  "transformers_version": "5.14.1"
+}

--- a/examples/train/kimi_k3_dspark/launch_extractor_node.sh
+++ b/examples/train/kimi_k3_dspark/launch_extractor_node.sh
@@ -3,7 +3,8 @@
 # One Kimi-K3 extraction node. Run this on both nodes of the TP8 pair, with
 # NODE_RANK=0 on the head and NODE_RANK=1 on the other.
 #
-# Required: NODE_RANK, EXTRACT_ADDR (head node's fabric IP), MOONCAKE_MASTER
+# Required: NODE_RANK, EXTRACT_ADDR (head node's fabric IP), MOONCAKE_MASTER,
+#           FABRIC_SUBNET (prefix of the fast-fabric IPv4 subnet)
 
 set -euo pipefail
 
@@ -18,7 +19,8 @@ mooncake_master="${MOONCAKE_MASTER:?MOONCAKE_MASTER is required}"
 
 # Every rank must bind to the fast fabric, not the management NIC. Different
 # ranks picking different interfaces hang at rendezvous with no error.
-fabric_iface="$(ip -o -4 addr show | awk '$4 ~ /^10\.13\.84\./ {print $2; exit}')"
+fabric_subnet="${FABRIC_SUBNET:?FABRIC_SUBNET is required}"
+fabric_iface="$(ip -o -4 addr show | awk -v s="^$fabric_subnet" '$4 ~ s {print $2; exit}')"
 fabric_addr="$(ip -o -4 addr show dev "$fabric_iface" | awk '{sub(/\/.*/, "", $4); print $4; exit}')"
 
 export PYTHONPATH="$repo_root/hs_connectors/src:$repo_root/src${PYTHONPATH:+:$PYTHONPATH}"

--- a/examples/train/kimi_k3_dspark/launch_extractor_node.sh
+++ b/examples/train/kimi_k3_dspark/launch_extractor_node.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# One Kimi-K3 extraction node. Run this on both nodes of the TP8 pair, with
+# NODE_RANK=0 on the head and NODE_RANK=1 on the other.
+#
+# Required: NODE_RANK, EXTRACT_ADDR (head node's fabric IP), MOONCAKE_MASTER
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+model_path="${MODEL_PATH:-moonshotai/Kimi-K3}"
+vllm_python="${VLLM_PYTHON:-python}"
+
+node_rank="${NODE_RANK:-${SLURM_PROCID:?NODE_RANK is required (0 on the head node)}}"
+extract_addr="${EXTRACT_ADDR:?EXTRACT_ADDR is required (head node fabric IP)}"
+mooncake_master="${MOONCAKE_MASTER:?MOONCAKE_MASTER is required}"
+
+# Every rank must bind to the fast fabric, not the management NIC. Different
+# ranks picking different interfaces hang at rendezvous with no error.
+fabric_iface="$(ip -o -4 addr show | awk '$4 ~ /^10\.13\.84\./ {print $2; exit}')"
+fabric_addr="$(ip -o -4 addr show dev "$fabric_iface" | awk '{sub(/\/.*/, "", $4); print $4; exit}')"
+
+export PYTHONPATH="$repo_root/hs_connectors/src:$repo_root/src${PYTHONPATH:+:$PYTHONPATH}"
+export NCCL_SOCKET_IFNAME="$fabric_iface"
+export GLOO_SOCKET_IFNAME="$fabric_iface"
+export MOONCAKE_LOCAL_HOSTNAME="$fabric_addr"
+export NCCL_MNNVL_ENABLE=1
+export TORCH_DISTRIBUTED_USE_LIBUV=0
+export VLLM_ALLREDUCE_USE_FLASHINFER=1
+export VLLM_ENGINE_READY_TIMEOUT_S=3600
+export VLLM_USE_V2_MODEL_RUNNER=0
+export VLLM_USE_RUST_FRONTEND=1
+
+vllm_args=(
+  --served-model-name "$model_path"
+  --trust-remote-code
+  --load-format fastsafetensors
+  --moe-backend auto
+  --all2all-backend flashinfer_nvlink_one_sided
+  --enable-expert-parallel
+  --gpu-memory-utilization 0.95
+  --compilation-config '{"pass_config":{"fuse_allreduce_rms":false}}'
+  --tensor-parallel-size 8
+  --nnodes 2
+  --node-rank "$node_rank"
+  --master-addr "$extract_addr"
+  --port 8000
+  --max-model-len 8193
+  --max-num-seqs 64
+  --max-num-batched-tokens 32768
+  --kv-cache-dtype auto
+  --attention-config '{"mla_prefill_backend":"TRTLLM_RAGGED","use_prefill_query_quantization":false}'
+  --no-enable-prefix-caching
+  --language-model-only
+)
+if [[ "$node_rank" != "0" ]]; then
+  vllm_args+=(--headless)
+fi
+
+echo "[$(hostname -s)] extractor rank=$node_rank/2 tp=8 iface=$fabric_iface"
+cd "$repo_root"
+exec "$vllm_python" scripts/launch_vllm.py "$model_path" \
+  --hidden-states-backend mooncake \
+  --mooncake-master "$mooncake_master" \
+  --mooncake-metadata-server P2PHANDSHAKE \
+  --mooncake-protocol tcp \
+  --mooncake-global-segment-gib 32 \
+  --mooncake-local-buffer-gib 4 \
+  --mooncake-writer-threads 4 \
+  --target-layer-ids 24 48 72 88 92 \
+  --trust-remote-code \
+  -- "${vllm_args[@]}"

--- a/examples/train/kimi_k3_dspark/launch_train_node.sh
+++ b/examples/train/kimi_k3_dspark/launch_train_node.sh
@@ -3,7 +3,7 @@
 # DSpark draft training: 4 DDP ranks on one node, consuming hidden states from
 # the extractor through Mooncake.
 #
-# Required: MOONCAKE_MASTER, VLLM_ENDPOINT
+# Required: MOONCAKE_MASTER, VLLM_ENDPOINT, FABRIC_SUBNET
 
 set -euo pipefail
 
@@ -17,7 +17,8 @@ run_dir="${RUN_DIR:-$repo_root/runs/kimi_k3_dspark/$run_name}"
 mooncake_master="${MOONCAKE_MASTER:?MOONCAKE_MASTER is required}"
 vllm_endpoint="${VLLM_ENDPOINT:?VLLM_ENDPOINT is required}"
 
-fabric_iface="$(ip -o -4 addr show | awk '$4 ~ /^10\.13\.84\./ {print $2; exit}')"
+fabric_subnet="${FABRIC_SUBNET:?FABRIC_SUBNET is required}"
+fabric_iface="$(ip -o -4 addr show | awk -v s="^$fabric_subnet" '$4 ~ s {print $2; exit}')"
 fabric_addr="$(ip -o -4 addr show dev "$fabric_iface" | awk '{sub(/\/.*/, "", $4); print $4; exit}')"
 
 export PYTHONPATH="$repo_root/hs_connectors/src:$repo_root/src${PYTHONPATH:+:$PYTHONPATH}"

--- a/examples/train/kimi_k3_dspark/launch_train_node.sh
+++ b/examples/train/kimi_k3_dspark/launch_train_node.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# DSpark draft training: 4 DDP ranks on one node, consuming hidden states from
+# the extractor through Mooncake.
+#
+# Required: MOONCAKE_MASTER, VLLM_ENDPOINT
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+model_path="${MODEL_PATH:-/mnt/shared/weights/kimi-k3}"
+data_dir="${DATA_DIR:-$repo_root/runs/kimi_k3_dspark/data}"
+run_name="${RUN_NAME:-kimi-k3-dspark}"
+run_dir="${RUN_DIR:-$repo_root/runs/kimi_k3_dspark/$run_name}"
+
+mooncake_master="${MOONCAKE_MASTER:?MOONCAKE_MASTER is required}"
+vllm_endpoint="${VLLM_ENDPOINT:?VLLM_ENDPOINT is required}"
+
+fabric_iface="$(ip -o -4 addr show | awk '$4 ~ /^10\.13\.84\./ {print $2; exit}')"
+fabric_addr="$(ip -o -4 addr show dev "$fabric_iface" | awk '{sub(/\/.*/, "", $4); print $4; exit}')"
+
+export PYTHONPATH="$repo_root/hs_connectors/src:$repo_root/src${PYTHONPATH:+:$PYTHONPATH}"
+export NCCL_SOCKET_IFNAME="$fabric_iface"
+export GLOO_SOCKET_IFNAME="$fabric_iface"
+export MOONCAKE_LOCAL_HOSTNAME="$fabric_addr"
+export NCCL_MNNVL_ENABLE=1
+export TORCH_DISTRIBUTED_USE_LIBUV=0
+export OMP_NUM_THREADS=8
+
+mkdir -p "$run_dir/logs" "$run_dir/checkpoints"
+
+extra_args=()
+if [[ -n "${MAX_STEPS:-}" ]]; then
+  extra_args+=(--max-steps "$MAX_STEPS")
+fi
+
+echo "[$(hostname -s)] train endpoint=$vllm_endpoint iface=$fabric_iface"
+cd "$repo_root"
+exec torchrun --standalone --nproc-per-node 4 \
+  scripts/train.py \
+  --verifier-name-or-path "$model_path" \
+  --trust-remote-code \
+  --draft-config "$script_dir/k3_draft_layer_config.json" \
+  --data-path "$data_dir" \
+  --save-path "$run_dir/checkpoints" \
+  --draft-vocab-size 163840 \
+  --mask-token-id 163837 \
+  --epochs 1 \
+  --checkpoint-freq 0.1 \
+  --total-seq-len 8192 \
+  --train-data-ratio 0.999 \
+  --speculator-type dspark \
+  --target-layer-ids 24 48 72 88 92 \
+  --block-size 8 \
+  --max-anchors 1024 \
+  --dflash-decay-gamma 4.0 \
+  --markov-rank 256 \
+  --markov-head-type vanilla \
+  --enable-confidence-head \
+  --confidence-head-with-markov \
+  --confidence-head-alpha 1.0 \
+  --loss-fn '{"ce":0.1,"tv":0.9}' \
+  --optimizer muon \
+  --lr 1e-4 \
+  --scheduler-type cosine \
+  --scheduler-warmup-ratio 0.03 \
+  --hidden-states-backend mooncake \
+  --mooncake-master "$mooncake_master" \
+  --mooncake-metadata-server P2PHANDSHAKE \
+  --mooncake-protocol tcp \
+  --mooncake-global-segment-gib 0 \
+  --mooncake-local-buffer-gib 4 \
+  --mooncake-writer-threads 4 \
+  --vllm-endpoint "$vllm_endpoint" \
+  --on-missing generate \
+  --on-generate delete \
+  --request-timeout 900 \
+  --max-retries 5 \
+  --generation-validation-retries 2 \
+  --max-consecutive-generation-failures 20 \
+  --num-workers 2 \
+  --prefetch-factor 2 \
+  --log-freq 20 \
+  --log-dir "$run_dir/logs" \
+  --run-name "$run_name" \
+  "${extra_args[@]}"

--- a/examples/train/kimi_k3_dspark/prepare_data.sbatch
+++ b/examples/train/kimi_k3_dspark/prepare_data.sbatch
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Tokenizes the JSONL into an Arrow dataset and builds the draft vocabulary
+# mapping. Run this once, before any distributed job.
+#
+#   SOURCE_JSONL=/path/to/data.jsonl sbatch --export=ALL,SOURCE_JSONL \
+#     examples/train/kimi_k3_dspark/prepare_data.sbatch
+
+#SBATCH --job-name=k3-dspark-data
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=64
+#SBATCH --mem=512G
+#SBATCH --time=04:00:00
+#SBATCH --output=%x-%j.out
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+model_path="${MODEL_PATH:-/mnt/shared/weights/kimi-k3}"
+source_jsonl="${SOURCE_JSONL:?SOURCE_JSONL is required}"
+data_dir="${DATA_DIR:-$repo_root/runs/kimi_k3_dspark/data}"
+
+export PYTHONPATH="$repo_root/hs_connectors/src:$repo_root/src${PYTHONPATH:+:$PYTHONPATH}"
+export TOKENIZERS_PARALLELISM=false
+
+cd "$repo_root"
+python scripts/prepare_data.py \
+  --model "$model_path" \
+  --trust-remote-code \
+  --data "$source_jsonl" \
+  --output "$data_dir" \
+  --seq-length 8192 \
+  --num-preprocessing-workers 48 \
+  --minimum-valid-tokens 16

--- a/examples/train/kimi_k3_dspark/run.sbatch
+++ b/examples/train/kimi_k3_dspark/run.sbatch
@@ -35,9 +35,11 @@ train_node="${nodes[2]}"
 
 # The extractor head's address on the fast fabric: vLLM's rendezvous point and
 # the host for both the Mooncake master and the HTTP endpoint.
+fabric_subnet="${FABRIC_SUBNET:?FABRIC_SUBNET is required}"
 extract_addr="$(srun --overlap --nodes=1 --ntasks=1 --nodelist="${nodes[0]}" \
-  bash -c "ip -o -4 addr show | awk '\$4 ~ /^10\.13\.84\./ {sub(/\/.*/, \"\", \$4); print \$4; exit}'")"
+  bash -c "ip -o -4 addr show | awk -v s='^$fabric_subnet' '\$4 ~ s {sub(/\/.*/, \"\", \$4); print \$4; exit}'")"
 export EXTRACT_ADDR="$extract_addr"
+export FABRIC_SUBNET="$fabric_subnet"
 export MOONCAKE_MASTER="$extract_addr:50051"
 export VLLM_ENDPOINT="http://$extract_addr:8000/v1"
 export DATA_DIR="$data_dir"

--- a/examples/train/kimi_k3_dspark/run.sbatch
+++ b/examples/train/kimi_k3_dspark/run.sbatch
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Wires the three components together on a 3-node allocation:
+#   nodes 0-1  Kimi-K3 TP8 extractor (node 0 also runs the Mooncake master)
+#   node 2     DSpark draft training, 4 DDP ranks
+#
+# Submit with:  sbatch examples/train/kimi_k3_dspark/run.sbatch
+
+#SBATCH --job-name=k3-dspark
+#SBATCH --nodes=3
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=4
+#SBATCH --mem=0
+#SBATCH --exclusive
+#SBATCH --time=03:00:00
+#SBATCH --output=%x-%j.out
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../../.." && pwd)"
+data_dir="${DATA_DIR:-$repo_root/runs/kimi_k3_dspark/data}"
+run_name="${RUN_NAME:-kimi-k3-dspark-$SLURM_JOB_ID}"
+run_dir="$repo_root/runs/kimi_k3_dspark/$run_name"
+
+if ! compgen -G "$data_dir/*.arrow" >/dev/null || [[ ! -f "$data_dir/d2t.npy" ]]; then
+  echo "No prepared data in $data_dir; run prepare_data.sbatch first." >&2
+  exit 1
+fi
+mkdir -p "$run_dir/logs"
+
+mapfile -t nodes < <(scontrol show hostnames "$SLURM_JOB_NODELIST")
+extract_nodes="${nodes[0]},${nodes[1]}"
+train_node="${nodes[2]}"
+
+# The extractor head's address on the fast fabric: vLLM's rendezvous point and
+# the host for both the Mooncake master and the HTTP endpoint.
+extract_addr="$(srun --overlap --nodes=1 --ntasks=1 --nodelist="${nodes[0]}" \
+  bash -c "ip -o -4 addr show | awk '\$4 ~ /^10\.13\.84\./ {sub(/\/.*/, \"\", \$4); print \$4; exit}'")"
+export EXTRACT_ADDR="$extract_addr"
+export MOONCAKE_MASTER="$extract_addr:50051"
+export VLLM_ENDPOINT="http://$extract_addr:8000/v1"
+export DATA_DIR="$data_dir"
+export RUN_NAME="$run_name"
+export RUN_DIR="$run_dir"
+
+echo "Run:        $run_name"
+echo "Extraction: $extract_nodes (TP8, $VLLM_ENDPOINT)"
+echo "Training:   $train_node (4 DDP ranks)"
+echo "Mooncake:   $MOONCAKE_MASTER"
+
+background_pids=()
+cleanup() {
+  trap - EXIT INT TERM
+  for pid in "${background_pids[@]}"; do
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT INT TERM
+
+srun --overlap --nodes=1 --ntasks=1 --nodelist="${nodes[0]}" \
+  --output="$run_dir/logs/mooncake-master.log" \
+  mooncake_master --rpc_port 50051 --metrics_port 9003 \
+  --rpc_thread_num 8 --enable_disk_eviction=false --logtostderr=true &
+background_pids+=($!)
+
+srun --overlap --nodes=2 --ntasks=2 --ntasks-per-node=1 \
+  --nodelist="$extract_nodes" --gpus-per-node=4 \
+  --output="$run_dir/logs/extractor-%t.log" \
+  bash "$script_dir/launch_extractor_node.sh" &
+extractor_pid=$!
+background_pids+=("$extractor_pid")
+
+deadline=$((SECONDS + 3600))
+until curl --silent --fail "http://$extract_addr:8000/health" >/dev/null 2>&1; do
+  if ! kill -0 "$extractor_pid" 2>/dev/null; then
+    echo "Extractor exited before becoming healthy; see $run_dir/logs/extractor-*.log" >&2
+    exit 1
+  fi
+  if (( SECONDS >= deadline )); then
+    echo "Timed out waiting for the extractor to report healthy." >&2
+    exit 1
+  fi
+  sleep 5
+done
+echo "Extractor is healthy. Starting training."
+
+srun --overlap --nodes=1 --ntasks=1 --nodelist="$train_node" --gpus-per-node=4 \
+  --output="$run_dir/logs/trainer.log" \
+  bash "$script_dir/launch_train_node.sh"
+
+echo "Training completed: $run_dir/checkpoints"


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Add a multi-node Kimi K3 training example which uses slurm to setup and run the training jobs. Note: the training example is not meant to be a directly usable user script (i.e. it has a lot of hardcoded parameters and is designed for a specific server setup), but rather intended as an example that can then be adapted to new setups. 


## Tests

Based off of scripts that were used for large scale training run. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>