### PR TITLE
feat(launch_vllm): add eval subcommand for spec-decode serving (RFC #880)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Training, eval, and vLLM-launch scripts write reproducibility artifacts so runs 
 
 - **Training** (`src/speculators/train/utils.py`): `save_train_command()` writes `train_command.txt` (timestamp, git SHA, world size, package versions, full argv) into the checkpoint directory.
 - **Eval** (`scripts/evaluate/evaluate.py`): `save_eval_provenance()` writes `eval_command.txt` (timestamp, git SHA, package versions, full argv) into the output directory.
-- **vLLM launch** (`scripts/launch_vllm.py`): `_save_vllm_provenance()` writes `vllm_command.txt`, `vllm.patch`, and `checkpoint_sha256.txt` into `--provenance-dir`.
+- **vLLM launch** (`scripts/launch_vllm.py`): `_save_vllm_provenance()` writes `vllm_command.txt`, `vllm.patch`, and `checkpoint_sha256.txt` into `--provenance-dir`. Two subcommands:
+  - `launch_vllm.py train MODEL` (default): hidden-states extraction for training data generation.
+  - `launch_vllm.py eval MODEL --spec-model DRAFTER`: speculative decoding serving for evaluation.
 
 When publishing a model or eval results (HuggingFace, GitHub comments, etc.), always include the provenance artifacts (`train_command.txt`, `eval_command.txt`, `vllm_command.txt`, patches) so the run can be reproduced.

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -56,56 +56,15 @@ if "file" not in _backend_registry:
     _backend_registry["file"] = _InlineFileBackend  # type: ignore[assignment]
 
 
-def parse_args():
-    parser = argparse.ArgumentParser(
-        description="Launch vLLM for hidden states extraction",
-        usage=(
-            "launch_vllm.py [-h] MODEL [--hidden-states-backend BACKEND] "
-            "[--target-layer-ids TARGET_LAYER_IDS [TARGET_LAYER_IDS ...]] -- *VLLM_ARGS"
-        ),
-    )
-    parser.add_argument(
-        "model", type=str, help="Model name or path to extract hidden states from"
-    )
-
-    parser.add_argument(
-        "--hidden-states-backend",
-        choices=list(_backend_registry.keys()),
-        default="file",
-        help=(
-            "Hidden states transfer backend. Each backend may add its own "
-            "CLI arguments (see below). Default: 'file'."
-        ),
-    )
-    for backend_cls in _backend_registry.values():
-        backend_cls.add_launch_args(parser)
-
-    parser.add_argument(
-        "--target-layer-ids",
-        type=int,
-        nargs="+",
-        help=(
-            "(Optional) A (space separated) list of integer layer ids. Defaults to "
-            "[2, num_hidden_layers // 2, num_hidden_layers - 3]. "
-            "Note: if set, you must also pass the same value into the training process"
-        ),
-    )
-    parser.add_argument(
-        "--include-last-layer",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help=(
-            "Append the last layer (num_hidden_layers) to "
-            "target_layer_ids for verifier hidden states extraction. Default: True"
-        ),
-    )
+def _add_shared_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--provenance-dir",
         type=str,
         default=None,
         help=(
-            "Directory to write vllm_command.txt, vllm.patch, and "
-            "checkpoint_sha256.txt. Defaults to vllm_<model>_<timestamp>/."
+            "Directory to write vllm_command.txt, vllm.patch, "
+            "and checkpoint_sha256.txt. "
+            "Defaults to vllm_<mode>_<model>_<timestamp>/."
         ),
     )
     parser.add_argument(
@@ -113,18 +72,108 @@ def parse_args():
         action="store_true",
         default=False,
         help=(
-            "Skip SHA256 hashing of .safetensors files. Useful for large "
-            "checkpoints where hashing adds significant launch latency. "
-            "When set, checkpoint_sha256.txt records file sizes and "
-            "modification times instead."
+            "Skip SHA256 hashing of .safetensors files. Useful "
+            "for large checkpoints where hashing adds significant "
+            "launch latency. When set, checkpoint_sha256.txt "
+            "records file sizes and modification times instead."
         ),
     )
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Print the command that would be executed without running it",
+        help="Print the command without running it",
     )
