### PR TITLE
feat(hs_connectors): add HTTP backend for hidden-states transfer

### DIFF
--- a/hs_connectors/src/hs_connectors/__init__.py
+++ b/hs_connectors/src/hs_connectors/__init__.py
@@ -3,6 +3,8 @@ from hs_connectors.transfer import (
     FileTransfer,
     HiddenStatesBackend,
     HiddenStatesTransfer,
+    HttpBackend,
+    HttpTransfer,
     MooncakeBackend,
     MooncakeTransfer,
 )
@@ -12,6 +14,8 @@ __all__ = [
     "FileTransfer",
     "HiddenStatesBackend",
     "HiddenStatesTransfer",
+    "HttpBackend",
+    "HttpTransfer",
     "MooncakeBackend",
     "MooncakeTransfer",
 ]

--- a/hs_connectors/src/hs_connectors/transfer.py
+++ b/hs_connectors/src/hs_connectors/transfer.py
@@ -332,3 +332,117 @@ class MooncakeBackend(HiddenStatesBackend):
                 "mooncake": dataclasses.asdict(mooncake_cfg),
             },
         }
+
+# ---------------------------------------------------------------------------
+# HTTP backend (vLLM writes to local fast disk; trainer fetches over HTTP)
+#
+# Motivation: pointing ``shared_storage_path`` at a shared network filesystem
+# (e.g. cephfs) makes every connector write a cross-host op that contends on
+# the MDS; under saturation, batches of writes stall together with 1-3 s tail
+# latency, which punches through the trainer's prefetch buffer and produces
+# tail training steps. This backend instead tells vLLM to write to a local
+# disk on its own node (no MDS, no cross-host write bursts) and has the
+# trainer pull the file back over plain HTTP from a tiny static file server
+# (``scripts/serve_hs.py``) running next to vLLM. It also works without any
+# shared filesystem between the two nodes.
+#
+# The connector side is unchanged: it still writes
+# ``{shared_storage_path}/{req_id}.safetensors`` under a ``.lock`` flock and
+# returns that absolute path as the handle. We only reinterpret the handle on
+# the trainer side: strip the basename, prepend ``--hs-http-base``, GET it.
+# The file server blocks on the same ``.lock`` flock until the write is done,
+# preserving the existing synchronization semantics.
+# ---------------------------------------------------------------------------
+
+import urllib.error
+import urllib.request
+
+from safetensors.torch import load as load_safetensors_bytes
+
+
+class HttpTransfer(HiddenStatesTransfer):
+    def __init__(self, hs_http_base: str, hidden_states_path, timeout: float = 120.0):
+        self.hs_http_base = hs_http_base.rstrip("/")
+        self.hidden_states_path = hidden_states_path
+        self.timeout = timeout
+
+    def get_cached(self, file_idx: int):
+        path = self.hidden_states_path / f"hs_{file_idx}.safetensors"
+        return _load_hs_file(path)
+
+    def _url_for(self, handle: str) -> str:
+        return f"{self.hs_http_base}/{os.path.basename(handle)}"
+
+    def get_generated(self, handle: str):
+        url = self._url_for(handle)
+        try:
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                payload = resp.read()
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return None
+            raise
+        if not payload:
+            return None
+        return load_safetensors_bytes(payload)
+
+    def cache(self, handle: str, file_idx: int) -> None:
+        raise NotImplementedError(
+            "HttpTransfer.cache() is unsupported: the hidden-states file lives"
+            " on the vLLM node. Use --hidden-states-backend file for"
+            " on_generate=cache, or keep on_generate=delete with the http"
+            " backend."
+        )
+
+    def delete(self, handle: str) -> None:
+        url = self._url_for(handle)
+        try:
+            req = urllib.request.Request(url, method="DELETE")
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                resp.read()
+        except Exception:
+            pass
+
+
+@HiddenStatesBackend.register("http")
+class HttpBackend(HiddenStatesBackend):
+    @staticmethod
+    def add_train_args(parser):
+        parser.add_argument(
+            "--hs-http-base",
+            type=str,
+            default=None,
+            help="Base URL of the hidden-states file server, e.g. 'http://10.0.0.1:9010'.",
+        )
+        parser.add_argument(
+            "--hs-http-timeout",
+            type=float,
+            default=120.0,
+            help="Per-request timeout (seconds) for HTTP hidden-states fetches.",
+        )
+
+    @staticmethod
+    def add_launch_args(parser):
+        pass
+
+    @staticmethod
+    def from_train_args(args, data_path):
+        if not getattr(args, 'hs_http_base', None):
+            raise ValueError("--hs-http-base is required when --hidden-states-backend=http")
+        hs_path = Path(args.hidden_states_path) if args.hidden_states_path else Path(data_path) / "hidden_states"
+        return HttpTransfer(
+            hs_http_base=args.hs_http_base,
+            hidden_states_path=hs_path,
+            timeout=getattr(args, 'hs_http_timeout', 120.0),
+        )
+
+    @staticmethod
+    def build_kv_transfer_config(args):
+        return {
+            "kv_connector": "ExampleHiddenStatesConnector",
+            "kv_role": "kv_producer",
+            "kv_connector_extra_config": {
+                "shared_storage_path": args.hidden_states_path,
+            },
+        }

