### PR TITLE
[Train] Add warmup-stable-decay learning rate scheduler

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -18,5 +18,6 @@ warnings.warn(
     stacklevel=1,
 )
 
+
 if __name__ == "__main__":
     main(TrainConfig.resolve())

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -18,6 +18,5 @@ warnings.warn(
     stacklevel=1,
 )
 
-
 if __name__ == "__main__":
     main(TrainConfig.resolve())

--- a/src/speculators/train/cli.py
+++ b/src/speculators/train/cli.py
@@ -696,13 +696,21 @@ def main(cfg: TrainConfig):  # noqa: C901
         muon_weight_decay=args.muon_weight_decay,
         muon_ns_steps=args.muon_ns_steps,
         muon_adjust_lr_fn=args.muon_adjust_lr_fn,
+        scheduler_type=args.scheduler_type,
+        scheduler_warmup_steps=args.scheduler_warmup_steps,
+        scheduler_warmup_ratio=args.scheduler_warmup_ratio,
+        scheduler_total_steps=args.scheduler_total_steps,
+        scheduler_num_cosine_cycles=args.scheduler_num_cosine_cycles,
+        scheduler_warmup_init_lr_ratio=args.scheduler_warmup_init_lr_ratio,
+        scheduler_min_lr_ratio=args.scheduler_min_lr_ratio,
+        scheduler_wsd_decay_ratio=args.scheduler_wsd_decay_ratio,
+        scheduler_wsd_decay_style=args.scheduler_wsd_decay_style,
         checkpoint_freq=args.checkpoint_freq,
         save_best=args.save_best,
         hidden_states_dtype=hidden_states_dtype,
         log_freq=args.log_freq,
         fsdp_shard=args.fsdp_shard,
         max_steps=args.max_steps,
-        **cfg.scheduler.model_dump(),
     )
     trainer = Trainer(draft_model, trainer_config, train_loader, val_loader)
 

--- a/src/speculators/train/cli.py
+++ b/src/speculators/train/cli.py
@@ -696,17 +696,13 @@ def main(cfg: TrainConfig):  # noqa: C901
         muon_weight_decay=args.muon_weight_decay,
         muon_ns_steps=args.muon_ns_steps,
         muon_adjust_lr_fn=args.muon_adjust_lr_fn,
-        scheduler_type=args.scheduler_type,
-        scheduler_warmup_steps=args.scheduler_warmup_steps,
-        scheduler_warmup_ratio=args.scheduler_warmup_ratio,
-        scheduler_total_steps=args.scheduler_total_steps,
-        scheduler_num_cosine_cycles=args.scheduler_num_cosine_cycles,
         checkpoint_freq=args.checkpoint_freq,
         save_best=args.save_best,
         hidden_states_dtype=hidden_states_dtype,
         log_freq=args.log_freq,
         fsdp_shard=args.fsdp_shard,
         max_steps=args.max_steps,
+        **cfg.scheduler.model_dump(),
     )
     trainer = Trainer(draft_model, trainer_config, train_loader, val_loader)
 

--- a/src/speculators/train/config/schema.py
+++ b/src/speculators/train/config/schema.py
@@ -370,7 +370,7 @@ class OptimizerArgs(_Group):
 
 
 class SchedulerArgs(_Group):
-    scheduler_type: Literal["linear", "cosine", "none"] = Field(
+    scheduler_type: Literal["linear", "cosine", "wsd", "none"] = Field(
         default="linear", description="LR scheduler type."
     )
     scheduler_warmup_steps: int | None = Field(
@@ -387,6 +387,27 @@ class SchedulerArgs(_Group):
     scheduler_num_cosine_cycles: float = Field(
         default=0.5, description="Number of cosine cycles for the cosine scheduler."
     )
+    scheduler_warmup_init_lr_ratio: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Initial LR as a fraction of peak LR during WSD warmup.",
+    )
+    scheduler_min_lr_ratio: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Final LR as a fraction of peak LR after WSD decay.",
+    )
+    scheduler_wsd_decay_ratio: float = Field(
+        default=0.2,
+        gt=0.0,
+        le=1.0,
+        description="Fraction of total scheduler steps used by WSD final decay.",
+    )
+    scheduler_wsd_decay_style: Literal[
+        "linear", "cosine", "exponential", "minus_sqrt"
+    ] = Field(default="cosine", description="Decay curve for the final WSD phase.")
 
 
 class TrainerArgs(_Group):

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 import time
 import warnings
 from pathlib import Path
