### PR TITLE
removed no-enable-chunked-prefill

### DIFF
--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -145,10 +145,6 @@ def main():
         *vllm_args,
     ]
 
-    disable_cp_arg = "--no-enable-chunked-prefill"
-    if disable_cp_arg not in cmd:
-        cmd.append(disable_cp_arg)
-
     print("Running command:")
     print(" ".join(cmd))
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
`launch_vllm.py` is appending `--no-enable-chunked-prefill` on all requests. This issue should be resolved on vLLM now. For hybrid mamba models (e.g. Qwen/Qwen3.5-4B), vLLM auto-selects the align mamba cache mode when prefix caching is enabled, and align requires chunked prefill. Our nightly all fail with
```
pydantic_core.ValidationError: 1 validation error for VllmConfig
  Assertion failed, Chunked prefill is required for mamba cache mode 'align'.
```
Turning this off to let the model run.

## Tests
Tested our e2e smoke test locally using vllm nightly build. Started an e2e [run](https://github.com/neuralmagic/llm-compressor-testing/actions/runs/31419326984).

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