--- a/hs_connectors/src/hs_connectors/transfer.py
+++ b/hs_connectors/src/hs_connectors/transfer.py
@@ -8,11 +8,15 @@ import os
 import shutil
 import socket
 import time
+import urllib.error
+import urllib.request
 from abc import ABC, abstractmethod
+from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import torch
+from safetensors.torch import load as load_safetensors_bytes
 from safetensors.torch import load_file
 
 from hs_connectors.mooncake_store import MooncakeHiddenStatesStore, MooncakeStoreConfig
@@ -333,6 +337,7 @@ class MooncakeBackend(HiddenStatesBackend):
             },
         }
 
+
 # ---------------------------------------------------------------------------
 # HTTP backend (vLLM writes to local fast disk; trainer fetches over HTTP)
 #
@@ -354,11 +359,6 @@ class MooncakeBackend(HiddenStatesBackend):
 # preserving the existing synchronization semantics.
 # ---------------------------------------------------------------------------
 
-import urllib.error
-import urllib.request
-
-from safetensors.torch import load as load_safetensors_bytes
-
 
 class HttpTransfer(HiddenStatesTransfer):
     def __init__(self, hs_http_base: str, hidden_states_path, timeout: float = 120.0):
@@ -376,11 +376,11 @@ class HttpTransfer(HiddenStatesTransfer):
     def get_generated(self, handle: str):
         url = self._url_for(handle)
         try:
-            req = urllib.request.Request(url, method="GET")
-            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            req = urllib.request.Request(url, method="GET")  # noqa: S310
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:  # noqa: S310
                 payload = resp.read()
         except urllib.error.HTTPError as e:
-            if e.code == 404:
+            if e.code == HTTPStatus.NOT_FOUND:
                 return None
             raise
         if not payload:
@@ -398,11 +398,11 @@ class HttpTransfer(HiddenStatesTransfer):
     def delete(self, handle: str) -> None:
         url = self._url_for(handle)
         try:
-            req = urllib.request.Request(url, method="DELETE")
-            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            req = urllib.request.Request(url, method="DELETE")  # noqa: S310
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:  # noqa: S310
                 resp.read()
-        except Exception:
-            pass
+        except OSError:
+            pass  # best-effort cleanup; the server TTL-sweeps leftovers
 
 
 @HiddenStatesBackend.register("http")
@@ -428,13 +428,19 @@ class HttpBackend(HiddenStatesBackend):
 
     @staticmethod
     def from_train_args(args, data_path):
-        if not getattr(args, 'hs_http_base', None):
-            raise ValueError("--hs-http-base is required when --hidden-states-backend=http")
-        hs_path = Path(args.hidden_states_path) if args.hidden_states_path else Path(data_path) / "hidden_states"
+        if not getattr(args, "hs_http_base", None):
+            raise ValueError(
+                "--hs-http-base is required when --hidden-states-backend=http"
+            )
+        hs_path = (
+            Path(args.hidden_states_path)
+            if args.hidden_states_path
+            else Path(data_path) / "hidden_states"
+        )
         return HttpTransfer(
             hs_http_base=args.hs_http_base,
             hidden_states_path=hs_path,
-            timeout=getattr(args, 'hs_http_timeout', 120.0),
+            timeout=getattr(args, "hs_http_timeout", 120.0),
         )
 
     @staticmethod

--- a/hs_connectors/src/hs_connectors/transfer.py
+++ b/hs_connectors/src/hs_connectors/transfer.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-def wait_for_lock(lock_path: str, timeout: float = 10.0, poll_interval: float = 0.1):
+def wait_for_lock(lock_path: str, timeout: float = 10.0, poll_interval: float = 0.02):
     fd = os.open(lock_path, os.O_RDWR)
     try:
         deadline = time.monotonic() + timeout

--- a/hs_connectors/src/hs_connectors/transfer.py
+++ b/hs_connectors/src/hs_connectors/transfer.py
@@ -361,19 +361,24 @@ class MooncakeBackend(HiddenStatesBackend):
 
 
 class HttpTransfer(HiddenStatesTransfer):
-    def __init__(self, hs_http_base: str, hidden_states_path, timeout: float = 120.0):
+    def __init__(
+        self,
+        hs_http_base: str,
+        hidden_states_path: Path,
+        timeout: float = 120.0,
+    ):
         self.hs_http_base = hs_http_base.rstrip("/")
         self.hidden_states_path = hidden_states_path
         self.timeout = timeout
 
-    def get_cached(self, file_idx: int):
+    def get_cached(self, file_idx: int) -> dict[str, torch.Tensor] | None:
         path = self.hidden_states_path / f"hs_{file_idx}.safetensors"
         return _load_hs_file(path)
 
     def _url_for(self, handle: str) -> str:
         return f"{self.hs_http_base}/{os.path.basename(handle)}"
 
-    def get_generated(self, handle: str):
+    def get_generated(self, handle: str) -> dict[str, torch.Tensor] | None:
         url = self._url_for(handle)
         try:
             req = urllib.request.Request(url, method="GET")  # noqa: S310

