### PR TITLE
fix(train): don't rebuild resumed schedulers with last_epoch

### DIFF
--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -339,10 +339,8 @@ class Trainer:
         # Setup optimizer(s). The "muon" option returns two optimizers (Muon for the
         # 2D weight matrices, AdamW for everything else); "adamw" returns a single one.
         self.optimizers = build_optimizers(self.model, self.config)
-        last_epoch = -1
         if self.resume_from_checkpoint and self.checkpointer.previous_epoch != -1:
             self.checkpointer.load_optimizer_state_dict(self.model, self.optimizers)
-            last_epoch = self.checkpointer.previous_epoch
 
         # Setup scheduler(s) — one per optimizer so each optimizer's base LR (e.g.
         # Muon's higher LR vs AdamW's) is warmed up / decayed independently.
@@ -360,14 +358,12 @@ class Trainer:
                     opt,
                     num_warmup_steps=scheduler_warmup_steps,
                     num_training_steps=scheduler_total_steps,
-                    last_epoch=last_epoch,
                 )
             return get_cosine_schedule_with_warmup(
                 opt,
                 num_warmup_steps=scheduler_warmup_steps,
                 num_training_steps=scheduler_total_steps,
                 num_cycles=self.config.scheduler_num_cosine_cycles,
-                last_epoch=last_epoch,
             )
 
         self.schedulers = [make_scheduler(opt) for opt in self.optimizers]

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -340,7 +340,20 @@ class Trainer:
         # 2D weight matrices, AdamW for everything else); "adamw" returns a single one.
         self.optimizers = build_optimizers(self.model, self.config)
         if self.resume_from_checkpoint and self.checkpointer.previous_epoch != -1:
+            # Loading the optimizer state overwrites each param group's lr with
+            # the decayed value from the checkpoint, and scheduler construction
+            # below stamps the group lr as its base (initial_lr). Re-pin the
+            # configured LRs after loading: a resumed scheduler restores its
+            # true base_lrs from its own state_dict right after, and when that
+            # file is missing the schedule restarts from the configured base
+            # rather than adopting a decayed LR as the base forever.
+            configured_lrs = [
+                [group["lr"] for group in opt.param_groups] for opt in self.optimizers
+            ]
             self.checkpointer.load_optimizer_state_dict(self.model, self.optimizers)
+            for opt, lrs in zip(self.optimizers, configured_lrs, strict=True):
+                for group, lr in zip(opt.param_groups, lrs, strict=True):
+                    group["lr"] = lr
 
         # Setup scheduler(s) — one per optimizer so each optimizer's base LR (e.g.
         # Muon's higher LR vs AdamW's) is warmed up / decayed independently.

--- a/tests/unit/train/test_setup_model.py
+++ b/tests/unit/train/test_setup_model.py
@@ -192,6 +192,16 @@ def checkpoint_dir(tmp_path, tiny_model_on_gpu):
     ckpt_dir = tmp_path / "ckpt"
     checkpointer = SingleGPUCheckpointer(ckpt_dir)
     optimizer = torch.optim.AdamW(tiny_model_on_gpu.parameters(), lr=1e-4)
+    # Take one real step so the saved optimizer state is non-empty: the resume
+    # tests assert that it is actually restored, and a never-stepped AdamW
+    # would make that assertion vacuous. Weights are re-pinned to 42.0 after.
+    trainable = [p for p in tiny_model_on_gpu.parameters() if p.requires_grad]
+    torch.stack([p.float().sum() for p in trainable]).sum().backward()
+    optimizer.step()
+    optimizer.zero_grad(set_to_none=True)
+    with torch.no_grad():
+        for p in trainable:
+            p.fill_(42.0)
     checkpointer.save_checkpoint(tiny_model_on_gpu, optimizer, epoch=0)
     return ckpt_dir
 

--- a/tests/unit/train/test_trainer_scheduler.py
+++ b/tests/unit/train/test_trainer_scheduler.py
@@ -1,12 +1,16 @@
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 import torch
 from transformers import get_linear_schedule_with_warmup
 
+from speculators.train import checkpointer as checkpointer_module
 from speculators.train.checkpointer import SingleGPUCheckpointer
 from speculators.train.config import TrainConfig
