### PR TITLE
perf(losses): stop pinning target logits through the fused ce backward

### DIFF
--- a/src/speculators/losses/fused.py
+++ b/src/speculators/losses/fused.py
@@ -48,8 +48,6 @@ _OP_TV = tl.constexpr(4)
 # stats [_N_STATS, n_rows]: [0]/[1] draft row max / sum-exp, [2]/[3] same for
 # targets (unused by ce), [4] per-OP -- kl_div/rkl: row loss L | jsd:
 # KL(dp||mix) | tv: s_s | ce: argmax as float32 (exact: vocab < 2**24).
-# ce's [4] is the whole of what its backward needs from the targets, so it
-# alone takes targets_ptr=None there and drops them at the end of the forward.
 _N_STATS = 5
 
 
@@ -206,7 +204,7 @@ def loss_backward_kernel(
     lse_d = m_d + tl.log(z_d)
     extra = tl.load(stats_ptr + 4 * stats_row + pid)
     if OP != _OP_CE:
-        # ce is handed targets_ptr=None, so even the offsetting stays guarded.
+        # CE passes None for targets_ptr.
         targets_ptr += pid * n_cols
         m_t = tl.load(stats_ptr + 2 * stats_row + pid)
         z_t = tl.load(stats_ptr + 3 * stats_row + pid)
@@ -263,9 +261,7 @@ class _FusedLoss(torch.autograd.Function):
             BLOCK_SIZE=BLOCK_SIZE,
             num_warps=num_warps,
         )
-        # Dropping ce's targets frees [B*T, V] for the whole backward -- 2.9 GiB
-        # at DFlash's default anchor count. No win for a compound spec that also
-        # configures a distribution term, which re-pins the same buffer.
+        # CE backward only needs the target argmax cached in stats.
         ctx.save_for_backward(
             logits_flat, None if op == _OP_CE.value else targets_flat, stats
         )