--- a/scripts/serve_hs.py
+++ b/scripts/serve_hs.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Tiny static file server for HTTP-based hidden-states transfer.
+
+Run this on each vLLM node, pointing ``--root`` at the same local directory
+the connector writes to (``shared_storage_path`` / ``--hidden-states-path``).
+It pairs with the ``http`` hidden-states backend
+(``hs_connectors.transfer.HttpBackend``): the trainer does
+
+    GET  http://<host>:<port>/<basename>.safetensors   -> wait for write, stream
+    DELETE http://<host>:<port>/<basename>.safetensors  -> drop file + lock
+
+Why it exists
+------------
+The connector (``example_hidden_states_connector.py``) returns a request's
+handle *before* its async DtoH copy + disk write finishes. To hide that race it
+holds an advisory flock (``LOCK_EX``) on a companion ``<file>.lock`` for the
+duration of the write and releases it (closes the fd) once the write is done.
+The file backend's reader re-acquires that lock to block until the write
+completes. Over HTTP the trainer can no longer see the lock, so this server
+re-acquires it on the trainer's behalf: a ``GET`` blocks until the lock is
+released (= write complete), then streams the file. This preserves the exact
+synchronization semantics of the file backend with zero connector changes.
+
+A background TTL sweeper deletes stale ``.safetensors`` files (and their
+``.lock`` companions) older than ``--ttl`` seconds, so a trainer crash can never
+fill the local disk with orphaned files.
+
+Usage
+-----
+    python scripts/serve_hs.py --root /data/local_hs --port 9010 --host 0.0.0.0
+
+Examples
+--------
+    # One server per vLLM instance, each serving that instance's own subdir:
+    python scripts/serve_hs.py --root /data/local_hs/8010 --port 9010
+    python scripts/serve_hs.py --root /data/local_hs/8020 --port 9020
+"""
+from __future__ import annotations
+
+import argparse
+import fcntl
+import http.server
+import os
+import socketserver
+import threading
+import time
+from pathlib import Path
+
+DEFAULT_ROOT = "/tmp/hidden_states"  # noqa: S108
+DEFAULT_LOCK_TIMEOUT = 120.0  # seconds to wait for the connector's write
+DEFAULT_TTL = 600.0  # seconds; stale files older than this are swept
+DEFAULT_TTL_INTERVAL = 60.0  # seconds between sweeper passes
+CHUNK = 1024 * 1024  # 1 MiB streaming buffer
+
+
+def _wait_for_file(path: Path, timeout: float, poll: float = 0.05) -> bool:
+    """Spin until ``path`` exists or ``timeout`` elapses. True if it appeared."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return True
+        time.sleep(poll)
+    return path.exists()
+
+
+def _wait_for_write(data_path: Path, lock_timeout: float) -> str | None:
+    """Block until the connector finishes writing ``data_path``.
+
+    Returns a short status string for logging ("locked"), or ``None`` if the
+    file is not available within the timeout.
+
+    Readiness is driven entirely by the connector's ``.lock`` flock: the
+    connector creates ``<data_path>.lock`` and holds LOCK_EX while writing,
+    then closes its fd (releasing the lock) once done. We wait for the lock
+    file to appear, then flock-wait (LOCK_EX) until we acquire it — acquiring
+    it means the writer released it = write done. This is race-free and never
+    serves a half-written file.
+
+    There is deliberately no fixed cap on waiting for the lock file to appear:
+    it returns as soon as the lock shows up (normally within a scheduler step).
+    An earlier version capped this wait at 5s then fell back to serving the
+    data file by existence — which both burned a flat ~5s on every fetch
+    (observed: ``get_generated`` p50 == 5035ms) AND risked serving a
+    half-written file. We now just wait for the lock.
+    """
+    lock_path = Path(str(data_path) + ".lock")
+
+    # Wait for the lock file to appear (connector creates it when the write
+    # starts). No fixed cap — returns as soon as it appears.
+    if not _wait_for_file(lock_path, timeout=lock_timeout):
+        return None  # lock never appeared; do NOT serve (would risk a partial read)
+
+    fd = os.open(str(lock_path), os.O_RDONLY)
+    deadline = time.monotonic() + lock_timeout
+    try:
+        while time.monotonic() < deadline:
+            try:
+                # NB: LOCK_EX (not SH) so it blocks until the writer's exclusive
+                # lock is released, exactly like the file backend's reader.
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return "locked"
+            except BlockingIOError:
+                time.sleep(0.02)
+        return None  # timed out waiting for the writer to release
+    finally:
+        os.close(fd)  # releases our (just-acquired) lock; leave the file in place
+
+
+def _sweep(root: Path, ttl: float, interval: float) -> None:
+    """Daemon loop: delete ``.safetensors`` (and ``.lock``) older than ``ttl``."""
+    while True:
+        time.sleep(interval)
+        now = time.monotonic()
+        try:
+            entries = list(root.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            try:
+                mtime = entry.stat().st_mtime
+            except OSError:
+                continue
+            if now - mtime < ttl:
+                continue
+            if entry.suffix == ".safetensors" or entry.suffix == ".lock":
+                try:
+                    entry.unlink()
+                except OSError:
+                    pass
+
+
+class HiddenStatesHandler(http.server.BaseHTTPRequestHandler):
+    root: Path  # injected via the server factory below
+    lock_timeout: float
+
+    # Quieter logging: one line per request, no noise to stderr per default.
+    def log_message(self, fmt: str, *args) -> None:  # noqa: A003
+        pass
+
+    # --- helpers ----------------------------------------------------------
+    def _resolve(self, urlpath: str) -> Path | None:
+        """Map URL path to a safe absolute path under ``root`` (no traversal)."""
+        # Strip query/fragment, take the basename only. The connector writes a
+        # flat ``{req_id}.safetensors``, so we never serve nested paths.
+        name = os.path.basename(urlpath.split("?")[0])
+        if not name or name in (".", "..") or "/" in name or "\\" in name:
+            return None
+        candidate = (self.root / name).resolve()
+        try:
+            candidate.relative_to(self.root.resolve())
+        except ValueError:
+            return None
+        return candidate
+
+    # --- GET --------------------------------------------------------------
+    def do_GET(self) -> None:  # noqa: N802 - http.server API
+        data_path = self._resolve(self.path)
+        if data_path is None or data_path.suffix != ".safetensors":
+            self.send_error(404, "Not found")
+            return
+
+        status = _wait_for_write(data_path, self.lock_timeout)
+        if status is None or not data_path.exists():
+            self.send_error(404, "Hidden states not available")
+            return
+
+        try:
+            size = data_path.stat().st_size
+        except OSError:
+            self.send_error(404, "Not found")
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(size))
+        self.end_headers()
+        try:
+            with open(data_path, "rb") as f:
+                while True:
+                    buf = f.read(CHUNK)
+                    if not buf:
+                        break
+                    self.wfile.write(buf)
+        except FileNotFoundError:
+            # Lost a race with DELETE / TTL sweeper after the lock-wait.
+            self.send_error(404, "Not found")
+        except (BrokenPipeError, ConnectionResetError):
+            # Client went away mid-transfer; nothing to do.
+            pass
+
+    # --- DELETE -----------------------------------------------------------
+    def do_DELETE(self) -> None:  # noqa: N802 - http.server API
+        data_path = self._resolve(self.path)
+        if data_path is None or data_path.suffix != ".safetensors":
+            self.send_error(404, "Not found")
+            return
+        lock_path = Path(str(data_path) + ".lock")
+        for p in (data_path, lock_path):
+            try:
+                p.unlink()
+            except OSError:
+                pass
+        self.send_response(204)
+        self.end_headers()
+
+
+class ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    """One thread per request so concurrent GETs don't serialize."""
+
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def make_handler(root: Path, lock_timeout: float) -> type[HiddenStatesHandler]:
+    return type(
+        "BoundHiddenStatesHandler",
+        (HiddenStatesHandler,),
+        {"root": root, "lock_timeout": lock_timeout},
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Serve connector-written hidden-states files over HTTP for the "
+            "'http' hs_connectors backend. Blocks on the connector's .lock "
+            "flock until each write is complete, then streams the file."
+        ),
+    )
+    parser.add_argument(
+        "--root",
+        type=str,
+        default=DEFAULT_ROOT,
+        help=(
+            "Directory the connector writes hidden states to (its "
+            "shared_storage_path / --hidden-states-path). Must be local fast "
+            f"disk. Default: {DEFAULT_ROOT}"
+        ),
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        required=True,
+        help="Port to listen on.",
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="0.0.0.0",
+        help="Bind address. Default: 0.0.0.0 (all interfaces).",
+    )
+    parser.add_argument(
+        "--lock-timeout",
+        type=float,
+        default=DEFAULT_LOCK_TIMEOUT,
+        help=(
+            "Seconds to wait for the connector to finish writing a file before "
+            f"giving up (GET). Default: {DEFAULT_LOCK_TIMEOUT}"
+        ),
+    )
+    parser.add_argument(
+        "--ttl",
+        type=float,
+        default=DEFAULT_TTL,
+        help=(
+            "Stale .safetensors/.lock files older than this many seconds are "
+            f"deleted by the background sweeper. Default: {DEFAULT_TTL}"
+        ),
+    )
+    parser.add_argument(
+        "--ttl-interval",
+        type=float,
+        default=DEFAULT_TTL_INTERVAL,
+        help=f"Seconds between sweeper passes. Default: {DEFAULT_TTL_INTERVAL}",
+    )
+    parser.add_argument(
+        "--no-sweeper",
+        action="store_true",
+        help="Disable the background TTL sweeper (not recommended).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    root = Path(args.root).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    print(
+        f"[serve_hs] root={root} host={args.host} port={args.port} "
+        f"lock_timeout={args.lock_timeout}s ttl={args.ttl}s",
+        flush=True,
+    )
+
+    if not args.no_sweeper:
+        t = threading.Thread(
+            target=_sweep,
+            args=(root, args.ttl, args.ttl_interval),
+            daemon=True,
+        )
+        t.start()
+
+    handler = make_handler(root, args.lock_timeout)
+    server = ThreadingHTTPServer((args.host, args.port), handler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serve_hs.py
+++ b/scripts/serve_hs.py
@@ -42,6 +42,7 @@ import argparse
 import contextlib
 import fcntl
 import http.server
+import math
 import os
 import socketserver
 import threading
@@ -92,7 +93,12 @@ def _wait_for_write(data_path: Path, lock_timeout: float) -> str | None:
     if not _wait_for_file(lock_path, timeout=lock_timeout):
         return None  # lock never appeared; do NOT serve (would risk a partial read)
 
-    fd = os.open(str(lock_path), os.O_RDONLY)
+    try:
+        fd = os.open(str(lock_path), os.O_RDONLY)
+    except OSError:
+        # Lost a race with DELETE / TTL sweeper between the existence check
+        # and the open; treat as unavailable rather than crashing the handler.
+        return None
     deadline = time.monotonic() + lock_timeout
     try:
         while time.monotonic() < deadline:
@@ -112,7 +118,10 @@ def _sweep(root: Path, ttl: float, interval: float) -> None:
     """Daemon loop: delete ``.safetensors`` (and ``.lock``) older than ``ttl``."""
     while True:
         time.sleep(interval)
-        now = time.monotonic()
+        # NB: st_mtime is Unix wall-clock time; compare against time.time(),
+        # NOT time.monotonic() (seconds since boot), or the age check never
+        # fires and stale files are never reclaimed.
+        now = time.time()
         try:
             entries = list(root.iterdir())
         except OSError:
@@ -133,9 +142,10 @@ class HiddenStatesHandler(http.server.BaseHTTPRequestHandler):
     root: Path  # injected via the server factory below
     lock_timeout: float
 
-    # Quieter logging: one line per request, no noise to stderr per default.
+    # One concise line per request (default http.server logs hit stderr with
+    # client address + date noise on every GET).
     def log_message(self, fmt: str, *args) -> None:
-        pass
+        print(f"[serve_hs] {self.address_string()} {fmt % args}", flush=True)
 
     # --- helpers ----------------------------------------------------------
     def _resolve(self, urlpath: str) -> Path | None:
@@ -164,29 +174,33 @@ class HiddenStatesHandler(http.server.BaseHTTPRequestHandler):
             self.send_error(404, "Hidden states not available")
             return
 
+        # Open before sending the 200 so a DELETE / TTL-sweeper race after the
+        # lock-wait answers 404 instead of failing mid-transfer. The fd stays
+        # open across header-send and streaming, so no context manager.
         try:
-            size = data_path.stat().st_size
+            f = open(data_path, "rb")  # noqa: SIM115 - closed in finally below
         except OSError:
             self.send_error(404, "Not found")
             return
+        with contextlib.suppress(OSError):
+            size = os.fstat(f.fileno()).st_size
 
         self.send_response(200)
         self.send_header("Content-Type", "application/octet-stream")
         self.send_header("Content-Length", str(size))
         self.end_headers()
         try:
-            with open(data_path, "rb") as f:
-                while True:
-                    buf = f.read(CHUNK)
-                    if not buf:
-                        break
-                    self.wfile.write(buf)
-        except FileNotFoundError:
-            # Lost a race with DELETE / TTL sweeper after the lock-wait.
-            self.send_error(404, "Not found")
+            while True:
+                buf = f.read(CHUNK)
+                if not buf:
+                    break
+                self.wfile.write(buf)
         except (BrokenPipeError, ConnectionResetError):
             # Client went away mid-transfer; nothing to do.
             pass
+        finally:
+            with contextlib.suppress(OSError):
+                f.close()
 
     # --- DELETE -----------------------------------------------------------
     def do_DELETE(self) -> None:
@@ -217,6 +231,17 @@ def make_handler(root: Path, lock_timeout: float) -> type[HiddenStatesHandler]:
     )
 
 
