### PR TITLE
feat(regen): support local prompt files

### DIFF
--- a/docs/cli/response_regeneration.md
+++ b/docs/cli/response_regeneration.md
@@ -62,6 +62,7 @@ Extracts conversation turns from a dataset, regenerates each assistant response 
 ### Features
 
 - **Multi-turn support** — detects `messages`/`conversations` fields and regenerates each assistant turn against the model's own prior responses
+- **Local file support** for JSON/JSONL prompt datasets
 - **Auto-detects model** from vLLM server (no need to specify `--model`)
 - **Resume capability** to skip already-processed conversations
 - **Async processing** with configurable concurrency
@@ -78,6 +79,8 @@ python scripts/response_regeneration/script.py --dataset magpie
 #### Data Arguments
 
 - **`--dataset`** (str, default: `ultrachat`) Dataset preset to process (see [Supported Datasets](#supported-datasets)).
+
+- **`--dataset-file`** (str) Local JSON/JSONL file to process instead of a preset. Rows may contain `messages`, `conversations`, or `prompt` (a string or message list). Mutually exclusive with `--dataset`; `--split` and `--subset` do not apply.
 
 - **`--split`** (str, default: preset-specific) Dataset split. Defaults to the preset's split.
 
@@ -105,7 +108,7 @@ python scripts/response_regeneration/script.py --dataset magpie
 
 #### Output Arguments
 
-- **`--outfile`** (str, default: auto-generated) Output JSONL path. If not specified, auto-generated as `{dataset}_{model}.jsonl`.
+- **`--outfile`** (str, default: auto-generated) Output JSONL path. If not specified, auto-generated as `{dataset-or-file-stem}_{model}.jsonl`.
 
 - **`--resume`** (flag) Skip conversations already present in the output file (matched by `primary_id`: the row's `id`/`uuid` if it has one, otherwise a content hash).
 
@@ -188,4 +191,4 @@ Tools are **not executed**. The target's *k*-th regenerated call is paired with 
 
 A conversation stops early — keeping the rows completed so far — when the target emits a call that cannot be paired 1:1 with a cached result: it has exhausted the cached results, emitted parallel calls in a single generation, or called a different tool than the next cached result answers. Such conversations are counted under `truncated` in the progress bar.
 
-If `--outfile` is not specified, the filename is auto-generated based on dataset and model (e.g., `magpie_Llama-3.3-70B-Instruct.jsonl`).
+If `--outfile` is not specified, the filename is auto-generated from the preset name or local file stem and model (e.g., `magpie_Llama-3.3-70B-Instruct.jsonl`).

--- a/docs/cli/response_regeneration.md
+++ b/docs/cli/response_regeneration.md
@@ -74,13 +74,40 @@ Extracts conversation turns from a dataset, regenerates each assistant response 
 python scripts/response_regeneration/script.py --dataset magpie
 ```
 
+### Local Files
+
+Use `--dataset-file` to regenerate responses from a local `.json` or `.jsonl` file. **JSONL is recommended for large datasets** because it can be read one row at a time; a regular JSON file may need to be loaded completely before iteration. Each JSONL line, or each object in a top-level JSON array, must use one of these schemas:
+
+- `prompt`: a non-empty string or a non-empty list of message objects.
+- `messages`: a non-empty list of message objects.
+- `conversations`: a non-empty list of message objects.
+
+Message objects may use OpenAI-style `role`/`content` keys or ShareGPT-style `from`/`value` keys. The recognized input roles are `system`, `user`, and `human`; `human` is normalized to `user`. Existing `assistant`/`gpt` turns are discarded and regenerated. `tool` messages are retained as cached results for tool-call regeneration.
+
+For example, `my_prompts.jsonl` may contain:
+
+```jsonl
+{"id":"prompt-1","prompt":"Explain speculative decoding."}
+{"id":"prompt-2","messages":[{"role":"system","content":"Be concise."},{"role":"user","content":"What is EAGLE?"}]}
+{"id":"prompt-3","conversations":[{"from":"human","value":"Compare EAGLE and DFlash."}]}
+```
+
+Run regeneration with:
+
+```bash
+python scripts/response_regeneration/script.py \
+  --dataset-file ./my_prompts.jsonl
+```
+
+Column names such as `instruction`, `question`, and `text` are not inferred. Convert those rows to one of the schemas above or use a registered dataset preset with a normalization function.
+
 ### Arguments
 
 #### Data Arguments
 
 - **`--dataset`** (str, default: `ultrachat`) Dataset preset to process (see [Supported Datasets](#supported-datasets)).
 
-- **`--dataset-file`** (str) Local JSON/JSONL file to process instead of a preset. Rows may contain `messages`, `conversations`, or `prompt` (a string or message list). Mutually exclusive with `--dataset`; `--split` and `--subset` do not apply.
+- **`--dataset-file`** (str) Local JSON/JSONL file to process instead of a preset (see [Local Files](#local-files)). Mutually exclusive with `--dataset`; `--split` and `--subset` do not apply.
 
 - **`--split`** (str, default: preset-specific) Dataset split. Defaults to the preset's split.
 

--- a/docs/cli/response_regeneration.md
+++ b/docs/cli/response_regeneration.md
@@ -76,7 +76,7 @@ python scripts/response_regeneration/script.py --dataset magpie
 
 ### Local Files
 
-Use `--dataset-file` to regenerate responses from a local `.json` or `.jsonl` file. **JSONL is recommended for large datasets** because it can be read one row at a time; a regular JSON file may need to be loaded completely before iteration. Each JSONL line, or each object in a top-level JSON array, must use one of these schemas:
+Pass a local `.json` or `.jsonl` file to `--dataset` to regenerate its responses. **JSONL is recommended for large datasets** because it can be read one row at a time; a regular JSON file may need to be loaded completely before iteration. Each JSONL line, or each object in a top-level JSON array, must use one of these schemas:
 
 - `prompt`: a non-empty string or a non-empty list of message objects.
 - `messages`: a non-empty list of message objects.
@@ -96,7 +96,7 @@ Run regeneration with:
 
 ```bash
 python scripts/response_regeneration/script.py \
-  --dataset-file ./my_prompts.jsonl
+  --dataset ./my_prompts.jsonl
 ```
 
 Column names such as `instruction`, `question`, and `text` are not inferred. Convert those rows to one of the schemas above or use a registered dataset preset with a normalization function.
@@ -105,9 +105,7 @@ Column names such as `instruction`, `question`, and `text` are not inferred. Con
 
 #### Data Arguments
 
-- **`--dataset`** (str, default: `ultrachat`) Dataset preset to process (see [Supported Datasets](#supported-datasets)).
-
-- **`--dataset-file`** (str) Local JSON/JSONL file to process instead of a preset (see [Local Files](#local-files)). Mutually exclusive with `--dataset`; `--split` and `--subset` do not apply.
+- **`--dataset`** (str, default: `ultrachat`) Registered dataset preset (see [Supported Datasets](#supported-datasets)) or local JSON/JSONL file (see [Local Files](#local-files)). `--split` and `--subset` do not apply to local files.
 
 - **`--split`** (str, default: preset-specific) Dataset split. Defaults to the preset's split.
 

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -34,26 +34,24 @@ MULTIMODAL_DATASETS = {"sharegpt4v_coco"}
 REGEN_DATASETS = [name for name in DATASET_CONFIGS if name not in MULTIMODAL_DATASETS]
 
 
-def _dataset_choice(name: str) -> str:
-    """Reject multimodal presets with a reason, not a bare invalid choice."""
+def _dataset_source(name: str) -> str:
+    """Validate a registered preset or local JSON/JSONL file."""
     if name in MULTIMODAL_DATASETS:
         raise argparse.ArgumentTypeError(
             f"{name!r} is multimodal; response regeneration does not support "
             "images yet. Generate target-model responses with a multimodal-capable "
             "workflow, then convert them with `prepare_data.py`."
         )
-    return name
+    if name in REGEN_DATASETS:
+        return name
 
-
-def _dataset_file(path: str) -> str:
-    """Validate a local JSON/JSONL dataset path for argparse."""
-    dataset_path = Path(path)
+    dataset_path = Path(name)
     if dataset_path.suffix.lower() not in {".json", ".jsonl"}:
         raise argparse.ArgumentTypeError(
-            "--dataset-file must be a .json or .jsonl file"
+            f"{name!r} is not a supported dataset preset or local .json/.jsonl file"
         )
     if not dataset_path.is_file():
-        raise argparse.ArgumentTypeError(f"dataset file does not exist: {path}")
+        raise argparse.ArgumentTypeError(f"dataset file does not exist: {name}")
     return str(dataset_path)
 
 
@@ -87,18 +85,12 @@ def parse_args():
         default=None,
         help="Model name exposed by vLLM (auto-detected if not specified)",
     )
-    dataset_group = parser.add_mutually_exclusive_group()
-    dataset_group.add_argument(
+    parser.add_argument(
         "--dataset",
-        default=None,
-        type=_dataset_choice,
-        choices=REGEN_DATASETS,
-        help="Dataset to process",
-    )
-    dataset_group.add_argument(
-        "--dataset-file",
-        type=_dataset_file,
-        help="Local JSON/JSONL file with messages, conversations, or prompt rows",
+        default="ultrachat",
+        type=_dataset_source,
+        metavar="PRESET_OR_PATH",
+        help="Registered dataset preset or local .json/.jsonl file",
     )
     parser.add_argument(
         "--split",
@@ -159,12 +151,10 @@ def parse_args():
         ),
     )
     args = parser.parse_args()
-    if args.dataset is None and args.dataset_file is None:
-        args.dataset = "ultrachat"
-    if args.dataset_file is not None and (
+    if args.dataset not in REGEN_DATASETS and (
         args.split is not None or args.subset is not None
     ):
-        parser.error("--split and --subset only apply to --dataset presets")
+        parser.error("--split and --subset only apply to dataset presets")
 
     if args.max_retries < 0:
         parser.error("--max-retries must be >= 0")
@@ -779,10 +769,10 @@ async def worker(
 
 def load_input_dataset(args: argparse.Namespace) -> tuple[DatasetConfig, Any, str]:
     """Load either a registered Hugging Face preset or a local JSON/JSONL file."""
-    if args.dataset_file is not None:
+    if args.dataset not in REGEN_DATASETS:
         config = DatasetConfig(
-            name=Path(args.dataset_file).stem,
-            hf_path=args.dataset_file,
+            name=Path(args.dataset).stem,
+            hf_path=args.dataset,
             split="train",
             prompt_field="prompt",
         )
@@ -791,8 +781,6 @@ def load_input_dataset(args: argparse.Namespace) -> tuple[DatasetConfig, Any, st
         )
         return config, dataset, config.split
 
-    if args.dataset is None:
-        raise ValueError("dataset is required when dataset_file is not set")
     config = DATASET_CONFIGS[args.dataset]
     split = args.split if args.split is not None else config.split
     subset = args.subset if args.subset is not None else config.subset

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -10,6 +10,7 @@ import sys
 import time
 from collections import deque
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, cast
 
 import aiohttp
@@ -44,6 +45,18 @@ def _dataset_choice(name: str) -> str:
     return name
 
 
+def _dataset_file(path: str) -> str:
+    """Validate a local JSON/JSONL dataset path for argparse."""
+    dataset_path = Path(path)
+    if dataset_path.suffix.lower() not in {".json", ".jsonl"}:
+        raise argparse.ArgumentTypeError(
+            "--dataset-file must be a .json or .jsonl file"
+        )
+    if not dataset_path.is_file():
+        raise argparse.ArgumentTypeError(f"dataset file does not exist: {path}")
+    return str(dataset_path)
+
+
 # ---------------------------------------------------------------------------
 # CLI & run configuration
 # ---------------------------------------------------------------------------
@@ -74,12 +87,18 @@ def parse_args():
         default=None,
         help="Model name exposed by vLLM (auto-detected if not specified)",
     )
-    parser.add_argument(
+    dataset_group = parser.add_mutually_exclusive_group()
+    dataset_group.add_argument(
         "--dataset",
-        default="ultrachat",
+        default=None,
         type=_dataset_choice,
         choices=REGEN_DATASETS,
         help="Dataset to process",
+    )
+    dataset_group.add_argument(
+        "--dataset-file",
+        type=_dataset_file,
+        help="Local JSON/JSONL file with messages, conversations, or prompt rows",
     )
     parser.add_argument(
         "--split",
@@ -140,6 +159,13 @@ def parse_args():
         ),
     )
     args = parser.parse_args()
+    if args.dataset is None and args.dataset_file is None:
+        args.dataset = "ultrachat"
+    if args.dataset_file is not None and (
+        args.split is not None or args.subset is not None
+    ):
+        parser.error("--split and --subset only apply to --dataset presets")
+
     if args.max_retries < 0:
         parser.error("--max-retries must be >= 0")
     try:
@@ -166,10 +192,12 @@ def sanitize_filename(name: str) -> str:
 
 
 def _conversation_messages(row: dict[str, Any]) -> list:
-    """The ``messages`` or ``conversations`` list from a row, else []."""
+    """The ``messages``, ``conversations``, or message-list ``prompt``, else []."""
     convs = row.get("messages")
     if not (isinstance(convs, list) and convs):
         convs = row.get("conversations")
+    if not (isinstance(convs, list) and convs):
+        convs = row.get("prompt")
     return convs if isinstance(convs, list) else []
 
 
@@ -749,6 +777,29 @@ async def worker(
             queue.task_done()
 
 
+def load_input_dataset(args: argparse.Namespace) -> tuple[DatasetConfig, Any, str]:
+    """Load either a registered Hugging Face preset or a local JSON/JSONL file."""
+    if args.dataset_file is not None:
+        config = DatasetConfig(
+            name=Path(args.dataset_file).stem,
+            hf_path=args.dataset_file,
+            split="train",
+            prompt_field="prompt",
+        )
+        dataset = load_dataset(
+            "json", data_files=args.dataset_file, split="train", streaming=True
+        )
+        return config, dataset, "train"
+
+    if args.dataset is None:
+        raise ValueError("dataset is required when dataset_file is not set")
+    config = DATASET_CONFIGS[args.dataset]
+    split = args.split if args.split is not None else config.split
+    subset = args.subset if args.subset is not None else config.subset
+    dataset = load_dataset(config.hf_path, name=subset, split=split, streaming=True)
+    return config, dataset, split
+
+
 async def main():
     """Main async function to process dataset through vLLM endpoints."""
     args = parse_args()
@@ -765,20 +816,16 @@ async def main():
     # Decoder for the review-only `text` twin; see build_detokenizer.
     detokenize = build_detokenizer(args.model)
 
-    # Get dataset configuration
-    dataset_config = DATASET_CONFIGS[args.dataset]
+    dataset_config, dataset, split = load_input_dataset(args)
     dataset_id = dataset_config.hf_path
-
-    # Use dataset-specific defaults if not provided
-    split = args.split if args.split is not None else dataset_config.split
-    subset = args.subset if args.subset is not None else dataset_config.subset
 
     # Generate output filename if not specified
     if args.outfile is None:
         # Extract simple model name from full path
         model_name = args.model.split("/")[-1] if "/" in args.model else args.model
         model_name = sanitize_filename(model_name)
-        args.outfile = f"{args.dataset}_{model_name}.jsonl"
+        source_name = sanitize_filename(dataset_config.name)
+        args.outfile = f"{source_name}_{model_name}.jsonl"
 
     # Failed / partial conversations are written here instead of the training file.
     base, ext = os.path.splitext(args.outfile)
@@ -792,8 +839,6 @@ async def main():
     print()
 
     seen_ids = load_seen(args.outfile) if args.resume else set()
-    dataset = load_dataset(dataset_id, name=subset, split=split, streaming=True)
-
     queue: asyncio.Queue = asyncio.Queue(maxsize=args.concurrency * 4)
 
     ensure_parent_dirs(args.outfile, error_outfile)

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -782,9 +782,9 @@ def load_input_dataset(args: argparse.Namespace) -> tuple[DatasetConfig, Any, st
             prompt_field="prompt",
         )
         dataset = load_dataset(
-            "json", data_files=args.dataset_file, split="train", streaming=True
+            "json", data_files=config.hf_path, split=config.split, streaming=True
         )
-        return config, dataset, "train"
+        return config, dataset, config.split
 
     if args.dataset is None:
         raise ValueError("dataset is required when dataset_file is not set")
@@ -812,7 +812,6 @@ async def main():
     detokenize = build_detokenizer(args.model)
 
     dataset_config, dataset, split = load_input_dataset(args)
-    dataset_id = dataset_config.hf_path
 
     # Generate output filename if not specified
     if args.outfile is None:
@@ -826,7 +825,7 @@ async def main():
     base, ext = os.path.splitext(args.outfile)
     error_outfile = f"{base}.errors{ext or '.jsonl'}"
 
-    print(f"Using dataset: {dataset_id}")
+    print(f"Using dataset: {dataset_config.hf_path}")
     print(f"Split: {split}")
     print(f"Prompt field: {dataset_config.prompt_field}")
     print(f"Output file: {args.outfile}")

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -10,6 +10,7 @@ import sys
 import time
 from collections import deque
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any, cast
 
 import aiohttp
@@ -42,6 +43,18 @@ def _dataset_choice(name: str) -> str:
     return name
 
 
+def _dataset_file(path: str) -> str:
+    """Validate a local JSON/JSONL dataset path for argparse."""
+    dataset_path = Path(path)
+    if dataset_path.suffix.lower() not in {".json", ".jsonl"}:
+        raise argparse.ArgumentTypeError(
+            "--dataset-file must be a .json or .jsonl file"
+        )
+    if not dataset_path.is_file():
+        raise argparse.ArgumentTypeError(f"dataset file does not exist: {path}")
+    return str(dataset_path)
+
+
 # ---------------------------------------------------------------------------
 # CLI & run configuration
 # ---------------------------------------------------------------------------
@@ -72,12 +85,18 @@ def parse_args():
         default=None,
         help="Model name exposed by vLLM (auto-detected if not specified)",
     )
-    parser.add_argument(
+    dataset_group = parser.add_mutually_exclusive_group()
+    dataset_group.add_argument(
         "--dataset",
-        default="ultrachat",
+        default=None,
         type=_dataset_choice,
         choices=REGEN_DATASETS,
         help="Dataset to process",
+    )
+    dataset_group.add_argument(
+        "--dataset-file",
+        type=_dataset_file,
+        help="Local JSON/JSONL file with messages, conversations, or prompt rows",
     )
     parser.add_argument(
         "--split",
@@ -138,6 +157,13 @@ def parse_args():
         ),
     )
     args = parser.parse_args()
+    if args.dataset is None and args.dataset_file is None:
+        args.dataset = "ultrachat"
+    if args.dataset_file is not None and (
+        args.split is not None or args.subset is not None
+    ):
+        parser.error("--split and --subset only apply to --dataset presets")
+
     if args.max_retries < 0:
         parser.error("--max-retries must be >= 0")
     try:
@@ -164,10 +190,12 @@ def sanitize_filename(name: str) -> str:
 
 
 def _conversation_messages(row: dict[str, Any]) -> list:
-    """The ``messages`` or ``conversations`` list from a row, else []."""
+    """The ``messages``, ``conversations``, or message-list ``prompt``, else []."""
     convs = row.get("messages")
     if not (isinstance(convs, list) and convs):
         convs = row.get("conversations")
+    if not (isinstance(convs, list) and convs):
+        convs = row.get("prompt")
     return convs if isinstance(convs, list) else []
 
 
@@ -744,6 +772,29 @@ async def worker(
             queue.task_done()
 
 
+def load_input_dataset(args: argparse.Namespace) -> tuple[DatasetConfig, Any, str]:
+    """Load either a registered Hugging Face preset or a local JSON/JSONL file."""
+    if args.dataset_file is not None:
+        config = DatasetConfig(
+            name=Path(args.dataset_file).stem,
+            hf_path=args.dataset_file,
+            split="train",
+            prompt_field="prompt",
+        )
+        dataset = load_dataset(
+            "json", data_files=args.dataset_file, split="train", streaming=True
+        )
+        return config, dataset, "train"
+
+    if args.dataset is None:
+        raise ValueError("dataset is required when dataset_file is not set")
+    config = DATASET_CONFIGS[args.dataset]
+    split = args.split if args.split is not None else config.split
+    subset = args.subset if args.subset is not None else config.subset
+    dataset = load_dataset(config.hf_path, name=subset, split=split, streaming=True)
+    return config, dataset, split
+
+
 async def main():
     """Main async function to process dataset through vLLM endpoints."""
     args = parse_args()
@@ -760,20 +811,16 @@ async def main():
     # Decoder for the review-only `text` twin; see build_detokenizer.
     detokenize = build_detokenizer(args.model)
 
-    # Get dataset configuration
-    dataset_config = DATASET_CONFIGS[args.dataset]
+    dataset_config, dataset, split = load_input_dataset(args)
     dataset_id = dataset_config.hf_path
-
-    # Use dataset-specific defaults if not provided
-    split = args.split if args.split is not None else dataset_config.split
-    subset = args.subset if args.subset is not None else dataset_config.subset
 
     # Generate output filename if not specified
     if args.outfile is None:
         # Extract simple model name from full path
         model_name = args.model.split("/")[-1] if "/" in args.model else args.model
         model_name = sanitize_filename(model_name)
-        args.outfile = f"{args.dataset}_{model_name}.jsonl"
+        source_name = sanitize_filename(dataset_config.name)
+        args.outfile = f"{source_name}_{model_name}.jsonl"
 
     # Failed / partial conversations are written here instead of the training file.
     base, ext = os.path.splitext(args.outfile)
@@ -787,8 +834,6 @@ async def main():
     print()
 
     seen_ids = load_seen(args.outfile) if args.resume else set()
-    dataset = load_dataset(dataset_id, name=subset, split=split, streaming=True)
-
     queue: asyncio.Queue = asyncio.Queue(maxsize=args.concurrency * 4)
 
     ensure_parent_dirs(args.outfile, error_outfile)

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -246,7 +246,7 @@ def extract_conversation(
 
     # no usable user turn: fall back to the prompt_field
     prompt = row.get(prompt_field) if prompt_field else None
-    if prompt:
+    if isinstance(prompt, str) and prompt:
         return [{"role": "user", "content": prompt}], []
     return [], []
 

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -787,9 +787,9 @@ def load_input_dataset(args: argparse.Namespace) -> tuple[DatasetConfig, Any, st
             prompt_field="prompt",
         )
         dataset = load_dataset(
-            "json", data_files=args.dataset_file, split="train", streaming=True
+            "json", data_files=config.hf_path, split=config.split, streaming=True
         )
-        return config, dataset, "train"
+        return config, dataset, config.split
 
     if args.dataset is None:
         raise ValueError("dataset is required when dataset_file is not set")
@@ -817,7 +817,6 @@ async def main():
     detokenize = build_detokenizer(args.model)
 
     dataset_config, dataset, split = load_input_dataset(args)
-    dataset_id = dataset_config.hf_path
 
     # Generate output filename if not specified
     if args.outfile is None:
@@ -831,7 +830,7 @@ async def main():
     base, ext = os.path.splitext(args.outfile)
     error_outfile = f"{base}.errors{ext or '.jsonl'}"
 
-    print(f"Using dataset: {dataset_id}")
+    print(f"Using dataset: {dataset_config.hf_path}")
     print(f"Split: {split}")
     print(f"Prompt field: {dataset_config.prompt_field}")
     print(f"Output file: {args.outfile}")

--- a/scripts/response_regeneration/script.py
+++ b/scripts/response_regeneration/script.py
@@ -244,7 +244,7 @@ def extract_conversation(
 
     # no usable user turn: fall back to the prompt_field
     prompt = row.get(prompt_field) if prompt_field else None
-    if prompt:
+    if isinstance(prompt, str) and prompt:
         return [{"role": "user", "content": prompt}], []
     return [], []
 

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -12,7 +12,6 @@ import asyncio
 import copy
 import importlib.util
 import json
-import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -908,35 +907,15 @@ def test_dataset_source_rejects_multimodal_with_a_reason():
     assert regen._dataset_source("ultrachat") == "ultrachat"
 
 
-def test_dataset_source_validates_local_files(tmp_path):
+def test_parse_args_handles_local_dataset(monkeypatch, capsys, tmp_path):
     path = tmp_path / "prompts.jsonl"
-    path.write_text('{"prompt": "hello"}\n')
-
-    assert regen._dataset_source(str(path)) == str(path)
-    with pytest.raises(argparse.ArgumentTypeError, match="does not exist"):
-        regen._dataset_source(str(tmp_path / "missing.json"))
-    with pytest.raises(argparse.ArgumentTypeError, match="not a supported dataset"):
-        regen._dataset_source(str(tmp_path / "prompts.csv"))
-
-
-def test_parse_args_accepts_local_dataset(monkeypatch, tmp_path):
-    path = tmp_path / "prompts.jsonl"
-    path.write_text('{"prompt": "hello"}\n')
-    monkeypatch.setattr(sys, "argv", ["script.py", "--dataset", str(path)])
+    path.touch()
+    argv = ["script.py", "--dataset", str(path)]
+    monkeypatch.setattr("sys.argv", argv)
 
     assert regen.parse_args().dataset == str(path)
 
-
-@pytest.mark.parametrize("option", ["--split", "--subset"])
-def test_parse_args_rejects_preset_options_for_local_dataset(
-    monkeypatch, capsys, tmp_path, option
-):
-    path = tmp_path / "prompts.jsonl"
-    path.write_text('{"prompt": "hello"}\n')
-    monkeypatch.setattr(
-        sys, "argv", ["script.py", "--dataset", str(path), option, "custom"]
-    )
-
+    monkeypatch.setattr("sys.argv", [*argv, "--split", "custom"])
     with pytest.raises(SystemExit):
         regen.parse_args()
     assert "only apply to dataset presets" in capsys.readouterr().err
@@ -964,7 +943,7 @@ def test_parse_args_rejects_preset_options_for_local_dataset(
 )
 def test_load_input_dataset_from_local_file(tmp_path, filename, data):
     path = tmp_path / filename
-    path.write_text(json.dumps(data))
+    path.write_text(json.dumps(data) + "\n", encoding="utf-8")
     args = argparse.Namespace(
         dataset=str(path),
         split=None,

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -901,6 +901,25 @@ def test_dataset_choice_rejects_multimodal_with_a_reason():
     assert regen._dataset_choice("ultrachat") == "ultrachat"
 
 
+def test_load_input_dataset_from_local_jsonl(tmp_path):
+    path = tmp_path / "prompts.jsonl"
+    path.write_text(
+        json.dumps({"prompt": [{"role": "user", "content": "local prompt"}]})
+    )
+    args = argparse.Namespace(
+        dataset=None,
+        dataset_file=str(path),
+        split=None,
+        subset=None,
+    )
+
+    config, dataset, split = regen.load_input_dataset(args)
+    assert (config.name, config.prompt_field, split) == ("prompts", "prompt", "train")
+    assert regen.prepare_row(next(iter(dataset)), config)[1] == [
+        {"role": "user", "content": "local prompt"}
+    ]
+
+
 def test_tools_and_results_are_read_from_the_normalized_row():
     # Under a normalize_fn preset the conversation only appears in `messages`
     # after normalization; reading tools off the raw row regenerates tool-free.

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -12,6 +12,7 @@ import asyncio
 import copy
 import importlib.util
 import json
+import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -901,10 +902,44 @@ def test_prepare_row_merges_normalize_output_over_raw_row():
     assert turns == [{"role": "user", "content": "Hi"}]
 
 
-def test_dataset_choice_rejects_multimodal_with_a_reason():
+def test_dataset_source_rejects_multimodal_with_a_reason():
     with pytest.raises(argparse.ArgumentTypeError, match="does not support images"):
-        regen._dataset_choice("sharegpt4v_coco")
-    assert regen._dataset_choice("ultrachat") == "ultrachat"
+        regen._dataset_source("sharegpt4v_coco")
+    assert regen._dataset_source("ultrachat") == "ultrachat"
+
+
+def test_dataset_source_validates_local_files(tmp_path):
+    path = tmp_path / "prompts.jsonl"
+    path.write_text('{"prompt": "hello"}\n')
+
+    assert regen._dataset_source(str(path)) == str(path)
+    with pytest.raises(argparse.ArgumentTypeError, match="does not exist"):
+        regen._dataset_source(str(tmp_path / "missing.json"))
+    with pytest.raises(argparse.ArgumentTypeError, match="not a supported dataset"):
+        regen._dataset_source(str(tmp_path / "prompts.csv"))
+
+
+def test_parse_args_accepts_local_dataset(monkeypatch, tmp_path):
+    path = tmp_path / "prompts.jsonl"
+    path.write_text('{"prompt": "hello"}\n')
+    monkeypatch.setattr(sys, "argv", ["script.py", "--dataset", str(path)])
+
+    assert regen.parse_args().dataset == str(path)
+
+
+@pytest.mark.parametrize("option", ["--split", "--subset"])
+def test_parse_args_rejects_preset_options_for_local_dataset(
+    monkeypatch, capsys, tmp_path, option
+):
+    path = tmp_path / "prompts.jsonl"
+    path.write_text('{"prompt": "hello"}\n')
+    monkeypatch.setattr(
+        sys, "argv", ["script.py", "--dataset", str(path), option, "custom"]
+    )
+
+    with pytest.raises(SystemExit):
+        regen.parse_args()
+    assert "only apply to dataset presets" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(
@@ -931,8 +966,7 @@ def test_load_input_dataset_from_local_file(tmp_path, filename, data):
     path = tmp_path / filename
     path.write_text(json.dumps(data))
     args = argparse.Namespace(
-        dataset=None,
-        dataset_file=str(path),
+        dataset=str(path),
         split=None,
         subset=None,
     )

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -900,6 +900,25 @@ def test_dataset_choice_rejects_multimodal_with_a_reason():
     assert regen._dataset_choice("ultrachat") == "ultrachat"
 
 
+def test_load_input_dataset_from_local_jsonl(tmp_path):
+    path = tmp_path / "prompts.jsonl"
+    path.write_text(
+        json.dumps({"prompt": [{"role": "user", "content": "local prompt"}]})
+    )
+    args = argparse.Namespace(
+        dataset=None,
+        dataset_file=str(path),
+        split=None,
+        subset=None,
+    )
+
+    config, dataset, split = regen.load_input_dataset(args)
+    assert (config.name, config.prompt_field, split) == ("prompts", "prompt", "train")
+    assert regen.prepare_row(next(iter(dataset)), config)[1] == [
+        {"role": "user", "content": "local prompt"}
+    ]
+
+
 def test_tools_and_results_are_read_from_the_normalized_row():
     # Under a normalize_fn preset the conversation only appears in `messages`
     # after normalization; reading tools off the raw row regenerates tool-free.

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -147,6 +147,12 @@ _EXTRACT_CASES = [
         id="empty_messages_falls_back_to_prompt",
     ),
     pytest.param(
+        {"prompt": [{"role": "assistant", "content": "old answer"}]},
+        "prompt",
+        [],
+        id="message_list_prompt_without_user_skipped",
+    ),
+    pytest.param(
         {"messages": ["not-a-dict", {"role": "user", "content": "ok"}]},
         "prompt",
         [{"role": "user", "content": "ok"}],
@@ -901,11 +907,29 @@ def test_dataset_choice_rejects_multimodal_with_a_reason():
     assert regen._dataset_choice("ultrachat") == "ultrachat"
 
 
-def test_load_input_dataset_from_local_jsonl(tmp_path):
-    path = tmp_path / "prompts.jsonl"
-    path.write_text(
-        json.dumps({"prompt": [{"role": "user", "content": "local prompt"}]})
-    )
+@pytest.mark.parametrize(
+    ("filename", "data"),
+    [
+        pytest.param(
+            "prompts.jsonl",
+            {"prompt": [{"role": "user", "content": "local prompt"}]},
+            id="jsonl-message-list-prompt",
+        ),
+        pytest.param(
+            "prompts.jsonl",
+            {"prompt": "local prompt"},
+            id="jsonl-string-prompt",
+        ),
+        pytest.param(
+            "prompts.json",
+            [{"prompt": "local prompt"}],
+            id="json-string-prompt",
+        ),
+    ],
+)
+def test_load_input_dataset_from_local_file(tmp_path, filename, data):
+    path = tmp_path / filename
+    path.write_text(json.dumps(data))
     args = argparse.Namespace(
         dataset=None,
         dataset_file=str(path),

--- a/tests/unit/scripts/test_response_regeneration.py
+++ b/tests/unit/scripts/test_response_regeneration.py
@@ -147,6 +147,12 @@ _EXTRACT_CASES = [
         id="empty_messages_falls_back_to_prompt",
     ),
     pytest.param(
+        {"prompt": [{"role": "assistant", "content": "old answer"}]},
+        "prompt",
+        [],
+        id="message_list_prompt_without_user_skipped",
+    ),
+    pytest.param(
         {"messages": ["not-a-dict", {"role": "user", "content": "ok"}]},
         "prompt",
         [{"role": "user", "content": "ok"}],
@@ -900,11 +906,29 @@ def test_dataset_choice_rejects_multimodal_with_a_reason():
     assert regen._dataset_choice("ultrachat") == "ultrachat"
 
 
-def test_load_input_dataset_from_local_jsonl(tmp_path):
-    path = tmp_path / "prompts.jsonl"
-    path.write_text(
-        json.dumps({"prompt": [{"role": "user", "content": "local prompt"}]})
-    )
+@pytest.mark.parametrize(
+    ("filename", "data"),
+    [
+        pytest.param(
+            "prompts.jsonl",
+            {"prompt": [{"role": "user", "content": "local prompt"}]},
+            id="jsonl-message-list-prompt",
+        ),
+        pytest.param(
+            "prompts.jsonl",
+            {"prompt": "local prompt"},
+            id="jsonl-string-prompt",
+        ),
+        pytest.param(
+            "prompts.json",
+            [{"prompt": "local prompt"}],
+            id="json-string-prompt",
+        ),
+    ],
+)
+def test_load_input_dataset_from_local_file(tmp_path, filename, data):
+    path = tmp_path / filename
+    path.write_text(json.dumps(data))
     args = argparse.Namespace(
         dataset=None,
         dataset_file=str(path),


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Response regeneration currently accepts only registered dataset presets. This PR lets `--dataset` also accept a local JSON or JSONL prompt file without modifying `DATASET_CONFIGS`.

```bash
python scripts/response_regeneration/script.py \
  --dataset ./my_prompts.jsonl
```

Rows may use `messages`, `conversations`, or `prompt` as either a string or a message list. When `--outfile` is omitted, the local file stem is used in the generated output filename.

## Changes

- Accept registered presets or local `.json`/`.jsonl` paths through `--dataset`.
- Stream local JSON/JSONL files through the existing regeneration pipeline.
- Reject `--split` and `--subset` for local files.
- Document the local input mode and add focused CLI and loader coverage.

Split from #924.

## Tests

- `.venv/bin/pytest -q tests/unit/scripts/test_response_regeneration.py` — 48 passed
- `make quality` — passed

## Checklist

- [x] Purpose and motivation
- [x] Test plan and results
- [x] Documentation update
- [x] Human-authored or reviewed
