### PR TITLE
Response regen improvements

### DIFF
--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -127,6 +127,14 @@ def parse_args():
             f"(default: {DEFAULT_MAX_RETRIES})"
         ),
     )
+    parser.add_argument(
+        "--reasoning-effort-cycle",
+        default=None,
+        help=(
+            "Comma-separated reasoning effort levels to cycle through "
+            "per conversation, e.g. 'low,high,max'"
+        ),
+    )
     args = parser.parse_args()
     if args.max_retries < 0:
         parser.error("--max-retries must be >= 0")
@@ -138,6 +146,12 @@ def parse_args():
         parser.error(f"--sampling-params is not valid JSON: {e}")
     if not isinstance(args.sampling_params, dict):
         parser.error("--sampling-params must be a JSON object")
+    if args.reasoning_effort_cycle is not None:
+        args.reasoning_effort_cycle = [
+            level.strip() for level in args.reasoning_effort_cycle.split(",")
+        ]
+        if not args.reasoning_effort_cycle:
+            parser.error("--reasoning-effort-cycle must not be empty")
     return args
 
 
@@ -530,6 +544,7 @@ async def regenerate_conversation(
     sampling_params: dict[str, Any],
     samples: list[dict[str, Any]],
     detokenize: Callable[[list[int]], str],
+    reasoning_effort: str | None = None,
 ) -> bool:
     """Regenerate one conversation into per-generation boundary samples.
 
@@ -571,9 +586,18 @@ async def regenerate_conversation(
                 "max_tokens": max_tokens,
                 "return_token_ids": True,  # prompt_token_ids + completion token_ids
             }
+            if reasoning_effort is not None:
+                payload["reasoning_effort"] = reasoning_effort
             if tools:
                 payload["tools"] = tools
                 payload["tool_choice"] = "auto"
+
+            recorded_params = sampling_params
+            if reasoning_effort is not None:
+                recorded_params = {
+                    **sampling_params,
+                    "reasoning_effort": reasoning_effort,
+                }
 
             data = await post_fn(payload)
             sample, assistant_msg, tool_calls = _sample_from_response(
@@ -583,7 +607,7 @@ async def regenerate_conversation(
                 sample_index=len(samples),
                 idx=item["idx"],
                 endpoint=endpoint,
-                sampling_params=sampling_params,
+                sampling_params=recorded_params,
             )
             samples.append(sample)
             prefix.append(assistant_msg)
@@ -689,6 +713,7 @@ async def worker(
                 sampling_params=args.sampling_params,
                 samples=samples,
                 detokenize=detokenize,
+                reasoning_effort=item.get("reasoning_effort"),
             )
             # Written only after the conversation finishes -- a clean truncation
             # included, since rerunning it would truncate again. An exception
@@ -746,6 +771,10 @@ async def main():
         args.model = await detect_model(endpoint)
 
     print(f"Using model: {args.model}")
+    if args.reasoning_effort_cycle:
+        print(
+            f"Reasoning effort cycle: {' -> '.join(args.reasoning_effort_cycle)}"
+        )
 
     # Decoder for the review-only `text` twin; see build_detokenizer.
     detokenize = build_detokenizer(args.model)
@@ -872,15 +901,18 @@ async def main():
                     progress.update(1)
                     continue
 
-                await queue.put(
-                    {
-                        "idx": index,
-                        "primary_id": primary_id,
-                        "turns": turns,
-                        "tools": tools,
-                        "tool_results": tool_results,
-                    }
-                )
+                queue_item: dict[str, Any] = {
+                    "idx": index,
+                    "primary_id": primary_id,
+                    "turns": turns,
+                    "tools": tools,
+                    "tool_results": tool_results,
+                }
+                if args.reasoning_effort_cycle is not None:
+                    queue_item["reasoning_effort"] = args.reasoning_effort_cycle[
+                        processed_count % len(args.reasoning_effort_cycle)
+                    ]
+                await queue.put(queue_item)
                 processed_count += 1
 
             # Signal workers to stop

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -378,7 +378,7 @@ def build_detokenizer(model: str) -> Callable[[list[int]], str]:
     (the checkpoint, not a ``--served-model-name`` alias).
     """
     print(f"Loading tokenizer: {model}")
