### PR TITLE
fix(pr-review): flag speculators imports in launch_vllm.py

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -102,6 +102,7 @@ Apply path-specific focus based on which files changed:
 - **`src/speculators/data_generation/**`**: Hidden state extraction correctness, shift-based alignment (off-by-one), loss mask application before storage, vLLM client error handling.
 - **`src/speculators/convert/**`**: Weight mapping completeness, shape compatibility, key renaming correctness, legacy format assumptions.
 - **`src/speculators/config.py`**: Pydantic validators, serialization roundtrip, backward compat with saved checkpoints, registry auto-discovery.
+- **`scripts/launch_vllm.py`**: This script runs inside the vLLM virtualenv (`VLLM_PYTHON`), which does **not** have `speculators` installed. Any `import` from `speculators` (direct or transitive) will cause an `ImportError` at startup, crashing the vLLM server and breaking all e2e tests. Flag any such import with confidence 95+.
 - **`tests/**`**: Coverage of new code paths, edge cases for speculative decoding (vocab boundaries, multi-step loss), proper mocking of vLLM/GPU.
 
 Ignore: `**/*.pyc`, `**/build/**`, `**/.pytest_cache/**`, `**/.ruff_cache/**`, `**/__pycache__/**`, `**/*.egg-info/**`.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -102,7 +102,7 @@ Apply path-specific focus based on which files changed:
 - **`src/speculators/data_generation/**`**: Hidden state extraction correctness, shift-based alignment (off-by-one), loss mask application before storage, vLLM client error handling.
 - **`src/speculators/convert/**`**: Weight mapping completeness, shape compatibility, key renaming correctness, legacy format assumptions.
 - **`src/speculators/config.py`**: Pydantic validators, serialization roundtrip, backward compat with saved checkpoints, registry auto-discovery.
-- **`scripts/launch_vllm.py`**: This script runs inside the vLLM virtualenv (`VLLM_PYTHON`), which does **not** have `speculators` installed. Any `import` from `speculators` (direct or transitive) will cause an `ImportError` at startup, crashing the vLLM server and breaking all e2e tests. Flag any such import with confidence 95+.
+- **`scripts/launch_vllm.py`**: This script runs inside the vLLM virtualenv (`VLLM_PYTHON`), which does **not** have `speculators` installed. Make sure there's no `speculators` dependency and flag any such import with confidence 95+.
 - **`tests/**`**: Coverage of new code paths, edge cases for speculative decoding (vocab boundaries, multi-step loss), proper mocking of vLLM/GPU.
 
 Ignore: `**/*.pyc`, `**/build/**`, `**/.pytest_cache/**`, `**/.ruff_cache/**`, `**/__pycache__/**`, `**/*.egg-info/**`.


### PR DESCRIPTION
## Purpose

Prevent a repeat of #958 / #1008: `scripts/launch_vllm.py` runs inside the vLLM virtualenv (`VLLM_PYTHON`) where `speculators` is not installed. #958 added a `from speculators.provenance import ...` which caused an `ImportError` at startup, crashing the vLLM server and breaking every e2e test. #1008 reverted it.

This PR adds a path-specific rule to the `/pr-review` skill (Phase 4, line-level review) that flags any `speculators` import — direct or transitive — in `launch_vllm.py` with confidence 95+.

## Tests

- [x] Rule added to Phase 4 path-specific focus in `.claude/skills/pr-review/SKILL.md`
- [ ] Future PRs touching `scripts/launch_vllm.py` trigger the new check during `/pr-review`

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.