### PR TITLE
feat(train): add --gradient-checkpointing for DFlash/DSpark

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -128,6 +128,8 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 - **`--deterministic-cuda`** (flag) Enable deterministic CUDA operations. May impact performance.
 
+- **`--gradient-checkpointing`** (flag) Recompute draft-layer activations during the backward pass instead of storing them for it. This buys a large reduction in peak memory for a smaller increase in step time — on a DFlash run at default settings with a Qwen3-8B verifier, peak memory roughly halved while the step got about 13% slower. The saved activations are usually the largest single consumer of training memory, and the recompute cost falls entirely on the backward pass, so forward and optimizer time are unchanged. The exact ratio depends on `--num-layers`, `--max-anchors` and `--block-size`, since those set how much activation memory there is to recompute. Reach for it when a run does not fit, or to spend the freed memory on a larger `--max-anchors` or `--total-seq-len`. Only supported by DFlash and DSpark; other speculator types raise an error.
+
 - **`--loss-fn`** (str, default: `"ce"` for dflash, `"kl_div"` otherwise) Loss function specification. Pass a name for a single loss (`kl_div`, `rkl`, `jsd`, `ce`, `tv`, `nla`, `lk_hybrid`) or a JSON dict for a weighted combination, e.g. `'{"ce": 0.1, "tv": 0.9}'`. Required to be `ce` when `--per-position-loss-weight dpace` is used.
 
 ### Optimizer Arguments

--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -128,7 +128,7 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 - **`--deterministic-cuda`** (flag) Enable deterministic CUDA operations. May impact performance.
 
-- **`--gradient-checkpointing`** (flag) Recompute draft-layer activations during the backward pass instead of storing them for it. This buys a large reduction in peak memory for a smaller increase in step time — on a DFlash run at default settings with a Qwen3-8B verifier, peak memory roughly halved while the step got about 13% slower. The saved activations are usually the largest single consumer of training memory, and the recompute cost falls entirely on the backward pass, so forward and optimizer time are unchanged. The exact ratio depends on `--num-layers`, `--max-anchors` and `--block-size`, since those set how much activation memory there is to recompute. Reach for it when a run does not fit, or to spend the freed memory on a larger `--max-anchors` or `--total-seq-len`. Only supported by DFlash and DSpark; other speculator types raise an error.
+- **`--gradient-checkpointing`** (flag) Recompute DFlash/DSpark draft-layer activations during backward to reduce peak memory at the cost of step time. Disabled by default.
 
 - **`--loss-fn`** (str, default: `"ce"` for dflash, `"kl_div"` otherwise) Loss function specification. Pass a name for a single loss (`kl_div`, `rkl`, `jsd`, `ce`, `tv`, `nla`, `lk_hybrid`) or a JSON dict for a weighted combination, e.g. `'{"ce": 0.1, "tv": 0.9}'`. Required to be `ce` when `--per-position-loss-weight dpace` is used.
 

--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -128,7 +128,7 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 - **`--deterministic-cuda`** (flag) Enable deterministic CUDA operations. May impact performance.
 
-- **`--gradient-checkpointing`** (flag) Recompute DFlash/DSpark draft-layer activations during backward to reduce peak memory at the cost of step time. Disabled by default.
+- **`--gradient-checkpointing`** (flag) Recompute DFlash/DSpark draft-layer activations during backward to reduce peak memory at the cost of step time. Disabled by default, but recommended for full-scale training: the freed memory can support a longer packed sequence (`--total-seq-len`), more anchors (`--max-anchors`), or a larger `--block-size`. Leave it off only when the fixed workload has ample memory headroom and maximum step throughput is the priority.
 
 - **`--loss-fn`** (str, default: `"ce"` for dflash, `"kl_div"` otherwise) Loss function specification. Pass a name for a single loss (`kl_div`, `rkl`, `jsd`, `ce`, `tv`, `nla`, `lk_hybrid`) or a JSON dict for a weighted combination, e.g. `'{"ce": 0.1, "tv": 0.9}'`. Required to be `ce` when `--per-position-loss-weight dpace` is used.
 

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -51,6 +51,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from train import (
     build_draft_model,
+    configure_gradient_checkpointing,
     parse_vocab_mappings,
     set_seed,
 )
@@ -308,6 +309,7 @@ def run_benchmark(bench_args, train_args) -> dict:
 
     model_class = SpeculatorModel.registry[train_args.speculator_type]
     draft_model = build_draft_model(train_args, model_class, t2d, d2t, draft_vocab_size)