@@ -282,7 +278,7 @@ class _FusedLoss(torch.autograd.Function):
         grad_in = torch.empty_like(logits_flat)
         loss_backward_kernel[(B * T,)](
             logits_flat,
-            targets_flat,  # None for ce; its OP branch never dereferences it
+            targets_flat,
             grad_in,
             grad_output.contiguous().view(-1),
             stats,

--- a/src/speculators/losses/fused.py
+++ b/src/speculators/losses/fused.py
@@ -48,6 +48,8 @@ _OP_TV = tl.constexpr(4)
 # stats [_N_STATS, n_rows]: [0]/[1] draft row max / sum-exp, [2]/[3] same for
 # targets (unused by ce), [4] per-OP -- kl_div/rkl: row loss L | jsd:
 # KL(dp||mix) | tv: s_s | ce: argmax as float32 (exact: vocab < 2**24).
+# ce's [4] is the whole of what its backward needs from the targets, so it
+# alone takes targets_ptr=None there and drops them at the end of the forward.
 _N_STATS = 5
 
 
@@ -189,7 +191,6 @@ def loss_backward_kernel(
     """Recompute probabilities from the saved stats and apply the OP gradient."""
     pid = tl.program_id(0).to(tl.int64)
     logits_ptr += pid * n_cols
-    targets_ptr += pid * n_cols
     grad_in_ptr += pid * n_cols
 
     go = tl.load(grad_out_ptr + pid).cast(tl.float32)
@@ -205,6 +206,8 @@ def loss_backward_kernel(
     lse_d = m_d + tl.log(z_d)
     extra = tl.load(stats_ptr + 4 * stats_row + pid)
     if OP != _OP_CE:
+        # ce is handed targets_ptr=None, so even the offsetting stays guarded.
+        targets_ptr += pid * n_cols
         m_t = tl.load(stats_ptr + 2 * stats_row + pid)
         z_t = tl.load(stats_ptr + 3 * stats_row + pid)
         lse_t = m_t + tl.log(z_t)
@@ -260,7 +263,12 @@ class _FusedLoss(torch.autograd.Function):
             BLOCK_SIZE=BLOCK_SIZE,
             num_warps=num_warps,
         )
-        ctx.save_for_backward(logits_flat, targets_flat, stats)
+        # Dropping ce's targets frees [B*T, V] for the whole backward -- 2.9 GiB
+        # at DFlash's default anchor count. No win for a compound spec that also
+        # configures a distribution term, which re-pins the same buffer.
+        ctx.save_for_backward(
+            logits_flat, None if op == _OP_CE.value else targets_flat, stats
+        )
         ctx.op = op
         ctx.shape = (B, T, V)
         ctx.settings = (BLOCK_SIZE, num_warps)
@@ -274,7 +282,7 @@ class _FusedLoss(torch.autograd.Function):
         grad_in = torch.empty_like(logits_flat)
         loss_backward_kernel[(B * T,)](
             logits_flat,
-            targets_flat,
+            targets_flat,  # None for ce; its OP branch never dereferences it
             grad_in,
             grad_output.contiguous().view(-1),
             stats,

--- a/tests/unit/models/test_fused_losses.py
+++ b/tests/unit/models/test_fused_losses.py
@@ -128,13 +128,7 @@ def test_compiles_fullgraph(name, eager_fn, fused_name):
 
 @requires_cuda
 def test_ce_releases_targets_before_backward():
-    """ce must not keep the [B, T, V] targets alive across backward.
-
-    Its gradient is ``dp - onehot(argmax tp)`` and the forward already caches
-    that argmax in ``stats``, so saving the targets would pin a tensor the
-    backward never reads -- 2.9 GiB at DFlash's default anchor count. The
-    distribution losses do read them and must keep holding them.
-    """
+    """CE releases targets after forward; distribution losses retain them."""
     fused_losses = pytest.importorskip("speculators.losses.fused")
 
     def held_vs_target_bytes(fused_fn) -> tuple[int, int]:

--- a/tests/unit/models/test_fused_losses.py
+++ b/tests/unit/models/test_fused_losses.py
@@ -126,6 +126,36 @@ def test_compiles_fullgraph(name, eager_fn, fused_name):
     assert torch.isfinite(logits.grad).all()
 
 
+@requires_cuda
+def test_ce_releases_targets_before_backward():
+    """ce must not keep the [B, T, V] targets alive across backward.
+
+    Its gradient is ``dp - onehot(argmax tp)`` and the forward already caches
+    that argmax in ``stats``, so saving the targets would pin a tensor the
+    backward never reads -- 2.9 GiB at DFlash's default anchor count. The
+    distribution losses do read them and must keep holding them.
+    """
+    fused_losses = pytest.importorskip("speculators.losses.fused")
+
+    def held_vs_target_bytes(fused_fn) -> tuple[int, int]:
+        """(bytes the graph still holds after the forward, size of targets)."""
+        logits = torch.randn(1, 1024, 4096, device="cuda", requires_grad=True)
+        torch.cuda.synchronize()
+        base = torch.cuda.memory_allocated()
+        targets = torch.randn_like(logits)
+        loss = fused_fn(logits, targets).sum()
+        nbytes = targets.nbytes
+        del targets
+        held = torch.cuda.memory_allocated() - base
+        loss.backward()  # backward must still run without the targets
+        return held, nbytes
+
+    held, nbytes = held_vs_target_bytes(fused_losses.fused_ce_loss)
+    assert held < nbytes // 2
+    held, nbytes = held_vs_target_bytes(fused_losses.fused_kl_div_loss)
+    assert held >= nbytes
+
+
 def test_eager_implementation_supports_differentiable_targets():
     """The explicit eager implementation preserves target gradients."""
     torch.manual_seed(3)


### PR DESCRIPTION
## Summary

Fused CE retained the full target-logit tensor through backward even though backward only needs the target argmax cached during forward. This PR saves `None` for CE and guards target-pointer use behind the non-CE specialization.

At the measured 32k-vocabulary configuration (`max_anchors=512`, `block_size=16`, bf16), this releases 0.49 GiB. Without a vocabulary mapping, training uses the full verifier vocabulary; for Qwen3's 151,936-token vocabulary, the same configuration releases 2.32 GiB.

The saving scales with `max_anchors × block_size × vocabulary size × element size`, not packed `total_seq_len` at a fixed anchor count. Losses and gradients are unchanged. Distribution losses are unchanged, and compound losses containing one will still retain targets.

Follow-up to #951.

## Results

GB10, 512 anchors × 16 positions × 32k mapped vocabulary:

| | Before | After |
| --- | ---: | ---: |
| Held into backward | 1.31 GiB | 0.83 GiB |
| Backward-phase peak | 1.80 GiB | 1.31 GiB |

Gradient checksum was bit-identical; KL was unchanged.

## Tests

- `pytest tests/unit/models/test_fused_losses.py` — 16 passed
- `pytest tests/unit/models tests/unit/train` — 475 passed, 5 skipped

## Checklist

- [x] The purpose of the PR
- [x] The test plan/results
- [ ] (Optional) The necessary documentation update
- [x] I (a human) have written or reviewed the code in this PR to the best of my ability
