### PR TITLE
Suppress httpx logs on vllm render

### DIFF
--- a/src/speculators/data_generation/render_client.py
+++ b/src/speculators/data_generation/render_client.py
@@ -6,11 +6,14 @@ between two renders, not the server's ``assistant_tokens_mask`` (which needs
 already runs, so one tokenizer feeds the mask, hidden states, and serving.
 """
 
+import logging
 from http import HTTPStatus
 
 import httpx
 
 from speculators.data_generation.vllm_client import InvalidResponseError, with_retries
+
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 DEFAULT_RENDER_TIMEOUT = 30
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Currently we get a lot of noisy httpx logs when running preprocessing. This suppresses all httpx logs that aren't warnings or above. 

## Tests

Tested preprocessing locally. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
