### PR TITLE
Add Muse Glimmer training support

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -24,6 +24,7 @@ from speculators.models.utils import (
     resolve_draft_intermediate_size,
 )
 from speculators.train.config import TrainConfig
+from speculators.train.config.adapters import adapt_draft_config
 from speculators.train.dataloader import create_train_val_loaders
 from speculators.train.distributed import (
     get_rank,
@@ -132,14 +133,10 @@ def create_transformer_layer_config(  # noqa: C901
         )
 
     config_class = DRAFT_ARCH_CONFIGS[draft_arch]
-    verifier_config = AutoConfig.from_pretrained(
+    verifier_config = get_verifier_config(
         verifier_name_or_path,
         trust_remote_code=trust_remote_code,
     )
-
-    # For multimodal models (Qwen3VL, etc.), extract text_config
-    if hasattr(verifier_config, "text_config"):
-        verifier_config = verifier_config.text_config
 
     hidden_act = (
         hidden_act
@@ -274,6 +271,11 @@ def load_draft_transformer_layer_config(
         # A full speculator config was passed; use only the decoder definition.
         config_dict = config_dict["transformer_layer_config"]
 
+    verifier_config = get_verifier_config(
+        verifier_name_or_path,
+        trust_remote_code=trust_remote_code,
+    )
+    config_dict = adapt_draft_config(config_dict, verifier_config)
     model_type = config_dict.get("model_type")
     if not model_type:
         raise ValueError(
@@ -284,10 +286,6 @@ def load_draft_transformer_layer_config(
     config_class: type[PretrainedConfig] = type(AutoConfig.for_model(model_type))
     draft_config_obj = config_class.from_dict(config_dict)
 
-    verifier_config = get_verifier_config(
-        verifier_name_or_path,
-        trust_remote_code=trust_remote_code,
-    )
     if draft_config_obj.hidden_size != verifier_config.hidden_size:
         raise ValueError(
             f"--draft-config hidden_size ({draft_config_obj.hidden_size}) must match "
@@ -375,12 +373,10 @@ def parse_vocab_mappings(args: argparse.Namespace):
         "None. Using full verifier vocab"
     )
     # When vocab mapping is not provided, use the full verifier vocab
-    verifier_config = AutoConfig.from_pretrained(
+    verifier_config = get_verifier_config(
         args.verifier_name_or_path,
         trust_remote_code=args.trust_remote_code,
     )
-    if hasattr(verifier_config, "text_config"):
-        verifier_config = verifier_config.text_config
     return None, None, verifier_config.vocab_size
 
 

--- a/src/speculators/models/dflash/config.py
+++ b/src/speculators/models/dflash/config.py
@@ -60,6 +60,7 @@ class DFlashSpeculatorConfig(SpeculatorModelConfig):
 
     target_logit_softcap: float | None = Field(
         default=None,
+        gt=0.0,
         description=(
             "Optional tanh softcap applied after target_logit_scale when "
             "reconstructing verifier logits"

--- a/src/speculators/models/dflash/config.py
+++ b/src/speculators/models/dflash/config.py
@@ -53,6 +53,19 @@ class DFlashSpeculatorConfig(SpeculatorModelConfig):
         description="Hidden size of the target model (if different from draft model)",
     )
 
+    target_logit_scale: float = Field(
+        default=1.0,
+        description="Multiplier applied to reconstructed verifier logits",
+    )
+
+    target_logit_softcap: float | None = Field(
+        default=None,
+        description=(
+            "Optional tanh softcap applied after target_logit_scale when "
+            "reconstructing verifier logits"
+        ),
+    )
+
     aux_hidden_state_layer_ids: list[int] | None = Field(
         default=None,
         description="Layer IDs of the DFlash auxiliary hidden state layers",

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -24,6 +24,7 @@ from speculators.models.dflash.utils import (
 from speculators.models.utils import (
     conditional_torch_compile,
     flatten_rope_parameters,
+    get_verifier_config,
     resolve_target_layer_ids,
 )
 
@@ -193,6 +194,10 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             kwargs["verifier_name_or_path"],
             trust_remote_code=kwargs.get("trust_remote_code", False),
         )
+        target_config = get_verifier_config(
+            kwargs["verifier_name_or_path"],
+            trust_remote_code=kwargs.get("trust_remote_code", False),
+        )
         verifier_config._attn_implementation = kwargs.get(  # noqa: SLF001
             "draft_attn_impl", "simple_flex_attention"
         )
@@ -217,6 +222,10 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             "block_size": block_size,
             "aux_hidden_state_layer_ids": target_layer_ids,
             "mask_token_id": kwargs.get("mask_token_id"),
+            "target_logit_scale": getattr(target_config, "output_multiplier", 1.0),
+            "target_logit_softcap": getattr(
+                target_config, "final_logit_softcapping", None
+            ),
             "sliding_window_non_causal": kwargs.get("sliding_window_non_causal", False),
             "sample_from_anchor": sample_from_anchor,
             "speculators_config": SpeculatorsConfig(
@@ -268,6 +277,14 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
                 "was saved with mask_token_id set."
             )
         return self.config.mask_token_id
+
+    def _transform_verifier_logits(self, logits: torch.Tensor) -> torch.Tensor:
+        """Apply verifier output transforms recorded in its public config."""
+        logits = logits * self.config.target_logit_scale
+        if self.config.target_logit_softcap is not None:
+            softcap = self.config.target_logit_softcap
+            logits = softcap * torch.tanh(logits / softcap)
+        return logits
 
     @torch.compiler.disable
     def _create_attention_mask(
@@ -393,8 +410,12 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
                     if self.config.sample_from_anchor
                     else (anchored_block_indices - 1) % total_seq_len
                 )
-                targets = self.verifier_lm_head(
-                    self.verifier_norm(verifier_last_hidden_states[:, target_indices])
+                targets = self._transform_verifier_logits(
+                    self.verifier_lm_head(
+                        self.verifier_norm(
+                            verifier_last_hidden_states[:, target_indices]
+                        )
+                    )
                 )
             else:
                 verifier_logits = self.verifier_lm_head(
@@ -402,7 +423,9 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
                 )
                 if not self.config.sample_from_anchor:
                     verifier_logits = torch.roll(verifier_logits, 1, dims=1)
-                targets = verifier_logits[:, anchored_block_indices]
+                targets = self._transform_verifier_logits(
+                    verifier_logits[:, anchored_block_indices]
+                )
             # shape: [1, num_anchors*block_size, draft_vocab_size]
 
         for layer_idx, layer in enumerate(self.layers):

--- a/src/speculators/models/utils.py
+++ b/src/speculators/models/utils.py
@@ -17,17 +17,36 @@ def conditional_torch_compile(func=None, *args, **kwargs):
     return func
 
 
+def _text_config_from_dict(config: dict) -> PretrainedConfig:
+    model_type = config.get("model_type")
+    if not model_type:
+        return PretrainedConfig.from_dict(config)
+    try:
+        config_class = type(AutoConfig.for_model(model_type))
+    except ValueError:
+        return PretrainedConfig.from_dict(config)
+    return config_class.from_dict(config)
+
+
 def get_verifier_config(
     verifier_name_or_path: str,
     trust_remote_code: bool = False,
 ) -> PretrainedConfig:
-    verifier_config = AutoConfig.from_pretrained(
-        verifier_name_or_path,
-        trust_remote_code=trust_remote_code,
-    )
-    if hasattr(verifier_config, "text_config"):
-        verifier_config = verifier_config.text_config
-    return verifier_config
+    try:
+        verifier_config = AutoConfig.from_pretrained(
+            verifier_name_or_path,
+            trust_remote_code=trust_remote_code,
+        )
+        return getattr(verifier_config, "text_config", verifier_config)
+    except ValueError:
+        config_dict, _ = PretrainedConfig.get_config_dict(
+            verifier_name_or_path,
+            trust_remote_code=trust_remote_code,
+        )
+        text_config = config_dict.get("text_config")
+        if not isinstance(text_config, dict):
+            raise
+        return _text_config_from_dict(text_config)
 
 
 DEFAULT_TARGET_LAYER_IDS_WARNING = (

--- a/src/speculators/train/config/adapters.py
+++ b/src/speculators/train/config/adapters.py
@@ -17,7 +17,7 @@ def _adapt_muse_glimmer_assistant(
         "use_sliding_window",
         "sliding_attention" in config.get("layer_types", []),
     )
-    for key in ("architectures", "block_size", "target_layer_ids"):
+    for key in ("architectures", "block_size", "mask_token_id", "target_layer_ids"):
         config.pop(key, None)
     return config
 

--- a/src/speculators/train/config/adapters.py
+++ b/src/speculators/train/config/adapters.py
@@ -29,5 +29,8 @@ _DRAFT_CONFIG_ADAPTERS: dict[str, _DraftConfigAdapter] = {
 
 def adapt_draft_config(config: dict, verifier_config: PretrainedConfig) -> dict:
     """Normalize released draft wrapper configs to supported decoders."""
-    adapter = _DRAFT_CONFIG_ADAPTERS.get(config.get("model_type"))
+    model_type = config.get("model_type")
+    adapter = (
+        _DRAFT_CONFIG_ADAPTERS.get(model_type) if isinstance(model_type, str) else None
+    )
     return adapter(config, verifier_config) if adapter else dict(config)

--- a/src/speculators/train/config/adapters.py
+++ b/src/speculators/train/config/adapters.py
@@ -1,0 +1,33 @@
+"""Adapters for released draft wrapper configurations."""
+
+from collections.abc import Callable
+
+from transformers import PretrainedConfig
+
+_DraftConfigAdapter = Callable[[dict, PretrainedConfig], dict]
+
+
+def _adapt_muse_glimmer_assistant(
+    config: dict, verifier_config: PretrainedConfig
+) -> dict:
+    config = dict(config)
+    config["model_type"] = "qwen3"
+    config.setdefault("vocab_size", verifier_config.vocab_size)
+    config.setdefault(
+        "use_sliding_window",
+        "sliding_attention" in config.get("layer_types", []),
+    )
+    for key in ("architectures", "block_size", "target_layer_ids"):
+        config.pop(key, None)
+    return config
+
+
+_DRAFT_CONFIG_ADAPTERS: dict[str, _DraftConfigAdapter] = {
+    "muse_glimmer_assistant": _adapt_muse_glimmer_assistant,
+}
+
+
+def adapt_draft_config(config: dict, verifier_config: PretrainedConfig) -> dict:
+    """Normalize released draft wrapper configs to supported decoders."""
+    adapter = _DRAFT_CONFIG_ADAPTERS.get(config.get("model_type"))
+    return adapter(config, verifier_config) if adapter else dict(config)

--- a/src/speculators/train/vocab_mapping.py
+++ b/src/speculators/train/vocab_mapping.py
@@ -6,7 +6,8 @@ from pathlib import Path
 import torch
 from datasets import Dataset as HFDataset
 from tqdm import tqdm  # type: ignore[import-untyped]
-from transformers import AutoConfig
+
+from speculators.models.utils import get_verifier_config
 
 __all__ = [
     "build_vocab_mappings_from_distribution",
@@ -113,13 +114,7 @@ def get_target_vocab_size(
     if has_vocab:
         return target_vocab_size
 
-    config = AutoConfig.from_pretrained(
+    return get_verifier_config(
         target_model_path,
         trust_remote_code=trust_remote_code,
-    )
-
-    # For multimodal models (Qwen3VL, etc.), extract text_config
-    if hasattr(config, "text_config"):
-        config = config.text_config
-
-    return config.vocab_size
+    ).vocab_size

--- a/tests/unit/models/test_dflash_targets.py
+++ b/tests/unit/models/test_dflash_targets.py
@@ -6,7 +6,12 @@ from speculators.models.dflash import DFlashSpeculatorConfig
 from speculators.models.dflash.core import DFlashDraftModel
 
 
-def _tiny_model(sample_from_anchor: bool) -> DFlashDraftModel:
+def _tiny_model(
+    sample_from_anchor: bool,
+    *,
+    target_logit_scale: float = 1.0,
+    target_logit_softcap: float | None = None,
+) -> DFlashDraftModel:
     tl_config = Qwen3Config(
         hidden_size=16,
         intermediate_size=32,
@@ -24,6 +29,8 @@ def _tiny_model(sample_from_anchor: bool) -> DFlashDraftModel:
         aux_hidden_state_layer_ids=[0, 1],
         mask_token_id=0,
         sample_from_anchor=sample_from_anchor,
+        target_logit_scale=target_logit_scale,
+        target_logit_softcap=target_logit_softcap,
     )
     model = DFlashDraftModel(config)
     torch.nn.init.normal_(model.verifier_lm_head.weight)
@@ -33,9 +40,19 @@ def _tiny_model(sample_from_anchor: bool) -> DFlashDraftModel:
 
 @pytest.mark.parametrize("max_anchors", [5, 16])
 @pytest.mark.parametrize("sample_from_anchor", [False, True])
-def test_targets_match_full_sequence_roll(sample_from_anchor, max_anchors):
+@pytest.mark.parametrize(
+    ("target_logit_scale", "target_logit_softcap"),
+    [(1.0, None), (0.19611613513818404, 20.0)],
+)
+def test_targets_match_full_sequence_roll(
+    sample_from_anchor, max_anchors, target_logit_scale, target_logit_softcap
+):
     torch.manual_seed(0)
-    model = _tiny_model(sample_from_anchor)
+    model = _tiny_model(
+        sample_from_anchor,
+        target_logit_scale=target_logit_scale,
+        target_logit_softcap=target_logit_softcap,
+    )
     seq_len = 32
     hidden_states = torch.randn(1, seq_len, 2 * 16)
     verifier_last_hidden_states = torch.randn(1, seq_len, 16)
@@ -59,5 +76,10 @@ def test_targets_match_full_sequence_roll(sample_from_anchor, max_anchors):
         if not sample_from_anchor:
             full_logits = torch.roll(full_logits, 1, dims=1)
         expected = full_logits[:, anchored_block_indices]
+        expected = expected * target_logit_scale
+        if target_logit_softcap is not None:
+            expected = target_logit_softcap * torch.tanh(
+                expected / target_logit_softcap
+            )
 
     torch.testing.assert_close(targets, expected, atol=1e-5, rtol=0)


### PR DESCRIPTION
## Purpose

Add Muse Glimmer support for DFlash-family training.

Two follow-up PRs will cover DFlash → DSpark warm-start initialization and optional differential LR for DSpark heads. Together, these changes will upstream the training path used for [DaoCloud/Muse-Glimmer-30B-DSpark](https://huggingface.co/DaoCloud/Muse-Glimmer-30B-DSpark).

## Tests

On an NVIDIA H200:

```text
pytest -q tests/unit/models/test_utils.py tests/unit/models/test_dflash_targets.py
12 passed
```

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
