### PR TITLE
feat(plugins): dynamic hidden-states layer swap for extract_hidden_states

### DIFF
--- a/vllm_plugins/.gitignore
+++ b/vllm_plugins/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.egg-info/
+*.pyc
+.ruff_cache/

--- a/vllm_plugins/README.md
+++ b/vllm_plugins/README.md
@@ -1,0 +1,100 @@
+# vLLM dynamic hidden-states plugin
+
+Swap **which** target-model hidden layers are captured during speculator
+training-data generation (`method="extract_hidden_states"`) at runtime, over
+HTTP, without restarting the engine.
+
+Only the *set* of layer indices can change; the *count* is fixed at launch
+(baked into proposer buffers, the dummy-proposer KV-cache shape and the
+on-disk safetensors layout). Count mismatches are rejected (fail closed).
+
+## Works under `torch.compile` (no `--enforce-eager` needed)
+
+The stock capture uses a Python membership test —
+`if layer_idx in self.aux_hidden_state_layers` — which `torch.compile`
+constant-folds into the compiled forward, freezing the captured layer set. So a
+naive attribute swap is a silent no-op unless the engine runs `--enforce-eager`.
+
+This plugin ships a **general plugin** (`graph_patch.install`, auto-loaded via
+`VLLM_PLUGINS`) that replaces that membership test *before compilation* with a
+**masked accumulate**: it keeps `N` fixed accumulator buffers and folds every
+candidate layer's residual into them, weighted by a one-hot selection mask held
+in a registered buffer. The compiled graph is now selection-agnostic — which
+layers land in which slot is a function of the mask *contents*, not the traced
+code — so swapping is an in-place `mask.copy_(...)`. Same storage address, so
+the compiled graph *and* a captured CUDA graph read the new selection on the
+next forward. **No recompile, no `--enforce-eager`.**
+
+Cost: memory stays O(N) (N accumulators, not O(num_layers)); the price is a
+little compute — a fused multiply-add over every candidate layer's residual per
+output slot, negligible next to the attention/MLP matmuls.
+
+Verified empirically with Qwen3-8B (default `torch.compile` +
+`FULL_AND_PIECEWISE` CUDA graphs, no `--enforce-eager`): swapping only the first
+captured layer (2→6) changes exactly column 0 (`max|Δ|=21.125`) while columns
+for the unchanged layers 18/34 stay **bit-identical** (`Δ=0`), and the compiled
+masked path reproduces the eager baked path's values exactly. No recompilation
+is triggered by the swap.
+
+| Engine mode | Swap effective? |
+|---|---|
+| default `torch.compile` + CUDA graphs, plugin enabled | ✅ yes (masked accumulate) |
+| `--enforce-eager` (with or without the plugin) | ✅ yes |
+| default `torch.compile`, plugin **not** enabled | ❌ no (baked, silent no-op) |
+
+**Scope:** the patch covers models that capture through
+`EagleModelMixin._maybe_add_hidden_state` (Qwen2/Qwen3, Llama, and the other
+generic dense/MoE paths). A few models (e.g. `deepseek_v2`, `qwen3_next`) inline
+the membership test in their own forward and are **not** covered — those still
+need `--enforce-eager` for a live swap. The worker logs a warning if you swap
+when neither eager mode nor the patch is active.
+
+## Components
+
+- `dynamic_hidden_states.graph_patch.install` — pre-compile monkeypatch
+  (masked-accumulate) that makes layer selection a runtime buffer input, wired
+  via the `vllm.general_plugins` entry point (runs in every process, incl.
+  workers, before model load). This is what makes swaps work without eager mode.
+- `dynamic_hidden_states.worker_extension.AuxLayerWorkerExtension` — engine-side
+  worker RPC (`set_/get_aux_hidden_state_layers_rpc`), added to every worker via
+  `--worker-extension-cls`.
+- `dynamic_hidden_states.endpoint.AuxLayerEndpoint` — API-server-side endpoint
+  plugin registering `GET`/`POST /aux_hidden_state_layers`, wired via the
+  `vllm.endpoint_plugins` entry point.
+
+## Install
+
+```bash
+/workspace/vllm/.venv/bin/python -m pip install -e /workspace/speculators/vllm_plugins
+# or: uv pip install -e /workspace/speculators/vllm_plugins   (with the vLLM venv active)
+```
+
+## Serve
+
+Endpoint plugins are strict opt-in — they load only when named in
+`VLLM_PLUGINS`. The same `VLLM_PLUGINS=dynamic_hidden_states` also enables the
+general plugin (masked-accumulate patch), so no `--enforce-eager` is needed.
+
+```bash
+VLLM_PLUGINS=dynamic_hidden_states \
+vllm serve Qwen/Qwen3-8B \
+  --worker-extension-cls dynamic_hidden_states.worker_extension.AuxLayerWorkerExtension \
+  --speculative_config '{"method":"extract_hidden_states","num_speculative_tokens":1,"draft_model_config":{"hf_config":{"eagle_aux_hidden_state_layer_ids":[2,18,34]}}}' \
+  --kv_transfer_config '{"kv_connector":"ExampleHiddenStatesConnector","kv_role":"kv_producer","kv_connector_extra_config":{"shared_storage_path":"/dev/shm/hidden_states"}}'
+```
+
+## Use
+
+```bash
+# read current layers
+curl -s localhost:8000/aux_hidden_state_layers
+
+# swap (same count) — takes effect on the next forward, across all TP/PP workers
+curl -s -X POST localhost:8000/aux_hidden_state_layers \
+  -H 'content-type: application/json' \
+  -d '{"layers": [4, 16, 28]}'
+```
+
+The safetensors files written by the hidden-states connector carry no
+layer-set metadata, so a controller that swaps mid-run must record the
+`{timestamp/req-range -> layer set}` mapping itself.