+from speculators.train.optimizers import build_optimizers
 from speculators.train.trainer import (
+    Trainer,
     TrainerConfig,
     _resolve_scheduler_steps,
 )
@@ -109,3 +113,40 @@ def test_scheduler_resume_restores_optimizer_learning_rate(tmp_path: Path):
 
     assert resumed_scheduler.get_last_lr()[0] == pytest.approx(expected_lr)
     assert resumed_optimizer.param_groups[0]["lr"] == pytest.approx(expected_lr)
+
+
+def test_resume_without_scheduler_state_keeps_configured_base_lr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A checkpoint may carry a decayed optimizer LR but no scheduler file
+    (legacy checkpoints, or an interruption between the optimizer and scheduler
+    writes). The rebuilt scheduler must adopt the configured LR as its base,
+    not the decayed value the optimizer load put back into the param groups."""
+    monkeypatch.setattr(checkpointer_module, "get_current_device", lambda: "cpu")
+
+    config = TrainerConfig(
+        lr=1e-4,
+        num_epochs=5,
+        save_path=str(tmp_path),
+        resume_from_checkpoint=True,
+    )
+    model = torch.nn.Linear(2, 2)
+    model.dtype = torch.float32  # load_optimizer_state_dict reads it off the model
+
+    # Checkpoint an optimizer whose scheduled LR has decayed to ~zero.
+    (tmp_path / "0").mkdir()
+    saved = build_optimizers(model, config)
+    for group in saved[0].param_groups:
+        group["lr"] = 1e-9
+    torch.save([saved[0].state_dict()], tmp_path / "0" / "optimizer_state_dict.pt")
+
+    trainer = Trainer.__new__(Trainer)
+    trainer.model = model
+    trainer.config = config
+    trainer.resume_from_checkpoint = True
+    trainer.checkpointer = SingleGPUCheckpointer(tmp_path)
+    trainer.train_loader = MagicMock(__len__=MagicMock(return_value=20))
+    trainer.setup_optimizer()
+
+    assert trainer.schedulers[0].base_lrs == [pytest.approx(config.lr)]
+    assert trainer.optimizers[0].param_groups[0]["lr"] != pytest.approx(1e-9)


### PR DESCRIPTION
## Purpose

Fixes #1048: every distributed resume (DDP and FSDP) crashes in `setup_optimizer` with `KeyError: "param 'initial_lr' is not specified in param_groups[0]"`.

The `last_epoch=checkpointer.previous_epoch` passed at scheduler construction is redundant — `load_scheduler_state_dict()` restores the scheduler's real state three lines later — and wrong twice over: these are per-step schedulers, so an epoch index is the wrong unit, and `last_epoch >= 0` makes `LRScheduler.__init__` demand `initial_lr` in every param group, which the distributed optimizer load (`set_optimizer_state_dict`) does not round-trip. The fix is to drop it: construct with the default `last_epoch=-1` and let `load_scheduler_state_dict()` restore the true position. Net −4 lines in `trainer.py`.

Unmasking the crash exposed a second gap, also fixed here: the `checkpoint_dir` fixture saved a never-stepped AdamW, so `test_distributed_resume[ddp]`'s "optimizer state restored" assertion compared an empty dict to an empty dict (`[fsdp]` only passed it because DCP initializes state as a side effect). The fixture now takes one real optimizer step before saving.

One behavioral note: a legacy checkpoint with no scheduler file previously got a scheduler positioned at `last_epoch = epoch_index` — an epoch count where a step count is expected, so not a meaningful position. Such checkpoints now restart the schedule from step 0.

## Tests

`test_distributed_resume[ddp/fsdp]` go red → green on a multi-GPU machine. Full `tests/unit`:

| platform | result |
|---|---|
| 8x GPU, torch 2.11, transformers 5.8.1 | 792 passed, 0 skipped |
| 1 GPU (CI-equivalent), same | 787 passed, 5 skipped |
| Ascend NPU (aarch64), torch 2.9 + torch_npu, transformers 4.57.6 | 745 passed, 47 skipped |

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.