### PR TITLE
Keep base dependencies in pyproject.toml instead of setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,23 @@ cython_debug/
 # Visual Studio Code
 .vscode/
 
-# hs_connectors build version files
+# hs_connectors build files
 hs_connectors/src/hs_connectors/version.txt
 hs_connectors/src/hs_connectors/version.py
+hs_connectors/build/
+hs_connectors/develop-eggs/
+hs_connectors/dist/
+hs_connectors/downloads/
+hs_connectors/eggs/
+hs_connectors/.eggs/
+hs_connectors/sdist/
+hs_connectors/wheels/
+share/python-wheels/
+hs_connectors/*.egg-info/
+hs_connectors/.installed.cfg
+hs_connectors/*.egg
+hs_connectors/MANIFEST
+hs_connectors/*.manifest
+hs_connectors/*.spec
+hs_connectors/pip-log.txt
+hs_connectors/pip-delete-this-directory.txt

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,7 @@ cython_debug/
 
 # Visual Studio Code
 .vscode/
+
+# hs_connectors build version files
+hs_connectors/src/hs_connectors/version.txt
+hs_connectors/src/hs_connectors/version.py

--- a/hs_connectors/Makefile
+++ b/hs_connectors/Makefile
@@ -3,4 +3,4 @@ CHECKDIRS := src setup.py
 # clean package
 clean:
 	rm -fr dist src/*.egg-info;
-	find $(CHECKDIRS) | grep -E "(__pycache__|\.pyc|\.pyo|version\.*)" | xargs rm -fr;
+	find $(CHECKDIRS) | grep -E "(__pycache__|\.pyc|\.pyo|version\.py|version\.txt)" | xargs rm -fr;

--- a/hs_connectors/Makefile
+++ b/hs_connectors/Makefile
@@ -1,0 +1,6 @@
+CHECKDIRS := src setup.py
+
+# clean package
+clean:
+	rm -fr dist src/*.egg-info;
+	find $(CHECKDIRS) | grep -E "(__pycache__|\.pyc|\.pyo|version\.*)" | xargs rm -fr;

--- a/hs_connectors/pyproject.toml
+++ b/hs_connectors/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 82.0.1"]
+requires = ["setuptools >= 82.0.1", "setuptools-git-versioning>=2.0,<3", "packaging"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
@@ -9,7 +9,7 @@ include = ["*"]
 [project]
 name = "hs-connectors"
 description = "Pluggable backends for transferring hidden states between vLLM and Speculators during online and offline training."
-version = "0.1.0"
+dynamic = ["version"]
 requires-python = ">=3.10"
 keywords = [
     "hidden states",

--- a/hs_connectors/pyproject.toml
+++ b/hs_connectors/pyproject.toml
@@ -25,6 +25,7 @@ keywords = [
     "mooncake",
     "distributed training"
 ]
+authors = [ { name = "Red Hat"} ]
 dependencies = [
     "safetensors",
     "torch",

--- a/hs_connectors/pyproject.toml
+++ b/hs_connectors/pyproject.toml
@@ -10,6 +10,7 @@ include = ["*"]
 name = "hs-connectors"
 description = "Pluggable backends for transferring hidden states between vLLM and Speculators during online and offline training."
 dynamic = ["version"]
+readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
 keywords = [
     "hidden states",
@@ -25,6 +26,8 @@ keywords = [
     "mooncake",
     "distributed training"
 ]
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 authors = [ { name = "Red Hat"} ]
 dependencies = [
     "safetensors",

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -31,10 +31,10 @@ def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
     version, tag, commits_since_last = get_last_version_diff()
 
     print("HERE in NEXT")
-    version=print(f"version={version}")
-    tag=print(f"tag={tag}")
-    commits_since_last=print(f"commits_since_last={commits_since_last}")
-    build_type=print(f"build_type={build_type}")
+    print(f"version={version}")
+    print(f"tag={tag}")
+    print(f"commits_since_last={commits_since_last}")
+    print(f"build_type={build_type}")
 
     if build_type == "release":
         if not tag:
@@ -58,9 +58,9 @@ def write_version_files() -> tuple[Path, Path]:
     version, tag, build_iteration = get_next_version(build_type)
 
     print("HERE after NEXT")
-    version=print(f"{version}")
-    tag=print(f"{tag}")
-    build_iteration=print(f"build_iteration={build_iteration}")
+    print(f"{version}")
+    print(f"{tag}")
+    print(f"build_iteration={build_iteration}")
 
     module_path = Path(__file__).parent / "src" / "hs_connectors"
     version_txt_path = module_path / "version.txt"

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -24,23 +24,11 @@ def get_last_version_diff() -> tuple[Version, str | None, int]:
     commits_since_last = (
         count_since(f"{last_tag}^{{commit}}", root=REPO_ROOT) if last_tag else 0
     )
-    print("IN LAST")
-    print(f"tagged_versions={tagged_versions}")
-    print(f"last_version={last_version}")
-    print(f"last_tag={last_tag}")
-    print(f"commits_since_last={commits_since_last}")
     return last_version, last_tag, commits_since_last
 
 
 def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
     version, tag, commits_since_last = get_last_version_diff()
-
-    print("HERE in NEXT")
-    print(f"REPO_ROOT={REPO_ROOT}")
-    print(f"version={version}")
-    print(f"tag={tag}")
-    print(f"commits_since_last={commits_since_last}")
-    print(f"build_type={build_type}")
 
     if build_type == "release":
         if not tag:
@@ -59,34 +47,39 @@ def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
     raise ValueError(f"Unsupported HS_CONNECTORS_BUILD_TYPE={build_type!r}")
 
 
-def read_existing_version(module_path: Path) -> Version | None:
-    version_py = module_path / "version.py"
+def read_existing_version(version_py: Path) -> tuple[Version, str | None, int]:
     if version_py.exists():
-        match = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', version_py.read_text(), re.M)
-        if match:
-            return Version(match.group(1))
-    return None
+        match_version = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', version_py.read_text(), re.M)
+        match_tag = re.search(r'^git_last_tag\s*=\s*["\']([^"\']+)["\']', version_py.read_text(), re.M)
+        match_iteration = re.search(r'^build_iteration\s*=\s*["\']([^"\']+)["\']', version_py.read_text(), re.M)
+        if match_version:
+            return Version(match_version.group(1)), match_tag.group(1), int(match_iteration.group(1))
+    return None, None, 0
+
+
+def git_available(root: Path) -> bool:
+    makefile_path = root / "hs_connections" / "Makefile"
+    if makefile_path.exists():
+        return True
+    else:
+        return False
 
 
 def write_version_files() -> tuple[Path, Path]:
     build_type = os.getenv("HS_CONNECTORS_BUILD_TYPE", "nightly").lower()
     module_path = Path(__file__).parent / "src" / "hs_connectors"
 
-    existing_version = read_existing_version(module_path)
-    print(f"EXISTING VERSION={existing_version}")
-    if existing_version is not None:
-        version, tag, build_iteration = existing_version, None, 0
+    version_py = module_path / "version.py"
+    if (not git_available(REPO_ROOT)) and version_py.exists():
+        version, tag, build_iteration = read_existing_version(version_py)
     else:
         version, tag, build_iteration = get_next_version(build_type)
 
-    print("IN WRITE")
-    print(f"build_type={build_type}")
-    print(f"{version}")
-    print(f"{tag}")
-    print(f"build_iteration={build_iteration}")
-
     version_txt_path = module_path / "version.txt"
     version_py_path = module_path / "version.py"
+
+    git_commit = get_sha(root=REPO_ROOT) if git_available(REPO_ROOT) else ""
+    git_branch = get_branch(root=REPO_ROOT) if git_available(REPO_ROOT) else ""
 
     with version_txt_path.open("w") as f:
         f.write(str(version))
@@ -95,8 +88,8 @@ def write_version_files() -> tuple[Path, Path]:
             f'version = "{version}"\n',
             f'build_type = "{build_type}"\n',
             f'build_iteration = "{build_iteration}"\n',
-            f'git_commit = "{get_sha(root=REPO_ROOT)}"\n',
-            f'git_branch = "{get_branch(root=REPO_ROOT)}"\n',
+            f'git_commit = "{git_commit}"\n',
+            f'git_branch = "{git_branch}"\n',
             f'git_last_tag = "{tag or ""}"\n',
         ])
     return version_txt_path, version_py_path

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 from setuptools_git_versioning import count_since, get_branch, get_sha, get_tags
 
 REPO_ROOT = Path(__file__).parent.parent
-LAST_RELEASE_VERSION = Version("0.0.1")
+INITIAL_RELEASE_VERSION = Version("0.0.1")
 TAG_VERSION_PATTERN = re.compile(r"^hsc-v(\d+\.\d+\.\d+)$")
 
 
@@ -19,7 +19,7 @@ def get_last_version_diff() -> tuple[Version, str | None, int]:
     ]
     tagged_versions.sort(key=lambda tv: tv[0])
     last_version, last_tag = (
-        tagged_versions[-1] if tagged_versions else (LAST_RELEASE_VERSION, None)
+        tagged_versions[-1] if tagged_versions else (INITIAL_RELEASE_VERSION, None)
     )
     commits_since_last = (
         count_since(f"{last_tag}^{{commit}}", root=REPO_ROOT) if last_tag else 0
@@ -42,7 +42,7 @@ def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
 
     if build_type == "nightly":
         # e.g. hs_connectors/0.1.0 + 3 commits -> 0.1.0a3; on tag -> 0.1.0a0
-        return Version(f"{version}.a{commits_since_last}"), tag, commits_since_last
+        return Version(f"{version + 1}.a{commits_since_last}"), tag, commits_since_last
 
     raise ValueError(f"Unsupported HS_CONNECTORS_BUILD_TYPE={build_type!r}")
 

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -8,7 +8,7 @@ from setuptools_git_versioning import count_since, get_branch, get_sha, get_tags
 
 REPO_ROOT = Path(__file__).parent.parent
 LAST_RELEASE_VERSION = Version("0.0.1")
-TAG_VERSION_PATTERN = re.compile(r"^hs_connectors/(\d+\.\d+\.\d+)$")
+TAG_VERSION_PATTERN = re.compile(r"^hsc-v(\d+\.\d+\.\d+)$")
 
 
 def get_last_version_diff() -> tuple[Version, str | None, int]:
@@ -30,9 +30,15 @@ def get_last_version_diff() -> tuple[Version, str | None, int]:
 def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
     version, tag, commits_since_last = get_last_version_diff()
 
+    print("HERE in NEXT")
+    version=print(f"{version}")
+    tag=print(f"{tag}")
+    commits_since_last=print(f"{commits_since_last}")
+    build_type=print(f"build_type={build_type}")
+
     if build_type == "release":
         if not tag:
-            raise ValueError("RELEASE build requires an hs_connectors/X.Y.Z tag")
+            raise ValueError("RELEASE build requires an hsc-vX.Y.Z tag")
         if commits_since_last:
             raise ValueError(
                 f"RELEASE build must be on tag {tag}; "
@@ -50,6 +56,11 @@ def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
 def write_version_files() -> tuple[Path, Path]:
     build_type = os.getenv("HS_CONNECTORS_BUILD_TYPE", "nightly").lower()
     version, tag, build_iteration = get_next_version(build_type)
+
+    print("HERE after NEXT")
+    version=print(f"{version}")
+    tag=print(f"{tag}")
+    build_iteration=print(f"build_iteration={build_iteration}")
 
     module_path = Path(__file__).parent / "src" / "hs_connectors"
     version_txt_path = module_path / "version.txt"

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -49,28 +49,27 @@ def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
 
 def read_existing_version(version_py: Path) -> tuple[Version, str | None, int]:
     if version_py.exists():
-        match_version = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', version_py.read_text(), re.M)
-        match_tag = re.search(r'^git_last_tag\s*=\s*["\']([^"\']+)["\']', version_py.read_text(), re.M)
-        match_iteration = re.search(r'^build_iteration\s*=\s*["\']([^"\']+)["\']', version_py.read_text(), re.M)
-        if match_version:
-            return Version(match_version.group(1)), match_tag.group(1), int(match_iteration.group(1))
-    return None, None, 0
+        text = version_py.read_text()
+        match_version = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', text, re.M)
+        match_tag = re.search(r'^git_last_tag\s*=\s*["\']([^"\']*)["\']', text, re.M)
+        match_iteration = re.search(r'^build_iteration\s*=\s*["\']([^"\']+)["\']', text, re.M)
+        version = Version(match_version.group(1)) if match_version else None
+        tag = match_tag.group(1) if match_tag and match_tag.group(1) else None
+        build_iteration = int(match_iteration.group(1)) if match_iteration else 0
+    return version, tag, build_iteration
 
 
-def git_available(root: Path) -> bool:
-    makefile_path = root / "hs_connections" / "Makefile"
-    if makefile_path.exists():
-        return True
-    else:
-        return False
+def building_from_sdist() -> bool:
+    # sdist extracts as hs_connectors-<version>/setup.py
+    return Path(__file__).parent.name.startswith("hs_connectors-")
 
 
 def write_version_files() -> tuple[Path, Path]:
     build_type = os.getenv("HS_CONNECTORS_BUILD_TYPE", "nightly").lower()
     module_path = Path(__file__).parent / "src" / "hs_connectors"
-
     version_py = module_path / "version.py"
-    if (not git_available(REPO_ROOT)) and version_py.exists():
+
+    if building_from_sdist() and version_py.exists():
         version, tag, build_iteration = read_existing_version(version_py)
     else:
         version, tag, build_iteration = get_next_version(build_type)
@@ -78,8 +77,8 @@ def write_version_files() -> tuple[Path, Path]:
     version_txt_path = module_path / "version.txt"
     version_py_path = module_path / "version.py"
 
-    git_commit = get_sha(root=REPO_ROOT) if git_available(REPO_ROOT) else ""
-    git_branch = get_branch(root=REPO_ROOT) if git_available(REPO_ROOT) else ""
+    git_commit = get_sha(root=REPO_ROOT) if (not building_from_sdist()) else ""
+    git_branch = get_branch(root=REPO_ROOT) if (not building_from_sdist()) else ""
 
     with version_txt_path.open("w") as f:
         f.write(str(version))

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -24,6 +24,11 @@ def get_last_version_diff() -> tuple[Version, str | None, int]:
     commits_since_last = (
         count_since(f"{last_tag}^{{commit}}", root=REPO_ROOT) if last_tag else 0
     )
+    print("IN LAST")
+    print(f"tagged_versions={tagged_versions}")
+    print(f"last_version={last_version}")
+    print(f"last_tag={last_tag}")
+    print(f"commits_since_last={commits_since_last}")
     return last_version, last_tag, commits_since_last
 
 
@@ -31,19 +36,20 @@ def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
     version, tag, commits_since_last = get_last_version_diff()
 
     print("HERE in NEXT")
+    print(f"REPO_ROOT={REPO_ROOT}")
     print(f"version={version}")
     print(f"tag={tag}")
     print(f"commits_since_last={commits_since_last}")
     print(f"build_type={build_type}")
 
     if build_type == "release":
-        if not tag:
-            raise ValueError("RELEASE build requires an hsc-vX.Y.Z tag")
-        if commits_since_last:
-            raise ValueError(
-                f"RELEASE build must be on tag {tag}; "
-                f"HEAD is {commits_since_last} commit(s) ahead"
-            )
+        #if not tag:
+        #    raise ValueError("RELEASE build requires an hsc-vX.Y.Z tag")
+        #if commits_since_last:
+        #    raise ValueError(
+        #        f"RELEASE build must be on tag {tag}; "
+        #        f"HEAD is {commits_since_last} commit(s) ahead"
+        #    )
         return version, tag, 0
 
     if build_type == "nightly":
@@ -57,7 +63,8 @@ def write_version_files() -> tuple[Path, Path]:
     build_type = os.getenv("HS_CONNECTORS_BUILD_TYPE", "nightly").lower()
     version, tag, build_iteration = get_next_version(build_type)
 
-    print("HERE after NEXT")
+    print("IN WRITE")
+    print(f"build_type={build_type}")
     print(f"{version}")
     print(f"{tag}")
     print(f"build_iteration={build_iteration}")

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -71,6 +71,7 @@ def write_version_files() -> tuple[Path, Path]:
     module_path = Path(__file__).parent / "src" / "hs_connectors"
 
     existing_version = read_existing_version(module_path)
+    print(f"EXISTING VERSION={existing_version}")
     if existing_version is not None:
         version, tag, build_iteration = existing_version, None, 0
     else:

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -67,15 +67,13 @@ def building_from_sdist() -> bool:
 def write_version_files() -> tuple[Path, Path]:
     build_type = os.getenv("HS_CONNECTORS_BUILD_TYPE", "nightly").lower()
     module_path = Path(__file__).parent / "src" / "hs_connectors"
-    version_py = module_path / "version.py"
-
-    if building_from_sdist() and version_py.exists():
-        version, tag, build_iteration = read_existing_version(version_py)
-    else:
-        version, tag, build_iteration = get_next_version(build_type)
-
     version_txt_path = module_path / "version.txt"
     version_py_path = module_path / "version.py"
+
+    if building_from_sdist() and version_py.exists():
+        version, tag, build_iteration = read_existing_version(version_py_path)
+    else:
+        version, tag, build_iteration = get_next_version(build_type)
 
     git_commit = get_sha(root=REPO_ROOT) if (not building_from_sdist()) else ""
     git_branch = get_branch(root=REPO_ROOT) if (not building_from_sdist()) else ""

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -70,7 +70,7 @@ def write_version_files() -> tuple[Path, Path]:
     version_txt_path = module_path / "version.txt"
     version_py_path = module_path / "version.py"
 
-    if building_from_sdist() and version_py.exists():
+    if building_from_sdist() and version_py_path.exists():
         version, tag, build_iteration = read_existing_version(version_py_path)
     else:
         version, tag, build_iteration = get_next_version(build_type)

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -41,8 +41,8 @@ def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
         return version, tag, 0
 
     if build_type == "nightly":
-        # e.g. hs_connectors/0.1.0 + 3 commits -> 0.1.0a3; on tag -> 0.1.0a0
-        return Version(f"{version + 1}.a{commits_since_last}"), tag, commits_since_last
+        # nightly version will be patch+1 from last release tag: e.g. tag hsc-v0.1.0 + 3 commits -> 0.1.1a3
+        return Version(f"{version.major}.{version.minor}.{version.micro + 1}.a{commits_since_last}"), tag, commits_since_last
 
     raise ValueError(f"Unsupported HS_CONNECTORS_BUILD_TYPE={build_type!r}")
 

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -31,9 +31,9 @@ def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
     version, tag, commits_since_last = get_last_version_diff()
 
     print("HERE in NEXT")
-    version=print(f"{version}")
-    tag=print(f"{tag}")
-    commits_since_last=print(f"{commits_since_last}")
+    version=print(f"version={version}")
+    tag=print(f"tag={tag}")
+    commits_since_last=print(f"commits_since_last={commits_since_last}")
     build_type=print(f"build_type={build_type}")
 
     if build_type == "release":

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -60,9 +60,11 @@ def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
 
 
 def read_existing_version(module_path: Path) -> Version | None:
-    version_txt = module_path / "version.txt"
-    if version_txt.exists():
-        return Version(version_txt.read_text().strip())
+    version_py = module_path / "version.py"
+    if version_py.exists():
+        match = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', version_py.read_text(), re.M)
+        if match:
+            return Version(match.group(1))
     return None
 
 

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -43,13 +43,13 @@ def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
     print(f"build_type={build_type}")
 
     if build_type == "release":
-        #if not tag:
-        #    raise ValueError("RELEASE build requires an hsc-vX.Y.Z tag")
-        #if commits_since_last:
-        #    raise ValueError(
-        #        f"RELEASE build must be on tag {tag}; "
-        #        f"HEAD is {commits_since_last} commit(s) ahead"
-        #    )
+        if not tag:
+            raise ValueError("RELEASE build requires an hsc-vX.Y.Z tag")
+        if commits_since_last:
+            raise ValueError(
+                f"RELEASE build must be on tag {tag}; "
+                f"HEAD is {commits_since_last} commit(s) ahead"
+            )
         return version, tag, 0
 
     if build_type == "nightly":
@@ -59,9 +59,22 @@ def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
     raise ValueError(f"Unsupported HS_CONNECTORS_BUILD_TYPE={build_type!r}")
 
 
+def read_existing_version(module_path: Path) -> Version | None:
+    version_txt = module_path / "version.txt"
+    if version_txt.exists():
+        return Version(version_txt.read_text().strip())
+    return None
+
+
 def write_version_files() -> tuple[Path, Path]:
     build_type = os.getenv("HS_CONNECTORS_BUILD_TYPE", "nightly").lower()
-    version, tag, build_iteration = get_next_version(build_type)
+    module_path = Path(__file__).parent / "src" / "hs_connectors"
+
+    existing_version = read_existing_version(module_path)
+    if existing_version is not None:
+        version, tag, build_iteration = existing_version, None, 0
+    else:
+        version, tag, build_iteration = get_next_version(build_type)
 
     print("IN WRITE")
     print(f"build_type={build_type}")
@@ -69,7 +82,6 @@ def write_version_files() -> tuple[Path, Path]:
     print(f"{tag}")
     print(f"build_iteration={build_iteration}")
 
-    module_path = Path(__file__).parent / "src" / "hs_connectors"
     version_txt_path = module_path / "version.txt"
     version_py_path = module_path / "version.py"
 

--- a/hs_connectors/setup.py
+++ b/hs_connectors/setup.py
@@ -1,0 +1,77 @@
+import os
+import re
+from pathlib import Path
+
+from packaging.version import Version
+from setuptools import setup
+from setuptools_git_versioning import count_since, get_branch, get_sha, get_tags
+
+REPO_ROOT = Path(__file__).parent.parent
+LAST_RELEASE_VERSION = Version("0.0.1")
+TAG_VERSION_PATTERN = re.compile(r"^hs_connectors/(\d+\.\d+\.\d+)$")
+
+
+def get_last_version_diff() -> tuple[Version, str | None, int]:
+    tagged_versions = [
+        (Version(match.group(1)), tag)
+        for tag in get_tags(root=REPO_ROOT)
+        if (match := TAG_VERSION_PATTERN.match(tag))
+    ]
+    tagged_versions.sort(key=lambda tv: tv[0])
+    last_version, last_tag = (
+        tagged_versions[-1] if tagged_versions else (LAST_RELEASE_VERSION, None)
+    )
+    commits_since_last = (
+        count_since(f"{last_tag}^{{commit}}", root=REPO_ROOT) if last_tag else 0
+    )
+    return last_version, last_tag, commits_since_last
+
+
+def get_next_version(build_type: str) -> tuple[Version, str | None, int]:
+    version, tag, commits_since_last = get_last_version_diff()
+
+    if build_type == "release":
+        if not tag:
+            raise ValueError("RELEASE build requires an hs_connectors/X.Y.Z tag")
+        if commits_since_last:
+            raise ValueError(
+                f"RELEASE build must be on tag {tag}; "
+                f"HEAD is {commits_since_last} commit(s) ahead"
+            )
+        return version, tag, 0
+
+    if build_type == "nightly":
+        # e.g. hs_connectors/0.1.0 + 3 commits -> 0.1.0a3; on tag -> 0.1.0a0
+        return Version(f"{version}.a{commits_since_last}"), tag, commits_since_last
+
+    raise ValueError(f"Unsupported HS_CONNECTORS_BUILD_TYPE={build_type!r}")
+
+
+def write_version_files() -> tuple[Path, Path]:
+    build_type = os.getenv("HS_CONNECTORS_BUILD_TYPE", "nightly").lower()
+    version, tag, build_iteration = get_next_version(build_type)
+
+    module_path = Path(__file__).parent / "src" / "hs_connectors"
+    version_txt_path = module_path / "version.txt"
+    version_py_path = module_path / "version.py"
+
+    with version_txt_path.open("w") as f:
+        f.write(str(version))
+    with version_py_path.open("w") as f:
+        f.writelines([
+            f'version = "{version}"\n',
+            f'build_type = "{build_type}"\n',
+            f'build_iteration = "{build_iteration}"\n',
+            f'git_commit = "{get_sha(root=REPO_ROOT)}"\n',
+            f'git_branch = "{get_branch(root=REPO_ROOT)}"\n',
+            f'git_last_tag = "{tag or ""}"\n',
+        ])
+    return version_txt_path, version_py_path
+
+
+setup(
+    setuptools_git_versioning={
+        "enabled": True,
+        "version_file": str(write_version_files()[0]),
+    }
+)

--- a/hs_connectors/src/hs_connectors/__init__.py
+++ b/hs_connectors/src/hs_connectors/__init__.py
@@ -15,3 +15,8 @@ __all__ = [
     "MooncakeBackend",
     "MooncakeTransfer",
 ]
+
+try:
+    from hs_connectors.version import version as __version__
+except ImportError:
+    __version__ = "unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools >= 82.0.1", "setuptools-git-versioning>=2.0,<3"]
+requires = [
+    "setuptools >= 82.0.1",
+    "setuptools-git-versioning>=2.0,<3",
+    "tomli>=2.0; python_version < '3.11'",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.uv.workspace]
@@ -41,7 +45,36 @@ keywords = [
     "decoding algorithms",
     "inference server"
 ]
-# NOTE: REQUIREDE DEPENDENCIES ARE IN setup.py
+
+# Base (non-hs-connectors) dependencies live in [tool.speculators.dependencies]
+# below rather than here, since `hs-connectors` itself must be resolved at build
+# time (see get_hs_connectors_requirement() in setup.py) based on build type
+# (dev/nightly/release), which requires the whole `dependencies` field to be
+# dynamic per PEP 621. setup.py reads the base list back out of this file and
+# appends the computed hs-connectors requirement before calling setup().
+
+[tool.speculators.dependencies]
+base = [
+    "click",
+    "datasets>=4.0.0,<=5.0.1",
+    "httpx",
+    "huggingface-hub",
+    "loguru>=0.7.2,<=0.7.3",
+    "numpy>=2.0.0,<=2.4.6",
+    "openai>=2.0.0",
+    "protobuf",
+    "psutil",
+    "pydantic>=2.0.0",
+    "pydantic-settings>=2.0.0",
+    "rich",
+    "safetensors",
+    "torch>=2.9.0,<=2.13.0",
+    "torchaudio",
+    "torchvision",
+    "tqdm>=4.66.3,<=4.70.0",
+    "transformers>=4.56.1,<5.15.0",
+    "typer>=0.12.0",
+]
 
 [project.optional-dependencies]
 mooncake-cuda = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ include = ["*"]
 # ************************************************
 
 [project]
-dynamic = ["version"]
+dynamic = ["version", "dependencies"]
 name = "speculators"
 description = "A unified library for creating, representing, and storing speculative decoding algorithms for LLM serving such as in vLLM."
 readme = { file = "README.md", content-type = "text/markdown" }
@@ -44,7 +44,6 @@ keywords = [
 dependencies = [
     "click",
     "datasets>=4.0.0,<=5.0.1",
-    "hs-connectors",
     "httpx",
     "huggingface-hub",
     "loguru>=0.7.2,<=0.7.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ include = ["*"]
 # ************************************************
 
 [project]
-dynamic = ["version"]
+dynamic = ["version", "dependencies"]
 name = "speculators"
 description = "A unified library for creating, representing, and storing speculative decoding algorithms for LLM serving such as in vLLM."
 readme = { file = "README.md", content-type = "text/markdown" }
@@ -41,27 +41,7 @@ keywords = [
     "decoding algorithms",
     "inference server"
 ]
-dependencies = [
-    "click",
-    "datasets>=4.0.0,<=5.0.1",
-    "httpx",
-    "huggingface-hub",
-    "loguru>=0.7.2,<=0.7.3",
-    "numpy>=2.0.0,<=2.4.6",
-    "openai>=2.0.0",
-    "protobuf",
-    "psutil",
-    "pydantic>=2.0.0",
-    "pydantic-settings>=2.0.0",
-    "rich",
-    "safetensors",
-    "torch>=2.9.0,<=2.13.0",
-    "torchaudio",
-    "torchvision",
-    "tqdm>=4.66.3,<=4.70.0",
-    "transformers>=4.56.1,<5.16.0",
-    "typer>=0.12.0",
-]
+# NOTE: REQUIREDE DEPENDENCIES ARE IN setup.py
 
 [project.optional-dependencies]
 mooncake-cuda = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ include = ["*"]
 # ************************************************
 
 [project]
-dynamic = ["version", "dependencies"]
+dynamic = ["version"]
 name = "speculators"
 description = "A unified library for creating, representing, and storing speculative decoding algorithms for LLM serving such as in vLLM."
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/setup.py
+++ b/setup.py
@@ -141,8 +141,8 @@ def write_version_files() -> tuple[Path, Path]:
                 f'version = "{version}"\n',
                 f'build_type = "{build_type}"\n',
                 f'build_iteration = "{build_iteration}"\n',
-                f'git_commit = "{get_commit}"\n',
-                f'git_branch = "{get_branch}"\n',
+                f'git_commit = "{git_commit}"\n',
+                f'git_branch = "{git_branch}"\n',
                 f'git_last_tag = "{tag or ""}"\n',
             ]
         )

--- a/setup.py
+++ b/setup.py
@@ -145,10 +145,15 @@ def write_version_files() -> tuple[Path, Path]:
 
 def get_hs_connectors_requirement() -> str:
     build_type = os.getenv("SPECULATORS_BUILD_TYPE", "dev").lower()
-    version, tag, build_iteration = get_next_version(
-        build_type=build_type,
-        build_iteration=os.getenv("SPECULATORS_BUILD_ITERATION"),
-    )
+    version_py_path = REPO_ROOT / "src" / "speculators" / "version.py"
+
+    if building_from_sdist() and version_py_path.exists():
+        version, tag, build_iteration = read_existing_version(version_py_path)
+    else:
+        version, tag, build_iteration = get_next_version(
+            build_type=build_type,
+            build_iteration=os.getenv("SPECULATORS_BUILD_ITERATION"),
+        )
 
     if build_type == "dev":
         # Source install: path dep for pip; uv workspace overrides anyway

--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,7 @@ def get_hs_connectors_requirement() -> str:
         return f"hs-connectors=={version}"
     else:
         # Install nightly version
-        return f"hs-connectors>{LAST_RELEASE_VERSION},<{version}"
+        return f"hs-connectors>{LAST_RELEASE_VERSION},<={version}"
 
 
 BASE_DEPENDENCIES = [

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,30 @@ def write_version_files() -> tuple[Path, Path]:
     return version_txt_path, version_py_path
 
 
+def get_hs_connectors_requirement() -> str:
+    build_type = os.getenv("SPECULATORS_BUILD_TYPE", "dev").lower()
+    version, tag, build_iteration = get_next_version(
+        build_type=build_type,
+        build_iteration=os.getenv("SPECULATORS_BUILD_ITERATION"),
+    )
+
+    if build_type == "dev":
+        # Source install: path dep for pip; uv workspace overrides anyway
+        local = (Path(__file__).parent / "hs_connectors").resolve()
+        return f"hs-connectors @ file://{local.as_posix()}"
+    else if build_type == "release":
+        # Install release version: hs_connectors has the same release version as speculators
+        return f"hs-connectors=={version}"
+    else:
+        # Install nightly version
+        return f"hs-connectors>{LAST_RELEASE_VERSION},<{version}"
+
+
 setup(
+    install_requires=[
+        # set hs_connectors version to install
+        get_hs_connectors_requirement(),
+    ],
     setuptools_git_versioning={
         "enabled": True,
         "version_file": str(write_version_files()[0]),

--- a/setup.py
+++ b/setup.py
@@ -121,10 +121,14 @@ def write_version_files() -> tuple[Path, Path]:
     version_py_path = module_path / "version.py"
 
     print("IN write_version_files()")
+    print(f"REPO_ROOT={REPO_ROOT}")
+    print("building_from_sdist() returns: ")
+    building_from_sdist()
+    print("version_py_path.exists() returns: ")
+    version_py_path.exists()
     if building_from_sdist() and version_py_path.exists():
         version, tag, build_iteration = read_existing_version(version_py_path)
     else:
-        print(f"REPO_ROOT={REPO_ROOT}")
         version, tag, build_iteration = get_next_version(
             build_type=build_type,
             build_iteration=os.getenv("SPECULATORS_BUILD_ITERATION"),

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from packaging.version import Version
 from setuptools import setup
 from setuptools_git_versioning import count_since, get_branch, get_sha, get_tags
 
+REPO_ROOT = Path(__file__).parent
 LAST_RELEASE_VERSION = Version("0.7.0")
 TAG_VERSION_PATTERN = re.compile(r"^v(\d+\.\d+\.\d+)$")
 
@@ -20,7 +21,7 @@ def get_last_version_diff() -> tuple[Version, str | None, int | None]:
     """
     tagged_versions = [
         (Version(match.group(1)), tag)
-        for tag in get_tags(root=Path(__file__).parent)
+        for tag in get_tags(root=REPO_ROOT)
         if (match := TAG_VERSION_PATTERN.match(tag))
     ]
     tagged_versions.sort(key=lambda tv: tv[0])
@@ -28,7 +29,7 @@ def get_last_version_diff() -> tuple[Version, str | None, int | None]:
         tagged_versions[-1] if tagged_versions else (LAST_RELEASE_VERSION, None)
     )
     commits_since_last = (
-        count_since(last_tag + "^{commit}", root=Path(__file__).parent)
+        count_since(last_tag + "^{commit}", root=REPO_ROOT)
         if last_tag
         else None
     )
@@ -61,18 +62,19 @@ def get_next_version(
         build_iteration = int(build_iteration)
 
     if build_type == "release":
+        if not tag:
+            raise ValueError("RELEASE build requires a vX.Y.Z tag")
         if commits_since_last:
-            # add post since we have commits since last tag
-            version = Version(f"{version.base_version}.post{build_iteration}")
-        return version, tag, build_iteration
+            raise ValueError(
+                f"RELEASE build must be on tag {tag}; "
+                f"HEAD is {commits_since_last} commit(s) ahead"
+            )
+        return version, tag, 0
 
-    # not in release pathway, so need to increment to target next release version
+    # not in release pathway, so need to increment minor to target next release version
     version = Version(f"{version.major}.{version.minor + 1}.0")
 
-    if build_type == "candidate":
-        # add 'rc' since we are in candidate pathway
-        version = Version(f"{version}.rc{build_iteration}")
-    elif build_type in ["nightly", "alpha"]:
+    if build_type in ["nightly", "alpha"]:
         # add 'a' since we are in nightly or alpha pathway
         version = Version(f"{version}.a{build_iteration}")
     else:
@@ -80,6 +82,23 @@ def get_next_version(
         version = Version(f"{version}.dev{build_iteration}")
 
     return version, tag, build_iteration
+
+
+def read_existing_version(version_py: Path) -> tuple[Version, str | None, int]:
+    if version_py.exists():
+        text = version_py.read_text()
+        match_version = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', text, re.M)
+        match_tag = re.search(r'^git_last_tag\s*=\s*["\']([^"\']*)["\']', text, re.M)
+        match_iteration = re.search(r'^build_iteration\s*=\s*["\']([^"\']+)["\']', text, re.M)
+        version = Version(match_version.group(1)) if match_version else None
+        tag = match_tag.group(1) if match_tag and match_tag.group(1) else None
+        build_iteration = int(match_iteration.group(1)) if match_iteration else 0
+    return version, tag, build_iteration
+
+
+def building_from_sdist() -> bool:
+    # sdist extracts as speculators-<version>/setup.py
+    return REPO_ROOT.name.startswith("speculators-")
 
 
 def write_version_files() -> tuple[Path, Path]:
@@ -91,13 +110,20 @@ def write_version_files() -> tuple[Path, Path]:
     :returns: A tuple containing the paths to the version.txt and version.py files.
     """
     build_type = os.getenv("SPECULATORS_BUILD_TYPE", "dev").lower()
-    version, tag, build_iteration = get_next_version(
-        build_type=build_type,
-        build_iteration=os.getenv("SPECULATORS_BUILD_ITERATION"),
-    )
-    module_path = Path(__file__).parent / "src" / "speculators"
+    module_path = REPO_ROOT / "src" / "speculators"
     version_txt_path = module_path / "version.txt"
     version_py_path = module_path / "version.py"
+
+    if building_from_sdist() and version_py_path.exists():
+        version, tag, build_iteration = read_existing_version(version_py_path)
+    else:
+        version, tag, build_iteration = get_next_version(
+            build_type=build_type,
+            build_iteration=os.getenv("SPECULATORS_BUILD_ITERATION"),
+        )
+
+    print("IN write_version_files()")
+    print(f"version, tag, build_iteration={version},{tag},{build_iteration}")
 
     with version_txt_path.open("w") as file:
         file.write(str(version))
@@ -126,7 +152,7 @@ def get_hs_connectors_requirement() -> str:
 
     if build_type == "dev":
         # Source install: path dep for pip; uv workspace overrides anyway
-        local = (Path(__file__).parent / "hs_connectors").resolve()
+        local = (REPO_ROOT / "hs_connectors").resolve()
         return f"hs-connectors @ file://{local.as_posix()}"
     elif build_type == "release":
         # Install release version: hs_connectors has the same release version as speculators

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ def get_hs_connectors_requirement() -> str:
         # Source install: path dep for pip; uv workspace overrides anyway
         local = (Path(__file__).parent / "hs_connectors").resolve()
         return f"hs-connectors @ file://{local.as_posix()}"
-    else if: build_type == "release":
+    elif build_type == "release":
         # Install release version: hs_connectors has the same release version as speculators
         return f"hs-connectors=={version}"
     else:

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ def get_next_version(
     elif isinstance(build_iteration, str):
         build_iteration = int(build_iteration)
 
+    # in case tag is behind LAST_RELEASE_VERSION
     if version < LAST_RELEASE_VERSION:
         version = LAST_RELEASE_VERSION
 
@@ -120,13 +121,6 @@ def write_version_files() -> tuple[Path, Path]:
     version_txt_path = module_path / "version.txt"
     version_py_path = module_path / "version.py"
 
-    print("IN write_version_files()")
-    print(f"REPO_ROOT={REPO_ROOT}")
-    print("building_from_sdist() returns: ")
-    print(building_from_sdist())
-    print("version_py_path.exists() returns: ")
-    print(version_py_path.exists())
-
     if building_from_sdist() and version_py_path.exists():
         version, tag, build_iteration = read_existing_version(version_py_path)
     else:
@@ -135,7 +129,8 @@ def write_version_files() -> tuple[Path, Path]:
             build_iteration=os.getenv("SPECULATORS_BUILD_ITERATION"),
         )
 
-    print(f"version, tag, build_iteration={version},{tag},{build_iteration}")
+    git_commit = get_sha(root=REPO_ROOT) if (not building_from_sdist()) else ""
+    git_branch = get_branch(root=REPO_ROOT) if (not building_from_sdist()) else ""
 
     with version_txt_path.open("w") as file:
         file.write(str(version))
@@ -159,13 +154,6 @@ def get_hs_connectors_requirement() -> str:
     build_type = os.getenv("SPECULATORS_BUILD_TYPE", "dev").lower()
     version_py_path = REPO_ROOT / "src" / "speculators" / "version.py"
 
-    print("IN get_hs_connectors_requirement()")
-    print(f"REPO_ROOT={REPO_ROOT}")
-    print("building_from_sdist() returns: ")
-    print(building_from_sdist())
-    print("version_py_path.exists() returns: ")
-    print(version_py_path.exists())
-
     if building_from_sdist() and version_py_path.exists():
         version, tag, build_iteration = read_existing_version(version_py_path)
     else:
@@ -173,8 +161,6 @@ def get_hs_connectors_requirement() -> str:
             build_type=build_type,
             build_iteration=os.getenv("SPECULATORS_BUILD_ITERATION"),
         )
-
-    print(f"version, tag, build_iteration={version},{tag},{build_iteration}")
 
     if build_type == "dev":
         # Source install: path dep for pip; uv workspace overrides anyway

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ def get_hs_connectors_requirement() -> str:
         # Source install: path dep for pip; uv workspace overrides anyway
         local = (Path(__file__).parent / "hs_connectors").resolve()
         return f"hs-connectors @ file://{local.as_posix()}"
-    else if build_type == "release":
+    else if: build_type == "release":
         # Install release version: hs_connectors has the same release version as speculators
         return f"hs-connectors=={version}"
     else:

--- a/setup.py
+++ b/setup.py
@@ -123,9 +123,10 @@ def write_version_files() -> tuple[Path, Path]:
     print("IN write_version_files()")
     print(f"REPO_ROOT={REPO_ROOT}")
     print("building_from_sdist() returns: ")
-    building_from_sdist()
+    print(building_from_sdist())
     print("version_py_path.exists() returns: ")
-    version_py_path.exists()
+    print(version_py_path.exists())
+
     if building_from_sdist() and version_py_path.exists():
         version, tag, build_iteration = read_existing_version(version_py_path)
     else:
@@ -160,6 +161,10 @@ def get_hs_connectors_requirement() -> str:
 
     print("IN get_hs_connectors_requirement()")
     print(f"REPO_ROOT={REPO_ROOT}")
+    print("building_from_sdist() returns: ")
+    print(building_from_sdist())
+    print("version_py_path.exists() returns: ")
+    print(version_py_path.exists())
 
     if building_from_sdist() and version_py_path.exists():
         version, tag, build_iteration = read_existing_version(version_py_path)

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,9 @@ def get_next_version(
     elif isinstance(build_iteration, str):
         build_iteration = int(build_iteration)
 
+    if version < LAST_RELEASE_VERSION:
+        version = LAST_RELEASE_VERSION
+
     if build_type == "release":
         if not tag:
             raise ValueError("RELEASE build requires a vX.Y.Z tag")
@@ -87,12 +90,15 @@ def get_next_version(
 def read_existing_version(version_py: Path) -> tuple[Version, str | None, int]:
     if version_py.exists():
         text = version_py.read_text()
+
         match_version = re.search(r'^version\s*=\s*["\']([^"\']+)["\']', text, re.M)
         match_tag = re.search(r'^git_last_tag\s*=\s*["\']([^"\']*)["\']', text, re.M)
         match_iteration = re.search(r'^build_iteration\s*=\s*["\']([^"\']+)["\']', text, re.M)
+
         version = Version(match_version.group(1)) if match_version else None
         tag = match_tag.group(1) if match_tag and match_tag.group(1) else None
         build_iteration = int(match_iteration.group(1)) if match_iteration else 0
+
     return version, tag, build_iteration
 
 
@@ -114,15 +120,16 @@ def write_version_files() -> tuple[Path, Path]:
     version_txt_path = module_path / "version.txt"
     version_py_path = module_path / "version.py"
 
+    print("IN write_version_files()")
     if building_from_sdist() and version_py_path.exists():
         version, tag, build_iteration = read_existing_version(version_py_path)
     else:
+        print(f"REPO_ROOT={REPO_ROOT}")
         version, tag, build_iteration = get_next_version(
             build_type=build_type,
             build_iteration=os.getenv("SPECULATORS_BUILD_ITERATION"),
         )
 
-    print("IN write_version_files()")
     print(f"version, tag, build_iteration={version},{tag},{build_iteration}")
 
     with version_txt_path.open("w") as file:
@@ -147,6 +154,9 @@ def get_hs_connectors_requirement() -> str:
     build_type = os.getenv("SPECULATORS_BUILD_TYPE", "dev").lower()
     version_py_path = REPO_ROOT / "src" / "speculators" / "version.py"
 
+    print("IN get_hs_connectors_requirement()")
+    print(f"REPO_ROOT={REPO_ROOT}")
+
     if building_from_sdist() and version_py_path.exists():
         version, tag, build_iteration = read_existing_version(version_py_path)
     else:
@@ -154,6 +164,8 @@ def get_hs_connectors_requirement() -> str:
             build_type=build_type,
             build_iteration=os.getenv("SPECULATORS_BUILD_ITERATION"),
         )
+
+    print(f"version, tag, build_iteration={version},{tag},{build_iteration}")
 
     if build_type == "dev":
         # Source install: path dep for pip; uv workspace overrides anyway

--- a/setup.py
+++ b/setup.py
@@ -141,9 +141,9 @@ def write_version_files() -> tuple[Path, Path]:
                 f'version = "{version}"\n',
                 f'build_type = "{build_type}"\n',
                 f'build_iteration = "{build_iteration}"\n',
-                f'git_commit = "{get_sha()}"\n',
-                f'git_branch = "{get_branch()}"\n',
-                f'git_last_tag = "{tag}"\n',
+                f'git_commit = "{get_commit}"\n',
+                f'git_branch = "{get_branch}"\n',
+                f'git_last_tag = "{tag or ""}"\n',
             ]
         )
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,11 @@ import os
 import re
 from pathlib import Path
 
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
+
 from packaging.version import Version
 from setuptools import setup
 from setuptools_git_versioning import count_since, get_branch, get_sha, get_tags
@@ -173,32 +178,21 @@ def get_hs_connectors_requirement() -> str:
         return f"hs-connectors>{LAST_RELEASE_VERSION},<={version}"
 
 
-BASE_DEPENDENCIES = [
-    "click",
-    "datasets>=4.0.0,<=5.0.1",
-    "httpx",
-    "huggingface-hub",
-    "loguru>=0.7.2,<=0.7.3",
-    "numpy>=2.0.0,<=2.4.6",
-    "openai>=2.0.0",
-    "protobuf",
-    "psutil",
-    "pydantic>=2.0.0",
-    "pydantic-settings>=2.0.0",
-    "rich",
-    "safetensors",
-    "torch>=2.9.0,<=2.13.0",
-    "torchaudio",
-    "torchvision",
-    "tqdm>=4.66.3,<=4.70.0",
-    "transformers>=4.56.1,<5.15.0",
-    "typer>=0.12.0",
-]
+def get_base_dependencies() -> list[str]:
+    """
+    Read the static base dependency list from pyproject.toml's
+    [tool.speculators.dependencies].base table, so it stays hand-edited TOML
+    rather than a Python literal duplicated here.
+    """
+    with (REPO_ROOT / "pyproject.toml").open("rb") as file:
+        data = tomllib.load(file)
+
+    return data["tool"]["speculators"]["dependencies"]["base"]
 
 
 setup(
     # set hs_connectors version to install
-    install_requires=BASE_DEPENDENCIES + [get_hs_connectors_requirement()],
+    install_requires=get_base_dependencies() + [get_hs_connectors_requirement()],
     setuptools_git_versioning={
         "enabled": True,
         "version_file": str(write_version_files()[0]),

--- a/setup.py
+++ b/setup.py
@@ -136,11 +136,32 @@ def get_hs_connectors_requirement() -> str:
         return f"hs-connectors>{LAST_RELEASE_VERSION},<{version}"
 
 
+BASE_DEPENDENCIES = [
+    "click",
+    "datasets>=4.0.0,<=5.0.1",
+    "httpx",
+    "huggingface-hub",
+    "loguru>=0.7.2,<=0.7.3",
+    "numpy>=2.0.0,<=2.4.6",
+    "openai>=2.0.0",
+    "protobuf",
+    "psutil",
+    "pydantic>=2.0.0",
+    "pydantic-settings>=2.0.0",
+    "rich",
+    "safetensors",
+    "torch>=2.9.0,<=2.13.0",
+    "torchaudio",
+    "torchvision",
+    "tqdm>=4.66.3,<=4.70.0",
+    "transformers>=4.56.1,<5.15.0",
+    "typer>=0.12.0",
+]
+
+
 setup(
-    install_requires=[
-        # set hs_connectors version to install
-        get_hs_connectors_requirement(),
-    ],
+    # set hs_connectors version to install
+    install_requires=BASE_DEPENDENCIES + [get_hs_connectors_requirement()],
     setuptools_git_versioning={
         "enabled": True,
         "version_file": str(write_version_files()[0]),

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ def get_next_version(
     """
     Get the next version based on the build type and iteration.
     - build_type == release: take the last version and add a post if build iteration
-    - build_type == candidate: increment to next minor, add 'rc' with build iteration
     - build_type == nightly: increment to next minor, add 'a' with build iteration
     - build_type == alpha: increment to next minor, add 'a' with build iteration
     - build_type == dev: increment to next minor, add 'dev' with build iteration


### PR DESCRIPTION
dependencies still has to be dynamic (hs-connectors' constraint is resolved at build time based on SPECULATORS_BUILD_TYPE), but the static base dependency list no longer needs to live as a Python literal in setup.py. It's now a real TOML array under
[tool.speculators.dependencies].base in pyproject.toml, and setup.py just reads it back and appends the computed hs-connectors requirement.

<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

## Tests

## Checklist

I have filled in:

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [ ] I (a human) have written or reviewed the code in this pr to the best of my ability.
