### PR TITLE
fix: reject duplicate or negative target_layer_ids, fail clearly on tiny verifiers

### DIFF
--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -132,10 +132,16 @@ def main():
             num_hidden_layers - 3,
             num_hidden_layers,
         ]
-    if min(target_layer_ids) < 0 or len(set(target_layer_ids)) != len(target_layer_ids):
+    # Layer id ``num_hidden_layers`` (the final hidden state) is valid: the
+    # default above and --include-last-layer both emit it.
+    if (
+        min(target_layer_ids) < 0
+        or max(target_layer_ids) > num_hidden_layers
+        or len(set(target_layer_ids)) != len(target_layer_ids)
+    ):
         raise ValueError(
-            f"Invalid target layer ids {target_layer_ids}; "
-            "ids must be non-negative and distinct."
+            f"Invalid target layer ids {target_layer_ids}; ids must be "
+            f"distinct and within [0, {num_hidden_layers}]."
         )
 
     speculative_config = {

--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -132,6 +132,11 @@ def main():
             num_hidden_layers - 3,
             num_hidden_layers,
         ]
+    if min(target_layer_ids) < 0 or len(set(target_layer_ids)) != len(target_layer_ids):
+        raise ValueError(
+            f"Invalid target layer ids {target_layer_ids}; "
+            "ids must be non-negative and distinct."
+        )
 
     speculative_config = {
         "method": "extract_hidden_states",

--- a/src/speculators/models/utils.py
+++ b/src/speculators/models/utils.py
@@ -42,27 +42,42 @@ def resolve_target_layer_ids(
     verifier_name_or_path: str,
     trust_remote_code: bool = False,
 ) -> list[int]:
-    if target_layer_ids is not None:
-        if len(set(target_layer_ids)) != len(target_layer_ids):
-            raise ValueError(
-                f"target_layer_ids must be distinct, got {target_layer_ids}"
-            )
-        return target_layer_ids
-
     num_layers = get_verifier_config(
         verifier_name_or_path,
         trust_remote_code=trust_remote_code,
     ).num_hidden_layers
-    target_layer_ids = [2, num_layers // 2, num_layers - 3]
-    if min(target_layer_ids) < 0 or len(set(target_layer_ids)) != len(target_layer_ids):
+
+    if target_layer_ids is None:
+        explicit = False
+        target_layer_ids = [2, num_layers // 2, num_layers - 3]
+    else:
+        explicit = True
+
+    # Layer id ``num_layers`` (the final hidden state) is valid, matching the
+    # ids scripts/launch_vllm.py emits with --include-last-layer.
+    invalid = (
+        not target_layer_ids
+        or min(target_layer_ids) < 0
+        or max(target_layer_ids) > num_layers
+        or len(set(target_layer_ids)) != len(target_layer_ids)
+    )
+    if invalid:
+        if explicit:
+            raise ValueError(
+                f"target_layer_ids must be distinct and within [0, {num_layers}] "
+                f"for a verifier with {num_layers} hidden layers, "
+                f"got {target_layer_ids}"
+            )
         raise ValueError(
             f"Default target layer ids {target_layer_ids} are invalid for a verifier "
             f"with {num_layers} hidden layers; pass --target-layer-ids explicitly."
         )
-    warnings.warn(
-        DEFAULT_TARGET_LAYER_IDS_WARNING.format(target_layer_ids=target_layer_ids),
-        stacklevel=3,
-    )
+
+    if not explicit:
+        warnings.warn(
+            DEFAULT_TARGET_LAYER_IDS_WARNING.format(target_layer_ids=target_layer_ids),
+            stacklevel=3,
+        )
     return target_layer_ids
 
 

--- a/src/speculators/models/utils.py
+++ b/src/speculators/models/utils.py
@@ -43,6 +43,10 @@ def resolve_target_layer_ids(
     trust_remote_code: bool = False,
 ) -> list[int]:
     if target_layer_ids is not None:
+        if len(set(target_layer_ids)) != len(target_layer_ids):
+            raise ValueError(
+                f"target_layer_ids must be distinct, got {target_layer_ids}"
+            )
         return target_layer_ids
 
     num_layers = get_verifier_config(
@@ -50,6 +54,11 @@ def resolve_target_layer_ids(
         trust_remote_code=trust_remote_code,
     ).num_hidden_layers
     target_layer_ids = [2, num_layers // 2, num_layers - 3]
+    if min(target_layer_ids) < 0 or len(set(target_layer_ids)) != len(target_layer_ids):
+        raise ValueError(
+            f"Default target layer ids {target_layer_ids} are invalid for a verifier "
+            f"with {num_layers} hidden layers; pass --target-layer-ids explicitly."
+        )
     warnings.warn(
         DEFAULT_TARGET_LAYER_IDS_WARNING.format(target_layer_ids=target_layer_ids),
         stacklevel=3,

--- a/tests/unit/models/test_target_layer_ids.py
+++ b/tests/unit/models/test_target_layer_ids.py
@@ -32,10 +32,25 @@ def test_default_ids_fail_when_negative_or_repeated(num_layers, monkeypatch):
         resolve_target_layer_ids(None, "verifier")
 
 
-def test_explicit_ids_pass_through():
+def test_explicit_ids_pass_through(monkeypatch):
+    _verifier_with(28, monkeypatch)
     assert resolve_target_layer_ids([1, 9, 17], "verifier") == [1, 9, 17]
 
 
-def test_explicit_duplicate_ids_are_rejected():
+def test_explicit_last_layer_id_is_valid(monkeypatch):
+    """Id ``num_hidden_layers`` is the final hidden state (--include-last-layer)."""
+    _verifier_with(28, monkeypatch)
+    assert resolve_target_layer_ids([2, 14, 28], "verifier") == [2, 14, 28]
+
+
+def test_explicit_duplicate_ids_are_rejected(monkeypatch):
+    _verifier_with(28, monkeypatch)
     with pytest.raises(ValueError, match="distinct"):
         resolve_target_layer_ids([2, 2, 1], "verifier")
+
+
+@pytest.mark.parametrize("ids", [[-1, 2, 3], [2, 14, 29], []])
+def test_explicit_out_of_bounds_ids_are_rejected(ids, monkeypatch):
+    _verifier_with(28, monkeypatch)
+    with pytest.raises(ValueError, match="distinct and within"):
+        resolve_target_layer_ids(ids, "verifier")

--- a/tests/unit/models/test_target_layer_ids.py
+++ b/tests/unit/models/test_target_layer_ids.py
@@ -1,0 +1,41 @@
+"""Unit tests for target layer id resolution."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from speculators.models import utils as model_utils
+from speculators.models.utils import resolve_target_layer_ids
+
+
+def _verifier_with(num_layers, monkeypatch):
+    monkeypatch.setattr(
+        model_utils,
+        "get_verifier_config",
+        lambda *_a, **_k: SimpleNamespace(num_hidden_layers=num_layers),
+    )
+
+
+@pytest.mark.parametrize(
+    ("num_layers", "expected"), [(3, [2, 1, 0]), (7, [2, 3, 4]), (28, [2, 14, 25])]
+)
+def test_default_ids_when_distinct(num_layers, expected, monkeypatch):
+    _verifier_with(num_layers, monkeypatch)
+    with pytest.warns(UserWarning, match="not explicitly set"):
+        assert resolve_target_layer_ids(None, "verifier") == expected
+
+
+@pytest.mark.parametrize("num_layers", [0, 1, 2, 4, 5, 6])
+def test_default_ids_fail_when_negative_or_repeated(num_layers, monkeypatch):
+    _verifier_with(num_layers, monkeypatch)
+    with pytest.raises(ValueError, match="invalid for a verifier"):
+        resolve_target_layer_ids(None, "verifier")
+
+
+def test_explicit_ids_pass_through():
+    assert resolve_target_layer_ids([1, 9, 17], "verifier") == [1, 9, 17]
+
+
+def test_explicit_duplicate_ids_are_rejected():
+    with pytest.raises(ValueError, match="distinct"):
+        resolve_target_layer_ids([2, 2, 1], "verifier")

--- a/tests/unit/scripts/test_launch_vllm_layer_ids.py
+++ b/tests/unit/scripts/test_launch_vllm_layer_ids.py
@@ -18,8 +18,10 @@ import launch_vllm  # type: ignore[import-not-found]
         (28, [], True),  # default [2, 14, 25, 28]
         (4, [], False),  # default [2, 2, 1, 4] repeats an id
         (28, ["--target-layer-ids", "1", "9", "17"], True),
+        (28, ["--target-layer-ids", "2", "14", "28"], True),  # last layer is valid
         (28, ["--target-layer-ids", "2", "2", "1"], False),
         (28, ["--target-layer-ids", "-1", "2", "3"], False),
+        (28, ["--target-layer-ids", "2", "14", "29"], False),  # beyond last layer
     ],
 )
 def test_launch_rejects_invalid_target_layer_ids(
@@ -36,5 +38,5 @@ def test_launch_rejects_invalid_target_layer_ids(
     if ok:
         launch_vllm.main()
     else:
-        with pytest.raises(ValueError, match="non-negative and distinct"):
+        with pytest.raises(ValueError, match="distinct and within"):
             launch_vllm.main()

--- a/tests/unit/scripts/test_launch_vllm_layer_ids.py
+++ b/tests/unit/scripts/test_launch_vllm_layer_ids.py
@@ -1,0 +1,40 @@
+"""launch_vllm.py rejects invalid target layer ids before building the vLLM command."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import transformers
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+import launch_vllm  # type: ignore[import-not-found]
+
+
+@pytest.mark.parametrize(
+    ("num_layers", "extra_args", "ok"),
+    [
+        (28, [], True),  # default [2, 14, 25, 28]
+        (4, [], False),  # default [2, 2, 1, 4] repeats an id
+        (28, ["--target-layer-ids", "1", "9", "17"], True),
+        (28, ["--target-layer-ids", "2", "2", "1"], False),
+        (28, ["--target-layer-ids", "-1", "2", "3"], False),
+    ],
+)
+def test_launch_rejects_invalid_target_layer_ids(
+    num_layers, extra_args, ok, monkeypatch
+):
+    monkeypatch.setattr(
+        transformers.AutoConfig,
+        "from_pretrained",
+        classmethod(lambda *_a, **_k: SimpleNamespace(num_hidden_layers=num_layers)),
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["launch_vllm.py", "verifier", "--dry-run", *extra_args]
+    )
+    if ok:
+        launch_vllm.main()
+    else:
+        with pytest.raises(ValueError, match="non-negative and distinct"):
+            launch_vllm.main()

--- a/tests/unit/train/test_setup_model.py
+++ b/tests/unit/train/test_setup_model.py
@@ -859,6 +859,9 @@ def test_from_training_args_loads_vocab_mappings(vocab_mappings):
             norm_before_residual=False,
             ttt_steps=1,
             verifier_name_or_path="nm-testing/tinysmokellama-3.2",
+            # The 6-layer verifier makes the default [2, n // 2, n - 3]
+            # collapse to [2, 3, 3], which id validation now rejects.
+            target_layer_ids=[1, 3, 5],
         )
 
     assert model.t2d is not None, "t2d is None after from_training_args"


### PR DESCRIPTION
## Purpose

`resolve_target_layer_ids()` returns explicit ids unvalidated and, when unset, uses `[2, n // 2, n - 3]`, which repeats an id for verifiers with 4–6 layers (`4 → [2, 2, 1]`, `5 → [2, 2, 2]`, `6 → [2, 3, 3]`); `launch_vllm.py` builds its extraction default from the same formula. The extraction side deduplicates the ids while training sizes its hidden-state input by `len(target_layer_ids)`, so the mismatch only surfaces as a buffer shape error far from its cause. Real verifiers (≥ 7 layers) are unaffected.

We hit it running the end-to-end pipeline on a single device with a synthetic 4-layer verifier instead of Qwen3-0.6B: the run died in the extraction engine with nothing pointing at layer ids. This raises a clear error for duplicate explicit ids and colliding defaults in `resolve_target_layer_ids()`, and adds one shared non-negative/distinct check in `launch_vllm.py` after either branch so extraction fails before writing data; upper-bound checks against the verifier are left to #569.

## Tests

```
$ python -m pytest tests/unit/models/test_target_layer_ids.py tests/unit/scripts/test_launch_vllm_layer_ids.py tests/unit/models/test_dflash_targets.py tests/unit/test_config.py -q
48 passed
$ ruff check && ruff format --check && mypy --check-untyped-defs src/speculators/models/utils.py tests/unit/models/test_target_layer_ids.py tests/unit/scripts/test_launch_vllm_layer_ids.py
All checks passed!
```

## Checklist

- [x] The purpose of the PR is described.
- [x] The test plan and results are provided.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this PR to the best of my ability.