-    tokenizer = AutoTokenizer.from_pretrained(model)
+    tokenizer = AutoTokenizer.from_pretrained(model, trust_remote_code=True)
 
     def detokenize(token_ids: list[int]) -> str:
         # decode() is typed str | list[str]; a 1-D id list always yields str.

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -612,6 +612,15 @@ async def regenerate_conversation(
             samples.append(sample)
             prefix.append(assistant_msg)
 
+            prompt_token_ids = data.get("prompt_token_ids")
+            completion_token_ids = data["choices"][0].get("token_ids")
+            total_tokens = len(prompt_token_ids or []) + len(
+                completion_token_ids or []
+            )
+            if total_tokens > max_tokens:
+                truncated = True
+                break
+
             if not tool_calls:
                 break  # final answer: this user turn is done
 

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -135,6 +135,11 @@ def parse_args():
             "per conversation, e.g. 'low,high,max'"
         ),
     )
+    parser.add_argument(
+        "--reverse",
+        action="store_true",
+        help="Iterate through the dataset in reverse order (loads into memory)",
+    )
     args = parser.parse_args()
     if args.max_retries < 0:
         parser.error("--max-retries must be >= 0")
@@ -815,7 +820,13 @@ async def main():
     print()
 
     seen_ids = load_seen(args.outfile) if args.resume else set()
-    dataset = load_dataset(dataset_id, name=subset, split=split, streaming=True)
+    if args.reverse:
+        dataset = load_dataset(dataset_id, name=subset, split=split)
+        row_iter = ((i, dataset[i]) for i in range(len(dataset) - 1, -1, -1))
+        print(f"Reverse mode: {len(dataset)} rows, iterating last to first")
+    else:
+        dataset = load_dataset(dataset_id, name=subset, split=split, streaming=True)
+        row_iter = enumerate(dataset)
 
     queue: asyncio.Queue = asyncio.Queue(maxsize=args.concurrency * 4)
 
@@ -868,7 +879,7 @@ async def main():
             ]
 
             processed_count = 0
-            for index, row in enumerate(dataset):
+            for index, row in row_iter:
                 if args.limit is not None and processed_count >= args.limit:
                     break
 

--- a/scripts/response_regeneration/sweep_concurrency.sh
+++ b/scripts/response_regeneration/sweep_concurrency.sh
@@ -12,9 +12,9 @@
 #   # Sweep, then run full regeneration with the best concurrency
 #   ./sweep_concurrency.sh --model google/gemma-4-31B-it --dataset ultrachat --run --resume
 #
-#   # Custom endpoint and concurrency set
+#   # Custom endpoint, duration, and concurrency set
 #   ./sweep_concurrency.sh --endpoint http://host:8000/v1/chat/completions \
-#       --model MODEL --dataset tulu3 --concurrencies "64 256 1024 4096"
+#       --model MODEL --dataset tulu3 --duration 90 --concurrencies "64 256 1024 4096"
 #
 
 set -e
@@ -24,7 +24,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ── Sweep defaults ──────────────────────────────────────────────────
 ENDPOINT="http://127.0.0.1:8000/v1/chat/completions"
 CONCURRENCIES=(64 128 256 512 1024 2048)
-SAMPLES_PER_TRIAL=100
+DURATION=60
 WARMUP_SAMPLES=20
 RUN_AFTER=false
 
@@ -42,8 +42,8 @@ while [[ $# -gt 0 ]]; do
             IFS=' ,' read -ra CONCURRENCIES <<< "$2"
             shift 2
             ;;
-        --samples-per-trial)
-            SAMPLES_PER_TRIAL="$2"
+        --duration)
+            DURATION="$2"
             shift 2
             ;;
         --warmup-samples)
@@ -55,7 +55,6 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --concurrency)
-            # Silently drop: the whole point is to sweep this value.
             echo "Note: --concurrency ignored during sweep (use --concurrencies)"
             shift 2
             ;;