+    configure_gradient_checkpointing(draft_model, train_args.gradient_checkpointing)
 
     num_target_layers = len(draft_model.target_layer_ids)
     hidden_size = draft_model.config.transformer_layer_config.hidden_size
@@ -408,6 +410,7 @@ def run_benchmark(bench_args, train_args) -> dict:
             "optimizer": train_args.optimizer,
             "lr": train_args.lr,
             "hidden_states_dtype": train_args.hidden_states_dtype,
+            "gradient_checkpointing": train_args.gradient_checkpointing,
             "synthetic_data": is_synthetic,
             "fsdp_shard": train_args.fsdp_shard,
             "num_gpus_used": num_gpus_used,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -608,6 +608,14 @@ def main(cfg: TrainConfig):  # noqa: C901
 
     draft_model = build_draft_model(args, model_class, t2d, d2t, draft_vocab_size)
 
+    if args.gradient_checkpointing:
+        # use_reentrant=False is required, not just preferred: the draft layers are
+        # called with every input as a keyword argument, and
+        # GradientCheckpointingLayer forwards only positional args to the checkpoint
+        # function. Under the reentrant implementation no tensor input would reach it
+        # and gradients would silently stop flowing.
+        draft_model.gradient_checkpointing_enable({"use_reentrant": False})
+
     # Get target layer IDs from the model (resolved at model level)
     num_target_layers = len(draft_model.target_layer_ids)  # type: ignore[arg-type]
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -532,6 +532,14 @@ def build_draft_model(
     )
 
 
+def configure_gradient_checkpointing(
+    draft_model: SpeculatorModel, enabled: bool
+) -> None:
+    if enabled:
+        # Keyword-only layer inputs require non-reentrant checkpointing.
+        draft_model.gradient_checkpointing_enable({"use_reentrant": False})
+
+
 def main(cfg: TrainConfig):  # noqa: C901
     # Phase-1 adapter: the model layer still consumes a flat vars(args)-shaped
     # dict via **kwargs, so flatten the typed config back into a namespace here.
@@ -607,14 +615,7 @@ def main(cfg: TrainConfig):  # noqa: C901
     model_class = registry[args.speculator_type]
 
     draft_model = build_draft_model(args, model_class, t2d, d2t, draft_vocab_size)
-
-    if args.gradient_checkpointing:
-        # use_reentrant=False is required, not just preferred: the draft layers are
-        # called with every input as a keyword argument, and
-        # GradientCheckpointingLayer forwards only positional args to the checkpoint
-        # function. Under the reentrant implementation no tensor input would reach it
-        # and gradients would silently stop flowing.
-        draft_model.gradient_checkpointing_enable({"use_reentrant": False})
+    configure_gradient_checkpointing(draft_model, cfg.trainer.gradient_checkpointing)
 
     # Get target layer IDs from the model (resolved at model level)
     num_target_layers = len(draft_model.target_layer_ids)  # type: ignore[arg-type]

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -38,6 +38,9 @@ _compiled_create_block_mask = torch.compile(create_block_mask)
 class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
     config_class: ClassVar[type[DFlashSpeculatorConfig]] = DFlashSpeculatorConfig  # type: ignore[misc]
     _no_split_modules = ["Qwen3DFlashDecoderLayer"]
