### PR TITLE
feat: DeepSeek-V4-Flash DSpark draft model

### DIFF
--- a/src/speculators/models/__init__.py
+++ b/src/speculators/models/__init__.py
@@ -2,6 +2,7 @@ from speculators.models.attention import ALL_ATTENTION_FUNCTIONS  # noqa: F401
 
 from .dflash import DFlashDraftModel, DFlashSpeculatorConfig
 from .dspark import DSparkDraftModel, DSparkSpeculatorConfig
+from .dsv4_dspark import DSV4DSparkConfig, DSV4DSparkDraftModel
 from .eagle3 import Eagle3DraftModel, Eagle3SpeculatorConfig
 from .mtp import MTPDraftModel, MTPSpeculatorConfig
 from .peagle import PEagleDraftModel, PEagleSpeculatorConfig
@@ -9,6 +10,8 @@ from .peagle import PEagleDraftModel, PEagleSpeculatorConfig
 __all__ = [
     "DFlashDraftModel",
     "DFlashSpeculatorConfig",
+    "DSV4DSparkConfig",
+    "DSV4DSparkDraftModel",
     "DSparkDraftModel",
     "DSparkSpeculatorConfig",
     "Eagle3DraftModel",

--- a/src/speculators/models/dsv4_dspark/__init__.py
+++ b/src/speculators/models/dsv4_dspark/__init__.py
@@ -1,0 +1,19 @@
+"""DeepSeek-V4-Flash DSpark draft speculator.
+
+A self-contained, backend-agnostic implementation of the DSpark draft *backbone* for
+DeepSeek-V4-Flash: multi-head latent attention with per-head attention sinks, 256 routed
+experts + 1 shared per layer, and hyper-connections in place of the residual stream --
+plain PyTorch throughout.
+
+The DSpark *method* (anchor-block sampling, the Markov and confidence heads, the
+compound loss, and the SpeculatorModel / trainer / data contract) is reused as-is from
+:mod:`speculators.models.dspark`; this package adds only the DSV4-native backbone and
+the thin subclass that swaps it in.
+"""
+
+from __future__ import annotations
+
+from .config import DSparkDraftConfig
+from .core import DSV4DSparkConfig, DSV4DSparkDraftModel
+
+__all__ = ["DSV4DSparkConfig", "DSV4DSparkDraftModel", "DSparkDraftConfig"]

--- a/src/speculators/models/dsv4_dspark/backbone/__init__.py
+++ b/src/speculators/models/dsv4_dspark/backbone/__init__.py
@@ -1,0 +1,16 @@
+"""Backend-agnostic DSV4 decoder backbone for the DSpark draft.
+
+A self-contained torch implementation of the DeepSeek-V4-Flash decoder shape:
+multi-head latent attention with per-head sinks, 256 routed experts + 1 shared, and
+hyper-connections. Plain PyTorch throughout, with no dependency on any accelerator
+package.
+"""
+
+from __future__ import annotations
+
+from .norm import RMSNorm, UnweightedRMSNorm
+
+__all__ = [
+    "RMSNorm",
+    "UnweightedRMSNorm",
+]

--- a/src/speculators/models/dsv4_dspark/backbone/attention.py
+++ b/src/speculators/models/dsv4_dspark/backbone/attention.py
@@ -1,0 +1,219 @@
+"""Multi-head latent attention with a per-head learnable sink (DSV4 draft).
+
+Two layers here:
+
+* :func:`sink_block_attention` — the numerical core: a dense, non-causal
+  sink-softmax over ``[context + block]`` KV. Vanilla SDPA cannot
+  express the sink (it is an extra term in the softmax denominator), so this
+  eager einsum form is the sink-correct path.
+
+* :class:`LatentAttention` — the MLA projection stack (low-rank query
+  ``wq_a→q_norm→wq_b`` + per-head RMS, single shared-KV ``wkv→kv_norm``,
+  grouped low-rank output ``wo_a→wo_b``) plus the learnable ``sink``. Its
+  training forward assembles per-anchor-block queries/keys/values and calls
+  :func:`sink_block_attention`; it does not use a KV cache (teacher-forced).
+
+Weight-name note: the released checkpoint stores these as ``wq_a`` / ``wq_b`` /
+``wkv`` / ``wo_a`` / ``wo_b`` / ``attn_sink``; the loader maps those onto the
+descriptive attribute names here.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from .norm import RMSNorm, UnweightedRMSNorm
+from .rotary import apply_rotary_emb
+
+# k/v arrive as [N, Sk, D]: one shared KV head, no head axis.
+_SHARED_KV_RANK = 3
+# Cap on the fp32 logit block a single attention chunk may allocate. The dense
+# [N, Sq, H, Sk] intermediates are the largest tensors in the model: at 512 anchors over
+# a 22k-token context they are ~18 GB each, and three of them are live at once without
+# chunking. Chunking the query axis is exact -- the softmax normalizes per query row --
+# and leaves only the probabilities retained for backward, which activation
+# checkpointing then removes as well.
+_ATTN_CHUNK_BYTES = 1 << 30
+
+
+def sink_block_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    sink: torch.Tensor,
+    scale: float,
+    attn_bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Dense non-causal sink-softmax attention (fp32 accumulation).
+
+    Shapes: ``q [N, Sq, H, D]``, ``k/v [N, Sk, D]`` (a SINGLE shared KV head -- the DSV4
+    draft's MLA has one KV head shared across the H query heads), ``sink [H]``, optional
+    ``attn_bias [N, Sq, Sk]`` (or broadcastable) added to the logits *before* the sink
+    term. Returns ``[N, Sq, H, D]``.
+
+    Shared-KV einsums (``nkd``, not ``nkhd``) contract the single KV head against every
+    query head directly -- identical to broadcasting K/V to H heads first, but without
+    materializing the H-times-larger ``[N, Sk, H, D]`` tensor, and it is the shape a
+    fused shared-KV kernel expects.
+
+    The sink is a synthetic key whose logit is the per-head ``sink`` scalar; it
+    contributes to the softmax denominator but nothing to the value sum:
+    ``p_j = exp(s_j) / (Sum_j exp(s_j) + exp(sink))``.
+
+    The query axis is processed in chunks sized by :data:`_ATTN_CHUNK_BYTES`. The
+    softmax normalizes per query row, so chunking changes nothing but floating-point
+    associativity.
+    """
+    # Loud guard against a stale caller that pre-expands K/V to H heads.
+    if k.dim() != _SHARED_KV_RANK:
+        raise ValueError(
+            f"shared-KV sink attention wants k/v [N, Sk, D]; got {tuple(k.shape)}"
+        )
+    n, sq, h, _ = q.shape
+    sk = k.shape[1]
+    per_row = h * sk * 4  # one fp32 logit block for a single query position
+    chunk = max(1, _ATTN_CHUNK_BYTES // max(per_row, 1))
+    if chunk >= sq:
+        return _attend(q, k, v, sink, scale, attn_bias)
+    outs = [
+        _attend(
+            q[:, i : i + chunk],
+            k,
+            v,
+            sink,
+            scale,
+            _slice_bias(attn_bias, i, i + chunk, sq),
+        )
+        for i in range(0, sq, chunk)
+    ]
+    return torch.cat(outs, dim=1)
+
+
+def _slice_bias(
+    attn_bias: torch.Tensor | None, start: int, stop: int, sq: int
+) -> torch.Tensor | None:
+    """Take the query slice of an additive bias, leaving a broadcast one alone."""
+    if attn_bias is None or attn_bias.shape[-2] != sq:
+        return attn_bias
+    return attn_bias[..., start:stop, :]
+
+
+def _attend(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    sink: torch.Tensor,
+    scale: float,
+    attn_bias: torch.Tensor | None,
+) -> torch.Tensor:
+    s = torch.einsum("nqhd,nkd->nqhk", q.float(), k.float()) * scale
+    if attn_bias is not None:
+        s = s + attn_bias.float().unsqueeze(2)  # [N, Sq, 1, Sk] broadcast over heads
+    sink_h = sink.float().view(1, 1, -1, 1)
+    row_max = torch.maximum(s.max(dim=-1, keepdim=True).values, sink_h)
+    e = torch.exp(s - row_max)
+    denom = e.sum(dim=-1, keepdim=True) + torch.exp(sink_h - row_max)
+    p = e / denom
+    return torch.einsum("nqhk,nkd->nqhd", p, v.float()).to(q.dtype)
+
+
+class LatentAttention(nn.Module):
+    """MLA + per-head sink for one draft layer (teacher-forced, no KV cache).
+
+    ``forward`` takes the block hidden states (queries) and the context+block
+    hidden states (keys/values source) already assembled by the caller, plus the
+    precomputed rope frequencies for each, and returns the attention output projected
+    back to ``hidden_size``.
+    """
+
+    def __init__(self, cfg) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.num_heads = cfg.num_heads
+        self.head_dim = cfg.head_dim
+        self.rope_head_dim = cfg.rope_head_dim
+        self.n_groups = cfg.o_groups
+        self.eps = cfg.rms_norm_eps
+        self.scale = cfg.head_dim**-0.5
+
+        self.wq_a = nn.Linear(cfg.hidden_size, cfg.q_lora_rank, bias=False)
+        self.q_norm = RMSNorm(cfg.q_lora_rank, cfg.rms_norm_eps)
+        self.wq_b = nn.Linear(cfg.q_lora_rank, cfg.num_heads * cfg.head_dim, bias=False)
+        self.q_head_norm = UnweightedRMSNorm(cfg.rms_norm_eps)  # per-head RMS on q
+        self.wkv = nn.Linear(
+            cfg.hidden_size, cfg.head_dim, bias=False
+        )  # single shared KV head
+        self.kv_norm = RMSNorm(cfg.head_dim, cfg.rms_norm_eps)
+        self.wo_a = nn.Linear(
+            cfg.num_heads * cfg.head_dim // cfg.o_groups,
+            cfg.o_groups * cfg.o_lora_rank,
+            bias=False,
+        )
+        self.wo_b = nn.Linear(
+            cfg.o_groups * cfg.o_lora_rank, cfg.hidden_size, bias=False
+        )
+        self.attn_sink = nn.Parameter(torch.zeros(cfg.num_heads))
+
+    def project_q(self, block_x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+        """block_x [N, Sq, dim] -> q [N, Sq, H, head_dim], rope on the tail."""
+        rd = self.rope_head_dim
+        q = self.q_norm(self.wq_a(block_x))
+        q = self.wq_b(q).unflatten(-1, (self.num_heads, self.head_dim))
+        q = self.q_head_norm(q)
+        rope = apply_rotary_emb(q[..., -rd:], freqs_cis)
+        return torch.cat([q[..., :-rd], rope], dim=-1)
+
+    def project_kv(self, kv_x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+        """kv_x [N, Sk, dim] -> kv [N, Sk, head_dim], one shared KV head."""
+        rd = self.rope_head_dim
+        kv = self.kv_norm(self.wkv(kv_x))
+        rope = apply_rotary_emb(kv[..., -rd:], freqs_cis)
+        return torch.cat([kv[..., :-rd], rope], dim=-1)
+
+    def forward(
+        self,
+        block_x: torch.Tensor,
+        context_x: torch.Tensor,
+        block_freqs: torch.Tensor,
+        context_freqs: torch.Tensor,
+        attn_bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Block-gamma draft attention (teacher-forced, no KV cache).
+
+        ``block_x [N, gamma, dim]`` are the draft block hidden states (queries +
+        block keys/values); ``context_x [N, W, dim]`` is the target-hidden context
+        window (``main_x``) providing the sliding-window keys/values. Each block query
+        attends densely (non-causal) to ``[context | block]`` with the per-head sink.
+        Returns ``[N, gamma, dim]``.
+        """
+        q = self.project_q(block_x, block_freqs)  # [N, gamma, H, D]
+        kv_ctx = self.project_kv(context_x, context_freqs)  # [N, W, D]
+        kv_blk = self.project_kv(block_x, block_freqs)  # [N, gamma, D]
+        kv = torch.cat(
+            [kv_ctx, kv_blk], dim=1
+        )  # [N, W+gamma, D] (single shared KV head)
+        # Shared-KV: pass the single KV head directly (NO .expand to H heads). The
+        # nkd einsums broadcast it over the query heads -> identical output,
+        # without ever materializing the H×-larger [N, Sk, H, D] tensor (−~2.1 GB, ~20×
+        # forward).
+        o = sink_block_attention(q, kv, kv, self.attn_sink, self.scale, attn_bias)
+        return self.combine_output(o, block_freqs)
+
+    def combine_output(
+        self, o: torch.Tensor, q_freqs_cis: torch.Tensor
+    ) -> torch.Tensor:
+        """o [N, Sq, H, head_dim] -> hidden [N, Sq, dim] via grouped low-rank
+        projection.
+
+        First de-rotate the output's rope slice (K=V shared rotation), then the grouped
+        ``wo_a`` einsum + ``wo_b`` mix.
+        """
+        rd = self.rope_head_dim
+        derot = apply_rotary_emb(o[..., -rd:], q_freqs_cis, inverse=True)
+        o = torch.cat([o[..., :-rd], derot], dim=-1)
+        n, sq = o.shape[0], o.shape[1]
+        o = o.reshape(n, sq, self.n_groups, -1)
+        wo_a = self.wo_a.weight.view(self.n_groups, self.cfg.o_lora_rank, -1)
+        o = torch.einsum("nsgd,grd->nsgr", o, wo_a)
+        return self.wo_b(o.flatten(2))

--- a/src/speculators/models/dsv4_dspark/backbone/block.py
+++ b/src/speculators/models/dsv4_dspark/backbone/block.py
@@ -1,0 +1,70 @@
+"""One mHC-wrapped DSV4 draft decoder block.
+
+Residual flow keeps ``hc_mult`` streams; each sublayer (latent attention, then MoE) is
+wrapped by a :class:`~.hyper.HyperConnection`:
+
+    residual = streams
+    post, comb, x = attn_hc(streams);  x = attn_norm(x);  x = attn(x, …)
+    streams = place(x, residual, post, comb)
+    residual = streams
+    post, comb, x = ffn_hc(streams);   x = ffn_norm(x);   x = ffn(x)
+    streams = place(x, residual, post, comb)
+
+The attention is the block-gamma draft attention (:class:`~.attention.LatentAttention`),
+which additionally consumes the target-hidden context ``main_x`` and the rope
+frequencies for the block and context positions.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from .attention import LatentAttention
+from .hyper import HyperConnection, place
+from .moe import MoE
+from .norm import RMSNorm
+
+
+class MhcDecoderBlock(nn.Module):
+    """Latent-attention + MoE block with two-site hyper-connections."""
+
+    attn: LatentAttention
+    ffn: MoE
+    attn_norm: RMSNorm
+    ffn_norm: RMSNorm
+    attn_hc: HyperConnection
+    ffn_hc: HyperConnection
+
+    def __init__(self, cfg) -> None:
+        super().__init__()
+        self.attn = LatentAttention(cfg)
+        self.ffn = MoE(cfg)
+        self.attn_norm = RMSNorm(cfg.hidden_size, cfg.rms_norm_eps)
+        self.ffn_norm = RMSNorm(cfg.hidden_size, cfg.rms_norm_eps)
+        self.attn_hc = HyperConnection(cfg)
+        self.ffn_hc = HyperConnection(cfg)
+
+    def forward(
+        self,
+        streams: torch.Tensor,
+        context_x: torch.Tensor,
+        block_freqs: torch.Tensor,
+        context_freqs: torch.Tensor,
+        attn_bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """``streams [N, gamma, hc, dim]`` -> ``[N, gamma, hc, dim]``.
+
+        ``context_x [N, W, dim]`` is the shared target-hidden context (``main_x``).
+        """
+        residual = streams
+        post, comb, x = self.attn_hc(streams)
+        x = self.attn_norm(x)
+        x = self.attn(x, context_x, block_freqs, context_freqs, attn_bias)
+        streams = place(x, residual, post, comb)
+
+        residual = streams
+        post, comb, x = self.ffn_hc(streams)
+        x = self.ffn_norm(x)
+        x = self.ffn(x)
+        return place(x, residual, post, comb)

--- a/src/speculators/models/dsv4_dspark/backbone/hyper.py
+++ b/src/speculators/models/dsv4_dspark/backbone/hyper.py
@@ -1,0 +1,124 @@
+"""Manifold-constrained hyper-connections (mHC) for the DSV4 DSpark backbone.
+
+Instead of a single residual stream, each block keeps ``hc_mult`` copies. At a sublayer
+site (attention / MoE) a :class:`HyperConnection`:
+
+  * collapses the ``hc_mult`` streams to one input for the sublayer (``pre``
+    weights), and
+  * returns per-stream placement weights ``post`` and a Sinkhorn-projected
+    doubly-stochastic stream-mixing matrix ``comb`` used by :func:`place` to
+    fold the sublayer output back into the multi-stream residual.
+
+:class:`HyperHead` is the lighter final collapse (``hc_mult`` → 1) before the
+shared norm + lm_head.
+
+The math follows the reference exactly: ``pre = σ(·)+ε``, ``post = 2·σ(·)`` (no ε),
+``comb = softmax(·)+ε`` then Sinkhorn-Knopp (one column normalization, then ``iters-1``
+row/column passes).
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.nn import functional
+
+from .norm import UnweightedRMSNorm
+
+# Small-normal init for the projections created with torch.empty.
+_INIT_STD = 0.02
+
+
+def _hyper_connection(
+    module: HyperConnection, streams: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Reference mHC forward. ``streams [B, S, hc, D]`` -> ``(post, comb, collapsed)``.
+
+    ``post [B, S, hc]``, ``comb [B, S, hc, hc]`` (doubly-stochastic),
+    ``collapsed [B, S, D]``.
+    """
+    hc = module.hc_mult
+    eps = module.hc_eps
+    flat = module.input_norm(streams.flatten(start_dim=2).float())
+    mix = functional.linear(flat, module.fn.float())
+    pre_w, post_w, comb_w = mix.split([hc, hc, hc * hc], dim=-1)
+    pre_b, post_b, comb_b = module.base.float().split([hc, hc, hc * hc])
+    pre_s, post_s, comb_s = module.scale.float().unbind(0)
+
+    pre = torch.sigmoid(pre_w * pre_s + pre_b) + eps
+    post = 2 * torch.sigmoid(post_w * post_s + post_b)
+    comb_logits = comb_w.view(*comb_w.shape[:-1], hc, hc) * comb_s + comb_b.view(hc, hc)
+    comb = torch.softmax(comb_logits, dim=-1) + eps
+    # Sinkhorn-Knopp toward doubly-stochastic: start with one column pass (the softmax
+    # already made rows sum ~1), then iters-1 row/column passes.
+    comb = comb / (comb.sum(dim=-2, keepdim=True) + eps)
+    for _ in range(module.hc_sinkhorn_iters - 1):
+        comb = comb / (comb.sum(dim=-1, keepdim=True) + eps)
+        comb = comb / (comb.sum(dim=-2, keepdim=True) + eps)
+
+    collapsed = (pre.unsqueeze(-1) * streams).sum(dim=2).to(streams.dtype)
+    return post, comb, collapsed
+
+
+def place(
+    out: torch.Tensor,
+    residual_streams: torch.Tensor,
+    post: torch.Tensor,
+    comb: torch.Tensor,
+) -> torch.Tensor:
+    """Fold a sublayer output back into the multi-stream residual.
+
+    ``out [B, S, D]``, ``residual_streams [B, S, hc, D]``, ``post [B, S, hc]``,
+    ``comb [B, S, hc, hc]`` -> new streams ``[B, S, hc, D]``:
+    ``new[j] = post[j]·out + Σ_m comb[m, j]·residual[m]`` (matches the reference
+    ``sum(comb.unsqueeze(-1) * residual.unsqueeze(-2), dim=2)``).
+    """
+    placed = post.unsqueeze(-1) * out.unsqueeze(-2)
+    mixed = torch.sum(comb.unsqueeze(-1) * residual_streams.unsqueeze(-2), dim=2)
+    return (placed + mixed).type_as(out)
+
+
+class HyperConnection(nn.Module):
+    """One mHC site (attention or FFN)."""
+
+    def __init__(self, cfg) -> None:
+        super().__init__()
+        self.hc_mult = cfg.hc_mult
+        self.hc_sinkhorn_iters = cfg.hc_sinkhorn_iters
+        self.hc_eps = cfg.hc_eps
+        self.input_norm = UnweightedRMSNorm(cfg.rms_norm_eps)
+        mix = (2 + self.hc_mult) * self.hc_mult
+        self.fn = nn.Parameter(torch.empty(mix, self.hc_mult * cfg.hidden_size))
+        nn.init.normal_(self.fn, std=_INIT_STD)
+        self.base = nn.Parameter(torch.zeros(mix))
+        self.scale = nn.Parameter(torch.ones(3))  # index 0=pre, 1=post, 2=comb
+
+    def forward(
+        self, streams: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return _hyper_connection(self, streams)
+
+
+class HyperHead(nn.Module):
+    """Final mHC collapse: ``[B, S, hc, D]`` -> ``[B, S, D]`` (pre weights only)."""
+
+    def __init__(self, cfg) -> None:
+        super().__init__()
+        self.hc_mult = cfg.hc_mult
+        self.hc_eps = cfg.hc_eps
+        self.input_norm = UnweightedRMSNorm(cfg.rms_norm_eps)
+        self.hc_fn = nn.Parameter(
+            torch.empty(self.hc_mult, self.hc_mult * cfg.hidden_size)
+        )
+        nn.init.normal_(self.hc_fn, std=_INIT_STD)
+        self.hc_base = nn.Parameter(torch.zeros(self.hc_mult))
+        self.hc_scale = nn.Parameter(torch.ones(1))
+
+    def forward(self, streams: torch.Tensor) -> torch.Tensor:
+        flat = self.input_norm(streams.flatten(start_dim=2).float())
+        mixes = functional.linear(flat, self.hc_fn.float())
+        pre = (
+            torch.sigmoid(mixes * self.hc_scale.float() + self.hc_base.float())
+            + self.hc_eps
+        )
+        return (pre.unsqueeze(-1) * streams).sum(dim=2).to(streams.dtype)

--- a/src/speculators/models/dsv4_dspark/backbone/moe.py
+++ b/src/speculators/models/dsv4_dspark/backbone/moe.py
@@ -1,0 +1,291 @@
+"""Mixture-of-experts FFN for the DSV4 DSpark draft backbone.
+
+``256`` routed experts (SwiGLU with a magnitude clamp) + ``1`` shared expert,
+top-``k`` routing with ``sqrtsoftplus`` scoring. The draft layers are all score-routed
+(hash routing only applies to the target's first few layers, which the draft does not
+include), so no token-id / hash path is needed here.
+
+Routed experts are held as **stacked weights** (:class:`GroupedExperts`:
+``w1/w3 [E, inter, dim]``, ``w2 [E, dim, inter]``) rather than a ``ModuleList`` of
+per-expert Linears. This is the layout expert-parallelism and a grouped matmul
+both want (one ``Shard(0)`` DTensor per projection under EP; a single grouped GEMM
+instead of a 256-way loop). The dispatch here is the reference: it loops over experts,
+feeding each only its routed tokens.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+import torch
+from torch import nn
+from torch.nn import functional
+
+# Small-normal init for the projections created with torch.empty.
+_INIT_STD = 0.02
+
+
+class Router(nn.Module):
+    """Score-based top-k router (``sqrtsoftplus``).
+
+    ``bias`` shifts scores for *selection* (top-k) only; the combine
+    ``weights`` are gathered from the pre-bias scores, sum-normalized, then
+    scaled by ``route_scale`` (this is the non-softmax path).
+    """
+
+    weight: nn.Parameter
+    bias: torch.Tensor  # buffer, not a parameter
+
+    def __init__(self, cfg) -> None:
+        super().__init__()
+        self.topk = cfg.n_activated_experts
+        self.route_scale = cfg.route_scale
+        self.score_func = cfg.score_func
+        self.weight = nn.Parameter(torch.empty(cfg.n_routed_experts, cfg.hidden_size))
+        nn.init.normal_(self.weight, std=_INIT_STD)
+        # Aux-loss-free load-balancing bias (noaux_tc). It shifts the top-k
+        # selection only, never the combine weights, and is moved by a balancing rule
+        # rather than by backpropagation. A buffer rather than a parameter, so FSDP
+        # leaves it replicated: it stays identical across ranks and can be updated in
+        # place from the all-reduced global load.
+        self.register_buffer("bias", torch.zeros(cfg.n_routed_experts), persistent=True)
+        self.n_routed_experts = cfg.n_routed_experts
+        # DSPARK_LOG_EXPERT_LOAD=1 -> stash per-expert selection counts each fwd
+        # (diagnostic; core.py).
+        self._log_load = os.environ.get("DSPARK_LOG_EXPERT_LOAD") == "1"
+        # DSPARK_MOE_BALANCE_RATE turns the bias update on and sets its size in one
+        # go -- b_i += rate * sign(mean load - load_i), applied once per step from
+        # _backbone_forward. Unset means the bias stays frozen and routing is free to
+        # concentrate on a few experts.
+        _rate = os.environ.get("DSPARK_MOE_BALANCE_RATE")
+        self._balance_rate = float(_rate) if _rate else 0.0
+        self._balance = self._balance_rate > 0
+        self._sel_counts: torch.Tensor | None = None
+        self._step_load: torch.Tensor | None = None
+
+    def _score(self, scores: torch.Tensor) -> torch.Tensor:
+        if self.score_func == "softmax":
+            return scores.softmax(dim=-1)
+        if self.score_func == "sigmoid":
+            return scores.sigmoid()
+        return functional.softplus(scores).sqrt()  # sqrtsoftplus (DSV4 default)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        scores = self._score(functional.linear(x.float(), self.weight.float()))
+        selection = scores + self.bias.float()
+        indices = selection.topk(self.topk, dim=-1)[1]
+        weights = scores.gather(1, indices)
+        if self.score_func != "softmax":
+            weights = weights / weights.sum(dim=-1, keepdim=True)
+        weights = weights * self.route_scale
+        if self._log_load or (self._balance and self.training):
+            _cnt = (
+                torch.bincount(indices.reshape(-1), minlength=self.n_routed_experts)
+                .detach()
+                .float()
+            )
+            if (
+                self._log_load
+            ):  # this rank's per-expert selection histogram (diagnostic)
+                self._sel_counts = _cnt
+            if (
+                self._balance and self.training
+            ):  # stash for the per-step bias update (SET, so a recompute
+                # A clone, not _cnt: update_load_balance_bias all-reduces this in
+                # place, which would turn the diagnostic histogram above into a
+                # global sum. Re-set each forward, so a recompute does not double
+                # count.
+                self._step_load = _cnt.clone()
+        return weights, indices
+
+    @torch.no_grad()
+    def update_load_balance_bias(self) -> None:
+        """DeepSeek noaux_tc load balancing: nudge the (non-grad) selection ``bias``
+        toward uniform expert load WITHOUT an aux loss. ``b_i += rate * sign(avg_load -
+        load_i)`` (under-loaded up, over-loaded down). Called ONCE per step from
+        ``_backbone_forward``. Under EP the router runs on each rank's DP-shard of
+        tokens, so all-reduce the counts to the GLOBAL load — the bias is REPLICATED and
+        must
+        update identically on every rank. No-op when off or unstashed."""
+        if not self._balance or self._step_load is None:
+            return
+        load = self._step_load
+        import torch.distributed as dist  # noqa: PLC0415
+
+        if dist.is_initialized():
+            dist.all_reduce(
+                load, op=dist.ReduceOp.SUM
+            )  # -> global per-expert load (same on all ranks)
+        delta = self._balance_rate * torch.sign(load.mean() - load)
+        delta = (
+            delta - delta.mean()
+        )  # zero-mean the step so the bias cannot drift as a whole
+        self.bias.add_(
+            delta.to(self.bias.dtype)
+        )  # so it can't drift as a whole over a long run
+        self._step_load = None
+
+
+class Expert(nn.Module):
+    """SwiGLU expert with an optional magnitude clamp (fp32 activations).
+
+    Used for the single **shared** expert (a plain dense FFN). The routed experts live
+    in :class:`GroupedExperts` as stacked weights.
+    """
+
+    def __init__(self, dim: int, inter_dim: int, swiglu_limit: float = 0.0) -> None:
+        super().__init__()
+        self.w1 = nn.Linear(dim, inter_dim, bias=False)  # gate
+        self.w3 = nn.Linear(dim, inter_dim, bias=False)  # up
+        self.w2 = nn.Linear(inter_dim, dim, bias=False)  # down
+        self.swiglu_limit = swiglu_limit
+
+    def forward(
+        self, x: torch.Tensor, weight: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        dtype = x.dtype
+        gate = self.w1(x).float()
+        up = self.w3(x).float()
+        if self.swiglu_limit > 0:
+            up = torch.clamp(up, min=-self.swiglu_limit, max=self.swiglu_limit)
+            gate = torch.clamp(gate, max=self.swiglu_limit)
+        h = functional.silu(gate) * up
+        if weight is not None:
+            h = weight * h
+        return self.w2(h.to(dtype))
+
+
+def swiglu_grouped(
+    xg: torch.Tensor,
+    w1: torch.Tensor,
+    w3: torch.Tensor,
+    w2: torch.Tensor,
+    counts: torch.Tensor,
+    w_flat: torch.Tensor,
+    swiglu_limit: float,
+    matmul,
+) -> torch.Tensor:
+    """SwiGLU over token groups, one group per (local) expert. Shared by the eager
+    reference and any faster implementation (they differ only in
+    ``matmul``: a per-group loop vs a fused ``npu_grouped_matmul``).
+
+    ``xg[N, dim]`` are routed tokens already sorted by expert; ``counts[E]`` the
+    per-expert token count; ``w1/w3 [E, inter, dim]``, ``w2 [E, dim, inter]`` the
+    stacked expert weights; ``w_flat[N]`` the per-token router weight (applied pre-down,
+    matching :class:`Expert`). ``matmul(x, W, counts)`` does the grouped
+    ``x @ W`` with ``W[E, in, out]``.
+    """
+    gate = matmul(xg, w1.transpose(1, 2), counts)  # [N, inter]
+    up = matmul(xg, w3.transpose(1, 2), counts)
+    if swiglu_limit > 0:
+        up = torch.clamp(up, min=-swiglu_limit, max=swiglu_limit)
+        gate = torch.clamp(gate, max=swiglu_limit)
+    h = functional.silu(gate) * up
+    h = w_flat[:, None] * h
+    return matmul(h, w2.transpose(1, 2), counts)  # [N, dim]
+
+
+class GroupedExperts(nn.Module):
+    """Routed experts as stacked weights (``w1/w3 [E, inter, dim]``, ``w2 [E, dim,
+    inter]``).
+
+    ``E`` is the number of experts held locally. Under FSDP the stacked weights become
+    DTensors, so the forward reads ``.to_local()``.
+    """
+
+    def __init__(
+        self, dim: int, inter_dim: int, n_local: int, swiglu_limit: float
+    ) -> None:
+        super().__init__()
+        self.num_local_experts = n_local
+        self.swiglu_limit = swiglu_limit
+        # Weight layout [out, in] per expert (like nn.Linear.weight), stacked over
+        # experts, so a checkpoint round-trips to/from per-expert
+        # ``experts.{i}.w{1,2,3}.weight`` by a plain stack/index.
+        self.w1 = nn.Parameter(torch.empty(n_local, inter_dim, dim))  # gate
+        self.w3 = nn.Parameter(torch.empty(n_local, inter_dim, dim))  # up
+        self.w2 = nn.Parameter(torch.empty(n_local, dim, inter_dim))  # down
+        # nn.Linear's default init is kaiming_uniform_(a=sqrt(5)) -> U(-1/sqrt(fan_in));
+        # applied per expert (fan_in is dim for w1/w3, inter for w2, the same for every
+        # expert, so one fill matches).
+        b1, b2 = 1.0 / math.sqrt(dim), 1.0 / math.sqrt(inter_dim)
+        with torch.no_grad():
+            self.w1.uniform_(-b1, b1)
+            self.w3.uniform_(-b1, b1)
+            self.w2.uniform_(-b2, b2)
+
+    def local_weights(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """(w1, w3, w2) as local tensors (``.to_local()`` for Shard(0) DTensors)."""
+
+        def loc(p):
+            return p.to_local() if hasattr(p, "to_local") else p
+
+        return loc(self.w1), loc(self.w3), loc(self.w2)
+
+
+def _moe_dispatch(
+    x: torch.Tensor,
+    weights: torch.Tensor,
+    indices: torch.Tensor,
+    experts: GroupedExperts,
+    n_routed_experts: int,
+) -> torch.Tensor:
+    """Route ``x [tokens, dim]`` to its top-k experts and combine (fp32 accum).
+
+    Loops over ALL experts in a fixed order, feeding each only its routed tokens.
+    ``experts`` holds the full stacked routed-expert weights. Correct on any device
+    and not fast; it is also the oracle a faster implementation is checked against.
+    """
+    w1, w3, w2 = experts.local_weights()
+    lim = experts.swiglu_limit
+    y = torch.zeros_like(x, dtype=torch.float32)
+    for e in range(n_routed_experts):
+        tok, slot = torch.where(indices == e)
+        xe = x[tok].float()
+        gate = xe @ w1[e].t().float()
+        up = xe @ w3[e].t().float()
+        if lim > 0:
+            up = torch.clamp(up, min=-lim, max=lim)
+            gate = torch.clamp(gate, max=lim)
+        h = functional.silu(gate) * up
+        h = weights[tok, slot, None].float() * h
+        y[tok] += h @ w2[e].t().float()
+    return y
+
+
+class MoE(nn.Module):
+    """Routed + shared mixture of experts."""
+
+    router: Router
+    experts: GroupedExperts
+    shared_experts: Expert
+
+    def __init__(self, cfg) -> None:
+        super().__init__()
+        self.dim = cfg.hidden_size
+        self.n_routed_experts = (
+            cfg.n_routed_experts
+        )  # GLOBAL count (router + dispatch use it)
+        self.router = Router(cfg)
+        self.experts = GroupedExperts(
+            cfg.hidden_size, cfg.moe_inter_dim, cfg.n_routed_experts, cfg.swiglu_limit
+        )
+        # The released config carries exactly one shared expert; the checkpoint key is
+        # ``ffn.shared_experts.{w1,w2,w3}`` (a single expert), so this is a single
+        # module.
+        if cfg.n_shared_experts != 1:
+            raise ValueError(
+                "only n_shared_experts == 1 is supported (matches the release)."
+            )
+        self.shared_experts = Expert(
+            cfg.hidden_size, cfg.moe_inter_dim, cfg.swiglu_limit
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        shape = x.shape
+        x = x.reshape(-1, self.dim)
+        weights, indices = self.router(x)
+        y = _moe_dispatch(x, weights, indices, self.experts, self.n_routed_experts)
+        y = y + self.shared_experts(x)
+        return y.type_as(x).view(shape)

--- a/src/speculators/models/dsv4_dspark/backbone/norm.py
+++ b/src/speculators/models/dsv4_dspark/backbone/norm.py
@@ -1,0 +1,49 @@
+"""RMS normalization variants for the DSV4 DSpark draft backbone.
+
+Two flavors, both fp32-accumulated for bf16 stability:
+
+* :class:`RMSNorm` — learnable per-channel scale, ones-init: ``y = w · x̂``.
+* :class:`UnweightedRMSNorm` — no parameters: ``y = x̂`` (the scale is folded
+  into a downstream projection). Used on the per-head query inside MLA.
+
+where ``x̂ = x / sqrt(mean(x², -1) + eps)``.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class RMSNorm(nn.Module):
+    """Ones-init RMSNorm with fp32 variance accumulation."""
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        in_dtype = x.dtype
+        x32 = x.to(torch.float32)
+        x_normed = x32 * torch.rsqrt(x32.pow(2).mean(-1, keepdim=True) + self.eps)
+        return self.weight * x_normed.to(in_dtype)
+
+    def extra_repr(self) -> str:
+        return f"{tuple(self.weight.shape)}, eps={self.eps}"
+
+
+class UnweightedRMSNorm(nn.Module):
+    """Parameter-free RMS normalization (scale folded downstream)."""
+
+    def __init__(self, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * torch.rsqrt(x.float().square().mean(-1, keepdim=True) + self.eps).to(
+            x.dtype
+        )
+
+    def extra_repr(self) -> str:
+        return f"eps={self.eps}"

--- a/src/speculators/models/dsv4_dspark/backbone/rotary.py
+++ b/src/speculators/models/dsv4_dspark/backbone/rotary.py
@@ -1,0 +1,112 @@
+"""Rotary position embedding for the DSV4 DSpark draft (interleaved, YaRN-capable).
+
+Two pieces:
+
+* :func:`precompute_freqs_cis` builds complex exponentials ``e^{i·t·θ_k}`` with
+  optional YaRN frequency interpolation (a smooth linear ramp between the
+  ``beta_fast`` / ``beta_slow`` correction dims). The draft's sliding-window
+  attention runs YaRN **off** (pass ``original_seq_len=0``) with the base
+  ``rope_theta`` — matching the reference, which disables YaRN on the pure
+  sliding path.
+* :func:`apply_rotary_emb` rotates the trailing ``rope_head_dim`` slice of a
+  ``[..., D]`` tensor using the **interleaved** pairing ``(x0,x1),(x2,x3),…``.
+  ``inverse=True`` conjugates the rotation to de-rotate the attention output's
+  rope slice (needed because DSV4 shares K=V, so V carried the rotation).
+
+The result is applied out-of-place (returns a new tensor) rather than the reference's
+in-place ``copy_`` so it composes cleanly with autograd.
+"""
+
+from __future__ import annotations
+
+import math
+from functools import lru_cache
+
+import torch
+
+
+@lru_cache(maxsize=4)
+def precompute_freqs_cis(
+    dim: int,
+    seqlen: int,
+    original_seq_len: int,
+    base: float,
+    factor: float,
+    beta_fast: float,
+    beta_slow: float,
+    device: str = "cpu",
+) -> torch.Tensor:
+    """Complex rotary frequencies ``[seqlen, dim//2]`` with optional YaRN.
+
+    ``dim`` is the rope slice width (``rope_head_dim``). With
+    ``original_seq_len == 0`` YaRN is disabled and plain ``1/base^(2k/dim)``
+    frequencies are used (the draft's sliding-window path).
+    """
+
+    def correction_dim(num_rotations: float) -> float:
+        return (
+            dim
+            * math.log(original_seq_len / (num_rotations * 2 * math.pi))
+            / (2 * math.log(base))
+        )
+
+    def correction_range(low_rot: float, high_rot: float) -> tuple[int, int]:
+        low = math.floor(correction_dim(low_rot))
+        high = math.ceil(correction_dim(high_rot))
+        return max(low, 0), min(high, dim - 1)
+
+    def linear_ramp(lo: float, hi: float, n: int) -> torch.Tensor:
+        if lo == hi:
+            hi += 0.001
+        ramp = (torch.arange(n, dtype=torch.float32) - lo) / (hi - lo)
+        return torch.clamp(ramp, 0, 1)
+
+    freqs = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    if original_seq_len > 0:
+        low, high = correction_range(beta_fast, beta_slow)
+        smooth = 1 - linear_ramp(low, high, dim // 2)
+        freqs = freqs / factor * (1 - smooth) + freqs * smooth
+
+    t = torch.arange(seqlen, dtype=torch.float32)
+    angles = torch.outer(t, freqs)
+    freqs_cis = torch.polar(torch.ones_like(angles), angles)
+    return freqs_cis.to(device)
+
+
+def apply_rotary_emb(
+    x: torch.Tensor, freqs_cis: torch.Tensor, inverse: bool = False
+) -> torch.Tensor:
+    """Rotate ``x`` (``[B, S, ..., rope_dim]``) with REAL interleaved cos/sin.
+
+    ``freqs_cis`` is the interleaved rotary cache as a REAL tensor ``[S, rope_dim//2,
+    2]`` (``[...,0]``=cos, ``[...,1]``=sin); a complex ``[S, rope_dim//2]`` is accepted
+    and converted via ``view_as_real``. The rotation is applied as ``x·cos +
+    rotate_half(x)·sin`` rather than a complex multiply, for two reasons: a complex
+    cache cast to bf16 silently loses its imaginary part, which turns the rotation into
+    a scale and is not an error anyone sees; and complex indexing and multiplication are
+    not available on every accelerator backend. Interleaved:
+    ``out_2k = x_2k·cos_k - x_2k+1·sin_k``, ``out_2k+1 = x_2k·sin_k + x_2k+1·cos_k``.
+    ``inverse`` negates sin (de-rotation, K=V shared rotation).
+    """
+    if freqs_cis.is_complex():
+        freqs_cis = torch.view_as_real(freqs_cis)
+    cos = freqs_cis[..., 0].repeat_interleave(2, dim=-1)  # [S, rope_dim]
+    sin = freqs_cis[..., 1].repeat_interleave(2, dim=-1)
+    if inverse:
+        sin = -sin
+    # Broadcast cos/sin over batch + any head dims: shape [1, S, (1,)*extra, rope_dim].
+    seq_len = x.shape[1]
+    extra = x.ndim - 2  # dims between the seq axis and the rope axis
+    view_shape = (
+        (1, seq_len, *([1] * (extra - 1)), x.shape[-1])
+        if extra >= 1
+        else (1, seq_len, x.shape[-1])
+    )
+    cos = cos.reshape(*view_shape).float()
+    sin = sin.reshape(*view_shape).float()
+    xf = x.float()
+    pair = xf.unflatten(-1, (-1, 2))  # [..., rope//2, 2]
+    rotate_half = torch.stack((-pair[..., 1], pair[..., 0]), dim=-1).flatten(
+        -2
+    )  # interleaved
+    return (xf * cos + rotate_half * sin).to(x.dtype)

--- a/src/speculators/models/dsv4_dspark/checkpoint_mapping.py
+++ b/src/speculators/models/dsv4_dspark/checkpoint_mapping.py
@@ -1,0 +1,259 @@
+"""Mapping between the released DSV4 checkpoint layout and this model's parameters.
+
+DeepSeek ships the DSV4 DSpark draft inside the target checkpoint, under an ``mtp.*``
+namespace with one tensor per expert, and every DSV4 loader in the ecosystem reads that
+layout. Writing anything else would mean a conversion step before a checkpoint trained
+here could be served.
+
+The mapping is declared as ``WeightRenaming`` / ``WeightConverter`` rules registered for
+the model class, the way ``transformers`` handles every MoE checkpoint it ships:
+``from_pretrained`` applies them and ``save_pretrained`` applies the reverse, so one
+declaration covers both directions. ``MergeModulelist(dim=0)`` is the same operation
+that bridges Mixtral's per-expert checkpoints to a stacked expert parameter.
+
+``source_patterns`` are checkpoint keys; ``target_patterns`` are module names.
+
+    embed.weight                          <-> embed_tokens.weight        [129280, 4096]
+    head.weight                           <-> lm_head.weight             [129280, 4096]
+    mtp.0.main_proj.weight                <-> fc.weight                  [4096, 12288]
+    mtp.0.main_norm.weight                <-> hidden_norm.weight         [4096]
+    mtp.{last}.norm.weight                <-> norm.weight                [4096]
+    mtp.{last}.markov_head.*              <-> markov_head.*              [129280, 256]
+    mtp.{last}.confidence_head.*          <-> confidence_head.*          [1, 4352]
+    mtp.{last}.hc_head_{base,fn,scale}    <-> hc_head.hc_{base,fn,scale}
+    mtp.{i}.hc_attn_{base,fn,scale}       <-> layers.{i}.attn_hc.{...}
+    mtp.{i}.hc_ffn_{base,fn,scale}        <-> layers.{i}.ffn_hc.{...}
+    mtp.{i}.ffn.gate.{weight,bias}        <-> layers.{i}.ffn.router.{...}
+    mtp.{i}.ffn.experts.{e}.w{k}.weight   <-> layers.{i}.ffn.experts.w{k}   [256, ...]
+    mtp.{i}.attn.* / *_norm / shared      <-> layers.{i}.<same name>
+
+Two constraints shape the rules. The stage indices are pinned rather than matched with
+``\\d+``: the conditioning projection sits on the first stage and the heads on the last,
+and a module name does not carry a stage -- ``fc.weight`` reversed through a
+non-capturing pattern would produce the literal key ``mtp.\\d+.main_proj.weight``. And
+the rules are ordered generic-first, because the reverse direction applies them in
+reverse order: a catch-all placed last for loading runs first when saving and shadows
+every specific rule.
+
+``confidence_head.proj.bias`` has no slot in the released layout. The config field
+defaults to False, so a run does not create it; enabling it opts out of a byte-identical
+released layout.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# The number of decoder stages in the released DSV4-Flash draft. Pinned rules are built
+# for this depth by default; ``build_mapping`` takes a depth so another is expressible.
+RELEASED_N_LAYERS = 3
+
+# These live on a semi-private path: not exported at the ``transformers`` top level, and
+# the module moved between 4.x and 5.x. Failing to register must degrade to "keep the
+# module names", never to an import error at model-registration time.
+try:
+    import torch
+    from transformers.conversion_mapping import register_checkpoint_conversion_mapping
+    from transformers.core_model_loading import (
+        MergeModulelist,
+        WeightConverter,
+        WeightRenaming,
+        dot_natural_key,
+        rename_source_key,
+    )
+
+    _AVAILABLE = True
+except ImportError:  # pragma: no cover - depends on the installed transformers
+    _AVAILABLE = False
+
+
+def build_mapping(n_layers: int = RELEASED_N_LAYERS) -> list:
+    """The rules. ORDER IS GENERIC-FIRST -- see the note above; this is not a typo."""
+    last = n_layers - 1
+    rules: list = [
+        # --- per-stage ---
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.attn\.wq_a\.",
+            target_patterns=r"layers.\1.attn.wq_a.",
+        ),
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.attn\.wq_b\.",
+            target_patterns=r"layers.\1.attn.wq_b.",
+        ),
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.attn\.wkv\.",
+            target_patterns=r"layers.\1.attn.wkv.",
+        ),
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.attn\.wo_a\.",
+            target_patterns=r"layers.\1.attn.wo_a.",
+        ),
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.attn\.wo_b\.",
+            target_patterns=r"layers.\1.attn.wo_b.",
+        ),
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.attn\.q_norm\.",
+            target_patterns=r"layers.\1.attn.q_norm.",
+        ),
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.attn\.kv_norm\.",
+            target_patterns=r"layers.\1.attn.kv_norm.",
+        ),
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.attn\.attn_sink$",
+            target_patterns=r"layers.\1.attn.attn_sink",
+        ),
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.attn_norm\.",
+            target_patterns=r"layers.\1.attn_norm.",
+        ),
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.ffn_norm\.",
+            target_patterns=r"layers.\1.ffn_norm.",
+        ),
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.ffn\.shared_experts\.",
+            target_patterns=r"layers.\1.ffn.shared_experts.",
+        ),
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.ffn\.experts\.",
+            target_patterns=r"layers.\1.ffn.experts.",
+        ),
+        # the router is called `gate` in the release
+        WeightRenaming(
+            source_patterns=r"^mtp\.(\d+)\.ffn\.gate\.",
+            target_patterns=r"layers.\1.ffn.router.",
+        ),
+    ]
+    # --- per-stage: hyper-connections are flat in the release, nested in the module ---
+    for flat, nested in (("hc_attn", "attn_hc"), ("hc_ffn", "ffn_hc")):
+        for part in ("base", "fn", "scale"):
+            rules.append(
+                WeightRenaming(
+                    source_patterns=rf"^mtp\.(\d+)\.{flat}_{part}$",
+                    target_patterns=rf"layers.\1.{nested}.{part}",
+                )
+            )
+    rules += [
+        # --- top level (no stage prefix on the checkpoint side) ---
+        WeightRenaming(
+            source_patterns=r"^embed\.weight$", target_patterns="embed_tokens.weight"
+        ),
+        WeightRenaming(
+            source_patterns=r"^head\.weight$", target_patterns="lm_head.weight"
+        ),
+        # --- first stage only: the target-hidden conditioning ---
+        WeightRenaming(source_patterns=r"^mtp\.0\.main_proj\.", target_patterns="fc."),
+        WeightRenaming(
+            source_patterns=r"^mtp\.0\.main_norm\.", target_patterns="hidden_norm."
+        ),
+        # --- last stage only: heads that sit outside the layer stack ---
+        WeightRenaming(
+            source_patterns=rf"^mtp\.{last}\.norm\.", target_patterns="norm."
+        ),
+        WeightRenaming(
+            source_patterns=rf"^mtp\.{last}\.markov_head\.",
+            target_patterns="markov_head.",
+        ),
+        WeightRenaming(
+            source_patterns=rf"^mtp\.{last}\.confidence_head\.",
+            target_patterns="confidence_head.",
+        ),
+    ]
+    for part in ("base", "fn", "scale"):
+        rules.append(
+            WeightRenaming(
+                source_patterns=rf"^mtp\.{last}\.hc_head_{part}$",
+                target_patterns=f"hc_head.hc_{part}",
+            )
+        )
+    # --- the one real transformation: per-expert tensors -> one stacked parameter ---
+    for w in ("w1", "w2", "w3"):
+        rules.append(
+            WeightConverter(
+                source_patterns=f"ffn.experts.*.{w}.weight",
+                target_patterns=f"ffn.experts.{w}",
+                operations=[MergeModulelist(dim=0)],
+            )
+        )
+    return rules
+
+
+def register(
+    class_name: str = "DSV4DSparkDraftModel", n_layers: int = RELEASED_N_LAYERS
+) -> bool:
+    """Register the mapping, reporting whether it took so a caller can log it."""
+    if not _AVAILABLE:
+        logger.warning(
+            "transformers conversion-mapping API unavailable; DSV4-DSpark checkpoints "
+            "be written in module-name layout and will need conversion before serving."
+        )
+        return False
+    try:
+        register_checkpoint_conversion_mapping(
+            class_name, build_mapping(n_layers), overwrite=True
+        )
+    except (ValueError, TypeError, re.error) as exc:  # pragma: no cover
+        # Defensive: a bad rule must degrade to "keep module names", not break import.
+        logger.warning("could not register the DSV4-DSpark checkpoint mapping: %s", exc)
+        return False
+    return True
+
+
+def is_released_layout(state_dict: dict) -> bool:
+    """Released checkpoints put every stage under ``mtp.``; ours use ``layers.``."""
+    return any(key.startswith("mtp.") for key in state_dict)
+
+
+def to_module_layout(state_dict: dict, n_layers: int = RELEASED_N_LAYERS) -> dict:
+    """Released layout -> module names, applying the SAME rules in the load direction.
+
+    ``save_pretrained`` writes the released layout and ``from_pretrained`` reads it, but
+    the trainer resumes by reading the safetensors directly and calling
+    ``load_state_dict`` /
+    ``set_model_state_dict`` on the raw keys. Those see ``mtp.*`` against a model whose
+    parameters are ``layers.*``, and both are called with ``strict=False`` -- so without
+    this a resume loads NOTHING and silently continues from random initialisation.
+
+    This is not a second copy of the mapping: it runs the rule objects from
+    :func:`build_mapping` through ``transformers``' own ``rename_source_key``.
+
+    ``state_dict`` is consumed. Entries move into the result as they are converted, so
+    a 21B checkpoint is never held twice.
+    """
+    if not _AVAILABLE:
+        return state_dict
+    rules = build_mapping(n_layers)
+    renamings = [r for r in rules if not isinstance(r, WeightConverter)]
+    converters = [r for r in rules if isinstance(r, WeightConverter)]
+
+    converted: dict = {}
+    to_stack: dict[str, list] = {}
+    open_group = None
+
+    def flush() -> None:
+        while to_stack:
+            key, tensors = to_stack.popitem()
+            converted[key] = torch.stack(tensors, dim=0)  # MergeModulelist(dim=0)
+
+    # dot_natural_key, not sorted(): experts must stack 0,1,2,...,10 not 0,1,10,2. It
+    # also keeps one layer's experts contiguous, so a layer's stacks can be built and
+    # its per-expert sources released before the next layer starts -- the routed
+    # experts are most of the checkpoint, and holding the per-expert tensors and the
+    # stacked copies at once doubles the peak.
+    for key in sorted(state_dict, key=dot_natural_key):
+        new_key, matched_converter = rename_source_key(key, renamings, converters)
+        if matched_converter is None:
+            converted[new_key] = state_dict.pop(key)
+            continue
+        group = new_key.rsplit(".ffn.experts.", 1)[0]
+        if group != open_group:
+            flush()
+            open_group = group
+        to_stack.setdefault(new_key, []).append(state_dict.pop(key))
+    flush()
+    return converted

--- a/src/speculators/models/dsv4_dspark/config.py
+++ b/src/speculators/models/dsv4_dspark/config.py
@@ -1,0 +1,130 @@
+"""Shape and method configuration for the DeepSeek-V4-Flash DSpark draft.
+
+A plain dataclass, so the backbone modules can be built and unit-tested with nothing but
+torch. Defaults come from the released draft. :class:`~.core.DSV4DSparkConfig` is the
+``SpeculatorModelConfig`` the library serialises, and derives one of these from it.
+
+The draft reuses the target's decoder-layer shape -- latent attention with per-head
+sinks, 256 routed experts + 1 shared, hyper-connections -- over a short stack
+(``n_draft_layers``), plus the DSpark parts the target has no equivalent of: the
+``main_proj`` conditioning on target hidden states, and the Markov and confidence heads.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+
+@dataclass
+class DSparkDraftConfig:
+    """Shape + method config for the DSV4 DSpark draft.
+
+    Attribute names are deliberately mechanism-descriptive (not vendor class names) so
+    the model definition reads as a standalone port. The checkpoint weight-key mapping
+    (``mtp.N.attn.wq_a`` etc.) lives in the weight loader, not here.
+    """
+
+    # ---- vocabulary / hidden ------------------------------------------------
+    vocab_size: int = 129280
+    hidden_size: int = 4096
+    rms_norm_eps: float = 1e-6
+
+    # ---- draft stack --------------------------------------------------------
+    n_draft_layers: int = 3  # official n_mtp_layers
+    # block_size = BLOCK WIDTH = anchor(slot 0) + gamma draft masks. The draft
+    # trains/emits block_size-1 tokens (slot 0 is the GIVEN anchor, loss-masked in the
+    # forward; same as DFlash block16 -> 15 drafted). The released config's
+    # `dspark_block_size` is GAMMA (=5, num_spec=5) -> block_size = gamma+1 = 6. NOTE:
+    # Setting 5 here drafts only 4 (position_1..4). The trainer overrides it via
+    # --block-size; at save time the serving field dspark_block_size is block_size-1.
+    block_size: int = 6  # anchor + gamma(5) masks; drafts block_size-1 = 5
+    noise_token_id: int = 128799  # fills draft_input_ids[:, 1:] (the gamma mask slots)
+    target_layer_ids: tuple[int, ...] = (40, 41, 42)  # verifier layers -> main_proj
+    markov_rank: int = 256
+
+    # ---- multi-head latent attention (MLA) ----------------------------------
+    num_heads: int = 64
+    head_dim: int = 512  # per-head q/k/v width (nope | rope)
+    rope_head_dim: int = 64  # trailing rope slice of head_dim
+    q_lora_rank: int = 1024  # low-rank query bottleneck (wq_a -> wq_b)
+    o_lora_rank: int = 1024  # grouped output bottleneck (wo_a -> wo_b)
+    o_groups: int = 8  # head groups for the grouped output projection
+    window_size: int = 128  # sliding-window context the draft attends to
+    # RoPE (yarn); draft uses the "main" theta only (no compress path).
+    rope_theta: float = 10000.0
+    rope_factor: float = 16.0
+    original_seq_len: int = 65536
+    beta_fast: float = 32.0
+    beta_slow: float = 1.0
+
+    # ---- mixture of experts -------------------------------------------------
+    n_routed_experts: int = 256
+    n_shared_experts: int = 1
+    n_activated_experts: int = 6  # top-k
+    moe_inter_dim: int = 2048
+    score_func: str = "sqrtsoftplus"  # router scoring
+    route_scale: float = 1.5
+    swiglu_limit: float = 10.0
+
+    # ---- hyper-connections (mHC) -------------------------------------------
+    hc_mult: int = 4  # number of residual-stream copies
+    hc_sinkhorn_iters: int = 20
+    hc_eps: float = 1e-6
+
+    # ---- loss (DSpark distribution term + confidence BCE + block decay) ----- L = Σ_k
+    # w_k·[ce_alpha·CE + l1_alpha·L1 + conf_alpha·BCE_conf], w_k=exp(-(k-1)/γ).
+    ce_loss_alpha: float = 0.1
+    l1_loss_alpha: float = 0.9
+    confidence_alpha: float = 1.0
+    decay_gamma: float = 4.0
+
+    # ---- training-time weight dtype (bf16; the released ckpt is fp4/fp8) ----
+    dtype: str = "bfloat16"
+
+    def __post_init__(self) -> None:
+        if isinstance(self.target_layer_ids, list):
+            self.target_layer_ids = tuple(self.target_layer_ids)
+        if self.head_dim <= self.rope_head_dim:
+            raise ValueError("head_dim must exceed rope_head_dim (nope|rope split).")
+        if self.num_heads * self.head_dim % self.o_groups != 0:
+            raise ValueError("o_groups must divide num_heads*head_dim.")
+
+    @property
+    def num_target_layers(self) -> int:
+        return len(self.target_layer_ids)
+
+    @property
+    def nope_head_dim(self) -> int:
+        return self.head_dim - self.rope_head_dim
+
+    def small(self, **overrides) -> DSparkDraftConfig:
+        """A tiny variant for fast CPU parity/unit tests (few seconds).
+
+        Keeps every structural feature (MLA + sink + MoE + mHC + heads) but shrinks
+        widths/counts. Any field can be overridden via kwargs.
+        """
+        base: dict[str, Any] = {
+            "vocab_size": 256,
+            "hidden_size": 128,
+            "n_draft_layers": 3,
+            "block_size": 5,
+            "noise_token_id": 255,
+            "target_layer_ids": (0, 1, 2),
+            "markov_rank": 32,
+            "num_heads": 4,
+            "head_dim": 32,
+            "rope_head_dim": 8,
+            "q_lora_rank": 64,
+            "o_lora_rank": 64,
+            "o_groups": 2,
+            "window_size": 16,
+            "n_routed_experts": 8,
+            "n_shared_experts": 1,
+            "n_activated_experts": 2,
+            "moe_inter_dim": 128,
+            "hc_mult": 2,
+            "hc_sinkhorn_iters": 2,
+        }
+        base.update(overrides)
+        return replace(self, **base)

--- a/src/speculators/models/dsv4_dspark/core.py
+++ b/src/speculators/models/dsv4_dspark/core.py
@@ -1,0 +1,796 @@
+"""The DSpark method over a DeepSeek-V4-Flash decoder backbone.
+
+Subclasses :class:`~speculators.models.dspark.core.DSparkDraftModel` and overrides ONLY
+the decoder stack inside ``_backbone_forward``: anchor sampling, the target
+distribution, the Markov and confidence heads, the compound loss, registration,
+``from_training_args`` and the data contract are all inherited unchanged. In place of
+the Qwen3 DFlash decoder layers it runs the DSV4 stack -- multi-head latent attention
+with per-head sinks, a 256-expert MoE, and hyper-connections -- with DSV4's interleaved
+RoPE.
+
+The block-attention contract is identical to DFlash's: the draft block queries
+(``noise_embedding [1, TB, H]``) attend to ``[target-hidden context | block]`` under the
+additive ``attention_mask`` (block-diagonal + sliding window). ``MhcDecoderBlock``
+already takes exactly that shape (``block_x``, ``context_x``, per-position freqs,
+``attn_bias``), so this module only wires up the RoPE positions and the mask, and
+manages the hyper-connection streams across the stack (expand once, collapse with the
+HyperHead at the end).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import ClassVar, Literal, cast
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+from speculators import SpeculatorModelConfig
+from speculators.model import SpeculatorModel
+from speculators.models.dflash.utils import get_base_indices_for_anchored_blocks
+from speculators.models.dspark.config import DSparkSpeculatorConfig
+from speculators.models.dspark.core import DSparkDraftModel
+
+# Absolute (not relative) imports: transformers' custom_object_save parses the config
+# module's RELATIVE imports to bundle them for trust_remote_code, and mishandles
+# two-level ones (``from .backbone.block`` -> looks for the file ``backbone.block.py``).
+# Absolute imports are not parsed, so save_pretrained works.
+from speculators.models.dsv4_dspark import checkpoint_mapping
+from speculators.models.dsv4_dspark.backbone.block import MhcDecoderBlock
+from speculators.models.dsv4_dspark.backbone.hyper import HyperHead
+from speculators.models.dsv4_dspark.backbone.rotary import precompute_freqs_cis
+from speculators.models.dsv4_dspark.config import DSparkDraftConfig
+
+__all__ = ["DSV4DSparkConfig", "DSV4DSparkDraftModel", "resolve_init_parts"]
+
+# A parameter is "matrix-like" (and worth a NaN/Inf scan) from rank 2 up.
+_MATRIX_RANK = 2
+# Parts of a draft layer that can be warm-started from the verifier.
+_INIT_PARTS = frozenset({"attn", "moe", "hc", "norm"})
+
+
+def resolve_init_parts(requested: list[str] | None) -> frozenset[str]:
+    """Validate ``--init-from-target`` and expand ``all``."""
+    parts = frozenset(requested or ())
+    unknown = parts - _INIT_PARTS - {"all"}
+    if unknown:
+        raise ValueError(
+            f"--init-from-target: unknown part(s) {sorted(unknown)}; expected any of "
+            f"{sorted(_INIT_PARTS)} or 'all'"
+        )
+    return _INIT_PARTS if "all" in parts else parts
+
+
+# The additive attention bias is [1, TB, Sk]; anything wider carries a head axis.
+_BIAS_RANK = 3
+
+logger = logging.getLogger(__name__)
+
+
+@SpeculatorModelConfig.register("dsv4_dspark")
+class DSV4DSparkConfig(DSparkSpeculatorConfig):
+    """Dense-line DSpark config + the DSV4 sparse-backbone hyperparameters.
+
+    ``transformer_layer_config`` still carries the shared shape the SpeculatorModel
+    machinery needs (hidden_size, vocab_size, num_hidden_layers = draft depth,
+    rms_norm_eps); the fields below configure the MLA + MoE + mHC backbone.
+    """
+
+    speculators_model_type: Literal["dsv4_dspark"] = "dsv4_dspark"  # type: ignore[assignment]
+
+    # multi-head latent attention
+    num_heads: int = 64
+    head_dim: int = 512
+    rope_head_dim: int = 64
+    q_lora_rank: int = 1024
+    o_lora_rank: int = 1024
+    o_groups: int = 8
+    window_size: int = 128
+    rope_theta: float = 10000.0
+    rope_factor: float = 16.0
+    original_seq_len: int = 65536
+    beta_fast: float = 32.0
+    beta_slow: float = 1.0
+    # mixture of experts
+    n_routed_experts: int = 256
+    n_shared_experts: int = 1
+    n_activated_experts: int = 6
+    moe_inter_dim: int = 2048
+    score_func: str = "sqrtsoftplus"
+    route_scale: float = 1.5
+    swiglu_limit: float = 10.0
+    # hyper-connections
+    hc_mult: int = 4
+    hc_sinkhorn_iters: int = 20
+    hc_eps: float = 1e-6
+
+    def backbone_config(self) -> DSparkDraftConfig:
+        """Build the plain dataclass the backbone modules consume."""
+        tl = self.transformer_layer_config
+        return DSparkDraftConfig(
+            vocab_size=tl.vocab_size,
+            hidden_size=tl.hidden_size,
+            rms_norm_eps=tl.rms_norm_eps,
+            n_draft_layers=tl.num_hidden_layers,
+            block_size=self.block_size,
+            noise_token_id=self.mask_token_id or 0,
+            target_layer_ids=tuple(self.aux_hidden_state_layer_ids or (0, 1, 2)),
+            markov_rank=self.markov_rank,
+            num_heads=self.num_heads,
+            head_dim=self.head_dim,
+            rope_head_dim=self.rope_head_dim,
+            q_lora_rank=self.q_lora_rank,
+            o_lora_rank=self.o_lora_rank,
+            o_groups=self.o_groups,
+            window_size=self.window_size,
+            rope_theta=self.rope_theta,
+            rope_factor=self.rope_factor,
+            original_seq_len=self.original_seq_len,
+            beta_fast=self.beta_fast,
+            beta_slow=self.beta_slow,
+            n_routed_experts=self.n_routed_experts,
+            n_shared_experts=self.n_shared_experts,
+            n_activated_experts=self.n_activated_experts,
+            moe_inter_dim=self.moe_inter_dim,
+            score_func=self.score_func,
+            route_scale=self.route_scale,
+            swiglu_limit=self.swiglu_limit,
+            hc_mult=self.hc_mult,
+            hc_sinkhorn_iters=self.hc_sinkhorn_iters,
+            hc_eps=self.hc_eps,
+        )
+
+
+@SpeculatorModel.register("dsv4_dspark")
+class DSV4DSparkDraftModel(DSparkDraftModel):
+    """DSpark method (inherited) over the DSV4-native sparse backbone."""
+
+    config_class: ClassVar[type[DSV4DSparkConfig]] = DSV4DSparkConfig  # type: ignore[assignment,misc]
+    _no_split_modules: ClassVar[list[str]] = ["MhcDecoderBlock"]  # type: ignore[assignment,misc]
+
+    freqs_cis: torch.Tensor  # non-persistent buffer, see __init__
+
+    def __init__(self, config: DSV4DSparkConfig) -> None:
+        # Force the additive (eager) float mask BEFORE super().__init__ reads it to pick
+        # the mask builder: sink attention consumes it as an additive bias.
+        config.transformer_layer_config._attn_implementation = "eager"  # noqa: SLF001
+        # DFlash/DSpark __init__ builds fc(=main_proj role)/hidden_norm/norm/embed/
+        # lm_head/verifier + markov/confidence + a Qwen3 layer stack, discarded below.
+        super().__init__(config=config)
+        bb = config.backbone_config()
+        self.backbone_cfg = bb
+
+        # DSPARK_RECOMPUTE=1 recomputes each draft layer in backward instead of
+        # keeping its activations, trading step time for the memory to run larger
+        # batches. Applied in _backbone_forward.
+        self.grad_checkpoint = os.environ.get(
+            "DSPARK_RECOMPUTE", ""
+        ).strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+
+        # The released DSV4 layout has no slot for a bias on the confidence head, and
+        # upstream's ConfidenceHead always builds one. Replace the projection rather
+        # than changing how that head is built for every other DSpark draft.
+        if self.confidence_head is not None and not getattr(
+            config, "confidence_head_bias", False
+        ):
+            proj = self.confidence_head.proj
+            self.confidence_head.proj = nn.Linear(proj.in_features, 1, bias=False)
+
+        # Swap the decoder stack for the DSV4 blocks and the hyper-connection head.
+        self.layers = nn.ModuleList(
+            MhcDecoderBlock(bb) for _ in range(bb.n_draft_layers)
+        )
+        self.hc_head = HyperHead(bb)
+
+        # Interleaved DSV4 RoPE cache, indexed by absolute position (YaRN is off on
+        # the sliding path -> original_seq_len=0). Held as a REAL [seqlen, rope//2, 2]
+        # tensor rather than a complex one: a complex buffer cast to bf16 under AMP
+        # loses its imaginary part, which turns the rotation into a scale with nothing
+        # raised. The real cos/sin form survives that cast and indexes on any backend.
+        # See apply_rotary_emb.
+        self._rope_dim = bb.rope_head_dim
+        self.register_buffer(
+            "freqs_cis",
+            torch.view_as_real(
+                precompute_freqs_cis(
+                    bb.rope_head_dim,
+                    bb.original_seq_len or 1,
+                    0,
+                    bb.rope_theta,
+                    bb.rope_factor,
+                    bb.beta_fast,
+                    bb.beta_slow,
+                )
+            ).contiguous(),
+            persistent=False,
+        )
+        self._init_backbone_params()
+
+        # The released layout puts the conditioning projection on the first stage and
+        # the heads on the last, which a rule can only express with a concrete index.
+        # The module-level registration below covers the released depth; a draft of
+        # another depth re-registers for its own.
+        if bb.n_draft_layers != checkpoint_mapping.RELEASED_N_LAYERS:
+            checkpoint_mapping.register(n_layers=bb.n_draft_layers)
+
+    def freeze_routed_experts(self) -> int:
+        """Hold the routed experts read-only; returns how many tensors were frozen.
+
+        The routed experts are ~99% of this model's parameters, and training the rest
+        (attention, hyper-connections, the projections and the two heads) is a coherent
+        recipe on its own: with the experts read-only every rank holds the same weights,
+        nothing has to be sharded across ranks, and ordinary FSDP over the remainder is
+        enough. The optimizer picks this up on its own -- it already skips parameters
+        with ``requires_grad=False``.
+
+        The memory does not go away, it only stops being sharded: the frozen stack is
+        still resident on every rank.
+        """
+        frozen = 0
+        for block in self.blocks:
+            for param in block.ffn.experts.parameters():
+                param.requires_grad_(False)
+                frozen += 1
+        return frozen
+
+    @property
+    def blocks(self) -> list[MhcDecoderBlock]:
+        """``self.layers`` with its element type preserved.
+
+        ``nn.ModuleList`` indexing returns a bare ``Module``, which loses every
+        submodule this code reaches for (``ffn.router``, ``ffn.experts``, ``attn``).
+        """
+        return cast("list[MhcDecoderBlock]", list(self.layers))
+
+    def state_dict_from_checkpoint(self, state_dict: dict) -> dict:
+        """Translate a released-layout checkpoint into this model's parameter names.
+
+        ``save_pretrained`` writes the released ``mtp.*`` layout, but training does not
+        resume through ``from_pretrained``: it reads the safetensors directly, against
+        parameters named ``layers.*``. This runs before ``set_model_state_dict``, not
+        inside ``load_state_dict``, because that call has already sharded the tensors
+        it prepared into DTensors, and a full tensor handed over afterwards would be a
+        plain-versus-DTensor copy.
+
+        The guard is load-bearing: resume passes ``strict=False``, which it needs
+        because the verifier weights are absent by design, and that also turns a layout
+        mismatch into a silent no-op -- nothing loads, nothing raises, and training
+        continues from the initial weights.
+
+        Checkpoints already in module layout pass through: their keys match no rule.
+        """
+        if not checkpoint_mapping.is_released_layout(state_dict):
+            return state_dict
+        translated = checkpoint_mapping.to_module_layout(
+            state_dict, n_layers=self.backbone_cfg.n_draft_layers
+        )
+        uncovered = sorted(
+            name
+            for name, _ in self.named_parameters()
+            if name not in translated and not name.startswith("verifier_")
+        )
+        if uncovered:
+            raise RuntimeError(
+                f"a released-layout checkpoint left {len(uncovered)} parameters with "
+                f"no source, e.g. {uncovered[:3]}. Loading it would leave them at "
+                f"their initial values."
+            )
+        return translated
+
+    @classmethod
+    def from_training_args(
+        cls,
+        verifier_config: PretrainedConfig,
+        t2d: torch.Tensor | None = None,
+        d2t: torch.Tensor | None = None,
+        **kwargs,
+    ) -> DSV4DSparkDraftModel:
+        """Build the model from training arguments.
+
+        The DSV4 backbone shape comes from the config defaults, which are the released
+        draft's; only the DSpark method fields are taken from the CLI.
+        """
+        config = DSV4DSparkConfig(
+            **cls._build_base_config_kwargs("dsv4_dspark", verifier_config, **kwargs),
+            markov_rank=kwargs.get("markov_rank", 256),
+            markov_head_type=kwargs.get("markov_head_type", "vanilla"),
+            enable_confidence_head=kwargs.get("enable_confidence_head", True),
+            confidence_head_with_markov=kwargs.get("confidence_head_with_markov", True),
+        )
+        model = cls(config=config)
+        if kwargs.get("freeze_experts"):
+            n = model.freeze_routed_experts()
+            logger.info("--freeze-experts: %d routed-expert tensors held read-only", n)
+        model.load_vocab_mappings(t2d, d2t)
+        model.load_verifier_weights()
+        parts = resolve_init_parts(kwargs.get("init_from_target"))
+        if parts:
+            model.load_verifier_layer(parts)
+        return model
+
+    def load_verifier_weights(self) -> None:  # noqa: C901
+        """Load the shared frozen embed + lm_head + verifier norm from the DSV4
+        verifier, which uses the OFFICIAL DeepSeek key names (``embed.weight`` /
+        ``head.weight`` / ``norm.weight``) rather than HF's (``embed_tokens`` /
+        ``lm_head`` / ``model.norm``). Same masking/freezing as the base."""
+        import warnings  # noqa: PLC0415
+
+        from speculators.utils.loading import load_model_layers  # noqa: PLC0415
+
+        # On a meta build the parameters carry no data, so there is nothing to load;
+        # the real weights arrive by broadcast from rank 0. Freezing still has to
+        # happen here: every rank must agree on which parameters are trainable, or
+        # FSDP2's gradient reduce-scatter hangs.
+        if self.embed_tokens.weight.is_meta:
+            self.embed_tokens.weight.requires_grad_(False)
+            self.lm_head.weight.requires_grad_(False)
+            self.verifier_lm_head.weight.requires_grad_(False)
+            if hasattr(self, "verifier_norm"):
+                self.verifier_norm.weight.requires_grad_(False)
+            return
+
+        sc = getattr(getattr(self, "config", None), "speculators_config", None)
+        if sc is None or sc.verifier.name_or_path is None:
+            return
+        w = load_model_layers(
+            ["embed.weight", "head.weight", "norm.weight"], sc.verifier.name_or_path
+        )
+        embed_w = w["embed.weight"]
+        lm_head_w = w.get("head.weight", embed_w)
+
+        if self.embed_tokens.weight.isnan().any():
+            self.embed_tokens.load_state_dict({"weight": embed_w})
+        if self.use_draft_vocab:
+            if self.t2d is None or not torch.any(self.t2d).item():
+                raise ValueError("t2d not set; call load_vocab_mappings first.")
+            lm_head_w = lm_head_w[
+                self.t2d.to(device=lm_head_w.device, dtype=torch.bool), :
+            ]
+        if self.lm_head.weight.isnan().any():
+            self.lm_head.load_state_dict(
+                {"weight": lm_head_w.detach().clone()}, strict=False
+            )
+        self.verifier_lm_head.load_state_dict(
+            {"weight": lm_head_w.detach().clone()}, strict=False
+        )
+        if hasattr(self, "verifier_norm"):
+            if "norm.weight" not in w:
+                warnings.warn(
+                    f"no norm.weight in {sc.verifier.name_or_path}; using default.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            else:
+                self.verifier_norm.load_state_dict({"weight": w["norm.weight"]})
+        self.embed_tokens.weight.requires_grad_(False)
+        self.lm_head.weight.requires_grad_(False)
+        self.verifier_lm_head.weight.requires_grad_(False)
+        if hasattr(self, "verifier_norm"):
+            self.verifier_norm.weight.requires_grad_(False)
+
+    def load_verifier_moe(self) -> None:
+        """Warm-start only the MoE. See :meth:`load_verifier_layer`."""
+        self.load_verifier_layer({"moe"})
+
+    def load_verifier_layer(self, parts) -> None:  # noqa: C901
+        """Warm-start the requested PARTS of each draft layer from the matching verifier
+        layer: draft layer ``n`` <- verifier layer ``target_layer_ids[n]`` (the layers
+        ``main_proj`` conditions on). A draft layer is architecturally a DSV4 target
+        layer, so this is a strong TRAINABLE init (not frozen), unlike the shared
+        embed/lm_head.
+
+        ``parts`` is any subset of:
+          * ``"attn"`` — the MLA **core** projections
+          (wq_a/q_norm/wq_b/wkv/kv_norm/wo_a/
+            wo_b/attn_sink). The verifier's sparse-attn ``compressor``/``indexer``
+            submodules
+            are skipped — the draft does dense sliding-window sink attention (no such
+            parts).
+          * ``"hc"``   — the two hyper-connections (``attn_hc`` <- ``hc_attn_*``,
+            ``ffn_hc`` <- ``hc_ffn_*``; the sole flat->dotted rename).
+          * ``"norm"`` — the two RMSNorms (``attn_norm``, ``ffn_norm``).
+          * ``"moe"``  — routed experts (EP-local slice) + router (<- ``ffn.gate``) +
+          shared.
+            The router is never warm-started: neither its weight nor its balance
+            bias transfers to a different hidden distribution.
+
+        EP-aware for experts (the stacked ``GroupedExperts`` weights are still plain
+        per-rank tensors at build time — before the ``Shard(0)`` wrap — so each rank
+        copies only its
+        ``[ep_expert_offset : +n_local]`` slice); the rest are replicated (full copy per
+        rank). No-op on meta params (non-rank0 under ``--init-on-meta``; broadcast
+        fills). Requires the draft dims to match the verifier's (the faithful config);
+        raises on any missing
+        key / shape mismatch. The verifier uses DeepSeek names, so copies are 1:1."""
+        import logging  # noqa: PLC0415
+
+        from speculators.utils.loading import load_model_layers  # noqa: PLC0415
+
+        parts = set(parts)
+        if not parts:
+            return
+        # meta build (non-rank0 under --init-on-meta): weights arrive via broadcast.
+        if self.blocks[0].ffn.router.weight.is_meta:
+            return
+        sc = getattr(getattr(self, "config", None), "speculators_config", None)
+        if sc is None or sc.verifier.name_or_path is None:
+            return
+        path = sc.verifier.name_or_path
+        bb = self.backbone_cfg
+        tids = bb.target_layer_ids
+        if len(tids) < bb.n_draft_layers:
+            raise ValueError(
+                f"init-from-target needs >= n_draft_layers ({bb.n_draft_layers}) "
+                f"target_layer_ids, got {tids}."
+            )
+
+        # replicated (non-EP) parts: (verifier-key suffix, draft attribute path). For
+        # attn and norm the two are identical; hc renames the flat hc_{attn,ffn}_* ->
+        # attn_hc/ffn_hc.
+        part_map = {
+            "attn": [
+                ("attn.wq_a.weight", "attn.wq_a.weight"),
+                ("attn.q_norm.weight", "attn.q_norm.weight"),
+                ("attn.wq_b.weight", "attn.wq_b.weight"),
+                ("attn.wkv.weight", "attn.wkv.weight"),
+                ("attn.kv_norm.weight", "attn.kv_norm.weight"),
+                ("attn.wo_a.weight", "attn.wo_a.weight"),
+                ("attn.wo_b.weight", "attn.wo_b.weight"),
+                ("attn.attn_sink", "attn.attn_sink"),
+            ],
+            "hc": [
+                ("hc_attn_fn", "attn_hc.fn"),
+                ("hc_attn_base", "attn_hc.base"),
+                ("hc_attn_scale", "attn_hc.scale"),
+                ("hc_ffn_fn", "ffn_hc.fn"),
+                ("hc_ffn_base", "ffn_hc.base"),
+                ("hc_ffn_scale", "ffn_hc.scale"),
+            ],
+            "norm": [
+                ("attn_norm.weight", "attn_norm.weight"),
+                ("ffn_norm.weight", "ffn_norm.weight"),
+            ],
+        }
+
+        def _need(dct: dict, k: str):
+            if k not in dct:
+                raise KeyError(f"init-from-target: '{k}' not found in verifier {path}")
+            return dct[k]
+
+        def _copy(param, src) -> None:
+            src = src.to(device=param.device, dtype=param.dtype)
+            if tuple(src.shape) != tuple(param.shape):
+                raise ValueError(
+                    f"init-from-target: source shape {tuple(src.shape)} != draft "
+                    f"{tuple(param.shape)} -- needs a config matching the verifier."
+                )
+            param.data.copy_(src)
+
+        def _resolve(module, dotted: str):
+            obj = module
+            for a in dotted.split("."):
+                obj = getattr(obj, a)
+            return obj
+
+        for n in range(bb.n_draft_layers):
+            blk = self.blocks[n]
+            pre = f"layers.{tids[n]}."
+
+            simple = [
+                (pre + vk, da)
+                for part in ("attn", "hc", "norm")
+                if part in parts
+                for vk, da in part_map[part]
+            ]
+
+            moe_keys: list[str] = []
+            eids: list[int] = []
+            if "moe" in parts:
+                ffn = blk.ffn
+                off = int(getattr(ffn, "ep_expert_offset", 0))
+                eids = [off + i for i in range(ffn.experts.w1.shape[0])]
+                moe_keys = [
+                    pre + "ffn.gate.weight",
+                    pre + "ffn.gate.bias",
+                    pre + "ffn.shared_experts.w1.weight",
+                    pre + "ffn.shared_experts.w2.weight",
+                    pre + "ffn.shared_experts.w3.weight",
+                ]
+                for e in eids:
+                    moe_keys += [
+                        f"{pre}ffn.experts.{e}.w1.weight",
+                        f"{pre}ffn.experts.{e}.w2.weight",
+                        f"{pre}ffn.experts.{e}.w3.weight",
+                    ]
+
+            w = load_model_layers([vk for vk, _ in simple] + moe_keys, path)
+
+            for vk, da in simple:
+                _copy(_resolve(blk, da), _need(w, vk))
+
+            if "moe" in parts:
+                # The experts are warm-started; the router is not. The verifier's
+                # gate.weight was fitted to spread its own much wider hidden
+                # distribution, and on the draft's narrower one it concentrates routing
+                # on a few experts; its balance bias solves for the verifier's routing,
+                # not the draft's. A small normal init routes close to uniformly at
+                # step 0 and lets training find the draft's own routing. Set here
+                # explicitly, since the build-time torch.empty is not usable.
+                nn.init.normal_(ffn.router.weight, std=0.02)
+                for wn in ("w1", "w2", "w3"):
+                    _copy(
+                        getattr(ffn.shared_experts, wn).weight,
+                        _need(w, f"{pre}ffn.shared_experts.{wn}.weight"),
+                    )
+                # routed experts: stacked [n_local, out, in]; local slot i <- global
+                # expert off+i
+                for wn in ("w1", "w2", "w3"):
+                    stacked = getattr(ffn.experts, wn)
+                    slot_shape = tuple(stacked.shape[1:])
+                    for i, e in enumerate(eids):
+                        src = _need(w, f"{pre}ffn.experts.{e}.{wn}.weight").to(
+                            device=stacked.device, dtype=stacked.dtype
+                        )
+                        if tuple(src.shape) != slot_shape:
+                            raise ValueError(
+                                f"init-from-target: expert {e} {wn} "
+                                f"{tuple(src.shape)} != "
+                                f"draft slot {slot_shape} (needs faithful config)."
+                            )
+                        stacked.data[i].copy_(src)
+
+        router_note = " [router: freshly initialized]" if "moe" in parts else ""
+        logging.getLogger(__name__).info(
+            "init-from-target: warm-started %s of %d draft layers from verifier %s.%s",
+            sorted(parts),
+            bb.n_draft_layers,
+            list(tids[: bb.n_draft_layers]),
+            router_note,
+        )
+
+    def _init_backbone_params(self) -> None:
+        """Initialize the freshly-built backbone params (post_init ran on the old
+        Qwen3 layers). Uninitialized ``torch.empty`` params (mHC fn) would NaN."""
+        # Meta build (non-rank0 under --init-on-meta): no data to init; the random init
+        # done on rank 0 is broadcast to every rank in the FSDP setup.
+        if any(p.is_meta for p in self.parameters()):
+            return
+        std = 0.02
+        for m in [*self.layers, self.hc_head]:
+            for name, p in m.named_parameters():
+                matrix_like = p.dim() >= _MATRIX_RANK and (
+                    ".fn" in name or "weight" in name or "hc_fn" in name
+                )
+                degenerate = matrix_like and (
+                    torch.isnan(p).any()
+                    or not p.abs().sum().isfinite()
+                    or p.abs().sum() == 0
+                )
+                if degenerate:
+                    nn.init.normal_(p, std=std)
+
+    def _rebuild_freqs(self, seqlen: int) -> None:
+        self.freqs_cis = (
+            torch.view_as_real(
+                precompute_freqs_cis(
+                    self._rope_dim,
+                    seqlen,
+                    0,
+                    self.backbone_cfg.rope_theta,
+                    self.backbone_cfg.rope_factor,
+                    self.backbone_cfg.beta_fast,
+                    self.backbone_cfg.beta_slow,
+                )
+            )
+            .contiguous()
+            .to(self.freqs_cis.device)
+        )
+
+    def _rope_at(self, positions: torch.Tensor) -> torch.Tensor:
+        """Rotary cache at the given absolute positions.
+
+        Returns a REAL ``[len, rope_dim//2, 2]`` view (cos in ``[...,0]``, sin in
+        ``[...,1]``); the buffer holds ``view_as_real(freqs)``. See
+        :func:`apply_rotary_emb` for why the real form rather than a complex one.
+        """
+        # from_pretrained's meta-init zeroes persistent=False FLOATING buffers via
+        # to_empty() (it doesn't re-run __init__ and freqs_cis isn't in the state_dict)
+        # -> rebuild once. (Training builds via from_training_args, no meta, so this is
+        # a one-shot no-op there.)
+        if not getattr(self, "_freqs_ok", False):
+            self._freqs_ok = True
+            if not bool(self.freqs_cis.any()):
+                self._rebuild_freqs(self.freqs_cis.shape[0])
+        if positions.numel() and int(positions.max()) >= self.freqs_cis.shape[0]:
+            self._rebuild_freqs(int(positions.max()) + 1)
+        return self.freqs_cis.to(positions.device)[positions]
+
+    def _backbone_forward(  # noqa: C901
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        loss_mask: torch.Tensor,
+        verifier_last_hidden_states: torch.Tensor,
+        document_ids: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        **kwargs,
+    ):
+        """DFlash scaffolding (copied) with the decoder stack swapped for our
+        DSV4 sparse stack + DSV4 RoPE. Returns the same 5-tuple DSpark consumes."""
+        device = hidden_states.device
+        total_seq_len = hidden_states.shape[1]
+        num_anchors = kwargs.pop("max_anchors", 3072)
+
+        if position_ids is None:
+            position_ids = torch.arange(
+                total_seq_len, dtype=torch.long, device=device
+            ).unsqueeze(0)
+
+        full_attn_mask, sliding_window_attn_mask, anchor_positions, anchor_valid = (
+            self._build_attention_mask(loss_mask, num_anchors, document_ids, device)
+        )
+
+        mask_tokens_size = num_anchors * self.block_size
+        mask_token_ids = torch.full(
+            (1, mask_tokens_size), self.mask_token_id, dtype=torch.long, device=device
+        )
+        mask_token_ids[:, :: self.block_size] = input_ids[:, anchor_positions]
+        noise_embedding = self.embed_tokens(mask_token_ids)  # [1, TB, H]
+
+        fc_output = self.fc(hidden_states)
+        fc_output = self.hidden_norm(fc_output)  # [1, T, H]  (main_x context)
+
+        block_positions = get_base_indices_for_anchored_blocks(
+            position_ids[0, anchor_positions], self.block_size
+        )  # [TB]
+        ctx_positions = position_ids[0]  # [T]
+
+        anchored_block_indices = get_base_indices_for_anchored_blocks(
+            anchor_positions, self.block_size
+        )
+
+        with torch.no_grad():
+            # verifier_last_hidden_states is already the verifier's final
+            # post-norm hidden state, so its next-token logits are one lm_head
+            # away; normalising again would not be the distribution the verifier
+            # accepts against.
+            verifier_logits = self.verifier_lm_head(verifier_last_hidden_states)
+            if not self.config.sample_from_anchor:
+                # False: shift right by one, so slot j predicts the token at
+                # position j and slot 0 is the given anchor. True (the DSpark
+                # convention): no shift, slot k predicts position k+1.
+                verifier_logits = torch.roll(verifier_logits, 1, dims=1)
+            targets = verifier_logits[:, anchored_block_indices]
+
+        # DSV4 RoPE freqs at the ctx and block absolute positions.
+        ctx_freqs = self._rope_at(ctx_positions)
+        block_freqs = self._rope_at(block_positions)
+
+        # mHC streams across the stack; each block attends noise -> [ctx | block].
+        hc = self.backbone_cfg.hc_mult
+        streams = noise_embedding.unsqueeze(2).repeat(1, 1, hc, 1)  # [1, TB, hc, H]
+
+        # noaux_tc load balancing: nudge the selection bias from the PREVIOUS step's
+        # load, before this step's layers run. The bias must stay constant across a
+        # forward and its activation-checkpoint recompute, or the recompute routes
+        # differently and the saved tensors no longer match. The one-step lag is
+        # immaterial, and the all-reduce inside makes the update identical on every
+        # rank.
+        if self.training and getattr(self.blocks[0].ffn.router, "_balance", False):
+            if not getattr(self, "_balance_logged", False):
+                self._balance_logged = True
+                import torch.distributed as _d  # noqa: PLC0415
+
+                if not _d.is_initialized() or _d.get_rank() == 0:
+                    _r0 = self.blocks[0].ffn.router
+                    logger.info(
+                        "MoE noaux_tc load balancing on: rate=%s across %d routers",
+                        getattr(_r0, "_balance_rate", None),
+                        len(self.layers),
+                    )
+            for _layer in self.blocks:
+                _layer.ffn.router.update_load_balance_bias()
+
+        for layer_idx, layer in enumerate(self.layers):
+            attn_bias = (
+                sliding_window_attn_mask
+                if layer_idx in self.sliding_window_indices
+                else full_attn_mask
+            )
+            layer_args = (
+                streams,
+                fc_output,
+                block_freqs,
+                ctx_freqs,
+                self._mask_to_bias(attn_bias),
+            )
+            if self.grad_checkpoint and self.training:
+                # Recompute this layer in backward to free its activations.
+                # use_reentrant=False so any collective inside the MoE replays
+                # correctly under the saved-tensor hooks.
+                from torch.utils.checkpoint import checkpoint  # noqa: PLC0415
+
+                streams = checkpoint(layer, *layer_args, use_reentrant=False)
+            else:
+                streams = layer(*layer_args)
+
+        # Expert-utilisation counters: routing collapse (a handful of the experts
+        # taking most of the tokens) does not show up in the loss curve, so report it
+        # directly. Rank 0 only, roughly every 20th forward, and free when off.
+        if getattr(self.blocks[0].ffn.router, "_log_load", False):
+            self._eload_ctr = getattr(self, "_eload_ctr", 0) + 1
+            import torch.distributed as _dist  # noqa: PLC0415
+
+            _rk = _dist.get_rank() if _dist.is_initialized() else 0
+            if _rk == 0 and self._eload_ctr % 20 == 1:
+                for _n in range(len(self.blocks)):
+                    _c = getattr(self.blocks[_n].ffn.router, "_sel_counts", None)
+                    if _c is None:
+                        continue
+                    n_exp = _c.shape[0]
+                    _cf = _c.float()
+                    _tot = _cf.sum().clamp(min=1)
+                    _p = _cf / _tot
+                    _used = int((_c > 0).sum())
+                    _tk = min(16, n_exp)
+                    _tv, _ti = _cf.topk(_tk)
+                    _top = float(_tv.sum() / _tot)
+                    _ent = float(
+                        -(_p[_p > 0] * _p[_p > 0].log()).sum()
+                        / torch.log(torch.tensor(float(n_exp)))
+                    )
+                    # The hottest expert ids: the same ids across inits and datasets
+                    # means router collapse; ids that follow the data do not.
+                    logger.info(
+                        "[MoE load L%d] used=%d/%d dead=%d effective=%.1f "
+                        "top%d=%.2f entropy=%.3f hot=%s "
+                        "(entropy 1.0 = uniform, low = collapsed)",
+                        _n,
+                        _used,
+                        n_exp,
+                        n_exp - _used,
+                        float(torch.exp(-(_p[_p > 0] * _p[_p > 0].log()).sum())),
+                        _tk,
+                        _top,
+                        _ent,
+                        _ti.tolist(),
+                    )
+
+        hidden = self.norm(self.hc_head(streams))  # [1, TB, H]
+        logits = self.lm_head(hidden)
+
+        aligned_loss_mask = loss_mask.clone()[:, anchored_block_indices]
+        aligned_loss_mask = aligned_loss_mask * (
+            anchor_valid.repeat_interleave(self.block_size)
+            .unsqueeze(0)
+            .to(aligned_loss_mask.dtype)
+        )
+        if not self.config.sample_from_anchor:
+            # False: slot 0 is the given anchor rather than a prediction, so its
+            # loss is masked. True: slot 0 is trained from the anchor's hidden state.
+            aligned_loss_mask[:, :: self.block_size] = 0
+
+        return hidden, logits, targets, aligned_loss_mask, anchored_block_indices
+
+    @staticmethod
+    def _mask_to_bias(mask: torch.Tensor | None) -> torch.Tensor | None:
+        """Reshape the DFlash eager float mask to the sink attn_bias [1, TB, Sk]."""
+        if mask is None:
+            return None
+        # eager float mask is [1, 1, TB, Sk] (or [1, TB, Sk]); collapse the head dim.
+        while mask.dim() > _BIAS_RANK:
+            mask = mask.squeeze(1)
+        return mask
+
+
+# Registering at import is what makes ``save_pretrained`` write the released layout and
+# ``from_pretrained`` read it, with no converter in between. It is a no-op for every
+# other model, and degrades to "keep module names" if the transformers API moves.
+checkpoint_mapping.register()

--- a/src/speculators/train/checkpointer.py
+++ b/src/speculators/train/checkpointer.py
@@ -275,6 +275,21 @@ def load_safetensors_state_dict(path: Path, device: str) -> dict[str, torch.Tens
     return full_state_dict
 
 
+def state_dict_from_checkpoint(model: PreTrainedModel, state_dict: dict) -> dict:
+    """Let a model translate its own on-disk layout back into module names.
+
+    A speculators checkpoint is also the artifact the inference engine loads, so a
+    model may deliberately write keys that are not its parameter names -- the DSV4
+    DSpark draft writes the released ``mtp.*`` per-expert layout so vLLM can load it
+    unconverted. Resume reads those keys raw, so it has to ask rather than assume.
+
+    A model that does not define the method gets back the object it passed in.
+    """
+    raw_model = model.module if isinstance(model, DistributedDataParallel) else model
+    hook = getattr(raw_model, "state_dict_from_checkpoint", None)
+    return state_dict if hook is None else hook(state_dict)
+
+
 def patch_config_dtype(config_path: Path, float_dtype: torch.dtype) -> None:
     """Patch config.json to match the actual on-disk tensor dtype.
 
@@ -304,6 +319,7 @@ class SingleGPUCheckpointer(BaseCheckpointer):
             self.model_path(self.previous_epoch),
             device,
         )
+        full_state_dict = state_dict_from_checkpoint(model, full_state_dict)
         full_state_dict = convert_float_dtype(
             full_state_dict, float_dtype or model.dtype
         )
@@ -363,6 +379,7 @@ class DistributedCheckpointer(BaseCheckpointer):
         full_state_dict = load_safetensors_state_dict(
             self.model_path(self.previous_epoch), "cpu"
         )
+        full_state_dict = state_dict_from_checkpoint(model, full_state_dict)
         full_state_dict = convert_float_dtype(
             full_state_dict, float_dtype or model.dtype
         )

--- a/src/speculators/train/config/schema.py
+++ b/src/speculators/train/config/schema.py
@@ -151,6 +151,20 @@ class DraftArgs(_Group):
         description="Whether to train embedding layer weights (default: False).",
         json_schema_extra=_CLI_BOOL_OPTIONAL,
     )
+    freeze_experts: bool = Field(
+        default=False,
+        description="For MoE drafts: hold the routed experts read-only. They keep "
+        "their initial values, get no gradients and are left out of the optimizer, "
+        "so a large expert stack trains without expert parallelism (default: False).",
+        json_schema_extra=_CLI_BOOL_OPTIONAL,
+    )
+    init_from_target: list[str] = Field(
+        default_factory=list,
+        description="Warm-start these parts of every draft layer from the "
+        "corresponding verifier layer instead of initializing them fresh: any of "
+        "'attn', 'moe', 'hc', 'norm', or 'all'. The MoE router is never warm-started, "
+        "only its experts. Off by default.",
+    )
     norm_before_fc: bool | None = Field(
         default=None,
         description="Apply a single RMSNorm to the concatenated auxiliary hidden "

--- a/tests/unit/models/test_dsv4_released_layout.py
+++ b/tests/unit/models/test_dsv4_released_layout.py
@@ -1,0 +1,385 @@
+"""The DSV4 draft must save in the layout the released draft ships, key for key.
+
+Two independent checks, because either one alone passes on a broken mapping. The round
+trip catches a mapping that loses data, but not one that is self-consistently wrong: a
+rule and its own inverse agree with each other whatever they emit. Comparing the emitted
+key set against the released one is the check with standing.
+
+The released key set is stated here rather than read from a checkpoint, so the test runs
+anywhere. It is transcribed from the released draft's weight index.
+"""
+
+import pytest
+import torch
+import torch.distributed as dist
+
+transformers = pytest.importorskip("transformers")
+
+from safetensors import safe_open  # noqa: E402
+from safetensors.torch import save_file  # noqa: E402
+from torch.distributed.checkpoint.state_dict import (  # noqa: E402
+    StateDictOptions,
+    set_model_state_dict,
+)
+
+from speculators.config import SpeculatorsConfig, VerifierConfig  # noqa: E402
+from speculators.models.dspark.config import (  # noqa: E402
+    DSparkSpeculatorConfig,
+)
+from speculators.models.dspark.core import DSparkDraftModel  # noqa: E402
+from speculators.models.dsv4_dspark import checkpoint_mapping  # noqa: E402
+from speculators.models.dsv4_dspark.backbone import attention  # noqa: E402
+from speculators.models.dsv4_dspark.core import (  # noqa: E402
+    DSV4DSparkConfig,
+    DSV4DSparkDraftModel,
+    resolve_init_parts,
+)
+from speculators.proposals.greedy import GreedyTokenProposalConfig  # noqa: E402
+from speculators.train.checkpointer import (  # noqa: E402
+    load_safetensors_state_dict,
+    state_dict_from_checkpoint,
+)
+
+N_LAYERS = 3
+N_EXPERTS = 4  # the release has 256; the mapping does not depend on how many
+
+# Per stage, what the released draft carries (checked against its weight index).
+_PER_STAGE = [
+    "attn.attn_sink",
+    "attn.kv_norm.weight",
+    "attn.q_norm.weight",
+    "attn.wkv.weight",
+    "attn.wo_a.weight",
+    "attn.wo_b.weight",
+    "attn.wq_a.weight",
+    "attn.wq_b.weight",
+    "attn_norm.weight",
+    "ffn.gate.bias",
+    "ffn.gate.weight",
+    "ffn.shared_experts.w1.weight",
+    "ffn.shared_experts.w2.weight",
+    "ffn.shared_experts.w3.weight",
+    "ffn_norm.weight",
+    "hc_attn_base",
+    "hc_attn_fn",
+    "hc_attn_scale",
+    "hc_ffn_base",
+    "hc_ffn_fn",
+    "hc_ffn_scale",
+]
+_FIRST_STAGE_ONLY = ["main_norm.weight", "main_proj.weight"]
+_LAST_STAGE_ONLY = [
+    "confidence_head.proj.weight",
+    "hc_head_base",
+    "hc_head_fn",
+    "hc_head_scale",
+    "markov_head.markov_w1.weight",
+    "markov_head.markov_w2.weight",
+    "norm.weight",
+]
+# Speculators carries the draft<->target vocab maps as buffers; the release has no
+# equivalent because its draft is not vocab-reduced. Extra keys, not missing ones.
+_SPECULATORS_EXTRA = {"t2d", "d2t"}
+
+
+def released_key_set(n_layers: int, n_experts: int) -> set[str]:
+    keys = {"embed.weight", "head.weight"}
+    for i in range(n_layers):
+        keys |= {f"mtp.{i}.{k}" for k in _PER_STAGE}
+        for e in range(n_experts):
+            keys |= {f"mtp.{i}.ffn.experts.{e}.w{w}.weight" for w in (1, 2, 3)}
+    keys |= {f"mtp.0.{k}" for k in _FIRST_STAGE_ONLY}
+    keys |= {f"mtp.{n_layers - 1}.{k}" for k in _LAST_STAGE_ONLY}
+    return keys
+
+
+def tiny_model(n_layers: int = N_LAYERS, **recipe) -> DSV4DSparkDraftModel:
+    """A DSV4 draft small enough for CPU, structurally identical to the real one."""
+    layer_config = transformers.LlamaConfig(
+        hidden_size=64,
+        vocab_size=97,
+        num_hidden_layers=n_layers,
+        rms_norm_eps=1e-6,
+        intermediate_size=64,
+        num_attention_heads=2,
+        sliding_window=8,
+        layer_types=["sliding_attention"] * n_layers,
+    )
+    config = DSV4DSparkConfig(
+        transformer_layer_config=layer_config,
+        num_heads=2,
+        head_dim=16,
+        rope_head_dim=8,
+        q_lora_rank=16,
+        o_lora_rank=16,
+        o_groups=2,
+        window_size=8,
+        n_routed_experts=N_EXPERTS,
+        n_shared_experts=1,
+        n_activated_experts=2,
+        moe_inter_dim=32,
+        hc_mult=2,
+        markov_rank=8,
+        block_size=3,
+        mask_token_id=5,
+        aux_hidden_state_layer_ids=list(range(n_layers)),
+        **recipe,
+        speculators_config=SpeculatorsConfig(
+            algorithm="dsv4_dspark",
+            proposal_methods=[GreedyTokenProposalConfig(speculative_tokens=3)],
+            default_proposal_method="greedy",
+            # None keeps `load_verifier_weights` from reaching for a real verifier.
+            verifier=VerifierConfig.from_config(layer_config, name_or_path=None),
+        ),
+    )
+    torch.manual_seed(0)
+    model = DSV4DSparkDraftModel(config)
+    for param in model.parameters():
+        # Distinctive values: a mis-mapped tensor of the right shape still fails.
+        torch.nn.init.normal_(param, std=1.0)
+    return model
+
+
+def saved_keys(path) -> set[str]:
+    keys: set[str] = set()
+    for shard in sorted(path.glob("*.safetensors")):
+        with safe_open(shard, framework="pt") as handle:
+            keys |= set(handle.keys())
+    return keys
+
+
+@pytest.fixture
+def registered():
+    assert checkpoint_mapping.register(n_layers=N_LAYERS)
+
+
+@pytest.mark.smoke
+def test_saved_keys_match_the_released_draft(tmp_path, registered):
+    model = tiny_model()
+    model.save_pretrained(tmp_path)
+
+    produced = saved_keys(tmp_path)
+    expected = released_key_set(N_LAYERS, N_EXPERTS)
+
+    assert produced - _SPECULATORS_EXTRA - expected == set(), (
+        "keys the release does not have"
+    )
+    assert expected - produced == set(), "released keys that were not produced"
+
+
+@pytest.mark.smoke
+def test_round_trip_is_bit_identical(tmp_path, registered):
+    model = tiny_model()
+    # verifier_* are re-read from the verifier at load, so they are not saved at all.
+    shared = {"verifier_lm_head.weight", "verifier_norm.weight"}
+    before = {k: v.clone() for k, v in model.state_dict().items() if k not in shared}
+
+    model.save_pretrained(tmp_path)
+    reloaded = DSV4DSparkDraftModel.from_pretrained(tmp_path)
+    after = {k: v for k, v in reloaded.state_dict().items() if k not in shared}
+
+    assert set(before) == set(after)
+    mismatched = [
+        k for k, v in before.items() if not torch.equal(v, after[k].to(v.dtype))
+    ]
+    assert mismatched == []
+
+
+@pytest.mark.smoke
+def test_experts_are_stacked_in_the_module_and_per_expert_on_disk(tmp_path, registered):
+    model = tiny_model()
+    assert model.state_dict()["layers.0.ffn.experts.w1"].shape[0] == N_EXPERTS
+
+    model.save_pretrained(tmp_path)
+    on_disk = saved_keys(tmp_path)
+    assert "layers.0.ffn.experts.w1" not in on_disk
+    assert (
+        sum(1 for k in on_disk if k.startswith("mtp.0.ffn.experts.")) == N_EXPERTS * 3
+    )
+
+
+@pytest.mark.smoke
+def test_resume_reads_back_the_layout_it_wrote(tmp_path, registered):
+    """The trainer resumes from raw safetensors keys, not through `from_pretrained`."""
+    trained = tiny_model()
+    trained.save_pretrained(tmp_path)
+
+    raw = load_safetensors_state_dict(tmp_path / "model.safetensors", "cpu")
+    assert any(k.startswith("mtp.") for k in raw), "expected the released layout"
+
+    resumed = tiny_model()  # zeroed, so parameters must actually be overwritten
+    for param in resumed.parameters():
+        torch.nn.init.zeros_(param)
+    converted = state_dict_from_checkpoint(resumed, raw)
+    resumed.load_state_dict(converted, strict=False)
+
+    shared = {"verifier_lm_head.weight", "verifier_norm.weight"}
+    for key, value in trained.state_dict().items():
+        if key in shared:
+            continue
+        assert torch.equal(value, resumed.state_dict()[key]), key
+
+
+@pytest.mark.smoke
+def test_the_distributed_resume_path_loads_the_same_weights(tmp_path, registered):
+    """The FSDP checkpointer resumes through `set_model_state_dict`, which shards
+    what it is given into DTensors before calling `load_state_dict` -- which is why
+    the translation happens before that call and not inside it."""
+    trained = tiny_model()
+    trained.save_pretrained(tmp_path)
+    raw = load_safetensors_state_dict(tmp_path / "model.safetensors", "cpu")
+
+    dist.init_process_group(
+        backend="gloo", store=dist.HashStore(), rank=0, world_size=1
+    )
+    try:
+        resumed = tiny_model()
+        for param in resumed.parameters():
+            torch.nn.init.zeros_(param)
+        set_model_state_dict(
+            resumed,
+            state_dict_from_checkpoint(resumed, raw),
+            options=StateDictOptions(
+                full_state_dict=True, broadcast_from_rank0=True, strict=False
+            ),
+        )
+    finally:
+        dist.destroy_process_group()
+
+    shared = {"verifier_lm_head.weight", "verifier_norm.weight"}
+    for key, value in trained.state_dict().items():
+        if key in shared:
+            continue
+        assert torch.equal(value, resumed.state_dict()[key]), key
+
+
+@pytest.mark.smoke
+def test_a_released_checkpoint_that_covers_nothing_is_refused(registered):
+    """strict=False is needed for the verifier weights; it must not hide a mismatch."""
+    model = tiny_model()
+    with pytest.raises(RuntimeError, match="no source"):
+        model.state_dict_from_checkpoint({"mtp.0.attn.wq_a.weight": torch.zeros(1)})
+
+
+@pytest.mark.smoke
+def test_the_checkpointer_hook_is_a_no_op_for_other_models():
+    """The hook in train/checkpointer.py must not change behaviour for other models."""
+    layer_config = transformers.Qwen3Config(
+        hidden_size=64,
+        vocab_size=97,
+        num_hidden_layers=2,
+        intermediate_size=64,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=32,
+        sliding_window=8,
+        layer_types=["full_attention"] * 2,
+    )
+    other = DSparkDraftModel(
+        DSparkSpeculatorConfig(
+            transformer_layer_config=layer_config,
+            block_size=3,
+            mask_token_id=5,
+            markov_rank=8,
+            aux_hidden_state_layer_ids=[0, 1],
+            speculators_config=SpeculatorsConfig(
+                algorithm="dspark",
+                proposal_methods=[GreedyTokenProposalConfig(speculative_tokens=3)],
+                default_proposal_method="greedy",
+                verifier=VerifierConfig.from_config(layer_config, name_or_path=None),
+            ),
+        )
+    )
+    assert not hasattr(other, "state_dict_from_checkpoint")
+    state = dict(other.state_dict())
+    assert state_dict_from_checkpoint(other, state) is state  # same object, untouched
+
+
+@pytest.mark.smoke
+def test_module_layout_checkpoints_still_load(tmp_path, registered):
+    """Every checkpoint written before this mapping existed uses module names with the
+    experts stacked. Those keys match no rule, so they pass through and still load."""
+    trained = tiny_model()
+    shared = {"verifier_lm_head.weight", "verifier_norm.weight"}
+    state = {k: v for k, v in trained.state_dict().items() if k not in shared}
+    save_file(
+        {k: v.contiguous() for k, v in state.items()}, tmp_path / "model.safetensors"
+    )
+    trained.config.save_pretrained(tmp_path)
+
+    reloaded = DSV4DSparkDraftModel.from_pretrained(tmp_path)
+    for key, value in state.items():
+        assert torch.equal(value, reloaded.state_dict()[key]), key
+
+
+@pytest.mark.smoke
+def test_freeze_routed_experts_leaves_the_rest_trainable(registered):
+    """`--freeze-experts`: the routed experts are ~99% of the parameters, and holding
+    them read-only is what lets this model train without expert parallelism."""
+    model = tiny_model()
+    expert_names = {
+        name
+        for name, _ in model.named_parameters()
+        if ".ffn.experts." in name and "shared" not in name
+    }
+    assert expert_names, "expected stacked routed-expert parameters"
+
+    # The verifier-shared embedding and head are already frozen by design, so compare
+    # against the state before the call rather than assuming everything else trains.
+    before = {name: p.requires_grad for name, p in model.named_parameters()}
+    frozen = model.freeze_routed_experts()
+    assert frozen == len(expert_names)
+
+    for name, param in model.named_parameters():
+        expected = False if name in expert_names else before[name]
+        assert param.requires_grad is expected, name
+    assert any(before[name] for name in expert_names), "experts should start trainable"
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        (None, frozenset()),
+        ([], frozenset()),
+        (["attn"], frozenset({"attn"})),
+        (["attn", "norm"], frozenset({"attn", "norm"})),
+        (["all"], frozenset({"attn", "moe", "hc", "norm"})),
+    ],
+)
+def test_init_from_target_selects_parts(requested, expected):
+    assert resolve_init_parts(requested) == expected
+
+
+def test_init_from_target_rejects_an_unknown_part():
+    with pytest.raises(ValueError, match="unknown part"):
+        resolve_init_parts(["attn", "bogus"])
+
+
+def test_chunked_attention_matches_the_unchunked_path(monkeypatch):
+    """Chunking the query axis bounds the dense fp32 logit block, which is the largest
+    allocation in the model. It has to be a memory change and nothing else."""
+    torch.manual_seed(0)
+    n, sq, heads, dim, sk = 1, 37, 4, 16, 53
+    q = torch.randn(n, sq, heads, dim, requires_grad=True)
+    k, v = torch.randn(n, sk, dim), torch.randn(n, sk, dim)
+    sink, bias = torch.randn(heads), torch.randn(n, sq, sk)
+    scale = dim**-0.5
+
+    whole = attention.sink_block_attention(q, k, v, sink, scale, bias)
+    grad_whole = torch.autograd.grad(whole.sum(), q, retain_graph=True)[0]
+
+    # ~5 query rows per chunk, so the loop runs several times.
+    monkeypatch.setattr(attention, "_ATTN_CHUNK_BYTES", heads * sk * 4 * 5)
+    chunked = attention.sink_block_attention(q, k, v, sink, scale, bias)
+    grad_chunked = torch.autograd.grad(chunked.sum(), q)[0]
+
+    torch.testing.assert_close(whole, chunked, rtol=0, atol=1e-5)
+    torch.testing.assert_close(grad_whole, grad_chunked, rtol=0, atol=1e-5)
+
+    # and with no bias to slice
+    torch.testing.assert_close(
+        attention.sink_block_attention(q, k, v, sink, scale),
+        attention._attend(q, k, v, sink, scale, None),
+        rtol=0,
+        atol=1e-5,
+    )


### PR DESCRIPTION
## Purpose

Follow-up to #952, split into two designs as @shanjiaz asked. This is the model
definition; the companion design (expert-parallel training) comes separately, and the two
are independent of each other.

Add a `dsv4_dspark` speculator: the DSpark algorithm (block drafting, a Markov transition
head, a confidence head) on a draft whose backbone mirrors DeepSeek-V4-Flash's decoder
layer. Three layers, ~21B total parameters, ~1.5B active.

One new directory, **2085 lines across 11 files**, plus 385 lines of tests. Zero deletions.

```
models/dsv4_dspark/
  __init__.py   19   config.py   130   core.py   796   checkpoint_mapping.py  259
  backbone/
    __init__.py 16   attention.py 219  moe.py    291   block.py   70
    hyper.py   124   rotary.py    112  norm.py    49
```

Three shared files, 34 lines between them, no behaviour change for any other model: three
lines of registration in `models/__init__.py`; two flags in `train/config/schema.py` that
only this model reads (`DraftArgs` already carries several of those); and in
`train/checkpointer.py` an optional hook so a model can translate its own on-disk layout
when a run resumes — a model that does not define it gets back the object it was passed,
which is a test rather than a claim.

**Why it needs its own model definition.** The draft is close to the target but not the
same, and the differences are in the attention: a per-head sink in the softmax denominator,
which no fused path takes, and a block drafter's access pattern — gamma-wide non-causal
queries over a sliding window of target context, no KV cache. Neither is reachable by
configuring an existing module.

**Not in this proposal.** Our tree carries four more files under `backbone/` — the
expert-parallel dispatch, a grouped GEMM, a kernel registry and a `torch.compile` wrapper.
None are here, and neither are the dispatch points: every heavy op calls its reference
implementation directly, so there is no plugin seam in this diff and no vendor call in it.
The dispatch belongs to the companion design; the rest is an accelerator story we would
rather bring separately.

**Three environment switches**, two of which we are happy to move: `DSPARK_RECOMPUTE`
(activation checkpointing per draft layer), `DSPARK_MOE_BALANCE_RATE` (the `noaux_tc` bias
update — the rate is also the switch), and `DSPARK_LOG_EXPERT_LOAD` (expert-utilisation
counters). The counters belong to the model, since routing collapse does not show in the
loss curve. The other two are recipe features that happen to live here — their own PR, or
config fields instead of environment reads, whichever you prefer. Either way, the numbers
below come from runs with both enabled.

## `--freeze-experts`

@zihanlin-ai's suggestion, and it removes the dependency on the expert-parallel design:
routed experts get `requires_grad=False` and drop out of the optimizer, so nothing is left
to shard and the two proposals can be reviewed in either order.

Two caveats. The memory does not go away, it stops being sharded — ~42 GB of frozen bf16
experts resident per rank, an 80 GB-class recipe. And we have not trained this way: every
number below is full-expert EP training, and we are not attaching an acceptance-length
claim to a regime we have not measured.

## `--init-from-target`

`--init-from-target attn moe hc norm` (or `all`) warm-starts those parts of each draft
layer from the matching verifier layer. Off by default: @zihanlin-ai found MTP lineage in
the released weights only in Flash-family layer 0, and we found the released draft's router
`gate.bias` balanced only in layer 0 and untouched elsewhere, yet scoring 4.42.

The router is never warm-started, only its experts. The verifier's `gate.weight` was fitted
to a much wider hidden distribution and concentrates the draft's routing on a few experts;
its balance bias solves for the verifier's own load. That is an argument, not a measurement
— we have not A/B'd inheriting the router — so it is stated here rather than left as a flag
whose default we could not defend.

@zihanlin-ai also asked for per-layer **and per-slot** expert-utilisation counters. This has
per-layer: used/dead counts, normalized entropy, effective expert count, and the hot-expert
set across steps, so a fixed collapsed subset can be told from a rotating one. Per-slot is
not there — the counters aggregate over a forward. Say the word and we will add it. Their
remaining points bear on expert-parallel training and are answered in the companion design.

## Performance

The expert compute is the reference implementation: correct, portable, not fast. We are not
quoting a speedup, because we have not benchmarked a fused grouped GEMM against it.

## Checkpoint layout — your call, not ours

Two conventions exist for a DSpark draft and they disagree:

| loader | reads |
|---|---|
| `vllm/models/deepseek_v4/nvidia/dspark.py` | `mtp.{0,1,2}.*` from the target checkpoint |
| `vllm_ascend/models/deepseek_v4/dspark.py` | `mtp.{i}.*` |
| `vllm/model_executor/models/qwen3_dspark.py` | speculators-native (`layers.*`, `d2t`/`t2d`) |

The split is by provenance, not hardware: drafts DeepSeek releases live in the target
checkpoint's `mtp.*` namespace, drafts speculators trains use this library's layout. We are
the first speculators-trained DSV4 draft, so the two have not collided before.

| | today | cost |
|---|---|---|
| **A** emit `mtp.*` | loads on GPU and Ascend unchanged | a speculators checkpoint that does not look like one |
| **B** emit speculators-native | nothing serves it | a loader branch in both vLLM and vllm-ascend |
| **C** emit native, ship an exporter | one documented step to serve | the step exists until B lands |

**We lean to A**: speculators and vLLM are one project, so a checkpoint this library trains
should be one the sibling engine can load. B does not exist, and C leaves the checkpoint
just as unloadable with an export step in front of it.

A is implemented as registered `WeightRenaming` / `WeightConverter` rules, the way
`transformers` handles Mixtral — no save override. It is also what keeps serving out of
scope: DeepSeek ships the draft *inside* the target checkpoint, 4,705 `mtp.*` tensors
alongside 67,606 target ones under a `config.json` that already carries the `dspark_*`
fields. A draft trained here writes exactly those 4,705, so nothing has to describe it.

Against A, and worth saying before someone finds it: the prefix is misleading and upstream
is already dealing with it. vLLM PR #52165 (open, closing issue #52111) puts it as
*"DeepSeek-V4-Flash-0731 and DeepSeek-V4-Pro-0813 do not have MTP heads — their `mtp.*`
tensors are DSpark drafters. vLLM routes them to `DeepSeekV4MTPModel` anyway and dies deep
in the weight loader."* If you would rather we emit the native layout and write the loader
changes as follow-up, we will.

One thing worth passing on either way: a round trip is not a sufficient check. A rule and
its own inverse agree whatever they emit, so a mapping can round-trip perfectly and still
write a layout no loader recognises. Ours did, until the key set was compared against the
release.

And the line we would draw: this proposal guarantees the checkpoint, not the engine. A run
that changes the recipe saves and reloads losslessly, and whatever the released layout has
no slot for keeps its module name rather than being forced into `mtp.*` under an invented
one. Whether an engine understands a recipe it has never seen is that engine's concern.
(Relatedly: `algos.py::update_dspark` falls back to `Qwen3DSparkModel`, so a
speculators-format DSV4 checkpoint reaches the wrong architecture. Choosing A is what keeps
this proposal independent of that.)

## Evidence

775,965 rows self-distilled from the target at temperature 0; 8 Ascend NPUs (EP8 + FSDP2),
hidden states supplied online by a live serving instance of the target. Scored on the same
stack, greedy, `num_speculative_tokens=5`:

| | gsm8k | math500 | humaneval | mbpp | mt-bench | 5-set mean | non-chat 4 |
|---|---:|---:|---:|---:|---:|---:|---:|
| released DeepSeek draft | 4.665 | 4.639 | 4.939 | 4.526 | 3.347 | **4.4232** | 4.6922 |
| this draft, 5 epochs | 4.845 | 4.565 | 4.971 | 4.546 | 3.154 | **4.4162** | **4.7317** |
| | | | | | | 99.84% | 100.84% |

Ahead on the four non-chat datasets; the remaining gap is multi-turn chat, which we read as
training-data coverage rather than architecture. The run is fully annealed and the last
three checkpoints span 0.014 on the five-set mean.

## Open questions

1. **What would you want to see before taking ~2000 lines in-tree?** We commit to
   maintaining it, keeping it working as the training stack moves, and testing it on the
   hardware we have. If there is a bar for a model this size — a test, a doc, a
   second-platform run — tell us and we will meet it.
2. **Is a reference expert implementation acceptable in-tree**, portable and correct but
   not fast? We think yes for a first landing, with performance as a separate conversation.
3. **Should `--freeze-experts` be the documented default** for anyone reproducing this
   without expert-parallel hardware, given we have not measured its quality?

## Tests

```
$ pytest tests/unit -q
798 passed, 5 skipped in 3:32
```

`make quality` passes as well, against the `ruff` and `mypy` versions `pyproject.toml`
pins.

Twelve of those tests are new and run on a CPU-sized model in about two seconds:

| test | what it pins |
|---|---|
| `test_saved_keys_match_the_released_draft` | the emitted key set equals the released draft's, exactly |
| `test_round_trip_is_bit_identical` | save then load returns the same tensors |
| `test_experts_are_stacked_in_the_module_and_per_expert_on_disk` | one stacked parameter in memory, one tensor per expert on disk |
| `test_resume_reads_back_the_layout_it_wrote` | the single-device resume path |
| `test_the_distributed_resume_path_loads_the_same_weights` | the same, through `set_model_state_dict` |
| `test_a_released_checkpoint_that_covers_nothing_is_refused` | `strict=False` cannot hide a total mismatch |
| `test_module_layout_checkpoints_still_load` | checkpoints written before the mapping existed |
| `test_the_checkpointer_hook_is_a_no_op_for_other_models` | the shared hook, on a Qwen3 DSpark draft |
| `test_freeze_routed_experts_leaves_the_rest_trainable` | `--freeze-experts` |
| `test_init_from_target_selects_parts` | `--init-from-target`, including `all` |
| `test_init_from_target_rejects_an_unknown_part` | an unknown part is refused, not ignored |
| `test_chunked_attention_matches_the_unchunked_path` | chunking the query axis changes only floating-point associativity |

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