@@ -83,6 +82,25 @@ echo ""
 SWEEP_TMPDIR=$(mktemp -d)
 trap 'rm -rf "$SWEEP_TMPDIR"' EXIT
 
+# ── Helper: count conversations and total completion tokens ─────────
+# Prints two space-separated values: conversation_count  token_count
+count_output() {
+    python3 -c "
+import json, sys
+seen = set()
+tokens = 0
+with open(sys.argv[1]) as f:
+    for line in f:
+        try:
+            d = json.loads(line)
+            seen.add(d.get('primary_id') or d.get('id'))
+            tokens += d.get('metadata', {}).get('usage', {}).get('completion_tokens', 0)
+        except (json.JSONDecodeError, KeyError):
+            pass
+print(len(seen), tokens)
+" "$1" 2>/dev/null || echo "0 0"
+}
+
 # ── Warmup ──────────────────────────────────────────────────────────
 echo "Warming up ($WARMUP_SAMPLES samples at concurrency 64)..."
 echo ""
@@ -103,42 +121,39 @@ echo ""
 SHUFFLED=($(printf '%s\n' "${CONCURRENCIES[@]}" | shuf))
 
 declare -A RESULTS_CONVS
-declare -A RESULTS_ELAPSED
+declare -A RESULTS_TOKENS
 declare -A RESULTS_RATE
 
 echo "Sweeping concurrencies: ${CONCURRENCIES[*]}"
-echo "Samples per trial: $SAMPLES_PER_TRIAL"
+echo "Duration per trial: ${DURATION}s"
 echo ""
 
 for C in "${SHUFFLED[@]}"; do
     OUTFILE="$SWEEP_TMPDIR/sweep_${C}.jsonl"
-    echo "── Trial: concurrency=$C ──"
+    touch "$OUTFILE"
+    echo "── Trial: concurrency=$C (${DURATION}s) ──"
 
-    START_NS=$(date +%s%N)
-    python "$SCRIPT_DIR/script.py" \
-        "${PYTHON_ARGS[@]}" \
-        --endpoint "$ENDPOINT" \
-        --concurrency "$C" \
-        --limit "$SAMPLES_PER_TRIAL" \
-        --outfile "$OUTFILE" \
-        2>&1 | tee "$SWEEP_TMPDIR/sweep_${C}.log"
-    END_NS=$(date +%s%N)
+    # Run for a fixed duration, then SIGINT to stop gracefully.
+    # script.py flushes after each completed conversation, so the output
+    # file contains all work that finished before the signal.
+    timeout --signal=INT "${DURATION}s" \
+        python "$SCRIPT_DIR/script.py" \
+            "${PYTHON_ARGS[@]}" \
+            --endpoint "$ENDPOINT" \
+            --concurrency "$C" \
+            --limit 999999 \
+            --outfile "$OUTFILE" \
+        || true
 
-    ELAPSED_S=$(awk "BEGIN {printf \"%.2f\", ($END_NS - $START_NS) / 1000000000}")
+    read -r CONV_COUNT TOKEN_COUNT <<< "$(count_output "$OUTFILE")"
+    TOKEN_RATE=$(awk "BEGIN {printf \"%.0f\", $TOKEN_COUNT / $DURATION}")
 
-    # script.py prints "Pipeline complete in Xs: Y conversations (Z ok, ...)"
-    OK_COUNT=$(grep -oP '\((\d+) ok' "$SWEEP_TMPDIR/sweep_${C}.log" | grep -oP '\d+' || echo "0")
-    if [ "$OK_COUNT" -eq 0 ]; then
-        OK_COUNT=$SAMPLES_PER_TRIAL
-    fi
+    RESULTS_CONVS[$C]=$CONV_COUNT
+    RESULTS_TOKENS[$C]=$TOKEN_COUNT
+    RESULTS_RATE[$C]=$TOKEN_RATE
 
