### PR TITLE
ci: add pre-commit hooks mirroring make quality

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,8 +48,13 @@ repos:
         args:
           - -c
           - |
-            if ! grep -q "^Signed-off-by: $(git config user.name) <$(git config user.email)>" "$(git rev-parse --git-path COMMIT_EDITMSG)"; then
-              printf "\nSigned-off-by: %s <%s>\n" "$(git config user.name)" "$(git config user.email)" >> "$(git rev-parse --git-path COMMIT_EDITMSG)"
+            trailer="Signed-off-by: $(git config user.name) <$(git config user.email)>"
+            msg_file="$(git rev-parse --git-path COMMIT_EDITMSG)"
+            # -F/-x match the trailer as a literal, complete line so names/emails
+            # containing regex metacharacters (or a line with an extra suffix)
+            # can't be mistaken for an existing sign-off.
+            if ! grep -Fqx -- "$trailer" "$msg_file"; then
+              printf "\n%s\n" "$trailer" >> "$msg_file"
             fi
         language: system
         stages: [commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,56 @@
+# See https://pre-commit.com for usage.
+# Install the git hooks with: pre-commit install
+# These hooks mirror the checks in `make quality` so issues are caught
+# locally before CI runs them.
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+default_stages:
+  - pre-commit
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Keep in sync with the `ruff` pin in pyproject.toml ([project.optional-dependencies].dev)
+    rev: v0.15.20
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/hukkin/mdformat
+    # Keep in sync with the `mdformat` pin in pyproject.toml
+    rev: 1.0.0
+    hooks:
+      - id: mdformat
+        # Plugins must match the `mdformat-*` pins in pyproject.toml so local
+        # formatting matches CI. Configuration is read from .mdformat.toml.
+        additional_dependencies:
+          - mdformat-footnote~=0.1.3
+          - mdformat-frontmatter~=2.1.2
+          - mdformat-gfm~=1.0.0
+          - mdformat-admon~=2.1.1
+          - mdformat-gfm-alerts~=2.0.0
+        exclude: ^CLAUDE\.md$
+  - repo: local
+    hooks:
+      # Runs mypy from the active (dev) environment. It reads its file list and
+      # settings from [tool.mypy] in pyproject.toml, so no filenames are passed.
+      - id: mypy
+        name: mypy
+        entry: mypy --check-untyped-defs
+        language: system
+        types: [python]
+        pass_filenames: false
+        require_serial: true
+      # Append a DCO Signed-off-by trailer if the commit message lacks one,
+      # matching the `git commit -s` requirement for vllm-project repos.
+      - id: signoff-commit
+        name: Sign-off commit
+        entry: bash
+        args:
+          - -c
+          - |
+            if ! grep -q "^Signed-off-by: $(git config user.name) <$(git config user.email)>" "$(git rev-parse --git-path COMMIT_EDITMSG)"; then
+              printf "\nSigned-off-by: %s <%s>\n" "$(git config user.name)" "$(git config user.email)" >> "$(git rev-parse --git-path COMMIT_EDITMSG)"
+            fi
+        language: system
+        stages: [commit-msg]
+        verbose: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,22 @@ To automatically fix style issues, use:
 make style
 ```
 
+### Pre-commit Hooks
+
+We provide [pre-commit](https://pre-commit.com/) hooks that run the same linting, formatting, and type checks as `make quality` (plus a DCO sign-off hook) before each commit, so problems are caught locally instead of in CI. After installing the `[dev]` dependencies, enable them once per clone:
+
+```bash
+pre-commit install
+```
+
+The hooks then run automatically on `git commit`. To run them against all files on demand:
+
+```bash
+pre-commit run --all-files
+```
+
+To bypass the hooks for a single commit, use `git commit --no-verify`; to skip one hook, prefix the command with `SKIP=<hook-id>` (e.g. `SKIP=mypy`).
+
 ## Running Tests
 
 For testing, we use [pytest](https://docs.pytest.org/) as our testing framework. We have different test suites for unit tests, integration tests, and end-to-end tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ dev = [
     # code quality
     "mypy~=2.1.0",
     "ruff~=0.15.20",
+    "pre-commit~=4.0",
 
     # docs quality
     "mdformat~=1.0.0",


### PR DESCRIPTION
## Summary

Adds [pre-commit](https://pre-commit.com/) hooks so lint/format/type issues are caught locally before CI runs them. The hooks mirror the existing `make quality` checks, so there's a single source of truth (config lives in `pyproject.toml` / `.mdformat.toml`).

vLLM (the parent project) already uses pre-commit; this brings speculators in line with that convention.

## What's included

`.pre-commit-config.yaml`:
- **ruff** — `ruff-check --fix` + `ruff-format` (pinned to `v0.15.20`, kept in sync with the `ruff` pin in `pyproject.toml`)
- **mdformat** — `rev 1.0.0` with the same plugin set as the `[dev]` extras; reads `.mdformat.toml`
- **mypy** — local hook running the same `mypy --check-untyped-defs` as `make quality`
- **signoff-commit** — a `commit-msg` hook that appends the DCO `Signed-off-by` trailer required by vllm-project repos (mirrors vLLM's own hook)
- `default_install_hook_types: [pre-commit, commit-msg]` so a single `pre-commit install` wires up both

Supporting changes:
- Add `pre-commit~=4.0` to the `[dev]` optional dependencies
- Document `pre-commit install` / usage in `CONTRIBUTING.md`

## Testing

- `pre-commit validate-config` passes
- `ruff-check`, `ruff-format`, and `mdformat` pass cleanly across the existing tree (no repo churn)
- The mypy hook runs the identical command to `make quality`

## Notes

- These hooks are **opt-in** for contributors (`pre-commit install`); they don't change CI behavior.
- The mypy hook currently runs on every commit (matching `make quality` and vLLM's primary mypy hook). Happy to move it to `stages: [manual]` (CI/on-demand only) if maintainers prefer faster commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)