### PR TITLE
set default max anchor to 512

### DIFF
--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -251,7 +251,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             kwargs["loss_fn"], kwargs.get("loss_implementation", "fused")
         )
         gamma = kwargs.get("dflash_decay_gamma", 4.0)
-        max_anchors = kwargs.get("max_anchors", 3072)
+        max_anchors = kwargs.get("max_anchors", 512)
         per_position_loss_weight = kwargs.get(
             "per_position_loss_weight", "fixed-exp-decay"
         )
@@ -351,7 +351,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         """
         device = hidden_states.device
         total_seq_len = hidden_states.shape[1]
-        num_anchors = kwargs.pop("max_anchors", 3072)
+        num_anchors = kwargs.pop("max_anchors", 512)
 
         if position_ids is None:
             position_ids = torch.arange(
@@ -455,7 +455,7 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
         position_ids: torch.Tensor | None = None,  # shape: [1, total_seq_len]
         loss_config: LossConfig | None = None,
         gamma: float = 4.0,
-        max_anchors: int = 3072,
+        max_anchors: int = 512,
         per_position_loss_weight: str = "fixed-exp-decay",
         dpace_alpha: float = 0.5,
         **kwargs,

--- a/src/speculators/train/config/schema.py
+++ b/src/speculators/train/config/schema.py
@@ -233,9 +233,9 @@ class DataArgs(_Group):
     num_workers: int = Field(default=12, description="Number of dataloader workers.")
     prefetch_factor: int = Field(default=4, description="Dataloader prefetch factor.")
     max_anchors: int = Field(
-        default=3072,
+        default=512,
         description="Maximum anchor positions for DFlash, DSpark, and P-EAGLE training "
-        "(default: 3072).",
+        "(default: 512).",
     )
 
     @field_validator("hidden_states_dtype")


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
Our max anchor is too high and makes each step slow

## Tests
current dflash runs have been using 512

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