--- a/vllm_plugins/dynamic_hidden_states/__init__.py
+++ b/vllm_plugins/dynamic_hidden_states/__init__.py
@@ -1,0 +1,12 @@
+"""Dynamic hidden-state layer swapping plugin for vLLM.
+
+Runtime control of *which* target-model hidden layers are captured during
+speculator-training data generation (``method="extract_hidden_states"``),
+without restarting the engine. See ``README.md`` for usage.
+"""
+
+from dynamic_hidden_states.endpoint import AuxLayerEndpoint
+from dynamic_hidden_states.graph_patch import install as install_mask_patch
+from dynamic_hidden_states.worker_extension import AuxLayerWorkerExtension
+
+__all__ = ["AuxLayerEndpoint", "AuxLayerWorkerExtension", "install_mask_patch"]

--- a/vllm_plugins/dynamic_hidden_states/endpoint.py
+++ b/vllm_plugins/dynamic_hidden_states/endpoint.py
@@ -1,0 +1,89 @@
+"""API-server-side endpoint plugin for aux hidden-state layer swapping.
+
+Registers ``GET``/``POST /aux_hidden_state_layers`` on the OpenAI-compatible
+server and forwards to the worker RPC installed by
+``AuxLayerWorkerExtension`` via ``EngineClient.collective_rpc`` (a string
+method name — raw callables cannot cross the msgpack/ZMQ boundary).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, FastAPI, HTTPException, Request
+from starlette.datastructures import State
+from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+
+    from vllm.engine.protocol import EngineClient
+
+# Namespace under "vllm." so vLLM's logging config surfaces these INFO lines.
+logger = init_logger(f"vllm.plugins.{__name__}")
+
+RPC_SET = "set_aux_hidden_state_layers_rpc"
+RPC_GET = "get_aux_hidden_state_layers_rpc"
+STATE_ATTR = "dynamic_hidden_states_engine_client"
+
+
+class AuxLayerEndpoint:
+    """Endpoint plugin exposing the aux hidden-state layer swap over HTTP."""
+
+    name = "dynamic_hidden_states"
+    required_tasks = ("generate",)
+
+    def attach_router(self, app: FastAPI) -> None:
+        router = APIRouter()
+
+        @router.get("/aux_hidden_state_layers")
+        async def get_layers(request: Request):
+            client = _get_client(request)
+            results = await client.collective_rpc(RPC_GET)
+            return {"layers": list(results[0]) if results else []}
+
+        @router.post("/aux_hidden_state_layers")
+        async def set_layers(request: Request, body: dict):
+            client = _get_client(request)
+            layers = body.get("layers")
+            if not isinstance(layers, list) or not layers:
+                raise HTTPException(
+                    status_code=400,
+                    detail="body must be {'layers': [int, ...]} (non-empty)",
+                )
+            try:
+                new = tuple(int(x) for x in layers)
+            except (TypeError, ValueError):
+                raise HTTPException(
+                    status_code=400, detail="all layers must be integers"
+                ) from None
+
+            try:
+                results = await client.collective_rpc(RPC_SET, args=(new,))
+            except Exception as e:  # surfaced to the client as a 400
+                # count mismatch, unsupported model, etc. -> client error
+                raise HTTPException(status_code=400, detail=str(e)) from e
+
+            applied = list(results[0]) if results else list(new)
+            logger.info("Applied aux hidden-state layers via HTTP: %s", applied)
+            return {"ok": True, "layers": applied}
+
+        app.include_router(router)
+
+    async def init_state(
+        self,
+        engine_client: EngineClient | None,
+        state: State,
+        args: Namespace,  # noqa: ARG002 - required by EndpointPlugin protocol
+    ) -> None:
+        setattr(state, STATE_ATTR, engine_client)
+
+
+def _get_client(request: Request) -> EngineClient:
+    client = getattr(request.app.state, STATE_ATTR, None)
+    if client is None:
+        raise HTTPException(
+            status_code=503,
+            detail="engine client unavailable (render server or not initialized)",
+        )
+    return client

--- a/vllm_plugins/dynamic_hidden_states/graph_patch.py
+++ b/vllm_plugins/dynamic_hidden_states/graph_patch.py
@@ -1,0 +1,158 @@
+"""Pre-compile monkeypatch making aux-layer selection a runtime tensor input.
+
+This is "Option B" (masked accumulate). The stock capture does::
+
+    if layer_idx in self.aux_hidden_state_layers:   # Python control flow
+        aux.append(hidden_states + residual)
+
+``torch.compile`` constant-folds that membership test into the compiled
+forward, freezing the captured layer set — which is why the naive
+attribute-swap only takes effect under ``--enforce-eager``.
+
+Instead we keep ``N`` fixed accumulator buffers and, at *every* candidate
+capture point, fold each layer's residual into them weighted by a one-hot
+selection mask held in a registered buffer::
+
+    value = hidden_states + residual
+    for slot in range(N):
+        aux[slot] += mask[layer_idx, slot] * value
+
+The graph is now selection-agnostic: which layers land in which slot is a
+function of the mask *contents*, not the traced code. Swapping layers is an
+in-place ``mask.copy_(...)`` — same storage address, so both the compiled
+graph and a captured CUDA graph read the new selection on the next forward.
+No recompile, no ``--enforce-eager``.
+
+Cost model: memory stays O(N) (N accumulators, not O(num_layers)); the price
+is a little compute — a fused multiply-add over every candidate layer's
+residual per output slot (negligible next to the attention/MLP matmuls).
+
+Installed via a ``vllm.general_plugins`` entry point so it patches
+``EagleModelMixin`` in the worker process *before* the target model is loaded
+and compiled.
+
+Scope: covers models that capture through
+``EagleModelMixin._maybe_add_hidden_state`` (Qwen2/Qwen3, Llama, and the other
+generic dense/MoE paths). A handful of models (e.g. deepseek_v2, qwen3_next)
+inline the ``layer_idx in self.aux_hidden_state_layers`` test in their own
+forward and are not covered by this patch — those still require
+``--enforce-eager`` for a live swap.
+"""
+
+from __future__ import annotations
+
+import torch
+from vllm.logger import init_logger
+from vllm.model_executor.models.interfaces import EagleModelMixin
+
+# Namespace under "vllm." so vLLM's logging config (which only attaches a
+# handler to the "vllm" logger) surfaces these INFO lines.
+logger = init_logger(f"vllm.plugins.{__name__}")
+
+MASK_ATTR = "aux_capture_mask"
+_PATCHED_FLAG = "_dyn_hidden_states_mask_patched"
+
+
+def _num_capture_points(model: object) -> int:
+    """Candidate capture points: embeddings (index 0) + one per decoder layer.
+
+    Matches the generic forward, which calls ``_maybe_add_hidden_state`` with
+    ``layer_idx=0`` for the embedding output and ``idx + 1`` for each layer.
+    """
+    layers = getattr(model, "layers", None)
+    if layers is None:
+        return 0
+    return len(layers) + 1
+
+
+def _build_mask(
+    layers: tuple[int, ...],
+    num_points: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """One-hot ``[num_points, N]`` mask; column j = j-th smallest layer index.
+
+    Ascending column order reproduces the stock append order (the loop appends
+    in layer order regardless of the requested tuple order), so downstream
+    column identity is unchanged.
+    """
+    ordered = sorted(int(x) for x in layers)
+    mask = torch.zeros(num_points, len(ordered), device=device, dtype=dtype)
+    for col, layer in enumerate(ordered):
+        if 0 <= layer < num_points:
+            mask[layer, col] = 1.0
+    return mask
+
+
+def _refresh_mask(model: object, layers: tuple[int, ...]) -> None:
+    """Register (first call, pre-compile) or in-place update the mask buffer.
+
+    After the first registration the buffer's storage is reused via ``copy_``
+    so the compiled/CUDA graph — which captured that storage address — reads
+    the new selection without a recompile. The layer *count* is fixed at
+    launch, so the shape never changes after the first call.
+    """
+    num_points = _num_capture_points(model)
+    n = len(layers)
+    if num_points == 0 or n == 0:
+        return
+
+    ref = next(model.parameters())  # match model compute dtype/device
+    mask = _build_mask(layers, num_points, ref.device, ref.dtype)
+
+    existing = getattr(model, MASK_ATTR, None)
+    same_shape = isinstance(existing, torch.Tensor) and existing.shape == mask.shape
+    if same_shape:
+        existing.copy_(mask)  # in-place: preserves storage address
+    else:
+        # First install, before compile. Non-persistent: derived from the
+        # layer set, not a trained weight, so keep it out of the state dict.
+        model.register_buffer(MASK_ATTR, mask, persistent=False)
+
+
+def _patched_set_aux_hidden_state_layers(
+    self: EagleModelMixin, layers: tuple[int, ...]
+) -> None:
+    self.aux_hidden_state_layers = tuple(int(x) for x in layers)
+    _refresh_mask(self, self.aux_hidden_state_layers)
+
+
+def _patched_maybe_add_hidden_state(
+    self: EagleModelMixin,
+    aux_hidden_states: list[torch.Tensor],
+    layer_idx: int,
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor | None,
+) -> list[torch.Tensor]:
+    mask = getattr(self, MASK_ATTR, None)
+    if mask is None:
+        return aux_hidden_states
+    n = mask.shape[1]
+    if n == 0 or layer_idx >= mask.shape[0]:
+        return aux_hidden_states
+
+    value = hidden_states + residual if residual is not None else hidden_states
+    # First candidate point of this forward: allocate the N accumulators.
+    if len(aux_hidden_states) == 0:
+        for _ in range(n):
+            aux_hidden_states.append(torch.zeros_like(value))
+
+    row = mask[layer_idx]  # [N], live buffer contents (not baked at trace time)
+    for j in range(n):
+        aux_hidden_states[j] = aux_hidden_states[j] + row[j] * value
+    return aux_hidden_states
+
+
+def install() -> None:
+    """Entry point for the ``vllm.general_plugins`` group (called with no args)."""
+    if getattr(EagleModelMixin, _PATCHED_FLAG, False):
+        return
+    EagleModelMixin._set_aux_hidden_state_layers = _patched_set_aux_hidden_state_layers
+    EagleModelMixin._maybe_add_hidden_state = _patched_maybe_add_hidden_state
+    setattr(EagleModelMixin, _PATCHED_FLAG, True)
+    logger.info(
+        "dynamic_hidden_states: installed masked-accumulate aux-capture patch; "
+        "layer swaps take effect at runtime without --enforce-eager "
+        "(for models using EagleModelMixin._maybe_add_hidden_state)."
+    )

--- a/vllm_plugins/dynamic_hidden_states/worker_extension.py
+++ b/vllm_plugins/dynamic_hidden_states/worker_extension.py
@@ -1,0 +1,114 @@
+"""Engine-side worker RPC for live aux hidden-state layer swapping.
+
+Mixed into every vLLM worker via ``--worker-extension-cls`` so its public
+methods become string-callable through ``collective_rpc``. This lets an
+external controller change *which* target-model layers emit auxiliary hidden
+states during ``method="extract_hidden_states"`` data generation, without
+restarting the engine.
+
+Only the *set* of layer indices can change; the *count* is baked into fixed
+proposer buffers, the dummy-proposer KV-cache shape and the on-disk
+safetensors layout, so a count change is rejected (fail closed).
+"""
+
+from __future__ import annotations
+
+from vllm.logger import init_logger
+from vllm.model_executor.models.interfaces import supports_eagle3
+
+# Namespace under "vllm." so vLLM's logging config surfaces these INFO lines.
+logger = init_logger(f"vllm.plugins.{__name__}")
+
+
+class AuxLayerWorkerExtension:
+    """Adds aux-layer RPC methods to the worker.
+
+    ``self`` is the concrete ``Worker`` at call time (the extension class is
+    injected into the worker's bases), so ``self.get_model()`` is available.
+    """
+
+    def get_aux_hidden_state_layers_rpc(self) -> tuple[int, ...]:
+        """Return the layer indices currently captured on this worker."""
+        container = self._aux_layer_container()
+        return tuple(getattr(container, "aux_hidden_state_layers", ()))
+
+    def set_aux_hidden_state_layers_rpc(self, layers) -> tuple[int, ...]:
+        """Swap the captured aux hidden-state layers on this worker.
+
+        Args:
+            layers: New layer indices. Must match the current count.
+
+        Returns:
+            The newly applied layer indices as a tuple.
+
+        Raises:
+            TypeError: If the target model does not support EAGLE-3 capture.
+            ValueError: If the new count differs from the current count.
+        """
+        model = self.get_model()
+        if not supports_eagle3(model):
+            raise TypeError(
+                f"target model {type(model).__name__} does not support "
+                "aux hidden-state capture (SupportsEagle3); is the engine "
+                "running with method='extract_hidden_states'?"
+            )
+
+        new = tuple(int(x) for x in layers)
+        container = self._aux_layer_container()
+        current = tuple(getattr(container, "aux_hidden_state_layers", ()))
+        if current and len(new) != len(current):
+            raise ValueError(
+                f"aux hidden-state layer count is fixed at {len(current)} "
+                "(proposer buffers, KV-cache and on-disk shape depend on it); "
+                f"got {len(new)}: {new}"
+            )
+
+        model.set_aux_hidden_state_layers(new)
+        logger.info("Swapped aux hidden-state layers %s -> %s", current, new)
+
+        # The swap takes effect on the next forward when EITHER the engine runs
+        # eager, OR the masked-accumulate patch (graph_patch.install) has made
+        # the selection a live buffer input. If neither holds, the compiled
+        # forward has the old layer set baked in and this is a silent no-op.
+        if not self._is_eager() and not self._mask_active(container):
+            logger.warning(
+                "Aux layer swap applied to the model object, but the engine is "
+                "NOT running with enforce_eager and the masked-accumulate patch "
+                "is not active: the captured layer set is baked into the "
+                "torch.compile/CUDA-graph forward and the swap will NOT take "
+                "effect. Enable the 'dynamic_hidden_states' general plugin "
+                "(VLLM_PLUGINS=dynamic_hidden_states) or relaunch with "
+                "--enforce-eager to swap at runtime."
+            )
+        return new
+
+    def _is_eager(self) -> bool:
+        vllm_config = getattr(self, "vllm_config", None)
+        if vllm_config is None:
+            return False
+        return bool(vllm_config.model_config.enforce_eager)
+
+    def _mask_active(self, container) -> bool:
+        """True if the masked-accumulate patch installed a live mask buffer.
+
+        When present, layer selection is a runtime buffer input and the swap
+        takes effect under torch.compile/CUDA graphs (no --enforce-eager).
+        """
+        from dynamic_hidden_states.graph_patch import MASK_ATTR
+
+        return getattr(container, MASK_ATTR, None) is not None
+
+    def _aux_layer_container(self):
+        """Resolve the ``EagleModelMixin`` holding ``aux_hidden_state_layers``.
+
+        Mirrors the language-model indirection in
+        ``SupportsEagle3.set_aux_hidden_state_layers`` so reads and writes
+        target the same object.
+        """
+        model = self.get_model()
+        parent = model
+        if hasattr(model, "get_language_model"):
+            parent = model.get_language_model()
+        elif hasattr(model, "language_model"):
+            parent = model.language_model
+        return getattr(parent, "model", parent)

--- a/vllm_plugins/pyproject.toml
+++ b/vllm_plugins/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools >= 82.0.1"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["dynamic_hidden_states*"]
+
+[project]
+name = "vllm-dynamic-hidden-states"
+version = "0.1.0"
+description = "vLLM plugin: runtime swapping of captured aux hidden-state layers for extract_hidden_states data generation."
+requires-python = ">=3.10"
+license = "Apache-2.0"
+
+# vLLM (and its fastapi dependency) is provided by the serving environment;
+# not pinned here so the plugin installs into an existing vLLM venv.
+dependencies = []
+
+# Discovered by the API-server front-end process. Strict opt-in: only loads
+# when named in VLLM_PLUGINS.
+[project.entry-points."vllm.endpoint_plugins"]
+dynamic_hidden_states = "dynamic_hidden_states.endpoint:AuxLayerEndpoint"
+
+# Loaded in every process (incl. workers) before model load. Applies the
+# masked-accumulate patch so layer swaps take effect without --enforce-eager.
+# Same name as above so a single VLLM_PLUGINS=dynamic_hidden_states enables both.
+[project.entry-points."vllm.general_plugins"]
+dynamic_hidden_states = "dynamic_hidden_states.graph_patch:install"
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP"]
+
+[tool.ruff.lint.per-file-ignores]
+# Manual integration script: prints results and uses asserts by design.
+"tests/*" = ["T201", "S101"]

--- a/vllm_plugins/tests/test_swap_e2e.py
+++ b/vllm_plugins/tests/test_swap_e2e.py
@@ -1,0 +1,139 @@
+"""End-to-end integration test for the dynamic hidden-states plugin.
+
+Requires a live vLLM server started WITH the plugin enabled
+(``VLLM_PLUGINS=dynamic_hidden_states``, which loads both the endpoint plugin
+and the masked-accumulate general plugin). The swap works under the default
+``torch.compile`` + CUDA graphs — no ``--enforce-eager`` needed.
+``--no-enable-prefix-caching`` is still required so identical prompts re-run the
+forward instead of being served from cache. Not a unit test — run it manually
+against a running server:
+
+    # 1 GPU, ~1-2 min to start
+    VLLM_PLUGINS=dynamic_hidden_states \
+    /workspace/vllm/.venv/bin/python -m vllm.entrypoints.openai.api_server \
+        --model Qwen/Qwen3-8B --port 8000 \
+        --no-enable-prefix-caching \
+        --worker-extension-cls \
+            dynamic_hidden_states.worker_extension.AuxLayerWorkerExtension \
+        --speculative_config '{"method":"extract_hidden_states",\
+"num_speculative_tokens":1,"draft_model_config":{"hf_config":\
+{"eagle_aux_hidden_state_layer_ids":[2,18,34]}}}' \
+        --kv_transfer_config '{"kv_connector":"ExampleHiddenStatesConnector",\
+"kv_role":"kv_producer","kv_connector_extra_config":\
+{"shared_storage_path":"/dev/shm/hidden_states"}}'
+
+    # then, once healthy:
+    /workspace/vllm/.venv/bin/python vllm_plugins/tests/test_swap_e2e.py
+
+The core assertion: swapping ONLY the first captured index (2 -> 6) changes
+exactly the first hidden-state column while the columns for the unchanged
+layers (18, 34) stay bit-identical for the same prompt.
+"""
+
+import glob
+import json
+import os
+import time
+import urllib.request
+
+import torch
+from vllm.distributed.kv_transfer.kv_connector.v1.example_hidden_states_connector import (  # noqa: E501
+    load_hidden_states,
+)
+
+BASE = os.environ.get("BASE_URL", "http://localhost:8000")
+STORE = os.environ.get("SHARED_STORAGE_PATH", "/dev/shm/hidden_states")
+MODEL = os.environ.get("MODEL", "Qwen/Qwen3-8B")
+PROMPT = "The capital of France is"
+
+
+def http(method, path, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        BASE + path, data=data, method=method,
+        headers={"content-type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+def _newest(before):
+    new = set(glob.glob(os.path.join(STORE, "*.safetensors"))) - before
+    assert new, "no new safetensors file was written"
+    return max(new, key=os.path.getmtime)
+
+
+def generate_and_capture():
+    before = set(glob.glob(os.path.join(STORE, "*.safetensors")))
+    status, _ = http("POST", "/v1/completions", {
+        "model": MODEL, "prompt": PROMPT, "max_tokens": 1, "temperature": 0.0,
+    })
+    assert status == 200, f"completion failed: {status}"
+    time.sleep(1.5)  # connector writes asynchronously
+    obj = load_hidden_states(_newest(before))
+    return obj["hidden_states"], obj["token_ids"]
+
+
+def errmsg(body):
+    if "detail" in body:
+        return body["detail"]
+    return body.get("error", {}).get("message", "")
+
+
+def report(name, ok, detail=""):
+    print(f"[{'PASS' if ok else 'FAIL'}] {name}" + (f"  {detail}" if detail else ""))
+    assert ok, f"{name} failed: {detail}"
+
+
+def main():
+    print("=" * 60)
+    http("POST", "/aux_hidden_state_layers", {"layers": [2, 18, 34]})
+
+    status, body = http("GET", "/aux_hidden_state_layers")
+    report("GET initial layers", status == 200 and body["layers"] == [2, 18, 34],
+           str(body))
+
+    hs_a, ids_a = generate_and_capture()
+    report("baseline capture shape [T,3,H]",
+           hs_a.ndim == 3 and hs_a.shape[1] == 3, f"shape={tuple(hs_a.shape)}")
+
+    status, body = http("POST", "/aux_hidden_state_layers", {"layers": [6, 18, 34]})
+    report("POST swap [6,18,34]",
+           status == 200 and body["layers"] == [6, 18, 34], str(body))
+    status, body = http("GET", "/aux_hidden_state_layers")
+    report("GET reflects [6,18,34]", body["layers"] == [6, 18, 34], str(body))
+
+    hs_b, ids_b = generate_and_capture()
+    report("same prompt tokens across runs", torch.equal(ids_a, ids_b),
+           f"{ids_a.tolist()} vs {ids_b.tolist()}")
+
+    d0 = (hs_a[:, 0] - hs_b[:, 0]).abs().max().item()
+    d1 = (hs_a[:, 1] - hs_b[:, 1]).abs().max().item()
+    d2 = (hs_a[:, 2] - hs_b[:, 2]).abs().max().item()
+    report("swapped column changed (col0: 2->6)",
+           not torch.allclose(hs_a[:, 0], hs_b[:, 0], atol=1e-3), f"max|Δ|={d0:.4f}")
+    report("layer 18 identical (col1)",
+           torch.allclose(hs_a[:, 1], hs_b[:, 1], atol=1e-3), f"max|Δ|={d1:.6f}")
+    report("layer 34 identical (col2)",
+           torch.allclose(hs_a[:, 2], hs_b[:, 2], atol=1e-3), f"max|Δ|={d2:.6f}")
+
+    status, body = http("POST", "/aux_hidden_state_layers", {"layers": [1, 2]})
+    report("reject count mismatch (400)",
+           status == 400 and "fixed" in errmsg(body), f"{status} {errmsg(body)}")
+
+    status, body = http("POST", "/aux_hidden_state_layers", {"layers": []})
+    report("reject empty layers (400)", status == 400, str(status))
+
+    status, body = http("POST", "/aux_hidden_state_layers", {"layers": [2, 18, 34]})
+    report("restore [2,18,34]",
+           status == 200 and body["layers"] == [2, 18, 34], str(body))
+
+    print("=" * 60)
+    print("ALL TESTS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a self-contained vLLM **plugin** (`vllm_plugins/dynamic_hidden_states`) that
lets you swap **which** target-model hidden layers are captured during
speculator training-data generation (`method="extract_hidden_states"`) **at
runtime over HTTP**, without restarting the engine. Only the *set* of layer
indices changes; the *count* is fixed at launch (proposer buffers, dummy-proposer
KV-cache shape and on-disk safetensors layout depend on it), so count changes are
rejected (fail closed).

This is opt-in and touches no vLLM core files — it wires in entirely through
public plugin entry points and `--worker-extension-cls`.

## How it works

- **`graph_patch.install`** (`vllm.general_plugins`) — a *pre-compile*
  monkeypatch of `EagleModelMixin._maybe_add_hidden_state` /
  `_set_aux_hidden_state_layers`. The stock capture uses a Python membership test
  (`if layer_idx in self.aux_hidden_state_layers`) that `torch.compile`
  constant-folds into the compiled forward, freezing the selection — so a naive
  attribute swap is a silent no-op unless the engine runs `--enforce-eager`.
  Instead we keep `N` fixed accumulator buffers and fold every candidate layer's
  residual into them weighted by a one-hot **selection mask held in a registered
  buffer**. The graph becomes selection-agnostic, so a swap is an in-place
  `mask.copy_(...)` — same storage address, read live by both the compiled graph
  and captured CUDA graphs. **No recompile, no `--enforce-eager`.** Memory stays
  O(N); the cost is a small multiply-add over every candidate layer's residual
  (~0.006% of forward FLOPs).
- **`AuxLayerWorkerExtension`** (`--worker-extension-cls`) — engine-side RPC
  (`get`/`set_aux_hidden_state_layers_rpc`) callable through `collective_rpc`.
- **`AuxLayerEndpoint`** (`vllm.endpoint_plugins`) — registers
  `GET`/`POST /aux_hidden_state_layers` on the OpenAI-compatible server.

## Testing

Verified on Qwen3-8B (1×H100) under the **default** `torch.compile` +
`FULL_AND_PIECEWISE` CUDA graphs (no `--enforce-eager`):

- Swapping only the first captured layer (2→6) changes exactly column 0
  (`max|Δ|=21.125`) while columns for unchanged layers 18/34 stay
  **bit-identical** (`Δ=0`).
- The compiled masked path reproduces the eager baked path's values **exactly**.
- **No recompilation** is triggered by a swap.
- Count-mismatch and empty-layer requests are rejected with `400`.

An end-to-end integration script is included at
`vllm_plugins/tests/test_swap_e2e.py` (run manually against a live server; see
its docstring and `vllm_plugins/README.md`).

## Scope / limitations

- Covers models that capture through `EagleModelMixin._maybe_add_hidden_state`
  (Qwen2/Qwen3, Llama, generic dense/MoE). Models that inline the membership test
  in their own forward (e.g. `deepseek_v2`, `qwen3_next`) are **not** covered by
  the compile patch and still need `--enforce-eager` for a live swap.
- The hidden-states connector's safetensors carry no layer-set metadata, so a
  controller that swaps mid-run must record its own `{time/req-range → layer set}`
  mapping.

## Notes

Opening as a **draft** for discussion — feedback welcome on whether this belongs
here as a plugin vs. upstreaming the masked-accumulate capture into vLLM core.