-    RATE=$(awk "BEGIN {printf \"%.2f\", $OK_COUNT / $ELAPSED_S}")
-
-    RESULTS_CONVS[$C]=$OK_COUNT
-    RESULTS_ELAPSED[$C]=$ELAPSED_S
-    RESULTS_RATE[$C]=$RATE
-
-    echo "=> $OK_COUNT conversations in ${ELAPSED_S}s (${RATE}/s)"
+    echo ""
+    echo "=> $CONV_COUNT conversations, $TOKEN_COUNT tokens in ${DURATION}s (${TOKEN_RATE} tok/s)"
     echo ""
 done
 
@@ -157,17 +172,17 @@ done
 
 # ── Results table ───────────────────────────────────────────────────
 echo "==========================================="
-echo "Concurrency Sweep Results"
+echo "Concurrency Sweep Results (${DURATION}s per trial)"
 echo "==========================================="
-printf "%-15s %-15s %-10s\n" "Concurrency" "Conversations" "Conv/sec"
-printf "%-15s %-15s %-10s\n" "-----------" "-------------" "--------"
+printf "%-15s %-15s %-12s %-10s\n" "Concurrency" "Conversations" "Tokens" "Tok/sec"
+printf "%-15s %-15s %-12s %-10s\n" "-----------" "-------------" "------" "-------"
 for C in "${CONCURRENCIES[@]}"; do
     MARKER=""
     [ "$C" = "$BEST_C" ] && MARKER="  <-- best"
-    printf "%-15s %-15s %-10s%s\n" "$C" "${RESULTS_CONVS[$C]}" "${RESULTS_RATE[$C]}" "$MARKER"
+    printf "%-15s %-15s %-12s %-10s%s\n" "$C" "${RESULTS_CONVS[$C]}" "${RESULTS_TOKENS[$C]}" "${RESULTS_RATE[$C]}" "$MARKER"
 done
 echo ""
-echo "Optimal concurrency: $BEST_C ($BEST_RATE conv/s)"
+echo "Optimal concurrency: $BEST_C (${BEST_RATE} tok/s)"
 echo ""
 
 # ── Optional: chain into full regeneration ──────────────────────────