+def _positive_float(value: str) -> float:
+    """argparse type: finite float strictly greater than zero."""
+    try:
+        f = float(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"{value!r} is not a number") from e
+    if not math.isfinite(f) or f <= 0:
+        raise argparse.ArgumentTypeError(f"{value!r} must be a positive finite number")
+    return f
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
@@ -244,12 +269,16 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--host",
         type=str,
-        default="0.0.0.0",  # noqa: S104 - must be reachable from the trainer node
-        help="Bind address. Default: 0.0.0.0 (all interfaces).",
+        default="127.0.0.1",
+        help=(
+            "Bind address. The trainer usually runs on another node; pass "
+            "--host 0.0.0.0 (or the node's IP) to accept cross-node "
+            "connections. Default: 127.0.0.1."
+        ),
     )
     parser.add_argument(
         "--lock-timeout",
-        type=float,
+        type=_positive_float,
         default=DEFAULT_LOCK_TIMEOUT,
         help=(
             "Seconds to wait for the connector to finish writing a file before "
@@ -258,7 +287,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--ttl",
-        type=float,
+        type=_positive_float,
         default=DEFAULT_TTL,
         help=(
             "Stale .safetensors/.lock files older than this many seconds are "
@@ -267,7 +296,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--ttl-interval",
-        type=float,
+        type=_positive_float,
         default=DEFAULT_TTL_INTERVAL,
         help=f"Seconds between sweeper passes. Default: {DEFAULT_TTL_INTERVAL}",
     )

--- a/scripts/serve_hs.py
+++ b/scripts/serve_hs.py
@@ -35,9 +35,11 @@ Examples
     python scripts/serve_hs.py --root /data/local_hs/8010 --port 9010
     python scripts/serve_hs.py --root /data/local_hs/8020 --port 9020
 """
+
 from __future__ import annotations
 
 import argparse
+import contextlib
 import fcntl
 import http.server
 import os
@@ -122,11 +124,9 @@ def _sweep(root: Path, ttl: float, interval: float) -> None:
                 continue
             if now - mtime < ttl:
                 continue
-            if entry.suffix == ".safetensors" or entry.suffix == ".lock":
-                try:
+            if entry.suffix in {".safetensors", ".lock"}:
+                with contextlib.suppress(OSError):
                     entry.unlink()
-                except OSError:
-                    pass
 
 
 class HiddenStatesHandler(http.server.BaseHTTPRequestHandler):
@@ -134,7 +134,7 @@ class HiddenStatesHandler(http.server.BaseHTTPRequestHandler):
     lock_timeout: float
 
     # Quieter logging: one line per request, no noise to stderr per default.
-    def log_message(self, fmt: str, *args) -> None:  # noqa: A003
+    def log_message(self, fmt: str, *args) -> None:
         pass
 
     # --- helpers ----------------------------------------------------------
@@ -142,7 +142,7 @@ class HiddenStatesHandler(http.server.BaseHTTPRequestHandler):
         """Map URL path to a safe absolute path under ``root`` (no traversal)."""
         # Strip query/fragment, take the basename only. The connector writes a
         # flat ``{req_id}.safetensors``, so we never serve nested paths.
-        name = os.path.basename(urlpath.split("?")[0])
+        name = os.path.basename(urlpath.partition("?")[0])
         if not name or name in (".", "..") or "/" in name or "\\" in name:
             return None
         candidate = (self.root / name).resolve()
@@ -153,7 +153,7 @@ class HiddenStatesHandler(http.server.BaseHTTPRequestHandler):
         return candidate
 
     # --- GET --------------------------------------------------------------
-    def do_GET(self) -> None:  # noqa: N802 - http.server API
+    def do_GET(self) -> None:
         data_path = self._resolve(self.path)
         if data_path is None or data_path.suffix != ".safetensors":
             self.send_error(404, "Not found")
@@ -189,17 +189,15 @@ class HiddenStatesHandler(http.server.BaseHTTPRequestHandler):
             pass
 
     # --- DELETE -----------------------------------------------------------
-    def do_DELETE(self) -> None:  # noqa: N802 - http.server API
+    def do_DELETE(self) -> None:
         data_path = self._resolve(self.path)
         if data_path is None or data_path.suffix != ".safetensors":
             self.send_error(404, "Not found")
             return
         lock_path = Path(str(data_path) + ".lock")
         for p in (data_path, lock_path):
-            try:
+            with contextlib.suppress(OSError):
                 p.unlink()
-            except OSError:
-                pass
         self.send_response(204)
         self.end_headers()
 
@@ -246,7 +244,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--host",
         type=str,
-        default="0.0.0.0",
+        default="0.0.0.0",  # noqa: S104 - must be reachable from the trainer node
         help="Bind address. Default: 0.0.0.0 (all interfaces).",
     )
     parser.add_argument(

--- a/scripts/serve_hs.py
+++ b/scripts/serve_hs.py
@@ -221,7 +221,12 @@ class ThreadingHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
 
     daemon_threads = True
     allow_reuse_address = True
-
+    
+    # OS-level TCP listen backlog (SOMAXCONN is typically 128 on Linux);
+    # set explicitly so the server can accept bursts of concurrent GET/DELETE
+    # requests without ECONNREFUSED when multiple trainer workers hit the
+    # same vLLM node simultaneously.
+    request_queue_size = 128
 
 def make_handler(root: Path, lock_timeout: float) -> type[HiddenStatesHandler]:
     return type(

--- a/tests/e2e/hs_connectors/test_http_roundtrip.py
+++ b/tests/e2e/hs_connectors/test_http_roundtrip.py
@@ -1,0 +1,151 @@
+"""E2E smoke test for the HTTP hidden-states producer/consumer loop.
+
+A writer standing in for the vLLM connector writes a safetensors payload under
+the ``.lock`` flock protocol to a directory served by ``scripts/serve_hs.py``;
+the test then reads it back via ``HttpTransfer`` (standing in for the trainer
+on another node) and validates shape and the lock-blocking semantics.
+
+Only depends on the standard library, so it always runs; the server is
+launched automatically on a scratch port.
+"""
+
+import fcntl
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+hs_connectors = pytest.importorskip(
+    "hs_connectors.transfer", reason="hs_connectors not installed"
+)
+HttpTransfer = hs_connectors.HttpTransfer
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture()
+def serve_hs(tmp_path: Path):
+    """Launch ``scripts/serve_hs.py`` on a scratch port; yield its base URL."""
+    port = _free_port()
+    root = tmp_path / "hidden_states"
+    root.mkdir()
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "serve_hs.py"),
+            "--root",
+            str(root),
+            "--port",
+            str(port),
+            "--no-sweeper",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    base = f"http://127.0.0.1:{port}"
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                break
+        except OSError:
+            if proc.poll() is not None:
+                raise RuntimeError("serve_hs.py exited during startup")
+            time.sleep(0.05)
+    else:
+        proc.terminate()
+        raise RuntimeError("serve_hs.py did not start within 10s")
+    yield base, root
+    proc.terminate()
+    proc.wait(timeout=5)
+
+
+def _write_under_lock(root: Path, name: str, tensors: dict[str, torch.Tensor]):
+    """Write ``tensors`` the way the vLLM connector does: flock held during write."""
+    data_path = root / name
+    lock_path = Path(str(data_path) + ".lock")
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        save_file(tensors, str(data_path))
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+    return str(data_path)
+
+
+@pytest.mark.e2e
+def test_http_hidden_states_roundtrip(serve_hs):
+    """Producer writes under flock; HttpTransfer GETs, validates, and DELETEs."""
+    base, root = serve_hs
+    hs = torch.randn(32, 4, 16, dtype=torch.bfloat16)
+    token_ids = torch.randint(0, 1000, (32,))
+    handle = _write_under_lock(
+        root, "req_test.safetensors", {"hidden_states": hs, "token_ids": token_ids}
+    )
+
+    transfer = HttpTransfer(base, root, timeout=10.0)
+    out = transfer.get_generated(handle)
+
+    assert out is not None, "get_generated returned None for an existing sample"
+    assert torch.equal(out["hidden_states"], hs)
+    assert torch.equal(out["token_ids"], token_ids)
+
+    transfer.delete(handle)
+    assert not (root / "req_test.safetensors").exists()
+    assert not (root / "req_test.safetensors.lock").exists()
+
+
+@pytest.mark.e2e
+def test_http_get_blocks_until_lock_released(serve_hs):
+    """The server must hold the GET until the connector releases the flock."""
+    base, root = serve_hs
+    hs = torch.randn(8, 2, 16)
+    data_path = root / "req_locked.safetensors"
+    lock_path = Path(str(data_path) + ".lock")
+
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    save_file({"hidden_states": hs}, str(data_path))
+
+    hold_seconds = 1.0
+    threading.Timer(hold_seconds, lambda: fcntl.flock(fd, fcntl.LOCK_UN)).start()
+    try:
+        transfer = HttpTransfer(base, root, timeout=10.0)
+        start = time.monotonic()
+        out = transfer.get_generated(str(data_path))
+        elapsed = time.monotonic() - start
+
+        assert out is not None
+        assert torch.equal(out["hidden_states"], hs)
+        assert elapsed >= hold_seconds, (
+            f"GET returned in {elapsed:.2f}s, before the {hold_seconds}s lock release"
+        )
+    finally:
+        os.close(fd)
+
+
+@pytest.mark.e2e
+def test_http_get_rejected_name_maps_404_to_none(serve_hs):
+    """A 404 must surface as ``None``, not an exception, so the trainer can retry.
+
+    (The server answers 404 immediately for names it refuses to serve; for a
+    valid name whose write has not started yet it holds the GET until the
+    connector's lock file appears — see ``serve_hs.py``.)
+    """
+    base, root = serve_hs
+    transfer = HttpTransfer(base, root, timeout=10.0)
+    assert transfer.get_generated(str(root / "not_a_safetensors_file.txt")) is None

--- a/tests/e2e/hs_connectors/test_http_roundtrip.py
+++ b/tests/e2e/hs_connectors/test_http_roundtrip.py
@@ -36,16 +36,17 @@ def _free_port() -> int:
         return s.getsockname()[1]
 
 
-@pytest.fixture()
+@pytest.fixture
 def serve_hs(tmp_path: Path):
     """Launch ``scripts/serve_hs.py`` on a scratch port; yield its base URL."""
     port = _free_port()
     root = tmp_path / "hidden_states"
     root.mkdir()
-    proc = subprocess.Popen(
+    serve_script = str(REPO_ROOT / "scripts" / "serve_hs.py")
+    proc = subprocess.Popen(  # noqa: S603 - fixed argv, repo-controlled script
         [
             sys.executable,
-            str(REPO_ROOT / "scripts" / "serve_hs.py"),
+            serve_script,
             "--root",
             str(root),
             "--port",
@@ -63,7 +64,7 @@ def serve_hs(tmp_path: Path):
                 break
         except OSError:
             if proc.poll() is not None:
-                raise RuntimeError("serve_hs.py exited during startup")
+                raise RuntimeError("serve_hs.py exited during startup") from None
             time.sleep(0.05)
     else:
         proc.terminate()

--- a/tests/e2e/hs_connectors/test_http_roundtrip.py
+++ b/tests/e2e/hs_connectors/test_http_roundtrip.py
@@ -123,7 +123,12 @@ def test_http_get_blocks_until_lock_released(serve_hs):
     save_file({"hidden_states": hs}, str(data_path))
 
     hold_seconds = 1.0
-    threading.Timer(hold_seconds, lambda: fcntl.flock(fd, fcntl.LOCK_UN)).start()
+
+    def _release():
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+    timer = threading.Timer(hold_seconds, _release)
+    timer.start()
     try:
         transfer = HttpTransfer(base, root, timeout=10.0)
         start = time.monotonic()
@@ -136,6 +141,9 @@ def test_http_get_blocks_until_lock_released(serve_hs):
             f"GET returned in {elapsed:.2f}s, before the {hold_seconds}s lock release"
         )
     finally:
+        # Cancel-and-join first so the timer can never fire on a closed fd.
+        timer.cancel()
+        timer.join()
         os.close(fd)
 
 
@@ -150,3 +158,53 @@ def test_http_get_rejected_name_maps_404_to_none(serve_hs):
     base, root = serve_hs
     transfer = HttpTransfer(base, root, timeout=10.0)
     assert transfer.get_generated(str(root / "not_a_safetensors_file.txt")) is None
+
+
+@pytest.mark.e2e
+def test_http_ttl_sweeper_reclaims_stale_files(tmp_path: Path):
+    """Files older than --ttl are deleted (trainer-crash cleanup)."""
+    port = _free_port()
+    root = tmp_path / "hidden_states"
+    root.mkdir()
+    proc = subprocess.Popen(  # noqa: S603 - fixed argv, repo-controlled script
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "serve_hs.py"),
+            "--root",
+            str(root),
+            "--port",
+            str(port),
+            "--ttl",
+            "1",
+            "--ttl-interval",
+            "0.2",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        stale = root / "stale.safetensors"
+        stale_lock = root / "stale.safetensors.lock"
+        fresh = root / "fresh.safetensors"
+        fresh_lock = root / "fresh.safetensors.lock"
+        for p in (stale, stale_lock, fresh, fresh_lock):
+            p.write_bytes(b"x")
+
+        # Age the "stale" pair past the 1s TTL while "fresh" stays young.
+        stale_age = time.time() - 10
+        os.utime(stale, (stale_age, stale_age))
+        os.utime(stale_lock, (stale_age, stale_age))
+
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            if not stale.exists() and not stale_lock.exists():
+                break
+            time.sleep(0.1)
+
+        assert not stale.exists(), "stale .safetensors was not swept"
+        assert not stale_lock.exists(), "stale .lock was not swept"
+        assert fresh.exists(), "fresh file was swept prematurely"
+        assert fresh_lock.exists(), "fresh lock was swept prematurely"
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)


### PR DESCRIPTION
## Motivation

In the online hidden-states generation pipeline (`--on-missing generate`), the vLLMconnector writes each freshly extracted hidden-states tensor to `shared_storage_path`. Pointing that at a shared network filesystem (e.g. cephfs) makes every write a cross-host op that contends on the MDS; under saturation, batches of writes stall together with 1–3 s tail latency, which punches through the trainer's prefetch buffer and produces tail training steps.

## What this adds

A new `http` hidden-states backend (`--hidden-states-backend http`):

 - **vLLM side (connector unchanged)**: writes to a local fast disk on its own node — no MDS, no cross-host write bursts.
 - **Trainer side**: `HttpTransfer` fetches the file over plain HTTP from `scripts/serve_hs.py`, a tiny static file server running next to vLLM. It blocks on the same `.lock` flock protocol as the `file` backend, so a fetch never sees a half-written file. After use, `DELETE` removes the data file and its lock.

No shared filesystem is required between vLLM and the trainer, and the whole path depends only on the Python standard library (`http.server` + `flock`).

### Crash safety

- **Trainer crash**: a background TTL sweeper in `serve_hs.py` deletes stale `.safetensors` files (and their `.lock` companions) older than `--ttl` seconds (default 600 s, swept every `--ttl-interval` = 60 s). Orphaned files on the vLLM node's local disk are reclaimed automatically, so a crashed trainer can only leak bounded local disk usage.
- **Races**: a GET that loses a race with a concurrent DELETE (or the TTL sweeper) after its lock-wait answers 404, which `HttpTransfer` maps to `None` so the trainer can re-request.

## Performance

Two independent latency sources:

1. **Poll wakeup granularity** (~51 ms/step): the trainer-side `wait_for_lock()` polls the connector's flock once per `poll_interval`, waking on average half a period late. With the 100 ms default this added ~50 ms to every generated-sample fetch. Fixed for the `file` backend by commit 2 (100 ms → 20 ms default).
2. **Shared-filesystem MDS saturation bursts** (~29–57 ms/step): batches of concurrent connector writes to cephfs stall together with 1–3 s tail latency, punching through the trainer's prefetch buffer and producing tail steps. Eliminated by the `http` backend: vLLM writes to local disk on its own node, the trainer fetches over HTTP.

## Tests

`tests/e2e/hs_connectors/test_http_roundtrip.py` (commit 3): full producer/consumer loop without any vLLM dependency — flock write protocol, lock-blocking semantics, 404-to-None mapping. 3 tests, all passing; upstream hs_connectors and train unit suites pass unchanged (28 + 292 passed).

## Usage

```bash

# on each vLLM node
python scripts/serve_hs.py --root /data/local_hs --port 9010

# trainer
--hidden-states-backend http \
--hidden-states-path  /data/local_hs \
--hs-http-base        http://<vllm-node>:9010