### PR TITLE
fix(train): make a zero-std noise transform RNG-neutral

### DIFF
--- a/src/speculators/train/noise_transforms.py
+++ b/src/speculators/train/noise_transforms.py
@@ -7,6 +7,10 @@ class TransformTensors:
         self.std = std
 
     def __call__(self, data):
+        if self.std == 0:
+            # Disabled noise must not consume RNG: sampling and multiplying by
+            # zero leaves the values unchanged but advances the generator.
+            return data
         for tensor in self.tensors:
             data[tensor] = self.transform(data[tensor])
         return data

--- a/tests/unit/train/test_noise_transforms.py
+++ b/tests/unit/train/test_noise_transforms.py
@@ -1,0 +1,24 @@
+"""Unit tests for the hidden-state noise transforms."""
+
+import pytest
+import torch
+
+from speculators.train.noise_transforms import AddGaussianNoise, AddUniformNoise
+
+
+@pytest.mark.parametrize("cls", [AddGaussianNoise, AddUniformNoise])
+def test_zero_std_is_identity_and_consumes_no_rng(cls):
+    """With std=0 the data is returned unchanged and the generator does not advance."""
+    data = {"hidden_states": torch.arange(6.0).reshape(2, 3)}
+    before = torch.get_rng_state()
+    out = cls(std=0.0)(dict(data))
+    assert torch.equal(out["hidden_states"], data["hidden_states"])
+    assert torch.equal(torch.get_rng_state(), before)
+
+
+@pytest.mark.parametrize("cls", [AddGaussianNoise, AddUniformNoise])
+def test_positive_std_still_adds_noise(cls):
+    """Non-zero std keeps the existing behaviour."""
+    data = {"hidden_states": torch.zeros(2, 3)}
+    out = cls(std=0.1)(dict(data))
+    assert not torch.equal(out["hidden_states"], data["hidden_states"])


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

`AddGaussianNoise` / `AddUniformNoise` with `std=0` still sample a full noise tensor and multiply it by zero: the values are unchanged, but the torch generator advances on every batch. `create_train_val_loaders` always installs the transform, so a run with `--noise-std 0` consumes RNG differently from one with noise on, and the two cannot be compared as exact replays (e.g. when checking that disabling noise is the only difference between two runs).

How we noticed: while profiling the collate path of a downstream online hidden-state pipeline with noise disabled, every row was still paying a full `randn_like` over the `[seq, num_layers × hidden]` tensor, and the generator kept advancing — both wasted work in the loader and a silent difference between noise-on and noise-off runs. Not a failure, a profiling find.

Return the data untouched when `std == 0` — a 4-line change in the base class, behaviour for `std > 0` unchanged.

## Tests

`tests/unit/train/test_noise_transforms.py`: for both transforms, `std=0` returns identical data and leaves `torch.get_rng_state()` unchanged; `std>0` still adds noise.

```
$ python -m pytest tests/unit/train/test_noise_transforms.py -q
4 passed
$ ruff check && ruff format --check && mypy --check-untyped-defs src/speculators/train/noise_transforms.py tests/unit/train/test_noise_transforms.py
All checks passed!
```

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [ ] I (a human) have written or reviewed the code in this pr to the best of my ability.