--- a/scripts/response_regeneration/sweep_concurrency.sh
+++ b/scripts/response_regeneration/sweep_concurrency.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+#
+# Sweep concurrency levels against a running vLLM server to find the
+# optimal --concurrency for response regeneration.
+#
+# Prerequisites: a vLLM server must already be running.
+#
+# Usage:
+#   # Sweep only — prints results table and recommended concurrency
+#   ./sweep_concurrency.sh --model google/gemma-4-31B-it --dataset ultrachat
+#
+#   # Sweep, then run full regeneration with the best concurrency
+#   ./sweep_concurrency.sh --model google/gemma-4-31B-it --dataset ultrachat --run --resume
+#
+#   # Custom endpoint and concurrency set
+#   ./sweep_concurrency.sh --endpoint http://host:8000/v1/chat/completions \
+#       --model MODEL --dataset tulu3 --concurrencies "64 256 1024 4096"
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Sweep defaults ──────────────────────────────────────────────────
+ENDPOINT="http://127.0.0.1:8000/v1/chat/completions"
+CONCURRENCIES=(64 128 256 512 1024 2048)
+SAMPLES_PER_TRIAL=100
+WARMUP_SAMPLES=20
+RUN_AFTER=false
+
+# ── Argument parsing ───────────────────────────────────────────────
+# Everything not consumed below passes through to script.py.
+PYTHON_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --endpoint)
+            ENDPOINT="$2"
+            shift 2
+            ;;
+        --concurrencies)
+            IFS=' ,' read -ra CONCURRENCIES <<< "$2"
+            shift 2
+            ;;
+        --samples-per-trial)
+            SAMPLES_PER_TRIAL="$2"
+            shift 2
+            ;;
+        --warmup-samples)
+            WARMUP_SAMPLES="$2"
+            shift 2
+            ;;
+        --run)
+            RUN_AFTER=true
+            shift
+            ;;
+        --concurrency)
+            # Silently drop: the whole point is to sweep this value.
+            echo "Note: --concurrency ignored during sweep (use --concurrencies)"
+            shift 2
+            ;;
+        *)
+            PYTHON_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# ── Health check ────────────────────────────────────────────────────
+MODELS_ENDPOINT="${ENDPOINT/\/v1\/chat\/completions/\/v1\/models}"
+printf "Checking server at %s... " "$MODELS_ENDPOINT"
+if ! curl -s --connect-timeout 5 --max-time 10 "$MODELS_ENDPOINT" > /dev/null 2>&1; then
+    echo "FAILED"
+    echo ""
+    echo "Error: vLLM server not reachable at $MODELS_ENDPOINT"
+    echo "Start a vLLM server first, then re-run this script."
+    exit 1
+fi
+echo "OK"
+echo ""
+
+# ── Temp directory (cleaned up on exit) ─────────────────────────────
+SWEEP_TMPDIR=$(mktemp -d)
+trap 'rm -rf "$SWEEP_TMPDIR"' EXIT
+
+# ── Warmup ──────────────────────────────────────────────────────────
+echo "Warming up ($WARMUP_SAMPLES samples at concurrency 64)..."
+echo ""
+WARMUP_START=$(date +%s%N)
+python "$SCRIPT_DIR/script.py" \
+    "${PYTHON_ARGS[@]}" \
+    --endpoint "$ENDPOINT" \
+    --concurrency 64 \
+    --limit "$WARMUP_SAMPLES" \
+    --outfile "$SWEEP_TMPDIR/warmup.jsonl"
+WARMUP_END=$(date +%s%N)
+WARMUP_S=$(awk "BEGIN {printf \"%.1f\", ($WARMUP_END - $WARMUP_START) / 1000000000}")
+echo ""
+echo "Warmup done (${WARMUP_S}s)"
+echo ""
+
+# ── Randomised sweep ───────────────────────────────────────────────
+SHUFFLED=($(printf '%s\n' "${CONCURRENCIES[@]}" | shuf))
+
+declare -A RESULTS_CONVS
+declare -A RESULTS_ELAPSED
+declare -A RESULTS_RATE
+
+echo "Sweeping concurrencies: ${CONCURRENCIES[*]}"
+echo "Samples per trial: $SAMPLES_PER_TRIAL"
+echo ""
+
+for C in "${SHUFFLED[@]}"; do
+    OUTFILE="$SWEEP_TMPDIR/sweep_${C}.jsonl"
+    echo "── Trial: concurrency=$C ──"
+
+    START_NS=$(date +%s%N)
+    python "$SCRIPT_DIR/script.py" \
+        "${PYTHON_ARGS[@]}" \
+        --endpoint "$ENDPOINT" \
+        --concurrency "$C" \
+        --limit "$SAMPLES_PER_TRIAL" \
+        --outfile "$OUTFILE" \
+        2>&1 | tee "$SWEEP_TMPDIR/sweep_${C}.log"
+    END_NS=$(date +%s%N)
+
+    ELAPSED_S=$(awk "BEGIN {printf \"%.2f\", ($END_NS - $START_NS) / 1000000000}")
+
+    # script.py prints "Pipeline complete in Xs: Y conversations (Z ok, ...)"
+    OK_COUNT=$(grep -oP '\((\d+) ok' "$SWEEP_TMPDIR/sweep_${C}.log" | grep -oP '\d+' || echo "0")
+    if [ "$OK_COUNT" -eq 0 ]; then
+        OK_COUNT=$SAMPLES_PER_TRIAL
+    fi
+
+    RATE=$(awk "BEGIN {printf \"%.2f\", $OK_COUNT / $ELAPSED_S}")
+
+    RESULTS_CONVS[$C]=$OK_COUNT
+    RESULTS_ELAPSED[$C]=$ELAPSED_S
+    RESULTS_RATE[$C]=$RATE
+
+    echo "=> $OK_COUNT conversations in ${ELAPSED_S}s (${RATE}/s)"
+    echo ""
+done
+
+echo ""
+
+# ── Find best ───────────────────────────────────────────────────────
+BEST_C=""
+BEST_RATE="0"
+for C in "${CONCURRENCIES[@]}"; do
+    RATE=${RESULTS_RATE[$C]}
+    if awk "BEGIN {exit !($RATE > $BEST_RATE)}"; then
+        BEST_RATE=$RATE
+        BEST_C=$C
+    fi
+done
+
+# ── Results table ───────────────────────────────────────────────────
+echo "==========================================="
+echo "Concurrency Sweep Results"
+echo "==========================================="
+printf "%-15s %-15s %-10s\n" "Concurrency" "Conversations" "Conv/sec"
+printf "%-15s %-15s %-10s\n" "-----------" "-------------" "--------"
+for C in "${CONCURRENCIES[@]}"; do
+    MARKER=""
+    [ "$C" = "$BEST_C" ] && MARKER="  <-- best"
+    printf "%-15s %-15s %-10s%s\n" "$C" "${RESULTS_CONVS[$C]}" "${RESULTS_RATE[$C]}" "$MARKER"
+done
+echo ""
+echo "Optimal concurrency: $BEST_C ($BEST_RATE conv/s)"
+echo ""
+
+# ── Optional: chain into full regeneration ──────────────────────────
+if [ "$RUN_AFTER" = true ]; then
+    echo "==========================================="
+    echo "Running full regeneration (concurrency=$BEST_C)"
+    echo "==========================================="
+    echo ""
+    python "$SCRIPT_DIR/script.py" \
+        "${PYTHON_ARGS[@]}" \
+        --endpoint "$ENDPOINT" \
+        --concurrency "$BEST_C"
+    exit $?
+fi
+
+echo "Run full regeneration with:"
+echo "  python $SCRIPT_DIR/script.py ${PYTHON_ARGS[*]} --endpoint $ENDPOINT --concurrency $BEST_C"

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -599,7 +599,14 @@ def _fake_post(responses):
 
 
 def _regen(
-    item, responses, *, model="m", max_tokens=64, endpoint="ep", sampling_params=None
+    item,
+    responses,
+    *,
+    model="m",
+    max_tokens=64,
+    endpoint="ep",
+    sampling_params=None,
+    reasoning_effort=None,
 ):
     post, sent = _fake_post(responses)
     samples: list = []
