### PR TITLE
fix(data): skip NaN hidden states instead of crashing training

### DIFF
--- a/src/speculators/train/data.py
+++ b/src/speculators/train/data.py
@@ -301,9 +301,7 @@ class ArrowDataset(BaseDataset):
                     self.transfer.cache(handle, file_idx)
                 case "delete":
                     self.transfer.delete(handle)
-        except Exception as e:
-            if isinstance(e, ValueError) and "NaN" in str(e):
-                raise
+        except Exception as e:  # noqa: BLE001
             warnings.warn(
                 f"Failed to load/cache hidden states for sample {index}: {e}",
                 stacklevel=1,


### PR DESCRIPTION
## Summary
- Remove the special-case re-raise for NaN hidden states in `ArrowDataset._maybe_generate_hs()`.
- NaN hidden states can occasionally occur during on-the-fly generation via vLLM. Previously this crashed the entire training run. Now NaN samples are warned and skipped like other generation failures, relying on the existing collate-level `None` filtering.

## Test plan
- [x] Verified that `CollateFn.__call__` already filters `None` samples and creates an empty placeholder if the entire batch is `None`
- [ ] Run training with on-the-fly hidden state generation and confirm training continues past NaN samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)