+    # Qwen3DFlashDecoderLayer already extends GradientCheckpointingLayer; this opts
+    # the model into PreTrainedModel.gradient_checkpointing_enable().
+    supports_gradient_checkpointing = True
     _keys_to_ignore_on_load_missing: ClassVar[list[str]] = [  # type: ignore[misc]
         "embed_tokens.weight",
         "verifier_norm.weight",

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -38,8 +38,7 @@ _compiled_create_block_mask = torch.compile(create_block_mask)
 class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
     config_class: ClassVar[type[DFlashSpeculatorConfig]] = DFlashSpeculatorConfig  # type: ignore[misc]
     _no_split_modules = ["Qwen3DFlashDecoderLayer"]
-    # Qwen3DFlashDecoderLayer already extends GradientCheckpointingLayer; this opts
-    # the model into PreTrainedModel.gradient_checkpointing_enable().
+    # Decoder layers already implement Transformers' checkpointing protocol.
     supports_gradient_checkpointing = True
     _keys_to_ignore_on_load_missing: ClassVar[list[str]] = [  # type: ignore[misc]
         "embed_tokens.weight",

--- a/src/speculators/train/config/schema.py
+++ b/src/speculators/train/config/schema.py
@@ -401,6 +401,12 @@ class TrainerArgs(_Group):
         "parameters are fully replicated (DDP-like). Enable when the model does not "
         "fit in a single GPU's memory.",
     )
+    gradient_checkpointing: bool = Field(
+        default=False,
+        description="Recompute draft-layer activations during the backward pass "
+        "instead of keeping them, trading step time for memory. Only supported by "
+        "DFlash and DSpark.",
+    )
     max_steps: int | None = Field(
         default=None,
         ge=1,

--- a/src/speculators/train/config/schema.py
+++ b/src/speculators/train/config/schema.py
@@ -403,9 +403,8 @@ class TrainerArgs(_Group):
     )
     gradient_checkpointing: bool = Field(
         default=False,
-        description="Recompute draft-layer activations during the backward pass "
-        "instead of keeping them, trading step time for memory. Only supported by "
-        "DFlash and DSpark.",
+        description="Recompute DFlash/DSpark draft-layer activations during backward "
+        "to reduce peak memory at the cost of step time.",
     )
     max_steps: int | None = Field(
         default=None,

--- a/tests/unit/models/test_dflash_gradient_checkpointing.py
+++ b/tests/unit/models/test_dflash_gradient_checkpointing.py
@@ -1,0 +1,93 @@
+import pytest
+import torch
+from transformers.models.qwen3.modeling_qwen3 import Qwen3Config
+
+from speculators.models.dflash import DFlashSpeculatorConfig
+from speculators.models.dflash.core import DFlashDraftModel
+from speculators.models.dspark.core import DSparkDraftModel
+
+
+def _tiny_model() -> DFlashDraftModel:
+    tl_config = Qwen3Config(
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        vocab_size=64,
+        _attn_implementation="eager",  # type: ignore[call-arg]
+    )
+    config = DFlashSpeculatorConfig(
+        transformer_layer_config=tl_config,
+        draft_vocab_size=64,
+        block_size=4,
+        aux_hidden_state_layer_ids=[0, 1],
+        mask_token_id=0,
+    )
+    model = DFlashDraftModel(config)
+    # These three are left uninitialized by the constructor (they are normally loaded
+    # from the verifier), so they hold garbage that would poison the forward.
+    for weight in (
+        model.embed_tokens.weight,
+        model.lm_head.weight,
+        model.verifier_lm_head.weight,
+    ):
+        torch.nn.init.normal_(weight, std=0.02)
+    torch.nn.init.ones_(model.verifier_norm.weight)
+    return model
+
+
+def _backbone_grads(model: DFlashDraftModel) -> dict[str, torch.Tensor]:
+    """Run one backbone forward/backward and return the draft-layer gradients."""
+    torch.manual_seed(0)
+    seq_len = 32
+    hidden, *_ = model._backbone_forward(
+        hidden_states=torch.randn(1, seq_len, 2 * 16),
+        input_ids=torch.randint(0, 64, (1, seq_len)),
+        loss_mask=torch.ones(1, seq_len),
+        verifier_last_hidden_states=torch.randn(1, seq_len, 16),
+        document_ids=torch.zeros(1, seq_len, dtype=torch.long),
+        max_anchors=8,
+    )
+    model.zero_grad(set_to_none=True)
+    hidden.pow(2).sum().backward()
+    return {
+        name: param.grad.clone()
+        for name, param in model.named_parameters()
+        if name.startswith("layers.") and param.grad is not None
+    }
+
+
+@pytest.mark.parametrize("model_cls", [DFlashDraftModel, DSparkDraftModel])
+def test_model_declares_gradient_checkpointing_support(model_cls):
+    assert model_cls.supports_gradient_checkpointing is True
+
+
+def test_enable_sets_the_flag_on_every_draft_layer():
+    model = _tiny_model()
+    assert all(not layer.gradient_checkpointing for layer in model.layers)
+
+    model.gradient_checkpointing_enable({"use_reentrant": False})
+
+    assert all(layer.gradient_checkpointing for layer in model.layers)
+
+
+def test_gradients_match_without_checkpointing():
+    """Checkpointing must only change *when* activations exist, not the gradients.
+
+    This is the regression guard for `use_reentrant`: the draft layers take every
+    input as a keyword argument, so the reentrant implementation would receive no
+    tensor inputs and silently produce no gradients at all.
+    """
+    model = _tiny_model()
+    model.train()
+
+    expected = _backbone_grads(model)
+    model.gradient_checkpointing_enable({"use_reentrant": False})
+    actual = _backbone_grads(model)
+
+    assert actual.keys() == expected.keys()
+    assert expected  # guard against the comparison passing on an empty dict
+    for name, grad in expected.items():
+        torch.testing.assert_close(actual[name], grad)

--- a/tests/unit/models/test_dflash_gradient_checkpointing.py
+++ b/tests/unit/models/test_dflash_gradient_checkpointing.py
@@ -1,10 +1,9 @@
-import pytest
 import torch
 from transformers.models.qwen3.modeling_qwen3 import Qwen3Config
 
+from scripts.train import configure_gradient_checkpointing
 from speculators.models.dflash import DFlashSpeculatorConfig
 from speculators.models.dflash.core import DFlashDraftModel
-from speculators.models.dspark.core import DSparkDraftModel
 
 
 def _tiny_model() -> DFlashDraftModel:
@@ -59,34 +58,26 @@ def _backbone_grads(model: DFlashDraftModel) -> dict[str, torch.Tensor]:
     }
 
 
-@pytest.mark.parametrize("model_cls", [DFlashDraftModel, DSparkDraftModel])
-def test_model_declares_gradient_checkpointing_support(model_cls):
-    assert model_cls.supports_gradient_checkpointing is True
-
-
-def test_enable_sets_the_flag_on_every_draft_layer():
-    model = _tiny_model()
-    assert all(not layer.gradient_checkpointing for layer in model.layers)
-
-    model.gradient_checkpointing_enable({"use_reentrant": False})
-
-    assert all(layer.gradient_checkpointing for layer in model.layers)
-
-
-def test_gradients_match_without_checkpointing():
-    """Checkpointing must only change *when* activations exist, not the gradients.
-
-    This is the regression guard for `use_reentrant`: the draft layers take every
-    input as a keyword argument, so the reentrant implementation would receive no
-    tensor inputs and silently produce no gradients at all.
-    """
+def test_checkpointing_recomputes_without_changing_gradients():
     model = _tiny_model()
     model.train()
 
     expected = _backbone_grads(model)
-    model.gradient_checkpointing_enable({"use_reentrant": False})
-    actual = _backbone_grads(model)
 
+    calls = 0
+
+    def count_forwards(*_args):
+        nonlocal calls
+        calls += 1
+
+    handle = model.layers[0].register_forward_pre_hook(count_forwards)
+    try:
+        configure_gradient_checkpointing(model, enabled=True)
+        actual = _backbone_grads(model)
+    finally:
+        handle.remove()
+
+    assert calls > 1  # initial forward plus backward recomputation
     assert actual.keys() == expected.keys()
     assert expected  # guard against the comparison passing on an empty dict
     for name, grad in expected.items():


### PR DESCRIPTION
## Summary

Adds opt-in `--gradient-checkpointing` for DFlash and DSpark. It recomputes draft-layer activations during backward, reducing peak memory at the cost of step time.

The flag remains off by default. EAGLE-3, P-EAGLE, and MTP are unchanged.

## H100 results

DFlash with a Qwen3-8B verifier, `--total-seq-len 8192`, and current defaults (`--num-layers 5 --block-size 16`, CE, Muon) on one H100 80GB. Values are medians of three interleaved runs after warmup.

| max-anchors | Step time, off → on | Peak allocated, off → on |
| ---: | ---: | ---: |
| 512 *(default)* | 365 → 395 ms *(+8.2%)* | 33.0 → **25.5 GB** *(-22.6%)* |
| 1024 | 507 → 562 ms *(+10.9%)* | 44.1 → **31.2 GB** *(-29.1%)* |

The added time is in backward recomputation; forward and optimizer times were effectively unchanged.

<details>
<summary>Benchmark command and environment</summary>

```text
tree      007c7c1 (content-identical to current head b9f5e1e)
stack     Python 3.12.9, torch 2.13.0+cu130, CUDA 13.0, transformers 5.14.1
protocol  synthetic batches; 10 warmup + 4 measured steps; 3 interleaved repeats
command   python scripts/benchmark.py run --synthetic --warmup-steps 10 \
            --measured-steps 4 -- --speculator-type dflash \
            --verifier-name-or-path Qwen/Qwen3-8B [--gradient-checkpointing]
```

</details>

## Implementation

- Adds the training flag and CLI documentation.
- Enables non-reentrant checkpointing for `DFlashDraftModel` (inherited by DSpark).
- Records the setting in benchmark metadata.
- Adds a regression test for recomputation and gradient equivalence.

Non-reentrant checkpointing is required because draft layers pass inputs as keyword arguments; the reentrant wrapper forwards only positional arguments and would break draft-layer gradients.

## Validation

- Targeted tests: **490 passed, 5 skipped**
- Ruff and mypy: no findings introduced relative to `main`
- End-to-end training with checkpoint creation
