### PR TITLE
feat(eval): add eval_command.txt provenance artifact (RFC #880)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Speculators — Agent Guide
+
+## Provenance
+
+Training and eval scripts write reproducibility artifacts so runs can be recreated later.
+
+- **Training** (`src/speculators/train/utils.py`): `save_train_command()` writes `train_command.txt` (timestamp, git SHA, world size, package versions, full argv) into the checkpoint directory.
+- **Eval** (`scripts/evaluate/evaluate.py`): `save_eval_provenance()` writes `eval_command.txt` (timestamp, git SHA, package versions, full argv) into the output directory.
+
+When publishing a model or eval results (HuggingFace, GitHub comments, etc.), always include the provenance artifacts so the run can be reproduced.

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -25,8 +25,9 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import shlex
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from urllib.error import URLError
 from urllib.request import urlopen
@@ -44,6 +45,13 @@ from perf_utils import (
     parse_sweep_results,
     print_acceptance_report,
     run_guidellm,
+)
+
+from speculators.provenance import (
+    atomic_write,
+    find_package_repo,
+    git_sha,
+    package_versions,
 )
 
 logger = logging.getLogger("evaluate")
@@ -88,6 +96,30 @@ def _fetch_model_name(target: str) -> str | None:
 
 def _sanitize_dir_name(name: str) -> str:
     return name.replace("/", "_").replace(" ", "_")
+
+
+def save_eval_provenance(output_dir: Path) -> None:
+    """Write ``eval_command.txt`` into *output_dir*.
+
+    Records the full command line, timestamp, and package versions so the
+    eval can be reproduced.  Best-effort — never blocks the eval on failure.
+    """
+    try:
+        sha = git_sha(find_package_repo("speculators"))
+        versions = package_versions()
+        header = "\n".join(
+            [
+                f"# Timestamp: {datetime.now(timezone.utc).isoformat()}",
+                f"# Git SHA: {sha}",
+                *versions,
+            ]
+        )
+        atomic_write(
+            output_dir / "eval_command.txt",
+            f"{header}\n{shlex.join(sys.argv)}\n",
+        )
+    except OSError:
+        logger.warning("Failed to save eval_command.txt", exc_info=True)
 
 
 def _require_metrics(metrics_url: str) -> list:
@@ -258,6 +290,8 @@ def run_benchmark(args: argparse.Namespace) -> None:
     artifacts_dir = output_dir / "artifacts"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 
+    save_eval_provenance(output_dir)
+
     acceptance_csv = None
     perf_csv = None
     all_max_tokens: dict[str, int] = {}
@@ -418,7 +452,6 @@ def main() -> None:
             "Required when --dataset is a speedbench/ spec."
         ),
     )
-
     args = parser.parse_args()
 
     if args.output_dir is None:

--- a/tests/unit/scripts/test_eval_provenance.py
+++ b/tests/unit/scripts/test_eval_provenance.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts" / "evaluate"))
+
+
+from evaluate import (  # type: ignore[import-not-found]
+    save_eval_provenance,
+)
+
+
+class TestSaveEvalProvenance:
+    def test_creates_file(self, tmp_path: Path):
+        save_eval_provenance(tmp_path)
+        assert (tmp_path / "eval_command.txt").exists()
+
+    def test_contains_timestamp(self, tmp_path: Path):
+        save_eval_provenance(tmp_path)
+        content = (tmp_path / "eval_command.txt").read_text()
+        assert "# Timestamp:" in content
+
+    def test_contains_git_sha(self, tmp_path: Path):
+        save_eval_provenance(tmp_path)
+        content = (tmp_path / "eval_command.txt").read_text()
+        assert "# Git SHA:" in content
+
+    def test_contains_package_versions(self, tmp_path: Path):
+        save_eval_provenance(tmp_path)
+        content = (tmp_path / "eval_command.txt").read_text()
+        pkgs = ("speculators", "vllm", "transformers", "torch", "compressed-tensors")
+        for pkg in pkgs:
+            assert f"# {pkg}:" in content
+
+    def test_contains_sys_argv(self, tmp_path: Path):
+        argv = ["evaluate.py", "--target", "http://localhost:8000/v1"]
+        with patch.object(sys, "argv", argv):
+            save_eval_provenance(tmp_path)
+        content = (tmp_path / "eval_command.txt").read_text()
+        assert "evaluate.py --target" in content
+
+    def test_no_leftover_tmp_files(self, tmp_path: Path):
+        save_eval_provenance(tmp_path)
+        tmp_files = [
+            f for f in tmp_path.iterdir() if f.name.startswith(".eval_command")
+        ]
+        assert tmp_files == []
+
+    def test_best_effort_never_raises(self, tmp_path: Path):
+        with patch("evaluate.atomic_write", side_effect=OSError("disk full")):
+            save_eval_provenance(tmp_path)
+
+    def test_overwrites_existing(self, tmp_path: Path):
+        (tmp_path / "eval_command.txt").write_text("old content")
+        save_eval_provenance(tmp_path)
+        content = (tmp_path / "eval_command.txt").read_text()
+        assert "old content" not in content
+        assert "# Timestamp:" in content


### PR DESCRIPTION
## Summary

- Add `save_eval_provenance()` to `scripts/evaluate/evaluate.py` — writes `eval_command.txt` into the eval output directory
- Records: timestamp, git SHA, package versions, full command line via `shlex.join(sys.argv)`
- Best-effort — `OSError` is caught and logged, never blocks the eval
- Imports shared helpers from `speculators.provenance` (see base PR #981)
- Add AGENTS.md with eval provenance bullet

## Context

Part of [RFC #880](https://github.com/vllm-project/speculators/issues/880). This PR adds eval-side reproducibility artifacts. Training-side provenance is a separate PR in the stack.

## Test plan

- [x] `pytest tests/unit/scripts/test_eval_provenance.py` — 8 tests
- [x] `ruff check` passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)