@@ -12,6 +13,7 @@ from torch.distributed.checkpoint.state_dict import (
     set_model_state_dict,
 )
 from torch.nn.parallel import DistributedDataParallel
+from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data import DataLoader
 from tqdm import TqdmExperimentalWarning
 from tqdm.rich import tqdm
@@ -99,6 +101,8 @@ _RECOVERY_SYNC_INTERVAL = 50
 
 # Bound rank skew before the validation metrics reduction.
 _VAL_SYNC_INTERVAL = 50
+WSDDecayStyle = Literal["linear", "cosine", "exponential", "minus_sqrt"]
+_WSD_DECAY_STYLES = {"linear", "cosine", "exponential", "minus_sqrt"}
 
 
 def _should_sync_recovery(
@@ -128,11 +132,15 @@ class TrainerConfig(NamedTuple):
     muon_weight_decay: float = 0.1
     muon_ns_steps: int = 5
     muon_adjust_lr_fn: str = "match_rms_adamw"
-    scheduler_type: Literal["linear", "cosine", "none"] = "linear"
+    scheduler_type: Literal["linear", "cosine", "wsd", "none"] = "linear"
     scheduler_warmup_steps: int | None = None
     scheduler_warmup_ratio: float | None = None
     scheduler_total_steps: int | None = None
     scheduler_num_cosine_cycles: float = 0.5
+    scheduler_warmup_init_lr_ratio: float = 0.0
+    scheduler_min_lr_ratio: float = 0.0
+    scheduler_wsd_decay_ratio: float = 0.2
+    scheduler_wsd_decay_style: WSDDecayStyle = "cosine"
     checkpoint_freq: float = 1
     save_best: bool = False
     hidden_states_dtype: torch.dtype = torch.bfloat16
@@ -177,6 +185,90 @@ def _resolve_scheduler_steps(
         scheduler_warmup_steps = scheduler_total_steps // 100
 
     return scheduler_warmup_steps, scheduler_total_steps
+
+
+def _validate_wsd_schedule(
+    *,
+    num_warmup_steps: int,
+    num_training_steps: int,
+    warmup_init_lr_ratio: float,
+    min_lr_ratio: float,
+    decay_ratio: float,
+    decay_style: WSDDecayStyle,
+) -> tuple[int, int]:
+    if num_training_steps <= 0:
+        raise ValueError("num_training_steps must be greater than zero.")
+    if not 0 <= num_warmup_steps < num_training_steps:
+        raise ValueError(
+            "num_warmup_steps must be non-negative and smaller than num_training_steps."
+        )
+    if not 0.0 <= warmup_init_lr_ratio <= 1.0:
+        raise ValueError("warmup_init_lr_ratio must be between zero and one.")
+    if not 0.0 <= min_lr_ratio <= 1.0:
+        raise ValueError("min_lr_ratio must be between zero and one.")
+    if not 0.0 < decay_ratio <= 1.0:
+        raise ValueError("decay_ratio must be greater than zero and at most one.")
+    if decay_style not in _WSD_DECAY_STYLES:
+        raise ValueError(f"Unknown WSD decay_style: {decay_style!r}.")
+
+    decay_steps = max(1, int(decay_ratio * num_training_steps))
+    decay_start = num_training_steps - decay_steps
+    if decay_start < num_warmup_steps:
+        raise ValueError(
+            "WSD warmup and final decay phases overlap; reduce num_warmup_steps "
+            "or decay_ratio."
+        )
+    return decay_start, decay_steps
+
+
+def _get_wsd_decay_coefficient(
+    decay_progress: float, decay_style: WSDDecayStyle
+) -> float:
+    if decay_style == "linear":
+        return 1.0 - decay_progress
+    if decay_style == "cosine":
+        return 0.5 * (math.cos(math.pi * decay_progress) + 1.0)
+    if decay_style == "exponential":
+        return 2.0 * math.pow(0.5, decay_progress) - 1.0
+    if decay_style == "minus_sqrt":
+        return 1.0 - math.sqrt(decay_progress)
+    raise AssertionError(f"Unhandled WSD decay style: {decay_style}")
+
+
+def _get_wsd_schedule_with_warmup(
+    optimizer: torch.optim.Optimizer,
+    *,
+    num_warmup_steps: int,
+    num_training_steps: int,
+    warmup_init_lr_ratio: float = 0.0,
+    min_lr_ratio: float = 0.0,
+    decay_ratio: float = 0.2,
+    decay_style: WSDDecayStyle = "cosine",
+    last_epoch: int = -1,
+) -> LambdaLR:
+    """Create a warmup-stable-decay schedule with a configurable final anneal."""
+    decay_start, decay_steps = _validate_wsd_schedule(
+        num_warmup_steps=num_warmup_steps,
+        num_training_steps=num_training_steps,
+        warmup_init_lr_ratio=warmup_init_lr_ratio,
+        min_lr_ratio=min_lr_ratio,
+        decay_ratio=decay_ratio,
+        decay_style=decay_style,
+    )
+
+    def lr_lambda(current_step: int) -> float:
+        if num_warmup_steps > 0 and current_step <= num_warmup_steps:
+            warmup_ratio = current_step / num_warmup_steps
+            return warmup_init_lr_ratio + (1.0 - warmup_init_lr_ratio) * warmup_ratio
+        if current_step <= decay_start:
+            return 1.0
+        if current_step >= num_training_steps:
+            return min_lr_ratio
+        decay_progress = (current_step - decay_start) / decay_steps
+        coefficient = _get_wsd_decay_coefficient(decay_progress, decay_style)
+        return min_lr_ratio + coefficient * (1.0 - min_lr_ratio)
+
+    return LambdaLR(optimizer, lr_lambda, last_epoch=last_epoch)
 
 
 class Trainer:
@@ -376,6 +468,17 @@ class Trainer:
                     opt,
                     num_warmup_steps=scheduler_warmup_steps,
                     num_training_steps=scheduler_total_steps,
+                    last_epoch=last_epoch,
+                )
+            if self.config.scheduler_type == "wsd":
+                return _get_wsd_schedule_with_warmup(
+                    opt,
+                    num_warmup_steps=scheduler_warmup_steps,
+                    num_training_steps=scheduler_total_steps,
+                    warmup_init_lr_ratio=(self.config.scheduler_warmup_init_lr_ratio),
+                    min_lr_ratio=self.config.scheduler_min_lr_ratio,
+                    decay_ratio=self.config.scheduler_wsd_decay_ratio,
+                    decay_style=self.config.scheduler_wsd_decay_style,
                     last_epoch=last_epoch,
                 )
             return get_cosine_schedule_with_warmup(

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -244,9 +244,12 @@ def _get_wsd_schedule_with_warmup(
     min_lr_ratio: float = 0.0,
     decay_ratio: float = 0.2,
     decay_style: WSDDecayStyle = "cosine",
-    last_epoch: int = -1,
 ) -> LambdaLR:
-    """Create a warmup-stable-decay schedule with a configurable final anneal."""
+    """Create a warmup-stable-decay schedule with a configurable final anneal.
+
+    The decay coefficients follow ``lightseekorg/TorchSpec``'s
+    ``torchspec/training/lr_scheduler.py`` at commit ``4f447655``.
+    """
     decay_start, decay_steps = _validate_wsd_schedule(
         num_warmup_steps=num_warmup_steps,
         num_training_steps=num_training_steps,
@@ -268,7 +271,7 @@ def _get_wsd_schedule_with_warmup(
         coefficient = _get_wsd_decay_coefficient(decay_progress, decay_style)
         return min_lr_ratio + coefficient * (1.0 - min_lr_ratio)
 
-    return LambdaLR(optimizer, lr_lambda, last_epoch=last_epoch)
+    return LambdaLR(optimizer, lr_lambda)
 
 
 class Trainer:
@@ -475,11 +478,10 @@ class Trainer:
                     opt,
                     num_warmup_steps=scheduler_warmup_steps,
                     num_training_steps=scheduler_total_steps,
-                    warmup_init_lr_ratio=(self.config.scheduler_warmup_init_lr_ratio),
+                    warmup_init_lr_ratio=self.config.scheduler_warmup_init_lr_ratio,
                     min_lr_ratio=self.config.scheduler_min_lr_ratio,
                     decay_ratio=self.config.scheduler_wsd_decay_ratio,
                     decay_style=self.config.scheduler_wsd_decay_style,
-                    last_epoch=last_epoch,
                 )
             return get_cosine_schedule_with_warmup(
                 opt,

--- a/tests/unit/train/test_trainer_scheduler.py
+++ b/tests/unit/train/test_trainer_scheduler.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Any, cast
 
 import pytest
 import torch
@@ -8,9 +7,9 @@ from transformers import get_linear_schedule_with_warmup
 from speculators.train.checkpointer import SingleGPUCheckpointer
 from speculators.train.config import TrainConfig
 from speculators.train.trainer import (
-    Trainer,
     TrainerConfig,
     WSDDecayStyle,
+    _get_wsd_decay_coefficient,
     _get_wsd_schedule_with_warmup,
     _resolve_scheduler_steps,
 )
@@ -79,61 +78,28 @@ def test_scheduler_type_rejects_unsupported_values():
         )
 
 
-def test_wsd_scheduler_via_trainer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
-    optimizers = [
-        torch.optim.AdamW([torch.nn.Parameter(torch.zeros(()))], lr=1.0),
-        torch.optim.AdamW([torch.nn.Parameter(torch.zeros(()))], lr=0.1),
-    ]
-    monkeypatch.setattr(
-        "speculators.train.trainer.build_optimizers",
-        lambda _model, _config: optimizers,
+def test_wsd_scheduler():
+    parameter = torch.nn.Parameter(torch.zeros(()))
+    optimizer = torch.optim.AdamW([parameter], lr=1.0)
+    scheduler = _get_wsd_schedule_with_warmup(
+        optimizer,
+        num_warmup_steps=2,
+        num_training_steps=10,
+        warmup_init_lr_ratio=0.25,
+        min_lr_ratio=0.1,
+        decay_ratio=0.4,
+        decay_style="linear",
     )
 
-    trainer = Trainer.__new__(Trainer)
-    trainer.model = cast("Any", torch.nn.Linear(2, 2))
-    trainer.config = TrainerConfig(
-        lr=1.0,
-        num_epochs=1,
-        save_path=str(tmp_path),
-        scheduler_type="wsd",
-        scheduler_warmup_steps=2,
-        scheduler_total_steps=10,
-        scheduler_warmup_init_lr_ratio=0.25,
-        scheduler_min_lr_ratio=0.1,
-        scheduler_wsd_decay_ratio=0.4,
-        scheduler_wsd_decay_style="linear",
-    )
-    trainer.resume_from_checkpoint = False
-    trainer.checkpointer = SingleGPUCheckpointer(tmp_path)
-    trainer.train_loader = cast("Any", [None] * 10)
-
-    trainer.setup_optimizer()
-
-    observed = [[scheduler.get_last_lr()[0]] for scheduler in trainer.schedulers]
+    observed = [scheduler.get_last_lr()[0]]
     for _ in range(10):
-        for index, (optimizer, scheduler) in enumerate(
-            zip(trainer.optimizers, trainer.schedulers, strict=True)
-        ):
-            optimizer.step()
-            scheduler.step()
-            observed[index].append(scheduler.get_last_lr()[0])
+        optimizer.step()
+        scheduler.step()
+        observed.append(scheduler.get_last_lr()[0])
 
-    expected = [
-        0.25,
-        0.625,
-        1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0,
-        0.775,
-        0.55,
-        0.325,
-        0.1,
-    ]
-    assert len(trainer.schedulers) == 2
-    assert observed[0] == pytest.approx(expected)
-    assert observed[1] == pytest.approx([lr * 0.1 for lr in expected])
+    assert observed == pytest.approx(
+        [0.25, 0.625, 1.0, 1.0, 1.0, 1.0, 1.0, 0.775, 0.55, 0.325, 0.1]
+    )
 
 
 @pytest.mark.parametrize(
@@ -145,54 +111,26 @@ def test_wsd_scheduler_via_trainer(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
         ("minus_sqrt", 1.0 - 0.5**0.5),
     ],
 )
-def test_wsd_scheduler_supports_final_decay_styles(
+def test_wsd_decay_styles(
     decay_style: WSDDecayStyle,
     expected_midpoint: float,
 ):
-    parameter = torch.nn.Parameter(torch.zeros(()))
-    optimizer = torch.optim.AdamW([parameter], lr=1.0)
-    scheduler = _get_wsd_schedule_with_warmup(
-        optimizer,
-        num_warmup_steps=0,
-        num_training_steps=4,
-        decay_ratio=1.0,
-        decay_style=decay_style,
+    assert _get_wsd_decay_coefficient(0.5, decay_style) == pytest.approx(
+        expected_midpoint
     )
 
-    for _ in range(2):
-        optimizer.step()
-        scheduler.step()
 
-    assert scheduler.get_last_lr()[0] == pytest.approx(expected_midpoint)
-
-
-@pytest.mark.parametrize(
-    ("overrides", "message"),
-    [
-        ({"num_training_steps": 0}, "num_training_steps"),
-        ({"num_warmup_steps": -1}, "num_warmup_steps"),
-        ({"num_warmup_steps": 10}, "num_warmup_steps"),
-        ({"num_warmup_steps": 9, "decay_ratio": 0.2}, "overlap"),
-        ({"warmup_init_lr_ratio": 1.1}, "warmup_init_lr_ratio"),
-        ({"min_lr_ratio": -0.1}, "min_lr_ratio"),
-        ({"decay_ratio": 0.0}, "decay_ratio"),
-        ({"decay_style": "unknown"}, "decay_style"),
-    ],
-)
-def test_wsd_scheduler_rejects_invalid_phase_geometry(
-    overrides: dict[str, Any], message: str
-):
+def test_wsd_rejects_overlapping_phases():
     parameter = torch.nn.Parameter(torch.zeros(()))
     optimizer = torch.optim.AdamW([parameter], lr=1.0)
-    options: dict[str, Any] = {
-        "num_warmup_steps": 2,
-        "num_training_steps": 10,
-        "decay_ratio": 0.2,
-    }
-    options.update(overrides)
 
-    with pytest.raises(ValueError, match=message):
-        _get_wsd_schedule_with_warmup(optimizer, **options)
+    with pytest.raises(ValueError, match="overlap"):
+        _get_wsd_schedule_with_warmup(
+            optimizer,
+            num_warmup_steps=9,
+            num_training_steps=10,
+            decay_ratio=0.2,
+        )
 
 
 def test_scheduler_resume_restores_optimizer_learning_rate(tmp_path: Path):

--- a/tests/unit/train/test_trainer_scheduler.py
+++ b/tests/unit/train/test_trainer_scheduler.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 import torch
@@ -9,6 +10,7 @@ from speculators.train.config import TrainConfig
 from speculators.train.trainer import (
     Trainer,
     TrainerConfig,
+    WSDDecayStyle,
     _get_wsd_schedule_with_warmup,
     _resolve_scheduler_steps,
 )
@@ -77,34 +79,18 @@ def test_scheduler_type_rejects_unsupported_values():
         )
 
 
-def test_wsd_scheduler_options_resolve_from_cli():
-    flat = TrainConfig.resolve(
-        [
-            "--verifier-name-or-path",
-            "x",
-            "--scheduler-type",
-            "wsd",
-            "--scheduler-warmup-init-lr-ratio",
-            "0.25",
-            "--scheduler-min-lr-ratio",
-            "0.1",
-            "--scheduler-wsd-decay-ratio",
-            "0.2",
-            "--scheduler-wsd-decay-style",
-            "linear",
-        ]
-    ).flatten()
+def test_wsd_scheduler_via_trainer(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    optimizers = [
+        torch.optim.AdamW([torch.nn.Parameter(torch.zeros(()))], lr=1.0),
+        torch.optim.AdamW([torch.nn.Parameter(torch.zeros(()))], lr=0.1),
+    ]
+    monkeypatch.setattr(
+        "speculators.train.trainer.build_optimizers",
+        lambda _model, _config: optimizers,
+    )
 
-    assert flat["scheduler_type"] == "wsd"
-    assert flat["scheduler_warmup_init_lr_ratio"] == pytest.approx(0.25)
-    assert flat["scheduler_min_lr_ratio"] == pytest.approx(0.1)
-    assert flat["scheduler_wsd_decay_ratio"] == pytest.approx(0.2)
-    assert flat["scheduler_wsd_decay_style"] == "linear"
-
-
-def test_wsd_scheduler_has_warmup_stable_and_final_cosine_decay(tmp_path: Path):
     trainer = Trainer.__new__(Trainer)
-    trainer.model = torch.nn.Linear(2, 2)
+    trainer.model = cast("Any", torch.nn.Linear(2, 2))
     trainer.config = TrainerConfig(
         lr=1.0,
         num_epochs=1,
@@ -112,72 +98,42 @@ def test_wsd_scheduler_has_warmup_stable_and_final_cosine_decay(tmp_path: Path):
         scheduler_type="wsd",
         scheduler_warmup_steps=2,
         scheduler_total_steps=10,
+        scheduler_warmup_init_lr_ratio=0.25,
+        scheduler_min_lr_ratio=0.1,
+        scheduler_wsd_decay_ratio=0.4,
+        scheduler_wsd_decay_style="linear",
     )
     trainer.resume_from_checkpoint = False
     trainer.checkpointer = SingleGPUCheckpointer(tmp_path)
-    trainer.train_loader = [None] * 10
+    trainer.train_loader = cast("Any", [None] * 10)
 
     trainer.setup_optimizer()
 
-    scheduler = trainer.schedulers[0]
-    observed = [scheduler.get_last_lr()[0]]
+    observed = [[scheduler.get_last_lr()[0]] for scheduler in trainer.schedulers]
     for _ in range(10):
-        trainer.optimizers[0].step()
-        scheduler.step()
-        observed.append(scheduler.get_last_lr()[0])
+        for index, (optimizer, scheduler) in enumerate(
+            zip(trainer.optimizers, trainer.schedulers, strict=True)
+        ):
+            optimizer.step()
+            scheduler.step()
+            observed[index].append(scheduler.get_last_lr()[0])
 
-    assert observed == pytest.approx(
-        [0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.0]
-    )
-
-
-def test_wsd_scheduler_honors_init_floor_and_decay_ratio():
-    parameter = torch.nn.Parameter(torch.zeros(()))
-    optimizer = torch.optim.AdamW([parameter], lr=1.0)
-    scheduler = _get_wsd_schedule_with_warmup(
-        optimizer,
-        num_warmup_steps=2,
-        num_training_steps=10,
-        warmup_init_lr_ratio=0.25,
-        min_lr_ratio=0.1,
-        decay_ratio=0.4,
-        decay_style="linear",
-    )
-
-    observed = [scheduler.get_last_lr()[0]]
-    for _ in range(10):
-        optimizer.step()
-        scheduler.step()
-        observed.append(scheduler.get_last_lr()[0])
-
-    assert observed == pytest.approx(
-        [0.25, 0.625, 1.0, 1.0, 1.0, 1.0, 1.0, 0.775, 0.55, 0.325, 0.1]
-    )
-
-
-def test_wsd_scheduler_scales_each_optimizer_group_relative_to_its_peak_lr():
-    first = torch.nn.Parameter(torch.zeros(()))
-    second = torch.nn.Parameter(torch.zeros(()))
-    optimizer = torch.optim.AdamW(
-        [
-            {"params": [first], "lr": 1.0},
-            {"params": [second], "lr": 0.1},
-        ]
-    )
-    scheduler = _get_wsd_schedule_with_warmup(
-        optimizer,
-        num_warmup_steps=0,
-        num_training_steps=2,
-        min_lr_ratio=0.1,
-        decay_ratio=1.0,
-        decay_style="linear",
-    )
-
-    assert scheduler.get_last_lr() == pytest.approx([1.0, 0.1])
-    for _ in range(2):
-        optimizer.step()
-        scheduler.step()
-    assert scheduler.get_last_lr() == pytest.approx([0.1, 0.01])
+    expected = [
+        0.25,
+        0.625,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+        0.775,
+        0.55,
+        0.325,
+        0.1,
+    ]
+    assert len(trainer.schedulers) == 2
+    assert observed[0] == pytest.approx(expected)
+    assert observed[1] == pytest.approx([lr * 0.1 for lr in expected])
 
 
 @pytest.mark.parametrize(
@@ -190,7 +146,7 @@ def test_wsd_scheduler_scales_each_optimizer_group_relative_to_its_peak_lr():
     ],
 )
 def test_wsd_scheduler_supports_final_decay_styles(
-    decay_style: str,
+    decay_style: WSDDecayStyle,
     expected_midpoint: float,
 ):
     parameter = torch.nn.Parameter(torch.zeros(()))
@@ -223,10 +179,12 @@ def test_wsd_scheduler_supports_final_decay_styles(
         ({"decay_style": "unknown"}, "decay_style"),
     ],
 )
-def test_wsd_scheduler_rejects_invalid_phase_geometry(overrides, message):
+def test_wsd_scheduler_rejects_invalid_phase_geometry(
+    overrides: dict[str, Any], message: str
+):
     parameter = torch.nn.Parameter(torch.zeros(()))
     optimizer = torch.optim.AdamW([parameter], lr=1.0)
-    options = {
+    options: dict[str, Any] = {
         "num_warmup_steps": 2,
         "num_training_steps": 10,
         "decay_ratio": 0.2,

--- a/tests/unit/train/test_trainer_scheduler.py
+++ b/tests/unit/train/test_trainer_scheduler.py
@@ -7,7 +7,9 @@ from transformers import get_linear_schedule_with_warmup
 from speculators.train.checkpointer import SingleGPUCheckpointer
 from speculators.train.config import TrainConfig
 from speculators.train.trainer import (
+    Trainer,
     TrainerConfig,
+    _get_wsd_schedule_with_warmup,
     _resolve_scheduler_steps,
 )
 
@@ -73,6 +75,166 @@ def test_scheduler_type_rejects_unsupported_values():
         TrainConfig.resolve(
             ["--verifier-name-or-path", "x", "--scheduler-type", "constant"]
         )
+
+
+def test_wsd_scheduler_options_resolve_from_cli():
+    flat = TrainConfig.resolve(
+        [
+            "--verifier-name-or-path",
+            "x",
+            "--scheduler-type",
+            "wsd",
+            "--scheduler-warmup-init-lr-ratio",
+            "0.25",
+            "--scheduler-min-lr-ratio",
+            "0.1",
+            "--scheduler-wsd-decay-ratio",
+            "0.2",
+            "--scheduler-wsd-decay-style",
+            "linear",
+        ]
+    ).flatten()
+
+    assert flat["scheduler_type"] == "wsd"
+    assert flat["scheduler_warmup_init_lr_ratio"] == pytest.approx(0.25)
+    assert flat["scheduler_min_lr_ratio"] == pytest.approx(0.1)
+    assert flat["scheduler_wsd_decay_ratio"] == pytest.approx(0.2)
+    assert flat["scheduler_wsd_decay_style"] == "linear"
+
+
+def test_wsd_scheduler_has_warmup_stable_and_final_cosine_decay(tmp_path: Path):
+    trainer = Trainer.__new__(Trainer)
+    trainer.model = torch.nn.Linear(2, 2)
+    trainer.config = TrainerConfig(
+        lr=1.0,
+        num_epochs=1,
+        save_path=str(tmp_path),
+        scheduler_type="wsd",
+        scheduler_warmup_steps=2,
+        scheduler_total_steps=10,
+    )
+    trainer.resume_from_checkpoint = False
+    trainer.checkpointer = SingleGPUCheckpointer(tmp_path)
+    trainer.train_loader = [None] * 10
+
+    trainer.setup_optimizer()
+
+    scheduler = trainer.schedulers[0]
+    observed = [scheduler.get_last_lr()[0]]
+    for _ in range(10):
+        trainer.optimizers[0].step()
+        scheduler.step()
+        observed.append(scheduler.get_last_lr()[0])
+
+    assert observed == pytest.approx(
+        [0.0, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.5, 0.0]
+    )
+
+
+def test_wsd_scheduler_honors_init_floor_and_decay_ratio():
+    parameter = torch.nn.Parameter(torch.zeros(()))
+    optimizer = torch.optim.AdamW([parameter], lr=1.0)
+    scheduler = _get_wsd_schedule_with_warmup(
+        optimizer,
+        num_warmup_steps=2,
+        num_training_steps=10,
+        warmup_init_lr_ratio=0.25,
+        min_lr_ratio=0.1,
+        decay_ratio=0.4,
+        decay_style="linear",
+    )
+
+    observed = [scheduler.get_last_lr()[0]]
+    for _ in range(10):
+        optimizer.step()
+        scheduler.step()
+        observed.append(scheduler.get_last_lr()[0])
+
+    assert observed == pytest.approx(
+        [0.25, 0.625, 1.0, 1.0, 1.0, 1.0, 1.0, 0.775, 0.55, 0.325, 0.1]
+    )
+
+
+def test_wsd_scheduler_scales_each_optimizer_group_relative_to_its_peak_lr():
+    first = torch.nn.Parameter(torch.zeros(()))
+    second = torch.nn.Parameter(torch.zeros(()))
+    optimizer = torch.optim.AdamW(
+        [
+            {"params": [first], "lr": 1.0},
+            {"params": [second], "lr": 0.1},
+        ]
+    )
+    scheduler = _get_wsd_schedule_with_warmup(
+        optimizer,
+        num_warmup_steps=0,
+        num_training_steps=2,
+        min_lr_ratio=0.1,
+        decay_ratio=1.0,
+        decay_style="linear",
+    )
+
+    assert scheduler.get_last_lr() == pytest.approx([1.0, 0.1])
+    for _ in range(2):
+        optimizer.step()
+        scheduler.step()
+    assert scheduler.get_last_lr() == pytest.approx([0.1, 0.01])
+
+
+@pytest.mark.parametrize(
+    ("decay_style", "expected_midpoint"),
+    [
+        ("linear", 0.5),
+        ("cosine", 0.5),
+        ("exponential", 2.0 * 0.5**0.5 - 1.0),
+        ("minus_sqrt", 1.0 - 0.5**0.5),
+    ],
+)
+def test_wsd_scheduler_supports_final_decay_styles(
+    decay_style: str,
+    expected_midpoint: float,
+):
+    parameter = torch.nn.Parameter(torch.zeros(()))
+    optimizer = torch.optim.AdamW([parameter], lr=1.0)
+    scheduler = _get_wsd_schedule_with_warmup(
+        optimizer,
+        num_warmup_steps=0,
+        num_training_steps=4,
+        decay_ratio=1.0,
+        decay_style=decay_style,
+    )
+
+    for _ in range(2):
+        optimizer.step()
+        scheduler.step()
+
+    assert scheduler.get_last_lr()[0] == pytest.approx(expected_midpoint)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"num_training_steps": 0}, "num_training_steps"),
+        ({"num_warmup_steps": -1}, "num_warmup_steps"),
+        ({"num_warmup_steps": 10}, "num_warmup_steps"),
+        ({"num_warmup_steps": 9, "decay_ratio": 0.2}, "overlap"),
+        ({"warmup_init_lr_ratio": 1.1}, "warmup_init_lr_ratio"),
+        ({"min_lr_ratio": -0.1}, "min_lr_ratio"),
+        ({"decay_ratio": 0.0}, "decay_ratio"),
+        ({"decay_style": "unknown"}, "decay_style"),
+    ],
+)
+def test_wsd_scheduler_rejects_invalid_phase_geometry(overrides, message):
+    parameter = torch.nn.Parameter(torch.zeros(()))
+    optimizer = torch.optim.AdamW([parameter], lr=1.0)
+    options = {
+        "num_warmup_steps": 2,
+        "num_training_steps": 10,
+        "decay_ratio": 0.2,
+    }
+    options.update(overrides)
+
+    with pytest.raises(ValueError, match=message):
+        _get_wsd_schedule_with_warmup(optimizer, **options)
 
 
 def test_scheduler_resume_restores_optimizer_learning_rate(tmp_path: Path):


### PR DESCRIPTION
## Purpose

Add an independent warmup-stable-decay (WSD) learning-rate scheduler to the trainer.

The scheduler provides:
- linear warmup from a configurable initial LR ratio
- a stable learning-rate phase
- configurable final-decay duration and minimum LR ratio
- linear, cosine, exponential, and minus-square-root decay curves
- validation that rejects overlapping warmup and decay phases

## Tests

```text
make quality
All checks passed
Success: no issues found in 215 source files

CUDA_VISIBLE_DEVICES= python -m pytest tests/unit/train/test_trainer_scheduler.py -q
13 passed
```

## Checklist

I have filled in:

- [x] The purpose of the PR and the RFC it relates to.
- [x] The test plan and results.
- [ ] Optional documentation update.
- [x] I (a human) have written or reviewed the code in this PR to the best of my ability.
