### PR TITLE
fix(dflash): unify per-block accepted-length metrics

### DIFF
--- a/src/speculators/models/dflash/metrics.py
+++ b/src/speculators/models/dflash/metrics.py
@@ -12,7 +12,10 @@ from speculators.losses import (
     dpace_loss_decay,
     kl_div_loss,
 )
-from speculators.models.metrics import compute_accuracy_multi_step
+from speculators.models.metrics import (
+    compute_accepted_length_counts,
+    compute_accuracy_multi_step,
+)
 
 _DEFAULT_LOSS_CONFIG: LossConfig = {"kl_div": (kl_div_loss, 1.0)}
 
@@ -45,7 +48,8 @@ def compute_metrics(
             - loss: Scalar loss value
             - full_acc: Overall accuracy
             - position {i} acc: Accuracy at position i within blocks
-            - eal: Expected Accepted Length (headline speculative-decoding metric)
+            - eal: Expected Accepted Length, the mean per-block accepted run
+              plus the verifier's bonus token (headline metric)
     """
     if loss_config is None:
         loss_config = _DEFAULT_LOSS_CONFIG
@@ -94,15 +98,16 @@ def compute_metrics(
     metrics["full_acc_sum"] = correct_per_pos[start_pos:].sum()
     metrics["full_acc_total"] = total_per_pos[start_pos:].sum()
 
-    # EAL = sum_k prod_{i<=k} acc_i over drafted positions
-    eal = torch.zeros((), device=logits.device)
-    cum = torch.ones((), device=logits.device)
     for pos in range(start_pos, block_size):
         metrics[f"position_{pos}_acc_sum"] = correct_per_pos[pos]
         metrics[f"position_{pos}_acc_total"] = total_per_pos[pos]
-        acc = correct_per_pos[pos] / total_per_pos[pos].clamp(min=1.0)
-        cum = cum * acc
-        eal = eal + cum
-    metrics["eal_sum"] = eal
-    metrics["eal_total"] = ones.clone()
+
+    # Counted per block so the accepted run is formed before any averaging; the
+    # sum/total pair then pools across batches and ranks like every other metric.
+    eal_sum, eal_total = compute_accepted_length_counts(
+        (pred_ids == target_ids).reshape(-1, block_size)[:, start_pos:],
+        loss_mask.to(torch.bool).reshape(-1, block_size)[:, start_pos:],
+    )
+    metrics["eal_sum"] = eal_sum
+    metrics["eal_total"] = eal_total
     return loss, metrics

--- a/src/speculators/models/dflash2/metrics.py
+++ b/src/speculators/models/dflash2/metrics.py
@@ -1,4 +1,8 @@
-"""Runtime-aligned selector loss and metrics for DFlash2."""
+"""Runtime-aligned selector loss and metrics for DFlash2.
+
+``eal`` follows the realized greedy selector path. ``accept_len`` remains the
+analytical TV-overlap estimate over the unary logits.
+"""
 
 from collections.abc import Callable
 from functools import partial
@@ -15,6 +19,7 @@ from speculators.losses import (
     tv_loss,
 )
 from speculators.models.dspark.metrics import compute_metrics as compute_unary_metrics
+from speculators.models.metrics import compute_accepted_length_counts
 
 __all__ = [
     "compute_metrics",
@@ -195,6 +200,19 @@ def compute_metrics(
         num_blocks = unary_logits.shape[1] // block_size
         contains_target_blocks = contains_target.view(num_blocks, block_size)
         valid_blocks = valid.view(num_blocks, block_size)
+
+        # Teacher-forced predecessor tokens are exact while the greedy path is
+        # alive. Gate on the original unary candidate set because training may
+        # inject a missing target that would not be available during serving.
+        start_pos = 0 if sample_from_anchor else 1
+        selector_correct = teacher_forced_ids.eq(target_ids) & contains_target
+        eal_sum, eal_total = compute_accepted_length_counts(
+            selector_correct.view(num_blocks, block_size)[:, start_pos:],
+            valid_blocks[:, start_pos:],
+        )
+        metrics["eal_sum"] = eal_sum
+        metrics["eal_total"] = eal_total
+
         oracle_alive = torch.ones(
             num_blocks, dtype=torch.bool, device=unary_logits.device
         )

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -149,7 +149,7 @@ def compute_metrics(
         metrics["accept_rate_total"] = mask_f.sum().clamp_min(1.0)
 
     # Expected accepted draft length per block (DSpark's tau): the cumulative
-    # acceptance product summed over draft slots, plus the always-emitted anchor.
+    # acceptance product summed over draft slots, plus the always-emitted bonus.
     with torch.no_grad():
         per_block_len = accept_prefix.sum(dim=-1) + 1.0
         block_valid = (draft_mask.sum(dim=-1) > 0).to(accept_rate.dtype)

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -4,6 +4,11 @@ loss = compound_loss(logits, targets) + conf_alpha * BCE(confidence, accept_rate
 
 The confidence target ``accept_rate = sum_v min(q_v, p_v) = 1 - d_TV`` is the
 analytical acceptance rate (the overlap ``tv_loss`` already computes).
+
+Two acceptance lengths are reported, both counting the verifier's bonus token:
+``accept_len`` from that analytical rate (acceptance under rejection sampling)
+and ``eal`` from greedy argmax matches (acceptance at temperature 0, and the
+value comparable across the DFlash family).
 """
 
 from collections.abc import Callable
@@ -20,7 +25,10 @@ from speculators.losses import (
     dpace_loss_decay,
     tv_loss,
 )
-from speculators.models.metrics import compute_accuracy_multi_step
+from speculators.models.metrics import (
+    compute_accepted_length_counts,
+    compute_accuracy_multi_step,
+)
 
 __all__ = [
     "compute_metrics",
@@ -159,5 +167,14 @@ def compute_metrics(
     for pos in range(start_pos, block_size):
         metrics[f"position_{pos}_acc_sum"] = correct_per_pos[pos]
         metrics[f"position_{pos}_acc_total"] = total_per_pos[pos]
+
+    # Greedy counterpart to accept_len, on the same per-block/bonus-token
+    # convention, so DFlash-family runs compare on one number.
+    eal_sum, eal_total = compute_accepted_length_counts(
+        (pred_ids == target_ids).reshape(num_blocks, block_size)[:, start_pos:],
+        draft_mask.to(torch.bool),
+    )
+    metrics["eal_sum"] = eal_sum
+    metrics["eal_total"] = eal_total
 
     return loss, metrics

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -3,6 +3,33 @@
 import torch
 
 
+@torch.no_grad()
+def compute_accepted_length_counts(
+    correct: torch.Tensor,  # shape: [num_blocks, num_draft_slots]
+    valid: torch.Tensor,  # shape: [num_blocks, num_draft_slots]
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Count accepted length per speculative block as raw sum/total counts.
+
+    A block is accepted up to its first wrong draft slot, so its length is the
+    leading run of correct slots plus the verifier's always-emitted bonus token
+    (vLLM's convention). Forming the run inside the block preserves the
+    correlation between slots; a product of per-slot marginals discards it and
+    understates the result.
+
+    Args:
+        correct: Whether each draft slot matched the target.
+        valid: Whether each draft slot is trained on (block-shaped loss mask).
+
+    Returns:
+        Tuple of (accepted_length_sum, valid_block_total) as raw counts suitable
+        for distributed reduction before computing the ratio.
+    """
+    accepted = torch.logical_and(correct, valid).to(torch.float32)
+    per_block_len = accepted.cumprod(dim=-1).sum(dim=-1) + 1.0
+    block_valid = valid.any(dim=-1).to(torch.float32)
+    return (per_block_len * block_valid).sum(), block_valid.sum()
+
+
 def compute_accuracy_single_step(
     pred_ids: torch.Tensor,  # shape: [1, seq_len]
     target_ids: torch.Tensor,  # shape: [1, seq_len]

--- a/tests/unit/models/test_dflash2_model_definitions.py
+++ b/tests/unit/models/test_dflash2_model_definitions.py
@@ -388,17 +388,26 @@ def _selector_objective_inputs():
 def test_selector_loss_alpha_zero_preserves_unary_objective():
     (
         selector,
-        unary_logits,
-        hidden_states,
-        predecessor_ids,
-        _target_ids,
+        _unary_logits,
+        _hidden_states,
+        _predecessor_ids,
+        target_ids,
         targets,
         loss_mask,
     ) = _selector_objective_inputs()
+    # The selector corrects the first unary argmax. At the second draft slot the
+    # target is outside unary top-k but injected for training; choosing that
+    # injected target must still end the serving path.
+    unary_logits = torch.full_like(targets, -10.0)
+    unary_logits.scatter_(-1, target_ids.unsqueeze(-1), 5.0)
+    unary_logits.scatter_(-1, ((target_ids + 1) % 7).unsqueeze(-1), 6.0)
+    unary_logits[0, 2, target_ids[0, 2]] = -10.0
+    unary_logits[0, 2, (target_ids[0, 2] + 2) % 7] = 5.0
+    unary_logits.requires_grad_()
     loss_config = resolve_loss_config("ce", "eager")
     tv_loss_fn = resolve_loss_config("tv", "eager")["tv"][0]
 
-    expected, _ = compute_unary_metrics(
+    expected, unary_metrics = compute_unary_metrics(
         unary_logits,
         targets,
         None,
@@ -417,9 +426,9 @@ def test_selector_loss_alpha_zero_preserves_unary_objective():
     training_candidate_ids, target_positions, contains_target = (
         selector_training_candidates(candidate_ids, target_ids)
     )
-    candidate_logits = selector.score_candidates(
-        unary_logits, hidden_states, predecessor_ids, training_candidate_ids
-    )
+    assert contains_target.tolist() == [[True, True, False, True]]
+    candidate_logits = torch.zeros_like(training_candidate_ids, dtype=torch.float32)
+    candidate_logits.scatter_(-1, target_positions.unsqueeze(-1), 1.0)
     actual, metrics = compute_dflash2_metrics(
         unary_logits=unary_logits,
         targets=targets,
@@ -438,6 +447,14 @@ def test_selector_loss_alpha_zero_preserves_unary_objective():
     torch.testing.assert_close(actual, expected)
     torch.testing.assert_close(metrics["unary_loss_sum"], expected.detach())
     assert metrics["selector_loss_sum"] > 0
+    # One selected draft token plus the verifier's bonus token.
+    assert metrics["eal_sum"].item() == 2.0
+    assert metrics["eal_total"].item() == 1.0
+    # The inherited unary EAL would stop at the first drafted position.
+    assert unary_metrics["eal_sum"].item() == 1.0
+    torch.testing.assert_close(
+        metrics["accept_len_sum"], unary_metrics["accept_len_sum"]
+    )
 
 
 def test_selector_loss_reaches_every_selector_parameter():

--- a/tests/unit/models/test_dflash_metrics.py
+++ b/tests/unit/models/test_dflash_metrics.py
@@ -338,3 +338,62 @@ class TestComputeMetrics:
         for i in range(1, 4):
             assert torch.isclose(metrics[f"position_{i}_acc_sum"], expected_correct[i])
             assert torch.isclose(metrics[f"position_{i}_acc_total"], expected_total[i])
+
+
+class TestExpectedAcceptedLength:
+    """EAL is the mean per-block accepted run, plus the verifier's bonus token."""
+
+    # Four blocks of block_size=4; with sample_from_anchor=False the anchor is
+    # the bonus token, leaving three draft slots whose accepted runs are 3/2/1/0.
+    _TARGET_IDS = torch.zeros(1, 16, dtype=torch.long)
+    _PRED_IDS = torch.tensor([[0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1]])
+
+    def _metrics(self, block_slice: slice):
+        ids = self._PRED_IDS[:, block_slice]
+        return compute_metrics(
+            _ids_to_logits(ids, 2),
+            _ids_to_logits(self._TARGET_IDS[:, block_slice], 2),
+            torch.ones(1, ids.shape[1]),
+            block_size=4,
+        )[1]
+
+    def test_eal_is_mean_accepted_run_plus_bonus_token(self):
+        metrics = self._metrics(slice(None))
+        # runs 3, 2, 1, 0 -> mean 1.5, plus one bonus token per block
+        assert metrics["eal_sum"].item() == pytest.approx(10.0)
+        assert metrics["eal_total"].item() == pytest.approx(4.0)
+
+    def test_eal_ignores_how_blocks_are_split_into_batches(self):
+        """Regression: the run must be formed per block, never per batch.
+
+        Averaging per-batch products overstates and multiplying pooled
+        per-position marginals understates; only per-block counting is
+        invariant to the batch split.
+        """
+        whole = self._metrics(slice(None))
+        halves = [self._metrics(slice(0, 8)), self._metrics(slice(8, 16))]
+        accumulated = {
+            key: sum(m[key] for m in halves) for key in ("eal_sum", "eal_total")
+        }
+        assert accumulated["eal_sum"].item() == pytest.approx(whole["eal_sum"].item())
+        assert accumulated["eal_total"].item() == pytest.approx(
+            whole["eal_total"].item()
+        )
+
+        eal = accumulated["eal_sum"] / accumulated["eal_total"]
+        assert eal.item() == pytest.approx(2.5)
+        # The per-position marginals are .75/.50/.25, whose running product sums
+        # to 1.21875 (2.21875 with the bonus token) -- a different number.
+        assert eal.item() != pytest.approx(2.21875)
+
+    def test_eal_skips_fully_masked_blocks(self):
+        ids = torch.zeros(1, 8, dtype=torch.long)
+        loss_mask = torch.tensor([[0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0]])
+        _, metrics = compute_metrics(
+            _ids_to_logits(ids, 2),
+            _ids_to_logits(ids, 2),
+            loss_mask,
+            block_size=4,
+        )
+        assert metrics["eal_total"].item() == pytest.approx(1.0)
+        assert metrics["eal_sum"].item() == pytest.approx(4.0)

--- a/tests/unit/models/test_dflash_metrics.py
+++ b/tests/unit/models/test_dflash_metrics.py
@@ -357,12 +357,6 @@ class TestExpectedAcceptedLength:
             block_size=4,
         )[1]
 
-    def test_eal_is_mean_accepted_run_plus_bonus_token(self):
-        metrics = self._metrics(slice(None))
-        # runs 3, 2, 1, 0 -> mean 1.5, plus one bonus token per block
-        assert metrics["eal_sum"].item() == pytest.approx(10.0)
-        assert metrics["eal_total"].item() == pytest.approx(4.0)
-
     def test_eal_ignores_how_blocks_are_split_into_batches(self):
         """Regression: the run must be formed per block, never per batch.
 
@@ -371,6 +365,10 @@ class TestExpectedAcceptedLength:
         invariant to the batch split.
         """
         whole = self._metrics(slice(None))
+        # runs 3, 2, 1, 0 -> mean 1.5, plus one bonus token per block
+        assert whole["eal_sum"].item() == pytest.approx(10.0)
+        assert whole["eal_total"].item() == pytest.approx(4.0)
+
         halves = [self._metrics(slice(0, 8)), self._metrics(slice(8, 16))]
         accumulated = {
             key: sum(m[key] for m in halves) for key in ("eal_sum", "eal_total")

--- a/tests/unit/models/test_dspark_metrics.py
+++ b/tests/unit/models/test_dspark_metrics.py
@@ -2,7 +2,6 @@
 
 from functools import partial
 
-import pytest
 import torch
 
 from speculators.losses import resolve_loss_config
@@ -64,9 +63,11 @@ class TestComputeMetrics:
         assert float(loss) < 1e-2
         accept = metrics["accept_rate_sum"] / metrics["accept_rate_total"]
         assert float(accept) > 0.99
-        # One draft slot per block accepted w.p. ~1, plus the anchor token -> ~2.
+        # One draft slot per block accepted w.p. ~1, plus the bonus token -> ~2.
         accept_len = metrics["accept_len_sum"] / metrics["accept_len_total"]
         assert abs(float(accept_len) - 2.0) < 1e-2
+        eal = metrics["eal_sum"] / metrics["eal_total"]
+        assert abs(float(eal) - 2.0) < 1e-2
 
     def test_perfect_draft_anchor_sampled_includes_slot0(self):
         # sample_from_anchor=True (default): slot 0 is the first real prediction,
@@ -88,9 +89,11 @@ class TestComputeMetrics:
         assert float(loss) < 1e-2
         accept = metrics["accept_rate_sum"] / metrics["accept_rate_total"]
         assert float(accept) > 0.99
-        # Two draft slots per block accepted w.p. ~1, plus the anchor token -> ~3.
+        # Two draft slots per block accepted w.p. ~1, plus the bonus token -> ~3.
         accept_len = metrics["accept_len_sum"] / metrics["accept_len_total"]
         assert abs(float(accept_len) - 3.0) < 1e-2
+        eal = metrics["eal_sum"] / metrics["eal_total"]
+        assert abs(float(eal) - 3.0) < 1e-2
 
     def test_accept_rate_equals_softmax_overlap(self):
         """accept_rate (now 1 - tv) matches the explicit softmax-overlap formula."""
@@ -231,26 +234,3 @@ class TestComputeMetrics:
             assert key in metrics
         # all metric values must be tensors (so dist.reduce works in the trainer)
         assert all(torch.is_tensor(v) for v in metrics.values())
-
-
-class TestExpectedAcceptedLength:
-    def test_greedy_eal_matches_accept_len_convention(self):
-        # block_size=2, sample_from_anchor=True -> both slots are drafted.
-        # Block 0 is fully correct; block 1 breaks at its second slot.
-        target_ids = torch.tensor([[0, 0, 0, 0]])
-        pred_ids = torch.tensor([[0, 0, 0, 1]])
-        _, metrics = compute_metrics(
-            _ids_to_logits(pred_ids, 4),
-            _ids_to_logits(target_ids, 4),
-            None,
-            torch.ones(1, 4),
-            block_size=2,
-            loss_config=_DEFAULT_LOSS,
-        )
-        # runs 2 and 1, each plus the bonus token -> (3 + 2) / 2
-        assert metrics["eal_sum"].item() == pytest.approx(5.0)
-        assert metrics["eal_total"].item() == pytest.approx(2.0)
-        # Both lengths count the bonus token, so both are >= 1.
-        assert (
-            metrics["accept_len_sum"].item() / metrics["accept_len_total"].item() >= 1.0
-        )

--- a/tests/unit/models/test_dspark_metrics.py
+++ b/tests/unit/models/test_dspark_metrics.py
@@ -2,6 +2,7 @@
 
 from functools import partial
 
+import pytest
 import torch
 
 from speculators.losses import resolve_loss_config
@@ -230,3 +231,26 @@ class TestComputeMetrics:
             assert key in metrics
         # all metric values must be tensors (so dist.reduce works in the trainer)
         assert all(torch.is_tensor(v) for v in metrics.values())
+
+
+class TestExpectedAcceptedLength:
+    def test_greedy_eal_matches_accept_len_convention(self):
+        # block_size=2, sample_from_anchor=True -> both slots are drafted.
+        # Block 0 is fully correct; block 1 breaks at its second slot.
+        target_ids = torch.tensor([[0, 0, 0, 0]])
+        pred_ids = torch.tensor([[0, 0, 0, 1]])
+        _, metrics = compute_metrics(
+            _ids_to_logits(pred_ids, 4),
+            _ids_to_logits(target_ids, 4),
+            None,
+            torch.ones(1, 4),
+            block_size=2,
+            loss_config=_DEFAULT_LOSS,
+        )
+        # runs 2 and 1, each plus the bonus token -> (3 + 2) / 2
+        assert metrics["eal_sum"].item() == pytest.approx(5.0)
+        assert metrics["eal_total"].item() == pytest.approx(2.0)
+        # Both lengths count the bonus token, so both are >= 1.
+        assert (
+            metrics["accept_len_sum"].item() / metrics["accept_len_total"].item() >= 1.0
+        )


### PR DESCRIPTION
## Summary

This PR gives the DFlash family one definition for each accepted-length metric:

- `eal`: realized greedy accepted length per speculative block, including the verifier's bonus token;
- `accept_len`: analytical TV-overlap accepted length, retained where the unary TV tensor is already computed.

DFlash, DSpark, and DFlash2 now use the same block shape and bonus-token convention. Each metric is exported as an additive `*_sum` / `*_total` pair, so it pools correctly across micro-batches and distributed ranks.

## Why EAL must be counted per block

The old DFlash calculation multiplied per-position marginal accuracies inside each micro-batch and exported the result with a total of `1.0`. That has two problems:

- averaging those products gives batch composition equal weight rather than blocks;
- multiplying marginal position accuracies loses the within-block prefix correlation that determines speculative acceptance.

For accepted runs of 3/2/1/0 grouped as (3, 1) and (2, 0), the true mean drafted length is 1.5. The old per-batch products average to 1.25, while a product formed from globally pooled marginals gives 1.219. Counting the leading correct run in each block gives the exact 1.5 and remains additive.

`normalize_counted_metrics` is unchanged. It remains responsible only for normalizing already-reduced counts; no algorithm-specific pre/post-reduce hook is needed.

## Metric definitions

### Greedy `eal`

For every valid block, `eal` counts the leading run of correct greedy proposals and adds the verifier's always-emitted bonus token.

- DFlash uses the unary argmax path.
- DSpark uses its Markov-corrected argmax path.
- DFlash2 uses the realized selector path, not the unary argmax.

DFlash2's selector is trained with teacher-forced predecessor tokens. Those predecessor tokens are exact while an accepted greedy prefix remains alive. The metric also gates correctness on `contains_target`, so a target injected only to make the training candidate set well-defined cannot be counted as available during serving.

### TV `accept_len`

`accept_len` keeps DSpark's analytical cumulative TV-overlap estimator. It answers the rejection-sampling/temperature-above-zero question and reuses the per-position overlap tensor needed by DSpark's confidence metrics. It uses the same block shape and includes the same bonus token as `eal`.

## DFlash2 metric composition and follow-up refactor

DFlash2 currently imports DSpark's top-level `compute_metrics` function to obtain unary loss, TV, accuracy, and accepted-length metrics, disables the confidence head, and then appends selector-specific metrics. This reuse is convenient, but the ownership is unclear: a sibling algorithm implicitly controls DFlash2's metric dictionary, and changes to DSpark can silently alter DFlash2 behavior.

This PR stays focused by preserving that existing composition while explicitly replacing the inherited unary `eal` with selector-path `eal`.

A follow-up refactor should extract shared DFlash-family primitives for loss counts, greedy prefix length, and TV prefix length. DFlash, DSpark, and DFlash2 can then compose those primitives directly, removing the DFlash2-to-DSpark top-level dependency without changing the metric names or definitions established here.

## Behavior changes

- `eal` is now an exact mean of per-block greedy accepted lengths rather than a product of batch-level marginal accuracies.
- `eal` includes the verifier's bonus token, matching the convention already used by `accept_len`.
- DFlash2 `eal` measures its selector path rather than its unary argmax.
- Existing `eal_epoch` values are therefore not comparable with runs produced before this PR.

## Validation

- 205 model unit tests pass.
- Focused DFlash, DSpark, and DFlash2 coverage passes.
- Ruff lint, formatting, and Git whitespace checks pass.