@@ -613,6 +620,7 @@ def _regen(
             sampling_params=sampling_params or {},
             samples=samples,
             detokenize=_detok,
+            reasoning_effort=reasoning_effort,
         )
     )
     return samples, truncated, sent
@@ -744,6 +752,30 @@ def test_sampling_params_reach_the_request_and_metadata():
     assert sent[0]["max_tokens"] == 64
     # Recorded for reproducibility of the generated row.
     assert samples[0]["metadata"]["sampling_params"] == params
+
+
+def test_reasoning_effort_reaches_request_and_metadata():
+    item = {"idx": 0, "primary_id": "u", "turns": [{"role": "user", "content": "hi"}]}
+    responses = [_response(prompt_token_ids=[1, 2], token_ids=[3], content="hello")]
+    params = {"temperature": 0.6}
+    samples, _, sent = _regen(
+        item, responses, sampling_params=params, reasoning_effort="high"
+    )
+
+    assert sent[0]["reasoning_effort"] == "high"
+    assert samples[0]["metadata"]["sampling_params"] == {
+        "temperature": 0.6,
+        "reasoning_effort": "high",
+    }
+
+
+def test_reasoning_effort_absent_by_default():
+    item = {"idx": 0, "primary_id": "u", "turns": [{"role": "user", "content": "hi"}]}
+    responses = [_response(prompt_token_ids=[1, 2], token_ids=[3], content="hello")]
+    samples, _, sent = _regen(item, responses)
+
+    assert "reasoning_effort" not in sent[0]
+    assert "reasoning_effort" not in samples[0]["metadata"]["sampling_params"]
 
 
 def test_regenerate_plain_conversation_is_unchanged_and_sends_no_tools():


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

This pr includes:
- New concurrency sweeping script
- Option to rotate between different reasoning effort levels during response regen
- Better max_token truncation
- A `--reverse` iteration option

## Tests

Added a couple test cases and verified by using for larger response regen runs. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
