### PR TITLE
No error to build from non-release tagged commit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,9 @@ def get_next_version(
     version = max(version, LAST_RELEASE_VERSION)
 
     if build_type == "release":
-        #if not tag:
+        # if not tag:
         #    raise ValueError("RELEASE build requires a vX.Y.Z tag")
-        #if commits_since_last:
+        # if commits_since_last:
         #    raise ValueError(
         #        f"HEAD is {commits_since_last} commit(s) ahead"
         #    )

--- a/setup.py
+++ b/setup.py
@@ -67,13 +67,12 @@ def get_next_version(
     version = max(version, LAST_RELEASE_VERSION)
 
     if build_type == "release":
-        if not tag:
-            raise ValueError("RELEASE build requires a vX.Y.Z tag")
-        if commits_since_last:
-            raise ValueError(
-                f"RELEASE build must be on tag {tag}; "
-                f"HEAD is {commits_since_last} commit(s) ahead"
-            )
+        #if not tag:
+        #    raise ValueError("RELEASE build requires a vX.Y.Z tag")
+        #if commits_since_last:
+        #    raise ValueError(
+        #        f"HEAD is {commits_since_last} commit(s) ahead"
+        #    )
         return version, tag, 0
 
     # not in release pathway, so need to increment minor to target next release version


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
Relax `speculators` release build and not throw any errors if to use a non-release tag for the build. This will allow `hs-connectors` release to run tests with a speculators commit when speculators is not ready to release yet. Keep the code commented out for now.

## Tests

## Checklist

I have filled in:

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [ ] I (a human) have written or reviewed the code in this pr to the best of my ability.
