### PR TITLE
refactor: extract shared provenance helpers into speculators.provenance

### DIFF
--- a/src/speculators/provenance.py
+++ b/src/speculators/provenance.py
@@ -1,0 +1,130 @@
+"""Shared provenance helpers for reproducibility artifacts.
+
+Used by training, evaluation, and vLLM-launch scripts to record
+command lines, git state, and package versions.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import importlib.util
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+TRACKED_PACKAGES = (
+    "speculators",
+    "vllm",
+    "transformers",
+    "torch",
+    "compressed-tensors",
+)
+
+
+def atomic_write(path: Path, content: str) -> None:
+    """Write *content* to *path* atomically via tempfile + rename."""
+    fd, tmp = tempfile.mkstemp(
+        dir=path.parent, prefix=f".{path.name}_", suffix=".tmp"
+    )
+    tmp_path = Path(tmp)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        tmp_path.replace(path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def pkg_version(name: str) -> str:
+    """Return the installed version of *name*, or ``'not installed'``."""
+    try:
+        return importlib.metadata.version(name)
+    except importlib.metadata.PackageNotFoundError:
+        return "not installed"
+
+
+def find_repo_root(start: Path) -> Path | None:
+    """Walk up from *start* to the nearest directory containing ``.git``."""
+    try:
+        d = start.resolve()
+        if d.is_file():
+            d = d.parent
+        while d != d.parent:
+            if (d / ".git").exists():
+                return d
+            d = d.parent
+    except OSError:
+        pass
+    return None
+
+
+def find_package_repo(package_name: str) -> Path | None:
+    """Find the git repo root for an installed editable package."""
+    try:
+        spec = importlib.util.find_spec(package_name)
+        if spec and spec.origin:
+            return find_repo_root(Path(spec.origin))
+    except (ModuleNotFoundError, ValueError):
+        pass
+    return None
+
+
+def git_sha(repo_root: Path | None) -> str:
+    """Return the HEAD SHA of *repo_root*, or ``'unknown'`` on failure."""
+    if repo_root is None:
+        return "unknown"
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=5,
+            check=False,
+        )
+        return result.stdout.strip() or "unknown"
+    except (OSError, subprocess.TimeoutExpired):
+        return "unknown"
+
+
+def git_diff(repo_root: Path | None, *, timeout: int = 30) -> str:
+    """Return ``git diff HEAD`` for *repo_root*, or empty string on failure."""
+    if repo_root is None:
+        return ""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=timeout,
+            check=False,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+
+
+def run_git(
+    args: list[str], cwd: str | Path, *, timeout: int = 5
+) -> str:
+    """Run a git command and return stdout, or empty string on failure."""
+    try:
+        result = subprocess.run(  # noqa: S603
+            args,
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            timeout=timeout,
+            check=False,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+
+
+def package_versions(packages: tuple[str, ...] = TRACKED_PACKAGES) -> list[str]:
+    """Return ``['# pkg: version', ...]`` header lines for *packages*."""
+    return [f"# {p}: {pkg_version(p)}" for p in packages]

--- a/tests/unit/test_provenance.py
+++ b/tests/unit/test_provenance.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from speculators.provenance import (
+    atomic_write,
+    find_package_repo,
+    find_repo_root,
+    git_diff,
+    git_sha,
+    package_versions,
+    pkg_version,
+    run_git,
+)
+
+
+class TestAtomicWrite:
+    def test_creates_file(self, tmp_path: Path):
+        dest = tmp_path / "out.txt"
+        atomic_write(dest, "hello")
+        assert dest.read_text() == "hello"
+
+    def test_overwrites_existing(self, tmp_path: Path):
+        dest = tmp_path / "out.txt"
+        dest.write_text("old")
+        atomic_write(dest, "new")
+        assert dest.read_text() == "new"
+
+    def test_no_leftover_tmp_files(self, tmp_path: Path):
+        dest = tmp_path / "out.txt"
+        atomic_write(dest, "data")
+        tmp_files = [f for f in tmp_path.iterdir() if f.name.startswith(".")]
+        assert tmp_files == []
+
+
+class TestPkgVersion:
+    def test_known_package(self):
+        assert pkg_version("speculators") != "not installed"
+
+    def test_unknown_package(self):
+        assert pkg_version("nonexistent_pkg_xyz") == "not installed"
+
+
+class TestFindRepoRoot:
+    def test_finds_from_file(self):
+        root = find_repo_root(Path(__file__))
+        assert root is not None
+        assert (root / ".git").exists()
+
+    def test_finds_from_directory(self):
+        root = find_repo_root(Path(__file__).parent)
+        assert root is not None
+        assert (root / ".git").exists()
+
+    def test_returns_none_for_root(self):
+        assert find_repo_root(Path("/")) is None
+
+
+class TestFindPackageRepo:
+    def test_finds_speculators(self):
+        root = find_package_repo("speculators")
+        if root is not None:
+            assert (root / ".git").exists()
+
+    def test_returns_none_for_missing(self):
+        assert find_package_repo("nonexistent_pkg_xyz") is None
+
+
+class TestGitSha:
+    def test_returns_sha_or_unknown(self):
+        sha = git_sha(find_repo_root(Path(__file__)))
+        is_hex = len(sha) == 40 and all(c in "0123456789abcdef" for c in sha)
+        assert sha == "unknown" or is_hex
+
+    def test_none_returns_unknown(self):
+        assert git_sha(None) == "unknown"
+
+    def test_fallback_on_oserror(self):
+        with patch("speculators.provenance.subprocess.run", side_effect=OSError):
+            assert git_sha(Path("/tmp")) == "unknown"
+
+    def test_fallback_on_timeout(self):
+        with patch(
+            "speculators.provenance.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("git", 5),
+        ):
+            assert git_sha(Path("/tmp")) == "unknown"
+
+
+class TestGitDiff:
+    def test_none_returns_empty(self):
+        assert git_diff(None) == ""
+
+    def test_returns_string(self):
+        root = find_repo_root(Path(__file__))
+        result = git_diff(root)
+        assert isinstance(result, str)
+
+    def test_fallback_on_oserror(self):
+        with patch("speculators.provenance.subprocess.run", side_effect=OSError):
+            assert git_diff(Path("/tmp")) == ""
+
+
+class TestRunGit:
+    def test_rev_parse(self):
+        root = find_repo_root(Path(__file__))
+        if root:
+            sha = run_git(["git", "rev-parse", "HEAD"], root)
+            assert len(sha) == 40
+
+    def test_failure_returns_empty(self):
+        assert run_git(["git", "no-such-command"], ".") == ""
+
+    def test_oserror_returns_empty(self):
+        with patch("speculators.provenance.subprocess.run", side_effect=OSError):
+            assert run_git(["git", "status"], ".") == ""
+
+
+class TestPackageVersions:
+    def test_returns_header_lines(self):
+        lines = package_versions(("speculators",))
+        assert len(lines) == 1
+        assert lines[0].startswith("# speculators:")
+
+    def test_default_packages(self):
+        lines = package_versions()
+        assert len(lines) == 5


### PR DESCRIPTION
## Summary

- Extract shared provenance helpers (`atomic_write`, `pkg_version`, `find_repo_root`, `find_package_repo`, `git_sha`, `git_diff`, `run_git`, `package_versions`) into `src/speculators/provenance.py`
- Add comprehensive unit tests in `tests/unit/test_provenance.py` (22 tests)
- Base PR for the provenance stack — downstream PRs import from this module instead of duplicating helpers

## AGENTS.md

This PR does not add an `AGENTS.md` section — it's a pure refactor with no user-facing behavior.

## Context

Part of [RFC #880](https://github.com/vllm-project/speculators/issues/880). The eval, vLLM-launch, and training scripts all need the same provenance helpers (atomic writes, git SHA, package versions, etc.). This PR centralizes them so the rest of the stack can import instead of copy-pasting.

## Test plan

- [x] `pytest tests/unit/test_provenance.py` — 22 tests covering all helpers
- [x] `ruff check` passes
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)