-    return parser.parse_known_args()
+
+
+_SUBCOMMANDS = {"train", "eval"}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Launch vLLM for training or evaluation",
+    )
+    sub = parser.add_subparsers(dest="subcommand")
+
+    # --- train subcommand (default when no subcommand given) ---
+    train_parser = sub.add_parser(
+        "train",
+        help="Hidden-states extraction for training data generation",
+    )
+    train_parser.add_argument(
+        "model",
+        type=str,
+        help="Model name or path to extract hidden states from",
+    )
+    train_parser.add_argument(
+        "--hidden-states-backend",
+        choices=list(_backend_registry.keys()),
+        default="file",
+        help=(
+            "Hidden states transfer backend. Each backend may "
+            "add its own CLI arguments (see below). "
+            "Default: 'file'."
+        ),
+    )
+    for backend_cls in _backend_registry.values():
+        backend_cls.add_launch_args(train_parser)
+    train_parser.add_argument(
+        "--target-layer-ids",
+        type=int,
+        nargs="+",
+        help=(
+            "(Optional) Space-separated list of integer layer "
+            "ids. Defaults to "
+            "[2, num_hidden_layers // 2, num_hidden_layers - 3]."
+            " Note: if set, you must also pass the same value "
+            "into the training process"
+        ),
+    )
+    train_parser.add_argument(
+        "--include-last-layer",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Append the last layer (num_hidden_layers) to "
+            "target_layer_ids for verifier hidden states "
+            "extraction. Default: True"
+        ),
+    )
+    _add_shared_args(train_parser)
+
+    # --- eval subcommand ---
+    eval_parser = sub.add_parser(
+        "eval",
+        help="Speculative decoding serving for evaluation",
+    )
+    eval_parser.add_argument(
+        "model",
+        type=str,
+        help="Target model name or path",
+    )
+    eval_parser.add_argument(
+        "--spec-model",
+        type=str,
+        required=True,
+        help="Drafter model name or path",
+    )
+    eval_parser.add_argument(
+        "--spec-tokens",
+        type=int,
+        default=None,
+        help="Number of speculative tokens",
+    )
+    eval_parser.add_argument(
+        "--spec-method",
+        type=str,
+        default=None,
+        help="Speculative decoding method (optional)",
+    )
+    _add_shared_args(eval_parser)
+
+    argv = sys.argv[1:]
+    if argv and argv[0] not in _SUBCOMMANDS and not argv[0].startswith("-"):
+        argv = ["train", *argv]
+    return parser.parse_known_args(argv)
 
 
 def _warn(msg: str) -> None:
