### PR TITLE
fix(train): make cache cleanup accelerator-agnostic

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -712,8 +712,9 @@ def main(cfg: TrainConfig):  # noqa: C901
     # Cleanup
     del trainer, draft_model
     gc.collect()
-    if torch.cuda.is_available():
-        torch.cuda.empty_cache()
+    acc = torch.accelerator.current_accelerator(check_available=True)
+    if acc is not None:
+        torch.get_device_module(acc.type).empty_cache()
     maybe_destroy_distributed()
 
 


### PR DESCRIPTION
## Purpose

Replace the CUDA-specific post-training cache cleanup with a device-agnostic one: resolve the available accelerator and call `empty_cache()` on its device module. CUDA behavior is unchanged; CPU-only runs skip the call.

We intentionally avoid `torch.accelerator.memory.empty_cache()`: on Ascend with torch_npu 2.9/2.10 it raises an internal assert (`Allocator for npu is not a DeviceAllocator`), because the torch_npu allocator only subclasses `c10::DeviceAllocator` on master.

## Tests

- Ascend A3, torch 2.9.0 + torch_npu 2.9.0.post6: `torch.accelerator.memory.empty_cache()` asserts; `torch.get_device_module("npu").empty_cache()` works.
- H20, torch 2.9.0 and 2.11.0: both forms work.
- `ruff check` / `ruff format --check` / `mypy --python-version 3.12 --check-untyped-defs scripts/train.py`.

## Checklist

- [x] The purpose of the PR is described.
- [x] The test plan and results are provided.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this PR to the best of my ability.