### PR TITLE
feat(regen): add --skip flag to response_regeneration script

### DIFF
--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -96,6 +96,12 @@ def parse_args():
     )
     parser.add_argument("--limit", type=int, default=None, help="Stop after N rows")
     parser.add_argument(
+        "--skip",
+        type=int,
+        default=0,
+        help="Skip the first N rows before processing",
+    )
+    parser.add_argument(
         "--concurrency",
         type=int,
         default=64,
@@ -793,6 +799,7 @@ async def main():
 
     seen_ids = load_seen(args.outfile) if args.resume else set()
     dataset = load_dataset(dataset_id, name=subset, split=split, streaming=True)
+    dataset = dataset.skip(args.skip)
 
     queue: asyncio.Queue = asyncio.Queue(maxsize=args.concurrency * 4)
 


### PR DESCRIPTION
## Summary
- Adds a `--skip N` argument to `scripts/response_regeneration/script.py` that skips the first N rows of the dataset before processing
- Enables range-based partitioning across parallel regen workers (e.g. one worker processes from the front, another from the middle, another from the back)
- Uses HuggingFace's `IterableDataset.skip()` — applied after sharding but before the work queue, so it composes safely with `--resume` (which uses content-based `primary_id`, not positional indices)

**Example — three workers covering the full dataset without overlap:**
```bash
# Worker A: first third (forward)
python script.py --limit 475000 ...

# Worker B: middle third
python script.py --skip 475000 --limit 475000 ...

# Worker C: last third
python script.py --skip 950000 ...
```

## Test plan
- [ ] `--skip 0` (default) behaves identically to before
- [ ] `--skip N` with `--resume` correctly resumes from where it left off
- [ ] `--skip N` with `--limit M` processes exactly rows N through N+M


🤖 Generated with [Claude Code](https://claude.com/claude-code)