### PR TITLE
test(mtp): xfail flaky weekly MTP online regression test

### DIFF
--- a/tests/e2e/regression/test_mtp_online_acceptance.py
+++ b/tests/e2e/regression/test_mtp_online_acceptance.py
@@ -29,6 +29,7 @@ TRAINING_DATA_REPO = "inference-optimization/Qwen3.5-4B-responses"
 @requires_cuda
 @requires_transformers_version("5.2.0")
 @requires_vllm_version("0.22.0")
+@pytest.mark.xfail(strict=False, reason="Flaky: CUDA launch failure mid-training")
 def test_mtp_online_regression(
     tmp_path: Path,
     prompts: list[list[dict[str, str]]],


### PR DESCRIPTION
## Purpose

`test_mtp_online_regression` is flaky. It crashes intermittently mid-training (specially with vLLM nightly) with `CUDA error: unspecified launch failure` at varying training steps (step 31, 48, 76 — not deterministic), and has done so roughly one week in three since at least 2026-07-11. This is not a new regression — the weekly cadence (`@requires_cadence("weekly")`) masked the intermittency by providing only ~1 observation per cell per week.

Two prior fixes were attempted and both failed:
- PR #800 (`gpu_memory_utilization` reduction) — crash recurred the following week
- PR #909 (`enforce_eager=True`) — validated by a single green run, then crashed again on 08-15

Local investigation on dedicated 2×H100 GPUs with exact CI-matching environments showed a clear pattern:

| Environment | Attempts | Crashes | Rate |
|---|---|---|---|
| vLLM 0.27.1 stable (py3.13) | 4 | 0 | 0% |
| vLLM nightly 0.27.2rc1.dev109 (py3.12) | 4 | 2 | 50% |

The crash is significantly more frequent on the vLLM nightly cell, though CI history shows both cells fail at ~1-in-3 over time.

This PR marks the test with `pytest.mark.xfail(strict=False)` rather than skipping it. `strict=False` means:
- A crash (expected failure) does not break the suite
- A pass (`xpass`) is allowed and reported — providing a free signal for when the issue resolves upstream
- The test continues to run on every weekly CI invocation

When `xpass` starts appearing consistently in CI, the marker should be removed.

The smoke test (`test_mtp_finetuning_smoke` — 0.8B model, 50 samples) still runs on every commit and covers the full MTP pipeline end-to-end.

Failing CI run: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/31856577844

## Tests

Verified on both CI-matching local environments (dedicated 2×H100 80GB):

| Cell | Python | vLLM | Collected as xfail | Suite integrity |
|---|---|---|---|---|
| A | 3.13.15 | 0.27.1 (stable) | Yes | 982 tests, 0 collection errors |
| B | 3.12.14 | 0.27.2rc1.dev109 (nightly) | Yes | 982 tests, 0 collection errors |

```
$ CADENCE=weekly pytest tests/e2e/regression/test_mtp_online_acceptance.py --collect-only -m xfail -q
========================== 1 test collected in 0.19s ===========================
```

`make quality` clean (no new warnings).

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