@@ -275,11 +324,7 @@ def _save_vllm_provenance(
             _warn(f"could not save {artifact}: {exc}")
 
 
-def main():
-    args, vllm_args = parse_args()
-    if "--" in vllm_args:
-        vllm_args.remove("--")
-
+def _build_train_cmd(args, vllm_args):
     from transformers import AutoConfig  # noqa: PLC0415
 
     config = AutoConfig.from_pretrained(args.model)
@@ -314,7 +359,7 @@ def main():
     backend_cls = _backend_registry[args.hidden_states_backend]
     kv_transfer_config = backend_cls.build_kv_transfer_config(args)
 
-    cmd = [
+    return [
         sys.executable,
         "-m",
         "vllm.entrypoints.cli.main",
@@ -327,13 +372,44 @@ def main():
         *vllm_args,
     ]
 
+
+def _build_eval_cmd(args, vllm_args):
+    cmd = [
+        sys.executable,
+        "-m",
+        "vllm.entrypoints.cli.main",
+        "serve",
+        args.model,
+        "--spec-model",
+        args.spec_model,
+    ]
+    if args.spec_tokens is not None:
+        cmd.extend(["--spec-tokens", str(args.spec_tokens)])
+    if args.spec_method is not None:
+        cmd.extend(["--spec-method", args.spec_method])
+    cmd.extend(vllm_args)
+    return cmd
+
+
+def main():
+    args, vllm_args = parse_args()
+    if "--" in vllm_args:
+        vllm_args.remove("--")
+
+    if args.subcommand == "train":
+        cmd = _build_train_cmd(args, vllm_args)
+    else:
+        cmd = _build_eval_cmd(args, vllm_args)
+
+
     print("Running command:")
     print(" ".join(cmd))
 
     if not args.provenance_dir:
         sanitized = args.model.replace("/", "_").replace(" ", "_")
         ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        args.provenance_dir = f"vllm_{sanitized}_{ts}"
+        mode = args.subcommand
+        args.provenance_dir = f"vllm_{mode}_{sanitized}_{ts}"
     _save_vllm_provenance(
         cmd,
         args.provenance_dir,

--- a/tests/unit/scripts/test_provenance_integration.py
+++ b/tests/unit/scripts/test_provenance_integration.py
@@ -11,6 +11,7 @@ import pytest
 SCRIPTS_DIR = Path(__file__).resolve().parents[3] / "scripts"
 LAUNCH_VLLM = str(SCRIPTS_DIR / "launch_vllm.py")
 MODEL = "gpt2"
+DRAFTER = "some-org/drafter-model"
 
 
 @pytest.fixture
@@ -19,6 +20,8 @@ def provenance_dir(tmp_path: Path) -> Path:
 
 
 class TestLaunchVllmProvenance:
+    """Train subcommand integration tests."""
+
     def _run(
         self, provenance_dir: Path, *extra_args: str
     ) -> subprocess.CompletedProcess:
@@ -26,6 +29,7 @@ class TestLaunchVllmProvenance:
             [
                 sys.executable,
                 LAUNCH_VLLM,
+                "train",
                 MODEL,
                 "--dry-run",
                 "--provenance-dir",
@@ -61,7 +65,7 @@ class TestLaunchVllmProvenance:
 
     def test_default_provenance_dir_created(self, tmp_path: Path):
         result = subprocess.run(  # noqa: S603
-            [sys.executable, LAUNCH_VLLM, MODEL, "--dry-run"],
+            [sys.executable, LAUNCH_VLLM, "train", MODEL, "--dry-run"],
             capture_output=True,
             text=True,
             cwd=str(tmp_path),
@@ -72,10 +76,114 @@ class TestLaunchVllmProvenance:
         prov_dirs = [
             d
             for d in tmp_path.iterdir()
-            if d.is_dir() and d.name.startswith("vllm_gpt2_")
+            if d.is_dir() and d.name.startswith("vllm_train_gpt2_")
         ]
         assert len(prov_dirs) == 1
         prov = prov_dirs[0]
         assert (prov / "vllm_command.txt").exists()
         assert (prov / "vllm.patch").exists()
         assert (prov / "checkpoint_sha256.txt").exists()
+
+    def test_implicit_train_subcommand(self, provenance_dir: Path):
+        """MODEL without 'train' prefix defaults to train mode."""
+        result = subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                LAUNCH_VLLM,
+                MODEL,
+                "--dry-run",
+                "--provenance-dir",
+                str(provenance_dir),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        content = (provenance_dir / "vllm_command.txt").read_text()
+        assert "extract_hidden_states" in content
+
+
+class TestLaunchVllmEvalMode:
+    """Eval subcommand integration tests."""
+
+    def _run(
+        self, provenance_dir: Path, *extra_args: str
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                LAUNCH_VLLM,
+                "eval",
+                MODEL,
+                "--spec-model",
+                DRAFTER,
+                "--spec-tokens",
+                "3",
+                "--dry-run",
+                "--provenance-dir",
+                str(provenance_dir),
+                *extra_args,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+
+    def test_eval_mode_creates_provenance(self, provenance_dir: Path):
+        result = self._run(provenance_dir)
+        assert result.returncode == 0, result.stderr
+        assert (provenance_dir / "vllm_command.txt").exists()
+        assert (provenance_dir / "vllm.patch").exists()
+        assert (provenance_dir / "checkpoint_sha256.txt").exists()
+
+    def test_eval_command_contains_spec_flags(self, provenance_dir: Path):
+        self._run(provenance_dir)
+        content = (provenance_dir / "vllm_command.txt").read_text()
+        assert "--spec-model" in content
+        assert DRAFTER in content
+        assert "--spec-tokens" in content
+        assert "3" in content
+
+    def test_eval_command_no_train_flags(self, provenance_dir: Path):
+        self._run(provenance_dir)
+        content = (provenance_dir / "vllm_command.txt").read_text()
+        assert "--speculative_config" not in content
+        assert "--kv_transfer_config" not in content
+        assert "extract_hidden_states" not in content
+
+    def test_eval_mode_requires_spec_model(self, tmp_path: Path):
+        result = subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                LAUNCH_VLLM,
+                "eval",
+                MODEL,
+                "--dry-run",
+                "--provenance-dir",
+                str(tmp_path / "prov"),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        assert result.returncode != 0
+        assert "--spec-model" in result.stderr
+
+    def test_eval_mode_with_spec_method(self, provenance_dir: Path):
+        result = self._run(provenance_dir, "--spec-method", "dflash")
+        assert result.returncode == 0, result.stderr
+        content = (provenance_dir / "vllm_command.txt").read_text()
+        assert "--spec-method" in content
+        assert "dflash" in content
+
+    def test_eval_mode_passes_extra_vllm_args(self, provenance_dir: Path):
+        result = self._run(provenance_dir, "--", "--port", "8080", "--tp", "2")
+        assert result.returncode == 0, result.stderr
+        content = (provenance_dir / "vllm_command.txt").read_text()
+        assert "--port" in content
+        assert "8080" in content
+        assert "--tp" in content


### PR DESCRIPTION
## Summary

- Add `train`/`eval` subcommands to `scripts/launch_vllm.py`
- `train` (default): existing hidden-states extraction mode
- `eval`: simplified spec-decode serving with `--spec-model` and `--spec-tokens`
- Backward compatible: bare `MODEL` defaults to train subcommand
- Both modes share provenance artifact generation
- Update AGENTS.md with train/eval subcommand docs

## Context

Part of [RFC #880](https://github.com/vllm-project/speculators/issues/880). The eval subcommand makes it easy to launch vLLM for speculative decoding benchmarks without manually constructing `--speculative_config`.

## Test plan

- [x] `pytest tests/unit/scripts/test_provenance_integration.py` — 7 eval mode tests
- [x] `ruff check` passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)