### PR TITLE
fix(train): default DSpark drafts to five layers

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -54,7 +54,7 @@ torchrun --standalone --nproc_per_node=4 scripts/train.py \
 
 - **`--dry-run`** (flag) Build the speculator, initialize weights, save a checkpoint to `--save-path`, then exit before training. Useful to validate the config/weights in vLLM before launching a full run; the saved checkpoint can be fed straight back via `--from-pretrained`.
 
-- **`--num-layers`** (int, default: `5` for dflash, `1` otherwise) Number of transformer layers in the draft model.
+- **`--num-layers`** (int, default: `5` for dflash/dspark/dflash2, `1` otherwise) Number of transformer layers in the draft model.
 
 - **`--draft-arch`** (str, default: `"llama"`) Architecture for the synthesized draft decoder layers. Options: `llama`, `qwen3`. Used by Eagle3 and P-EAGLE, which select the decoder layer class from this value; DFlash always uses a Qwen3-style decoder regardless. Both are supported in vLLM for inference, and the target and draft architectures do not have to match.
 

--- a/src/speculators/train/config/schema.py
+++ b/src/speculators/train/config/schema.py
@@ -93,7 +93,7 @@ class DraftArgs(_Group):
     num_layers: int | None = Field(
         default=None,
         description="Number of draft decoder layers to synthesize. "
-        "(default: 5 for dflash, 1 otherwise).",
+        "(default: 5 for dflash/dspark/dflash2, 1 otherwise).",
     )
     draft_arch: Literal["llama", "qwen3"] | None = Field(
         default=None,
@@ -644,9 +644,10 @@ class TrainConfig(BaseSettings):
         pre-refactor ``parse_args``: unset ``draft_arch`` -> ``llama`` for eagle3 else
         ``qwen3``; unset ``norm_before_fc`` / ``norm_output`` -> ``True`` for eagle3
         else ``False``; unset ``muon_lr`` -> ``10 * lr``; unset ``num_layers`` -> ``5``
-        for dflash else ``1``; unset ``per_position_loss_weight`` -> ``dpace`` for
-        dflash else ``fixed-exp-decay``; unset ``loss_fn`` -> ``ce`` for dflash else
-        ``kl_div``; unset ``block_size`` -> ``16`` for dflash else ``8``.
+        for dflash/dspark/dflash2 else ``1``; unset ``per_position_loss_weight`` ->
+        ``dpace`` for dflash else ``fixed-exp-decay``; unset ``loss_fn`` -> ``ce`` for
+        dflash else ``kl_div``; unset ``block_size`` -> ``16`` for dflash else
+        ``8``.
 
         The dflash-conditional defaults reflect the recipe from
         https://github.com/vllm-project/speculators/issues/979: this combination
@@ -666,6 +667,7 @@ class TrainConfig(BaseSettings):
         """
         is_eagle3 = self.speculator_type == "eagle3"
         is_dflash = self.speculator_type == "dflash"
+        is_dflash_family = self.speculator_type in {"dflash", "dspark", "dflash2"}
         if self.draft.draft_arch is None:
             self.draft.draft_arch = "llama" if is_eagle3 else "qwen3"
         if self.draft.norm_before_fc is None:
@@ -675,7 +677,7 @@ class TrainConfig(BaseSettings):
         if self.optimizer.muon_lr is None:
             self.optimizer.muon_lr = 10 * self.optimizer.lr
         if self.draft.num_layers is None:
-            self.draft.num_layers = 5 if is_dflash else 1
+            self.draft.num_layers = 5 if is_dflash_family else 1
         if self.dflash.per_position_loss_weight is None:
             self.dflash.per_position_loss_weight = (
                 "dpace" if is_dflash else "fixed-exp-decay"

--- a/tests/unit/train/config/test_schema.py
+++ b/tests/unit/train/config/test_schema.py
@@ -60,11 +60,11 @@ def test_flatten_resolves_dflash_derived_defaults():
 
 
 def test_flatten_leaves_non_dflash_derived_defaults_unchanged():
-    # Only dflash gets the new defaults; every other speculator type keeps the
-    # pre-existing behavior.
+    # DSpark shares only the DFlash layer default; the remaining derived defaults
+    # keep their pre-existing behavior.
     for speculator_type in ("eagle3", "dspark", "peagle", "mtp"):
         flat = TrainConfig(speculator_type=speculator_type).flatten()
-        assert flat["num_layers"] == 1
+        assert flat["num_layers"] == (5 if speculator_type == "dspark" else 1)
         assert flat["per_position_loss_weight"] == "fixed-exp-decay"
         assert flat["loss_fn"] == "kl_div"
         assert flat["block_size"] == 8


### PR DESCRIPTION
Default `--num-layers` to 5 for DFlash, DSpark, and DFlash2; leave all other defaults unchanged.