### PR TITLE
Add XPress: a causal refiner over the DFlash block drafter

### DIFF
--- a/docs/user_guide/algorithms/index.md
+++ b/docs/user_guide/algorithms/index.md
@@ -1,6 +1,6 @@
 # Algorithms
 
-Speculators supports six speculative decoding algorithms. All are lossless -- they produce output from the same distribution as the target model.
+Speculators supports seven speculative decoding algorithms. All are lossless -- they produce output from the same distribution as the target model.
 
 ## [Eagle-3](eagle3.md)
 
@@ -21,6 +21,10 @@ Adds local dynamic convolutions and a predecessor-conditioned candidate selector
 ## [DSpark](dspark.md)
 
 Extends DFlash with a Markov head for intra-block token dependencies and a confidence head predicting per-position acceptance. Newest, with support improving rapidly.
+
+## [XPress](xpress.md)
+
+Extends DFlash with a causal refiner resolved by Jacobi iteration, giving each draft position visibility of the ones before it at a constant number of refine passes. Experimental training support.
 
 ## [MTP](mtp.md)
 

--- a/docs/user_guide/algorithms/xpress.md
+++ b/docs/user_guide/algorithms/xpress.md
@@ -1,0 +1,41 @@
+# XPress
+
+XPress extends [DFlash](dflash.md) with a causal refiner over the same block-parallel draft backbone. Pure block-parallel drafting decodes every position from its own marginal, so token *k* is chosen without seeing what the drafter picked at *k-1*; the verifier scores conditionally, and blocks that are individually plausible but jointly improbable are rejected early. The refiner reads each position's hidden state, a block-global summary and the previous token, mixes across the block through a lower-triangular (causal) mixer, and emits a bias on the base logits. Because the mixer is causal rather than a local smoother, the block is resolved by Jacobi iteration instead of a left-to-right loop, so the serial depth at inference is a constant K passes rather than the block size. The draft model subclasses DFlash, so the backbone, data pipeline and verifier support are unchanged.
+
+## How It Works
+
+### Causal Refiner Head
+
+The head projects the per-position hidden state, a block-mean summary and an embedding of the previous block token into a rank-`r` bottleneck, mixes across block positions with a per-channel lower-triangular matrix, applies a SwiGLU MLP, and reads out to the draft vocabulary as a logit bias. Everything except the two vocabulary projections lives in the bottleneck, so the head is small relative to the backbone.
+
+### Jacobi Training
+
+Training runs the refiner for several free-running rounds, each conditioned on the previous round's argmax with stop-grad between rounds. This is the exact recurrence inference performs, so the head is trained on the input distribution it will actually see rather than only on teacher-forced tokens. A base-logits term anchors the co-trained backbone so its standalone drafting quality does not erode.
+
+## Key Parameters
+
+| Parameter              | Default | Description                                                                        |
+| ---------------------- | ------- | ---------------------------------------------------------------------------------- |
+| `--xpress-rank`        | 256     | Low-rank dimension `r` of the refiner bottleneck                                   |
+| `--xpress-mlp-ratio`   | 2       | Refiner MLP expansion ratio (hidden = `r * ratio`)                                 |
+| `--num-jacobi-passes`  | 6       | Inference-time refine passes K, stored in the exported config                      |
+| `--consistency-passes` | 3       | Free-running Jacobi rounds used during training                                    |
+| `--consistency-weight` | 0.3     | Weight of the free-running consistency term                                        |
+| `--base-anchor-weight` | 0.6     | Weight of the base-logits term that anchors the co-trained backbone                |
+| `--decayed-loss-norm`  | off     | Normalize position-decayed losses by the decayed weight sum (a true weighted mean) |
+
+All DFlash parameters (`--block-size`, `--max-anchors`, `--num-layers`, ...) apply unchanged.
+
+## Pretrained Models
+
+To train your own, see `examples/train/xpress_qwen3_8b_regen_online.sh`.
+
+## Research & Citation
+
+XPress is based on research from UIUC: [arXiv Paper](https://arxiv.org/abs/2608.02438)
+
+## See Also
+
+- [DFlash](dflash.md) -- The base algorithm XPress extends
+- [DSpark](dspark.md) -- A different head over the same backbone, conditioning on the previous token only
+- [Train a Speculator](../tutorials/train.md) -- Step-by-step training guide

--- a/examples/train/xpress_morph_config.py
+++ b/examples/train/xpress_morph_config.py
@@ -1,0 +1,69 @@
+"""Re-type a converted DFlash checkpoint as an XPress starting point.
+
+``convert_model()`` knows nothing about XPress, so a warm start is two steps:
+convert the DFlash backbone normally, then run this to switch the config over and
+stamp the fields that live in the MODEL CONFIG rather than on the CLI. Keeping it
+separate leaves the upstream converter untouched.
+
+    python examples/train/xpress_morph_config.py <converted_dir> [--shift]
+
+Idempotent, and meant to be re-run: a checkpoint morphed by an older revision
+would otherwise silently miss any field added since.
+
+``--rank`` / ``--mlp-ratio`` size the refiner head. They matter here and nowhere
+else: a ``--from-pretrained`` run reads its architecture from this config, so the
+CLI flags of the same name are ignored on that path. The defaults (256 / 2, an MLP
+hidden of 512) are what the released checkpoints use.
+
+``--shift`` selects the DeepSeek/DSpark block convention
+(``sample_from_anchor=True``, every slot predicts the next token). The default is
+fill-in, which is what z-lab checkpoints are native to: slot 0 carries the known
+anchor and slots 1..B-1 predict.
+"""
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("checkpoint", type=Path, help="converted checkpoint dir")
+    parser.add_argument("--shift", action="store_true")
+    parser.add_argument("--rank", type=int, default=256)
+    parser.add_argument("--mlp-ratio", type=int, default=2)
+    args = parser.parse_args()
+
+    path = args.checkpoint / "config.json"
+    cfg = json.loads(path.read_text())
+    model_type = cfg.get("speculators_model_type")
+    if model_type not in ("dflash", "xpress"):
+        raise SystemExit(
+            f"expected a converted dflash/xpress checkpoint, got {model_type!r}"
+        )
+
+    cfg["speculators_model_type"] = "xpress"
+    cfg["architectures"] = ["XPressDraftModel"]
+    cfg["sample_from_anchor"] = args.shift
+    cfg["xpress_rank"] = args.rank
+    cfg["xpress_mlp_ratio"] = args.mlp_ratio
+    cfg.setdefault("num_jacobi_passes", 6)
+    cfg.setdefault("mask_token_id", 151669)
+    path.write_text(json.dumps(cfg, indent=2))
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logger.info(
+        "morphed %s: xpress, %s, block_size=%s, rank=%d, mlp_hidden=%d",
+        path,
+        "shift" if args.shift else "fill-in",
+        cfg.get("block_size"),
+        args.rank,
+        args.rank * args.mlp_ratio,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/train/xpress_qwen3_8b_regen_online.sh
+++ b/examples/train/xpress_qwen3_8b_regen_online.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# XPress on Qwen3-8B, one node / 8 GPUs: vLLM verifier on GPU 0, 7 trainer ranks on
+# GPUs 1-7. Trains on a REGENERATED corpus (on-policy responses from the target).
+#
+# The validated XPress b16 recipe. Every training flag below was audited rather than
+# guessed -- see XPRESS-TRAINING.md before changing any of them.
+#
+#   bash examples/train/xpress_qwen3_8b_regen_online.sh
+#
+# Known deviations from the published recipe (see XPRESS-TRAINING.md):
+#   * hidden states are produced online by vLLM; data order differs.
+#   * no fp32 master weights: the bf16 params are clipped (at the same 1.0) and
+#     stepped directly, rather than fp32 copies of them.
+#
+# EVAL protocol: the held-out split of --data-path (--train-data-ratio), accept length
+# averaged over conversations, block_size-1 Jacobi passes.
+set -Eeuo pipefail
+
+PY=${PY:-python}
+cd "$(cd "$(dirname "$0")/../.." && pwd)"
+
+if [[ -z "${VLLM_PY:-}" ]]; then
+    if $PY -c 'import vllm' 2>/dev/null; then
+        VLLM_PY=$PY
+    elif [[ -x ./.venv_vllm/bin/python ]] && ./.venv_vllm/bin/python -c 'import vllm' 2>/dev/null; then
+        VLLM_PY=$(cd .venv_vllm/bin && pwd)/python
+        echo "note: \$PY has no vllm; using ./.venv_vllm/bin/python for the verifier"
+    else
+        echo "FATAL: no interpreter with vllm found." >&2
+        echo "  \$PY ($PY) cannot import vllm, and ./.venv_vllm/bin/python is absent or lacks it." >&2
+        echo "  Fix: uv venv .venv_vllm --python 3.12 && VIRTUAL_ENV=.venv_vllm uv pip install 'vllm>=0.22.0'" >&2
+        echo "  Or set VLLM_PY=/path/to/python-with-vllm" >&2
+        exit 1
+    fi
+fi
+
+$VLLM_PY -c 'import vllm' 2>/dev/null || {
+    echo "FATAL: VLLM_PY ($VLLM_PY) cannot import vllm." >&2
+    exit 1
+}
+
+$VLLM_PY -c '
+from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory as F
+import sys
+if "ExampleHiddenStatesConnector" not in getattr(F, "_registry", {}):
+    sys.exit("this vllm build has no ExampleHiddenStatesConnector "
+             "(needed for hidden-state extraction); install a newer vllm")
+' || { echo "FATAL: see above ($VLLM_PY)" >&2; exit 1; }
+$PY -c 'import speculators, hs_connectors' 2>/dev/null || {
+    echo "FATAL: \$PY ($PY) cannot import speculators/hs_connectors." >&2
+    echo "  Fix: uv pip install -e ./hs_connectors -e .   (hs_connectors FIRST)" >&2
+    exit 1
+}
+
+export FLASHINFER_DISABLE_VERSION_CHECK=1
+export HF_HOME=${HF_HOME:-/root/.cache/huggingface}
+
+_want_tmp=${TMPDIR:-/dev/shm/spec-tmp}
+mkdir -p "$_want_tmp" 2>/dev/null || true
+_exec_ok=0
+if [[ -d "$_want_tmp" ]]; then
+    _probe="$_want_tmp/.execprobe.$$"
+    printf '#!/bin/sh\nexit 0\n' > "$_probe" 2>/dev/null && chmod +x "$_probe" 2>/dev/null \
+        && "$_probe" 2>/dev/null && _exec_ok=1
+    rm -f "$_probe"
+fi
+if [[ "$_exec_ok" != 1 ]]; then
+    _fallback=${XDG_CACHE_HOME:-$HOME/.cache}/spec-tmp
+    echo "note: $_want_tmp is not exec-capable (noexec mount?); using $_fallback instead" >&2
+    echo "      -- torch.compile dlopens .so files it builds under TMPDIR" >&2
+    _want_tmp=$_fallback
+    mkdir -p "$_want_tmp"
+fi
+export TMPDIR=$_want_tmp
+# Pin the compile caches explicitly so they follow TMPDIR even if something else
+# repoints TMPDIR later; these are the dirs that actually need exec permission.
+export TORCHINDUCTOR_CACHE_DIR=${TORCHINDUCTOR_CACHE_DIR:-$TMPDIR/torchinductor}
+export TRITON_CACHE_DIR=${TRITON_CACHE_DIR:-$TMPDIR/triton}
+mkdir -p "$TORCHINDUCTOR_CACHE_DIR" "$TRITON_CACHE_DIR"
+# wandb: export WANDB_API_KEY yourself (never hardcode it) and set the project.
+export WANDB_PROJECT=${WANDB_PROJECT:-ripple-dspark}
+
+# Self-diagnosis for a multi-week run. A wedged rank previously showed up only as a
+# frozen progress bar with no way to see WHERE it was wedged (py-spy needs CAP_SYS_PTRACE,
+# which containers usually withhold). With these, a stuck collective aborts with every
+# rank's stack plus an NCCL flight-recorder dump instead of hanging silently forever.
+export PYTHONFAULTHANDLER=${PYTHONFAULTHANDLER:-1}
+export TORCH_NCCL_TRACE_BUFFER_SIZE=${TORCH_NCCL_TRACE_BUFFER_SIZE:-2000}
+export TORCH_NCCL_DUMP_ON_TIMEOUT=${TORCH_NCCL_DUMP_ON_TIMEOUT:-1}
+export TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=${TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC:-1800}
+
+MODEL="Qwen/Qwen3-8B"
+OUT_ROOT=${OUT_ROOT:-/root/speculators_out}
+BACKBONE=$OUT_ROOT/dflash_b16_zlab_converted
+DATA_DIR=${DATA_DIR:-/root/DeepSpec/data}
+TRAIN_JSONL=${TRAIN_JSONL:-$DATA_DIR/qwen3_8B_refiner_train_nothink.jsonl}
+OUTPUT_DIR=$OUT_ROOT/xpress_b16_zlab_8gpu
+TRAIN_DATA=$OUTPUT_DIR/train
+RUN_NAME=${RUN_NAME:-xpress-b16-speculators-8gpu}
+VLLM_PORT=${VLLM_PORT:-8300}
+RDZV_PORT=${RDZV_PORT:-29610}
+SEQ_LENGTH=4096
+TARGET_LAYER_IDS="1 9 17 25 33"
+MAX_SAMPLES=${MAX_SAMPLES:-1311126}
+LOG_FREQ=${LOG_FREQ:-50}
+mkdir -p "$OUT_ROOT" "$OUTPUT_DIR"
+
+if [[ -t 1 ]]; then
+    echo "WARNING: stdout is a TTY. rich/tqdm and vLLM per-request logs share one" >&2
+    echo "  console lock; if the terminal (ssh/tmux) cannot drain them fast enough" >&2
+    echo "  the writer blocks while holding it and rank 0 stalls -- the other ranks" >&2
+    echo "  then spin in NCCL forever. A TTY run also dies with your ssh session." >&2
+    echo "  Prefer:  nohup bash $0 > run.log 2>&1 &" >&2
+    sleep 5
+fi
+
+echo "=== Step 0: convert z-lab b16 -> speculators format (idempotent) ==="
+if [ ! -f "$BACKBONE/config.json" ]; then
+    $PY - <<PYEOF
+from speculators.convert.entrypoints import convert_model
+convert_model(
+    model="z-lab/Qwen3-8B-DFlash-b16",
+    verifier="$MODEL",
+    algorithm="dflash",
+    output_path="$BACKBONE",
+    aux_hidden_state_layer_ids=[1, 9, 17, 25, 33],
+)
+PYEOF
+fi
+
+$PY examples/train/xpress_morph_config.py "$BACKBONE" --rank 256 --mlp-ratio 2
+
+echo "=== Step 1: prepare data (one-time; marker records WHAT was prepared) ==="
+prepare_split () {
+    local stamp="$2/.data_ready" want
+    want="$1|${3:-all}|$SEQ_LENGTH|$(stat -c %s "$1")"
+    if [[ -f "$stamp" && "$(cat "$stamp")" == "$want" ]]; then
+        echo "  [skip] $2 already prepared for $want"
+        return
+    fi
+    echo "  [prep] $2  <-  $1  (max-samples=${3:-all})"
+    rm -f "$stamp"
+    $PY scripts/prepare_data.py \
+        --model "$MODEL" --data "$1" --output "$2" \
+        --seq-length "$SEQ_LENGTH" --overwrite \
+        ${3:+--max-samples "$3"}
+    printf '%s' "$want" > "$stamp"
+}
+prepare_split "$TRAIN_JSONL" "$TRAIN_DATA" "$MAX_SAMPLES"
+
+rm -rf /tmp/hidden_states
+
+echo "=== Step 2: vLLM verifier on GPU 0 ==="
+CUDA_VISIBLE_DEVICES=0 $VLLM_PY scripts/launch_vllm.py "$MODEL" \
+    --target-layer-ids $TARGET_LAYER_IDS \
+    --port "$VLLM_PORT" &
+VLLM_PID=$!
+trap 'kill $VLLM_PID 2>/dev/null || true' EXIT
+for i in $(seq 1 180); do
+    curl -fsS "http://localhost:${VLLM_PORT}/v1/models" >/dev/null 2>&1 && break
+    kill -0 $VLLM_PID 2>/dev/null || { echo "FATAL: vLLM died during startup"; exit 1; }
+    sleep 5
+done
+curl -fsS "http://localhost:${VLLM_PORT}/v1/models" >/dev/null || { echo "FATAL: vLLM not ready"; exit 1; }
+echo "vLLM ready"
+
+echo "=== Step 3: 7 trainer ranks on GPUs 1-7 ==="
+CUDA_VISIBLE_DEVICES="1,2,3,4,5,6,7" PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+    $PY -m torch.distributed.run \
+    --nnodes 1 --node_rank 0 \
+    --rdzv_id xpressb16 --rdzv_backend c10d --rdzv_endpoint "127.0.0.1:${RDZV_PORT}" \
+    --nproc_per_node 7 \
+    scripts/train.py \
+    --verifier-name-or-path "$MODEL" \
+    --from-pretrained "$BACKBONE" \
+    --data-path "$TRAIN_DATA" \
+    --vllm-endpoint "http://localhost:${VLLM_PORT}/v1" \
+    --save-path "$OUTPUT_DIR/checkpoints" \
+    --epochs 10 \
+    --lr 6e-4 \
+    --scheduler-type cosine \
+    --scheduler-warmup-ratio 0.04 \
+    --optimizer adamw \
+    --weight-decay 0.0 \
+    --checkpoint-freq 0.02 \
+    --total-seq-len "$SEQ_LENGTH" \
+    --speculator-type xpress \
+    --max-anchors 400 \
+    --target-layer-ids $TARGET_LAYER_IDS \
+    --xpress-rank 256 \
+    --consistency-weight 0.3 \
+    --consistency-passes 3 \
+    --base-anchor-weight 0.6 \
+    --base-anchor-floor 0.2 \
+    --decayed-loss-norm \
+    --log-freq "$LOG_FREQ" \
+    --ce-from-data \
+    --loss-fn '{"ce": 0.1, "tv": 1.8}' \
+    --on-missing generate \
+    --on-generate delete \
+    --logger wandb \
+    --run-name "$RUN_NAME"

--- a/src/speculators/__init__.py
+++ b/src/speculators/__init__.py
@@ -40,6 +40,8 @@ from .models import (
     MTPSpeculatorConfig,
     PEagleDraftModel,
     PEagleSpeculatorConfig,
+    XPressDraftModel,
+    XPressSpeculatorConfig,
 )
 from .proposals import TokenProposalConfig
 
@@ -61,6 +63,8 @@ __all__ = [
     "SpeculatorsConfig",
     "TokenProposalConfig",
     "VerifierConfig",
+    "XPressDraftModel",
+    "XPressSpeculatorConfig",
     "reload_schemas",
 ]
 

--- a/src/speculators/losses/utils.py
+++ b/src/speculators/losses/utils.py
@@ -237,6 +237,7 @@ def compound_loss(
     pos_idx: torch.Tensor,
     loss_config: LossConfig,
     decay_fn: Callable[..., torch.Tensor] | None = None,
+    denom_decay: bool = False,
 ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
     """Compute a weighted sum of loss terms.
 
@@ -259,6 +260,7 @@ def compound_loss(
             pos_idx,
             loss_fn=fn,
             decay_fn=decay_fn,
+            denom_decay=denom_decay,
         )
         if multi:
             term_losses[f"{name}_loss"] = term.detach()
@@ -273,6 +275,7 @@ def loss_function(
     pos_idx: torch.Tensor,  # shape: [1, seq_len]
     loss_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] = kl_div_loss,
     decay_fn: Callable[..., torch.Tensor] | None = None,
+    denom_decay: bool = False,
 ):
     """Compute masked, optionally position-decayed training loss.
 
@@ -283,6 +286,8 @@ def loss_function(
         pos_idx: Position indices within each speculative block.
         loss_fn: Per-position loss function (default: kl_div_loss).
         decay_fn: Optional position-dependent decay weighting function.
+        denom_decay: Normalize by the decayed weight sum instead of the plain
+            mask sum, making the term a true weighted mean.
 
     Returns:
         Scalar mean loss across the batch.
@@ -292,13 +297,20 @@ def loss_function(
     loss_mask = loss_mask.to(elementwise_loss.dtype)
     elementwise_loss = elementwise_loss * loss_mask
 
+    decay_mult = None
     if decay_fn is not None:
         decay_mult = decay_fn(
             pos_idx.to(elementwise_loss.dtype), elementwise_loss=elementwise_loss
         )
         elementwise_loss = elementwise_loss * decay_mult
 
-    denominator = loss_mask.sum(dim=1) + _LOSS_REDUCTION_EPS
+    if denom_decay and decay_mult is not None:
+        # A decay that scales the numerator but not the denominator lowers the
+        # reported loss without changing the gradient direction; dividing by the
+        # decayed weight sum makes the term a true weighted mean.
+        denominator = (loss_mask * decay_mult).sum(dim=1) + _LOSS_REDUCTION_EPS
+    else:
+        denominator = loss_mask.sum(dim=1) + _LOSS_REDUCTION_EPS
 
     batch_loss = torch.sum(elementwise_loss, dim=1) / denominator  # shape: [1]
     return batch_loss.mean()  # shape: []

--- a/src/speculators/models/__init__.py
+++ b/src/speculators/models/__init__.py
@@ -6,6 +6,7 @@ from .dspark import DSparkDraftModel, DSparkSpeculatorConfig
 from .eagle3 import Eagle3DraftModel, Eagle3SpeculatorConfig
 from .mtp import MTPDraftModel, MTPSpeculatorConfig
 from .peagle import PEagleDraftModel, PEagleSpeculatorConfig
+from .xpress import XPressDraftModel, XPressSpeculatorConfig
 
 __all__ = [
     "DFlash2DraftModel",
@@ -20,4 +21,6 @@ __all__ = [
     "MTPSpeculatorConfig",
     "PEagleDraftModel",
     "PEagleSpeculatorConfig",
+    "XPressDraftModel",
+    "XPressSpeculatorConfig",
 ]

--- a/src/speculators/models/xpress/__init__.py
+++ b/src/speculators/models/xpress/__init__.py
@@ -1,0 +1,7 @@
+from .config import XPressSpeculatorConfig
+from .core import XPressDraftModel
+
+__all__ = [
+    "XPressDraftModel",
+    "XPressSpeculatorConfig",
+]

--- a/src/speculators/models/xpress/config.py
+++ b/src/speculators/models/xpress/config.py
@@ -1,0 +1,55 @@
+from typing import Literal
+
+from pydantic import Field
+
+from speculators import SpeculatorModelConfig
+from speculators.models.dflash.config import DFlashSpeculatorConfig
+
+__all__ = [
+    "XPressSpeculatorConfig",
+]
+
+
+@SpeculatorModelConfig.register("xpress")
+class XPressSpeculatorConfig(DFlashSpeculatorConfig):
+    """DFlash config plus the XPress causal-refiner head.
+
+    The refiner adds a per-position logit bias built from the previous block
+    token, the drafter's per-position hidden state, and a block-global hidden
+    summary, mixed causally across the block. At inference the block is
+    resolved with K parallel Jacobi passes instead of a serial per-position
+    loop. All DFlash fields are inherited unchanged.
+    """
+
+    speculators_model_type: Literal["xpress"] = "xpress"  # type: ignore[assignment]
+    architectures: list[str] = Field(
+        default_factory=lambda: ["XPressSpeculator"],
+        description="Model architectures that can load these weights",
+    )
+
+    sample_from_anchor: bool = Field(
+        default=False,
+        description=(
+            "Block layout convention. False (XPress default): fill-in layout — "
+            "slot 0 is the anchor, slots 1..B-1 predict; matches the released "
+            "XPress checkpoints. True: DeepSeek/DSpark convention where every "
+            "slot predicts the next token."
+        ),
+    )
+
+    xpress_rank: int = Field(
+        default=256,
+        description="Low-rank dimension r of the refiner (embed, fuse, mixer, MLP "
+        "all live in r-space).",
+    )
+    xpress_mlp_ratio: int = Field(
+        default=2,
+        description="Refiner MLP expansion: hidden = r * ratio (SwiGLU). The released\n"
+        "XPress checkpoints use 2 (r=256 -> hidden 512); 4 doubles the head's MLP\n"
+        "and is a different architecture.",
+    )
+    num_jacobi_passes: int = Field(
+        default=6,
+        description="Inference-time parallel refine passes K (engine-side knob; "
+        "stored so converted checkpoints carry the validated default).",
+    )

--- a/src/speculators/models/xpress/core.py
+++ b/src/speculators/models/xpress/core.py
@@ -1,0 +1,309 @@
+from typing import ClassVar, cast
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+
+from speculators.losses import LossConfig, resolve_loss_config
+from speculators.model import SpeculatorModel
+from speculators.models.dflash.core import DFlashDraftModel
+from speculators.models.utils import conditional_torch_compile
+from speculators.models.xpress.config import XPressSpeculatorConfig
+from speculators.models.xpress.metrics import (
+    compute_metrics,
+)
+from speculators.models.xpress.model_definitions import XPressRefinerHead
+
+_DEFAULT_LOSS_CONFIG: LossConfig | None = None
+
+__all__ = [
+    "XPressDraftModel",
+]
+
+
+def _buffer(module: nn.Module, name: str) -> torch.Tensor | None:
+    """Fetch a named buffer, or None when the module has no such tensor.
+
+    ``getattr`` on an ``nn.Module`` can return a submodule as easily as a buffer,
+    so the isinstance check is what makes the duck-typed rotary lookup below
+    safe as well as checkable.
+    """
+    value = getattr(module, name, None)
+    return value if isinstance(value, torch.Tensor) else None
+
+
+@SpeculatorModel.register("xpress")
+class XPressDraftModel(DFlashDraftModel):
+    """DFlash backbone plus the XPress causal-refiner head.
+
+    Training runs one teacher-forced refine pass plus ``consistency_passes``
+    free-running rounds (each conditioned on the previous round's argmax, the
+    exact recurrence of inference-time Jacobi decoding, stop-grad between
+    rounds), and anchors the co-trained backbone with a base-logits term.
+    Everything else is inherited from DFlash.
+    """
+
+    config_class: ClassVar[type[XPressSpeculatorConfig]] = XPressSpeculatorConfig  # type: ignore[misc]
+
+    def _init_weights(self, module) -> None:
+        """Initialize weights HF's ``from_pretrained`` reports as missing.
+
+        The speculators base classes define no ``_init_weights``, so on a
+        partial checkpoint (e.g. a converted DFlash backbone warm-starting an
+        XPress run) the missing ``refiner_head.*`` params would otherwise stay
+        as uninitialized meta-materialized memory — NaNs included. Loaded
+        weights are unaffected (HF only re-initializes missing modules).
+        """
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=0.02)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=0.02)
+        elif isinstance(module, XPressRefinerHead):
+            # raw mixer starts at zero (validated recipe: mixer_init=zeros);
+            # the causal tril + identity are applied functionally in forward.
+            module.mix_l.data.zero_()
+            # non-persistent buffer: not in any checkpoint, garbage after a
+            # meta-device load — recompute.
+            module.causal_tril.data.copy_(
+                torch.tril(torch.ones_like(module.causal_tril))
+            )
+
+    def _reinit_nonpersistent_buffers(self) -> None:
+        """Recompute non-persistent buffers after a meta-device load.
+
+        Non-persistent buffers live in NO checkpoint and belong to modules that
+        may have no missing *parameters*, so HF's ``from_pretrained`` neither
+        loads nor re-initializes them — they surface as uninitialized memory
+        (run-to-run nondeterministic NaNs, first observed in rotary_emb's
+        ``inv_freq``).
+        """
+        for module in self.modules():
+            inv_freq = _buffer(module, "inv_freq")
+            if inv_freq is not None and hasattr(module, "config"):
+                fresh = type(module)(module.config, device="cpu")
+                fresh_inv_freq = _buffer(fresh, "inv_freq")
+                if fresh_inv_freq is not None:
+                    inv_freq.data.copy_(
+                        fresh_inv_freq.to(inv_freq.device, inv_freq.dtype)
+                    )
+                if hasattr(fresh, "attention_scaling"):
+                    module.attention_scaling = fresh.attention_scaling
+                original = _buffer(module, "original_inv_freq")
+                fresh_original = _buffer(fresh, "original_inv_freq")
+                if original is not None and fresh_original is not None:
+                    original.data.copy_(
+                        fresh_original.to(original.device, original.dtype)
+                    )
+            elif isinstance(module, XPressRefinerHead):
+                module.causal_tril.data.copy_(
+                    torch.tril(torch.ones_like(module.causal_tril))
+                )
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):  # type: ignore[override]
+        model = cast("XPressDraftModel", super().from_pretrained(*args, **kwargs))
+        model._reinit_nonpersistent_buffers()  # noqa: SLF001
+        return model
+
+    def __init__(self, config: XPressSpeculatorConfig) -> None:
+        super().__init__(config=config)
+        self.refiner_head = XPressRefinerHead(
+            verifier_vocab_size=self.verifier_vocab_size,
+            draft_vocab_size=self.draft_vocab_size,
+            hidden_size=config.transformer_layer_config.hidden_size,
+            block_size=self.block_size,
+            rank=config.xpress_rank,
+            mlp_ratio=config.xpress_mlp_ratio,
+        )
+        self.post_init()
+
+    @classmethod
+    def from_training_args(
+        cls,
+        verifier_config: "PretrainedConfig",
+        t2d: torch.Tensor | None = None,
+        d2t: torch.Tensor | None = None,
+        **kwargs,
+    ) -> "XPressDraftModel":
+        """Create an XPress model from training arguments (mirrors DSpark)."""
+        sample_from_anchor_arg = kwargs.get("sample_from_anchor")
+        config = XPressSpeculatorConfig(
+            **cls._build_base_config_kwargs("xpress", verifier_config, **kwargs),
+            xpress_rank=kwargs.get("xpress_rank", 256),
+            xpress_mlp_ratio=kwargs.get("xpress_mlp_ratio", 2),
+            num_jacobi_passes=kwargs.get("num_jacobi_passes", 6),
+        )
+        if sample_from_anchor_arg is not None:
+            config.sample_from_anchor = sample_from_anchor_arg
+
+        model = cls(config=config)
+        model.load_vocab_mappings(t2d, d2t)
+        model.load_verifier_weights()
+        return model
+
+    @staticmethod
+    def get_trainer_kwargs(**kwargs) -> tuple[dict, dict]:
+        """Resolve XPress's compound loss and consistency knobs."""
+        implementation = kwargs.get("loss_implementation", "fused")
+        shared = {
+            "loss_config": resolve_loss_config(kwargs["loss_fn"], implementation),
+            "gamma": kwargs.get("dflash_decay_gamma", 4.0),
+            "max_anchors": kwargs.get("max_anchors", 3072),
+            "per_position_loss_weight": kwargs.get(
+                "per_position_loss_weight", "fixed-exp-decay"
+            ),
+            "dpace_alpha": kwargs.get("dpace_alpha", 0.5),
+            "consistency_weight": kwargs.get("consistency_weight", 0.3),
+            "consistency_passes": kwargs.get("consistency_passes", 3),
+            "base_anchor_weight": kwargs.get("base_anchor_weight", 0.6),
+            "base_anchor_full_weight": kwargs.get("base_anchor_full_weight", False),
+            "decayed_loss_norm": kwargs.get("decayed_loss_norm", False),
+            "ce_from_data": kwargs.get("ce_from_data", False),
+        }
+        return dict(shared), dict(shared)
+
+    def _draft_to_verifier_ids(self, draft_ids: torch.Tensor) -> torch.Tensor:
+        """Map draft-vocab argmax ids back to verifier-vocab ids (d2t offsets)."""
+        if self.d2t is not None:
+            return draft_ids + self.d2t[draft_ids]
+        return draft_ids
+
+    @conditional_torch_compile
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        loss_mask: torch.Tensor,
+        verifier_last_hidden_states: torch.Tensor,
+        document_ids: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        loss_config: LossConfig | None = None,
+        gamma: float = 4.0,
+        max_anchors: int = 3072,
+        per_position_loss_weight: str = "fixed-exp-decay",
+        dpace_alpha: float = 0.5,
+        consistency_weight: float = 0.3,
+        consistency_passes: int = 3,
+        base_anchor_weight: float | torch.Tensor = 0.6,
+        base_anchor_full_weight: bool = False,
+        decayed_loss_norm: bool = False,
+        ce_from_data: bool = False,
+        **kwargs,
+    ):
+        (
+            hidden,
+            logits,
+            targets,
+            aligned_loss_mask,
+            anchored_block_indices,
+        ) = self._backbone_forward(
+            hidden_states,
+            input_ids,
+            loss_mask,
+            verifier_last_hidden_states,
+            document_ids,
+            position_ids,
+            max_anchors=max_anchors,
+            **kwargs,
+        )
+
+        num_blocks = max_anchors
+        block = self.block_size
+        mask_tokens_size = num_blocks * block
+        block_tokens = input_ids[0, anchored_block_indices].view(num_blocks, block)
+        anchor_tokens = block_tokens[:, :1]
+        anchor_pos = anchored_block_indices.view(num_blocks, block)[:, 0]
+        am1_pos = (anchor_pos - 1).clamp(min=0)
+        am1_ok = (anchor_pos > 0) & (
+            document_ids[0, am1_pos] == document_ids[0, anchor_pos]
+        )
+        am1_tokens = torch.where(
+            am1_ok, input_ids[0, am1_pos], anchor_tokens[:, 0]
+        ).unsqueeze(1)
+
+        data_labels = None
+        if self.d2t is None:
+            if self.config.sample_from_anchor:
+                nxt = (anchored_block_indices + 1).clamp(max=input_ids.shape[1] - 1)
+                data_labels = input_ids[0, nxt].view(1, mask_tokens_size)
+            else:
+                data_labels = block_tokens.reshape(1, mask_tokens_size)
+
+        # ce_from_data: CE labels = the DATA tokens, not the teacher
+        # argmax. Requires the full verifier vocab.
+        ce_data_labels = None
+        if ce_from_data:
+            if data_labels is None:
+                raise ValueError(
+                    "ce_from_data requires draft_vocab == verifier_vocab "
+                    "(XPress recipes are full-vocab)"
+                )
+            ce_data_labels = data_labels
+        if self.config.sample_from_anchor:
+            # Slot k predicts token p+k+1; teacher prev for slot k = token p+k.
+            prev_tf = block_tokens
+        else:
+            # Fill-in: slot k predicts token p+k (slot 0 = anchor); teacher prev
+            # for slot k = token p+k-1 (shifted).
+            prev_tf = torch.cat([am1_tokens, block_tokens[:, :-1]], dim=1)
+
+        hidden_blocks = hidden.view(num_blocks, block, -1)
+        base_block_logits = logits.view(num_blocks, block, -1)
+        hcache = self.refiner_head.hidden_cache(
+            hidden_blocks.to(self.refiner_head.down_h.weight.dtype)
+        )
+
+        # Teacher-forced refine pass.
+        bias_tf = self.refiner_head.block_bias(prev_tf, hcache=hcache)
+        logits_tf = (base_block_logits + bias_tf).view(1, mask_tokens_size, -1)
+
+        round_logits: list[torch.Tensor] = []
+        if consistency_weight > 0.0 and consistency_passes > 0:
+            pred = self._draft_to_verifier_ids(
+                base_block_logits.detach().argmax(dim=-1)
+            )
+            for _ in range(int(consistency_passes)):
+                if self.config.sample_from_anchor:
+                    prev_j = torch.cat([anchor_tokens, pred[:, :-1]], dim=1)
+                else:
+                    pred[:, :1] = anchor_tokens  # slot 0 is the anchor, not predicted
+                    prev_j = torch.cat([am1_tokens, pred[:, :-1]], dim=1)
+                bias_j = self.refiner_head.block_bias(prev_j, hcache=hcache)
+                refined_j = base_block_logits + bias_j
+                round_logits.append(refined_j.view(1, mask_tokens_size, -1))
+                pred = self._draft_to_verifier_ids(refined_j.detach().argmax(dim=-1))
+
+        # The trainer's annealing schedule passes a 0-dim tensor so its value stays
+        # out of Dynamo's guards (a per-step float would recompile this frame until it
+        # hit recompile_limit and fell back to eager). Comparing a tensor here would
+        # make the branch data-dependent, so a tensor simply means "enabled" -- which
+        # holds by construction, and if the schedule's floor were 0 the anchor term
+        # would contribute exactly 0 anyway.
+        base_anchor_on = (
+            True
+            if isinstance(base_anchor_weight, torch.Tensor)
+            else base_anchor_weight > 0.0
+        )
+
+        loss, metrics = compute_metrics(
+            logits_tf,
+            round_logits,
+            logits if base_anchor_on else None,
+            targets,
+            aligned_loss_mask,
+            self.block_size,
+            loss_config=loss_config or resolve_loss_config('{"ce": 0.1, "tv": 0.9}'),
+            gamma=gamma,
+            consistency_weight=consistency_weight,
+            base_anchor_weight=base_anchor_weight,
+            base_anchor_full_weight=base_anchor_full_weight,
+            per_position_loss_weight=per_position_loss_weight,
+            dpace_alpha=dpace_alpha,
+            sample_from_anchor=self.config.sample_from_anchor,
+            decayed_loss_norm=decayed_loss_norm,
+            ce_data_labels=ce_data_labels,
+            data_labels=data_labels,
+        )
+        return None, loss, metrics

--- a/src/speculators/models/xpress/metrics.py
+++ b/src/speculators/models/xpress/metrics.py
@@ -1,0 +1,203 @@
+"""Loss and metrics for the XPress draft model.
+
+loss = compound_loss(refined_tf)                       # teacher-forced prev
+     + consistency_weight * mean_j compound_loss(refined_round_j)
+     + base_anchor_weight * compound_loss(base_logits)  # drafter anchor
+
+The consistency rounds re-feed the refiner its own argmax prev (round 0 seeds
+from the drafter's parallel argmax) — the input distribution the head actually
+meets during inference-time Jacobi decoding. Round losses are AVERAGED so
+``consistency_weight`` keeps its meaning as the round count varies. The anchor
+term holds the co-trained backbone's own logits to the target so the Jacobi
+seed does not decay: without it the backbone drifts to serve the refiner and the
+standalone drafter (the K=0 seed) degrades over a long co-training run.
+"""
+
+from functools import partial
+from typing import Any
+
+import torch
+from torch.nn.functional import cross_entropy, softmax
+
+from speculators.losses import (
+    LossConfig,
+    compound_loss,
+    dflash_loss_decay,
+    dpace_loss_decay,
+)
+
+__all__ = [
+    "compute_metrics",
+]
+
+
+def _hard_label_ce(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    loss_mask: torch.Tensor,
+    pos_idx: torch.Tensor,
+    decay_fn,
+    denom_decay: bool,
+) -> torch.Tensor:
+    """CE against HARD data labels with loss_function's weighting semantics
+    (mask, optional positional decay, decayed-or-mask denominator). The CE here
+    targets the token the sequence actually continued with (the
+    target model's own sample at regeneration time), not the teacher argmax."""
+
+    v = logits.shape[-1]
+    elem = cross_entropy(
+        logits.reshape(-1, v).float(), labels.reshape(-1), reduction="none"
+    ).view(1, -1)
+    mask = loss_mask.to(elem.dtype)
+    elem = elem * mask
+    decay_mult = None
+    if decay_fn is not None:
+        decay_mult = decay_fn(pos_idx.to(elem.dtype), elementwise_loss=elem)
+        elem = elem * decay_mult
+    if denom_decay and decay_mult is not None:
+        denom = (mask * decay_mult).sum(dim=1) + 1e-8
+    else:
+        denom = mask.sum(dim=1) + 1e-8
+    return (elem.sum(dim=1) / denom).mean()
+
+
+def compute_metrics(  # noqa: C901
+    logits_tf: torch.Tensor,
+    round_logits: list[torch.Tensor],
+    base_logits: torch.Tensor | None,
+    targets: torch.Tensor,
+    loss_mask: torch.Tensor,
+    block_size: int,
+    loss_config: LossConfig,
+    gamma: float = 4.0,
+    consistency_weight: float = 0.3,
+    base_anchor_weight: float | torch.Tensor = 0.6,
+    base_anchor_full_weight: bool = False,
+    per_position_loss_weight: str = "fixed-exp-decay",
+    dpace_alpha: float = 0.5,
+    sample_from_anchor: bool = False,
+    decayed_loss_norm: bool = False,
+    ce_data_labels: torch.Tensor | None = None,
+    data_labels: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, dict]:
+    """Compute the XPress loss and a metrics dict (``*_sum``/``*_total`` pairs)."""
+    device = logits_tf.device
+    seq_len = logits_tf.shape[1]
+    pos_idx = (torch.arange(seq_len, device=device) % block_size).unsqueeze(0)
+    if per_position_loss_weight == "dpace":
+        decay_fn = partial(
+            dpace_loss_decay,
+            loss_mask=loss_mask,
+            block_size=block_size,
+            dpace_alpha=dpace_alpha,
+        )
+    else:
+        decay_fn = partial(
+            dflash_loss_decay, gamma=gamma, sample_from_anchor=sample_from_anchor
+        )
+
+    ce_labels = ce_data_labels if "ce" in loss_config else None
+    if ce_labels is not None:
+        _cfg_soft = {k: v for k, v in loss_config.items() if k != "ce"}
+        _ce_weight = loss_config["ce"][1]
+
+    def _term_loss(lgts, term_decay_fn):
+        """compound loss with the CE component optionally re-pointed at the
+        DATA tokens instead of the teacher argmax."""
+        if ce_labels is None:
+            return compound_loss(
+                lgts,
+                targets,
+                loss_mask,
+                pos_idx,
+                loss_config=loss_config,
+                decay_fn=term_decay_fn,
+                denom_decay=decayed_loss_norm,
+            )
+        soft, terms = (
+            compound_loss(
+                lgts,
+                targets,
+                loss_mask,
+                pos_idx,
+                loss_config=_cfg_soft,
+                decay_fn=term_decay_fn,
+                denom_decay=decayed_loss_norm,
+            )
+            if _cfg_soft
+            else (lgts.new_zeros((), dtype=torch.float32), {})
+        )
+        ce = _hard_label_ce(
+            lgts, ce_labels, loss_mask, pos_idx, term_decay_fn, decayed_loss_norm
+        )
+        terms = dict(terms)
+        if _cfg_soft and not terms:
+            ((_only_name, (_, _only_w)),) = _cfg_soft.items()
+            terms[f"{_only_name}_loss"] = (
+                soft.detach() / _only_w if _only_w else soft.detach()
+            )
+        terms["ce_loss"] = ce.detach()
+        return soft + _ce_weight * ce, terms
+
+    loss_tf, term_losses = _term_loss(logits_tf, decay_fn)
+    loss = loss_tf
+
+    metrics: dict[str, Any] = {}
+    ones = torch.ones((), device=device)
+    metrics["tf_loss_sum"] = loss_tf.detach().clone()
+    metrics["tf_loss_total"] = ones.clone()
+
+    round_losses = []
+    for logits_j in round_logits:
+        loss_j, _ = _term_loss(logits_j, decay_fn)
+        round_losses.append(loss_j)
+    if round_losses:
+        loss_cons = torch.stack(round_losses).mean()
+        loss = loss + consistency_weight * loss_cons
+        metrics["consistency_loss_sum"] = loss_cons.detach().clone()
+        metrics["consistency_loss_total"] = ones.clone()
+        for j, loss_j in enumerate(round_losses):
+            metrics[f"consistency_round{j}_loss_sum"] = loss_j.detach().clone()
+            metrics[f"consistency_round{j}_loss_total"] = ones.clone()
+
+    if base_logits is not None:
+        anchor_decay_fn = None if base_anchor_full_weight else decay_fn
+        loss_base, _ = _term_loss(base_logits, anchor_decay_fn)
+        loss = loss + base_anchor_weight * loss_base
+        metrics["base_anchor_loss_sum"] = loss_base.detach().clone()
+        metrics["base_anchor_loss_total"] = ones.clone()
+
+    metrics["loss_sum"] = loss.detach().clone()
+    metrics["loss_total"] = ones.clone()
+    for term_name, term_val in term_losses.items():
+        metrics[f"{term_name}_sum"] = term_val
+        metrics[f"{term_name}_total"] = ones.clone()
+
+    # Analytical per-position acceptance rate of the (teacher-forced) refined
+    # drafter = distributional overlap with the target.
+    with torch.no_grad():
+
+        def _overlap(a_logits, b_logits, chunk=1024):
+            outs = []
+            for i in range(0, a_logits.shape[1], chunk):
+                ap = softmax(a_logits[:, i : i + chunk].float(), dim=-1)
+                bp = softmax(b_logits[:, i : i + chunk].float(), dim=-1)
+                outs.append(torch.minimum(ap, bp).sum(dim=-1))
+            return torch.cat(outs, dim=1)  # [1, T]
+
+        accept_rate = _overlap(logits_tf, targets)
+        mask_f = loss_mask.to(accept_rate.dtype)
+        metrics["accept_rate_sum"] = (accept_rate * mask_f).sum()
+        metrics["accept_rate_total"] = mask_f.sum().clamp_min(1.0)
+        # Top-1 accuracy compares the refined argmax against the DATA token the
+        # sequence continued with, not against the teacher's greedy argmax.
+        _acc_ref = data_labels if data_labels is not None else targets.argmax(dim=-1)
+        acc_hit = (logits_tf.argmax(dim=-1) == _acc_ref).to(mask_f.dtype)
+        metrics["accuracy_sum"] = (acc_hit * mask_f).sum()
+        metrics["accuracy_total"] = mask_f.sum().clamp_min(1.0)
+        if base_logits is not None:
+            base_accept = _overlap(base_logits, targets)
+            metrics["base_accept_rate_sum"] = (base_accept * mask_f).sum()
+            metrics["base_accept_rate_total"] = mask_f.sum().clamp_min(1.0)
+
+    return loss, metrics

--- a/src/speculators/models/xpress/model_definitions.py
+++ b/src/speculators/models/xpress/model_definitions.py
@@ -1,0 +1,71 @@
+import torch
+from torch import nn
+from torch.nn import functional as F  # noqa: N812
+
+__all__ = [
+    "XPressRefinerHead",
+]
+
+
+class XPressRefinerHead(nn.Module):
+    """Lightweight causal refiner producing a per-position logit bias."""
+
+    # register_buffer widens the attribute to Tensor | Module; the annotation
+    # tells the type checker which one it is.
+    causal_tril: torch.Tensor
+
+    def __init__(
+        self,
+        *,
+        verifier_vocab_size: int,
+        draft_vocab_size: int,
+        hidden_size: int,
+        block_size: int,
+        rank: int = 256,
+        mlp_ratio: int = 2,
+    ) -> None:
+        super().__init__()
+        if rank <= 0:
+            raise ValueError(f"rank must be > 0, got {rank}")
+        self.rank = rank
+        self.block_size = block_size
+        r = rank
+        self.token_embed = nn.Embedding(verifier_vocab_size, r)
+        self.down_h = nn.Linear(hidden_size, r, bias=False)
+        self.down_g = nn.Linear(hidden_size, r, bias=False)
+        self.in_proj = nn.Linear(3 * r, r, bias=False)
+        self.mix_l = nn.Parameter(torch.zeros(r, block_size, block_size))
+        mlp_hidden = r * mlp_ratio
+        self.mlp_gate = nn.Linear(r, mlp_hidden, bias=False)
+        self.mlp_up = nn.Linear(r, mlp_hidden, bias=False)
+        self.mlp_down = nn.Linear(mlp_hidden, r, bias=False)
+        self.readout = nn.Linear(r, draft_vocab_size, bias=False)
+        tril = torch.tril(torch.ones(block_size, block_size))
+        self.register_buffer("causal_tril", tril, persistent=False)
+
+    def hidden_cache(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Pass-invariant hidden features ``[down_h(h) ; down_g(g)]``.
+
+        hidden_states: ``[N, block, hidden]``. Returns ``[N, block, 2r]``.
+        Computed once per block and reused across refine passes.
+        """
+        g = hidden_states.mean(dim=1, keepdim=True).expand_as(hidden_states)
+        return torch.cat([self.down_h(hidden_states), self.down_g(g)], dim=-1)
+
+    def block_bias(
+        self,
+        prev_token_ids: torch.Tensor,
+        hidden_states: torch.Tensor | None = None,
+        hcache: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if hcache is None:
+            if hidden_states is None:
+                raise ValueError("block_bias needs hidden_states or hcache")
+            hcache = self.hidden_cache(hidden_states.to(self.down_h.weight.dtype))
+        lat = self.token_embed(prev_token_ids.long())
+        x = self.in_proj(torch.cat([hcache, lat.to(hcache.dtype)], dim=-1))
+        # c[n,k,r] = a[n,k,r] + sum_{j<=k} L[r,k,j] a[n,j,r]
+        l_eff = self.mix_l * self.causal_tril.to(self.mix_l.dtype)
+        x = x + torch.einsum("ckj,njc->nkc", l_eff, x)
+        x = x + self.mlp_down(F.silu(self.mlp_gate(x)) * self.mlp_up(x))
+        return self.readout(x)

--- a/src/speculators/train/config/resolution.py
+++ b/src/speculators/train/config/resolution.py
@@ -90,12 +90,13 @@ REQUIRED_FLAGS: dict[str, str] = _required_flags()
 
 # Algorithm group -> the speculator types that consume it. A group set to a
 # non-default value under a speculator_type absent from its set is ignored, and
-# warns. DFlash2 and DSpark share the DFlash backbone group; their exclusive
+# warns. DFlash2, DSpark and XPress share the DFlash backbone group; their exclusive
 # architecture knobs remain in their own groups. eagle3 uses no group.
 _ALGORITHM_GROUP_USERS: dict[str, frozenset[str]] = {
-    "dflash": frozenset({"dflash", "dflash2", "dspark"}),
+    "dflash": frozenset({"dflash", "dflash2", "dspark", "xpress"}),
     "dflash2": frozenset({"dflash2"}),
     "dspark": frozenset({"dspark"}),
+    "xpress": frozenset({"xpress"}),
     "peagle": frozenset({"peagle"}),
     "mtp": frozenset({"mtp"}),
 }

--- a/src/speculators/train/config/schema.py
+++ b/src/speculators/train/config/schema.py
@@ -313,7 +313,8 @@ class LossArgs(_Group):
         default=None,
         description="Loss function specification. A name (kl_div, rkl, jsd, ce, tv, "
         'nla, lk_hybrid) or a JSON dict for a weighted combination, e.g. \'{"ce": 0.1, '
-        '"tv": 0.9}\'. (default: "ce" for dflash, "kl_div" otherwise).',
+        '"tv": 0.9}\'. (default: "ce" for dflash, \'{"ce": 0.1, "tv": 0.9}\' for '
+        'xpress, "kl_div" otherwise).',
     )
     ttt_steps: int = Field(
         default=3,
@@ -526,6 +527,68 @@ class DSparkArgs(_Group):
     )
 
 
+class XPressArgs(_Group):
+    """XPress-exclusive knobs (causal-refiner head + Jacobi consistency)."""
+
+    xpress_rank: int = Field(
+        default=256,
+        description="XPress: low-rank dim r of the causal-refiner head.",
+    )
+    xpress_mlp_ratio: int = Field(
+        default=2,
+        description="XPress: refiner MLP expansion ratio (hidden = r * ratio). "
+        "The released checkpoints use 2 (r=256 -> hidden 512).",
+    )
+    num_jacobi_passes: int = Field(
+        default=6,
+        description="XPress: inference-time parallel refine passes K (stored in "
+        "the exported config; not used during training).",
+    )
+    consistency_weight: float = Field(
+        default=0.3,
+        description="XPress: weight of the free-running Jacobi consistency term "
+        "(0 disables it).",
+    )
+    consistency_passes: int = Field(
+        default=3,
+        description="XPress: number of free-running rounds the consistency term "
+        "unrolls (round j conditions on round j-1's argmax, stop-grad between "
+        "rounds; losses averaged).",
+    )
+    base_anchor_weight: float = Field(
+        default=0.6,
+        description="XPress: weight of the drafter-anchor loss on the backbone's "
+        "own logits (keeps the co-trained Jacobi seed from decaying).",
+    )
+    decayed_loss_norm: bool = Field(
+        default=False,
+        description=(
+            "Normalize position-decayed losses by the DECAYED weight sum (a true "
+            "weighted mean) instead of the undecayed mask count. "
+            "Uniform rescale of all terms (~4x at b16/gamma4); mainly changes "
+            "grad-clip engagement."
+        ),
+    )
+    ce_from_data: bool = Field(
+        default=False,
+        description="XPress: point the CE loss component at the DATA "
+        "tokens (the target's own continuation from regeneration) instead of the "
+        "teacher-argmax labels. Applies to the teacher-forced, consistency, and "
+        "anchor terms alike. Requires full verifier vocab.",
+    )
+    base_anchor_full_weight: bool = Field(
+        default=False,
+        description="XPress: apply the drafter-anchor with UNDECAYED per-position "
+        "weights (mask only), anchoring deep slots at full strength; the head's "
+        "learning loss keeps its decay. Default False preserves the historical "
+        "recipe, which is validated for z-lab b16 warm starts. Enable for "
+        "deepseek-native (shift) warm starts: with the decayed anchor their "
+        "standalone-drafter accept@6 eroded 0.52 -> 0.20 within 40k steps "
+        "(slot-6 anchor weight is only exp(-6/4)=0.22) while teacher-forced "
+        "greedy metrics kept rising.",
+    )
+
+
 class PEagleArgs(_Group):
     num_depths: int = Field(
         default=8,
@@ -565,9 +628,20 @@ _GROUPS: dict[str, type[_Group]] = {
     "dflash": DFlashArgs,
     "dflash2": DFlash2Args,
     "dspark": DSparkArgs,
+    "xpress": XPressArgs,
     "peagle": PEagleArgs,
     "mtp": MTPArgs,
 }
+
+
+# Unset ``--loss-fn`` / ``--block-size`` resolve per algorithm. XPress's entries are
+# the validated recipe and match the model's own fallback loss; everything absent
+# falls back to the generic default below.
+_DEFAULT_LOSS_FN: dict[str, str] = {
+    "dflash": "ce",
+    "xpress": '{"ce": 0.1, "tv": 0.9}',
+}
+_DEFAULT_BLOCK_SIZE: dict[str, int] = {"dflash": 16, "xpress": 16}
 
 
 class TrainConfig(BaseSettings):
@@ -648,7 +722,7 @@ class TrainConfig(BaseSettings):
     speculator_type: str = Field(
         default="eagle3",
         description="Type of speculator model to train "
-        "(eagle3, dflash, dflash2, dspark, peagle, mtp).",
+        "(eagle3, dflash, dflash2, dspark, xpress, peagle, mtp).",
     )
     dry_run: bool = Field(
         default=False,
@@ -675,6 +749,7 @@ class TrainConfig(BaseSettings):
     dflash: DFlashArgs = Field(default_factory=DFlashArgs)
     dflash2: DFlash2Args = Field(default_factory=DFlash2Args)
     dspark: DSparkArgs = Field(default_factory=DSparkArgs)
+    xpress: XPressArgs = Field(default_factory=XPressArgs)
     peagle: PEagleArgs = Field(default_factory=PEagleArgs)
     mtp: MTPArgs = Field(default_factory=MTPArgs)
 
@@ -684,10 +759,11 @@ class TrainConfig(BaseSettings):
         pre-refactor ``parse_args``: unset ``draft_arch`` -> ``llama`` for eagle3 else
         ``qwen3``; unset ``norm_before_fc`` / ``norm_output`` -> ``True`` for eagle3
         else ``False``; unset ``muon_lr`` -> ``10 * lr``; unset ``num_layers`` -> ``5``
-        for dflash/dspark/dflash2 else ``1``; unset ``per_position_loss_weight`` ->
-        ``dpace`` for dflash else ``fixed-exp-decay``; unset ``loss_fn`` -> ``ce`` for
-        dflash else ``kl_div``; unset ``block_size`` -> ``16`` for dflash else
-        ``8``.
+        for dflash/dspark/dflash2/xpress else ``1``; unset
+        ``per_position_loss_weight`` -> ``dpace`` for dflash else
+        ``fixed-exp-decay``; unset ``loss_fn`` -> ``ce`` for dflash,
+        ``{"ce": 0.1, "tv": 0.9}`` for xpress, else ``kl_div``; unset
+        ``block_size`` -> ``16`` for dflash and xpress else ``8``.
 
         The dflash-conditional defaults reflect the recipe from
         https://github.com/vllm-project/speculators/issues/979: this combination
@@ -710,7 +786,12 @@ class TrainConfig(BaseSettings):
         """
         is_eagle3 = self.speculator_type == "eagle3"
         is_dflash = self.speculator_type == "dflash"
-        is_dflash_family = self.speculator_type in {"dflash", "dspark", "dflash2"}
+        is_dflash_family = self.speculator_type in {
+            "dflash",
+            "dspark",
+            "dflash2",
+            "xpress",
+        }
         if self.draft.draft_arch is None:
             self.draft.draft_arch = "llama" if is_eagle3 else "qwen3"
         if self.draft.norm_before_fc is None:
@@ -728,9 +809,9 @@ class TrainConfig(BaseSettings):
                 "dpace" if is_dflash else "fixed-exp-decay"
             )
         if self.loss.loss_fn is None:
-            self.loss.loss_fn = "ce" if is_dflash else "kl_div"
+            self.loss.loss_fn = _DEFAULT_LOSS_FN.get(self.speculator_type, "kl_div")
         if self.dflash.block_size is None:
-            self.dflash.block_size = 16 if is_dflash else 8
+            self.dflash.block_size = _DEFAULT_BLOCK_SIZE.get(self.speculator_type, 8)
         return self
 
     @model_validator(mode="after")

--- a/tests/unit/models/test_denom_decay.py
+++ b/tests/unit/models/test_denom_decay.py
@@ -1,0 +1,73 @@
+"""Tests for the decayed-denominator loss normalization."""
+
+from functools import partial
+
+import torch
+
+from speculators.losses import exp_loss_decay, loss_function
+from speculators.losses.eager import kl_div_loss
+
+
+def _batch():
+    torch.manual_seed(0)
+    logits = torch.randn(2, 8, 16)
+    targets = torch.randn(2, 8, 16)
+    loss_mask = torch.ones(2, 8)
+    pos_idx = torch.arange(8).expand(2, 8).contiguous()
+    return logits, targets, loss_mask, pos_idx
+
+
+def test_denom_decay_is_a_true_weighted_mean():
+    """With a constant decay the weighted mean must equal the undecayed mean.
+
+    A decay that scales the numerator but not the denominator shrinks the
+    reported loss by the decay factor; dividing by the decayed weight sum
+    cancels it exactly, which is the property that makes the two normalizations
+    comparable across gamma.
+    """
+    logits, targets, loss_mask, pos_idx = _batch()
+    flat = torch.zeros_like(pos_idx)
+
+    plain = loss_function(logits, targets, loss_mask, flat, loss_fn=kl_div_loss)
+    weighted = loss_function(
+        logits,
+        targets,
+        loss_mask,
+        flat,
+        loss_fn=kl_div_loss,
+        decay_fn=partial(exp_loss_decay, gamma=0.5),
+        denom_decay=True,
+    )
+
+    torch.testing.assert_close(plain, weighted)
+
+
+def test_denom_decay_off_reproduces_the_stock_normalization():
+    logits, targets, loss_mask, pos_idx = _batch()
+    decay = partial(exp_loss_decay, gamma=0.5)
+
+    stock = loss_function(
+        logits, targets, loss_mask, pos_idx, loss_fn=kl_div_loss, decay_fn=decay
+    )
+    explicit_off = loss_function(
+        logits,
+        targets,
+        loss_mask,
+        pos_idx,
+        loss_fn=kl_div_loss,
+        decay_fn=decay,
+        denom_decay=False,
+    )
+
+    torch.testing.assert_close(stock, explicit_off)
+
+
+def test_denom_decay_without_a_decay_fn_is_a_no_op():
+    logits, targets, loss_mask, pos_idx = _batch()
+
+    off = loss_function(logits, targets, loss_mask, pos_idx, loss_fn=kl_div_loss)
+    on = loss_function(
+        logits, targets, loss_mask, pos_idx, loss_fn=kl_div_loss, denom_decay=True
+    )
+
+    torch.testing.assert_close(off, on)

--- a/tests/unit/models/test_xpress_head.py
+++ b/tests/unit/models/test_xpress_head.py
@@ -1,0 +1,99 @@
+import pytest
+import torch
+
+from speculators.models.xpress.model_definitions import XPressRefinerHead
+
+
+def _head(block_size: int = 4, rank: int = 8) -> XPressRefinerHead:
+    torch.manual_seed(0)
+    head = XPressRefinerHead(
+        verifier_vocab_size=32,
+        draft_vocab_size=32,
+        hidden_size=16,
+        block_size=block_size,
+        rank=rank,
+        mlp_ratio=2,
+    )
+    with torch.no_grad():
+        head.mix_l.normal_(std=0.1)
+    return head
+
+
+def _inputs(head: XPressRefinerHead, num_blocks: int = 3):
+    torch.manual_seed(1)
+    hidden = torch.randn(num_blocks, head.block_size, 16)
+    prev = torch.randint(0, 32, (num_blocks, head.block_size))
+    return hidden, prev
+
+
+def test_mixer_is_causal_across_the_block():
+    """Jacobi iteration is only valid if a settled prefix cannot be disturbed.
+
+    Changing the previous-token id at slot j must leave every slot k < j
+    untouched; if the mixer leaked backwards, an earlier slot could flip after it
+    had already been accepted and the fixed point would not exist.
+    """
+    head = _head()
+    hidden, prev = _inputs(head)
+
+    with torch.no_grad():
+        base = head.block_bias(prev, hidden_states=hidden)
+
+    for j in range(head.block_size):
+        perturbed = prev.clone()
+        perturbed[:, j] = (perturbed[:, j] + 7) % 32
+        with torch.no_grad():
+            out = head.block_bias(perturbed, hidden_states=hidden)
+        if j > 0:
+            torch.testing.assert_close(out[:, :j], base[:, :j])
+        assert not torch.allclose(out[:, j], base[:, j]), (
+            f"slot {j} did not react to its own input"
+        )
+
+
+def test_hidden_cache_matches_the_full_path():
+    """hcache is pass-invariant, so reusing it across Jacobi passes must be exact.
+
+    Training computes it once per block; if it drifted from the full path, the
+    refine passes after the first would be trained on different features than
+    they see.
+    """
+    head = _head()
+    hidden, prev = _inputs(head)
+
+    with torch.no_grad():
+        full = head.block_bias(prev, hidden_states=hidden)
+        cached = head.block_bias(prev, hcache=head.hidden_cache(hidden))
+
+    torch.testing.assert_close(full, cached)
+
+
+def test_fold_matches_the_serving_time_mixer():
+    """Serving folds the mixer to ``L * tril + I`` and drops the residual add.
+
+    Training stores raw ``mix_l`` and computes ``x + (L * tril) x``. The two must
+    be the same function or an exported checkpoint would mean something different
+    at inference time than it did during training.
+    """
+    head = _head()
+    r, b = head.rank, head.block_size
+    x = torch.randn(3, b, r)
+
+    l_eff = head.mix_l * head.causal_tril.to(head.mix_l.dtype)
+    training = x + torch.einsum("ckj,njc->nkc", l_eff, x)
+
+    folded = l_eff + torch.eye(b).expand(r, -1, -1)
+    serving = torch.bmm(folded, x.permute(2, 1, 0)).permute(2, 1, 0)
+
+    torch.testing.assert_close(training, serving)
+
+
+def test_rank_must_be_positive():
+    with pytest.raises(ValueError, match="rank must be > 0"):
+        XPressRefinerHead(
+            verifier_vocab_size=32,
+            draft_vocab_size=32,
+            hidden_size=16,
+            block_size=4,
+            rank=0,
+        )

--- a/tests/unit/train/config/test_xpress_registration.py
+++ b/tests/unit/train/config/test_xpress_registration.py
@@ -1,0 +1,46 @@
+from speculators.model import SpeculatorModel
+from speculators.models.xpress.core import XPressDraftModel
+from speculators.train.config.resolution import _ALGORITHM_GROUP_USERS
+from speculators.train.config.schema import TrainConfig
+
+
+def test_speculator_type_xpress_resolves_to_the_model():
+    """``--speculator-type xpress`` is resolved through the global registry.
+
+    Without the ``@register`` decorator the flag parses fine and then fails at
+    model construction, so pin the lookup rather than the decorator.
+    """
+    registry = SpeculatorModel.registry
+
+    assert registry is not None
+    assert registry["xpress"] is XPressDraftModel
+
+
+def test_xpress_group_is_exposed_with_the_released_defaults():
+    cfg = TrainConfig()
+
+    assert cfg.xpress.xpress_rank == 256
+    assert cfg.xpress.xpress_mlp_ratio == 2
+    assert cfg.xpress.num_jacobi_passes == 6
+
+
+def test_xpress_reads_the_dflash_group_and_owns_its_own():
+    """XPress is-a DFlash, so a dflash-group flag must not warn under xpress.
+
+    The group table is what decides whether a flag is silently ignored; leaving
+    xpress out of the dflash entry would make every backbone knob a no-op warning
+    on an xpress run.
+    """
+    assert "xpress" in _ALGORITHM_GROUP_USERS["dflash"]
+    assert _ALGORITHM_GROUP_USERS["xpress"] == frozenset({"xpress"})
+    assert "xpress" not in _ALGORITHM_GROUP_USERS["dspark"]
+
+
+def test_xpress_flags_survive_a_flatten_roundtrip():
+    cfg = TrainConfig()
+    cfg.xpress.xpress_rank = 128
+
+    flat = cfg.flatten()
+
+    assert flat["xpress_rank"] == 128
+    assert "num_jacobi_passes" in flat


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Adds **XPress**, a causal refiner over the DFlash block-parallel draft backbone, as a first-class algorithm alongside DFlash, DFlash2 and DSpark. Implements RFC #1051. Paper: https://arxiv.org/abs/2608.02438

A block-parallel drafter proposes a whole block in one forward pass, which makes drafting cheap, and decodes each position from its own marginal, which makes it inaccurate: token *k* is drawn without seeing what the drafter chose at *k-1*. The verifier scores conditionally, so blocks that are individually plausible but jointly improbable are rejected early, capping acceptance length.

XPress adds a small head that reads each position's hidden state, a block-global summary and the previous token, fuses them into a low-rank bottleneck, mixes across the block with a lower-triangular (causal) mixer, and reads back out as a bias on the base logits. Because the mixer is truly causal rather than a local smoother, the block is resolved by **Jacobi iteration** rather than a left-to-right loop: the same call runs K times, each pass re-feeding the previous pass's argmax, so the serial depth at inference is a constant K instead of the block size.

Training co-trains the head with the backbone over free-running Jacobi rounds. Each round conditioned on the previous round's argmax, which is the exact recurrence inference performs, with stop-grad between rounds, and anchors the backbone with a base-logits term so its standalone drafting quality does not erode.

`XPressDraftModel` subclasses `DFlashDraftModel`, so the backbone, data pipeline, verifier support and checkpointing are inherited unchanged.


### Shared code touched

*   `loss_function` / `compound_loss` gain `denom_decay` (default off), which normalizes a position-decayed loss by the decayed weight sum instead of scaling only the numerator. With the default the code path is unchanged.
*   `xpress` joins the DFlash backbone algorithm group and the DFlash-family defaults, so an XPress run without `--num-draft-layers` gets 5 layers rather than 1, and unset `--loss-fn` / `--block-size` resolve to the validated recipe (`{"ce": 0.1, "tv": 0.9}`, 16) rather than the generic defaults.
*   `XPressDraftModel` / `XPressSpeculatorConfig` are exported from the package root, which `tests/unit/test_package_imports.py` requires of every algorithm.

### Removed since the first revision

Following review, the following were taken out of this PR rather than fixed in place:

*   **fp32 master weights.** FSDP2's `MixedPrecisionPolicy(param_dtype=bf16, reduce_dtype=fp32)` already keeps the sharded masters and the optimizer step in fp32, so the shadow copies were redundant, and they detached from the sharded parameters, so the FSDP case was not handled correctly either.
*   **`--val-data-path`, `--eval-interval` / `--eval-max-batches`.** Mid-epoch validation and a separate validation corpus are trainer features unrelated to XPress and are planned as their own PR.
*   **`--no-packing`.** It fed the packer a constant length so each batch held one conversation per rank, which is how our reference recipe specifies its batch. Useful, misleadingly named, and unrelated to XPress. 
*   **`anchor_cap_to_max_valid`, `prefix_valid_mask`.** Both existed only to match our reference implementation. `prefix_valid_mask` fires only when a block spills into the next packed document *and* that document has supervised tokens within `block_size`, which effectively never happens. `models/dflash/utils.py` is back to upstream.
*   **The Jacobi-rollout accept-length metric** and its `eval_jacobi_passes` flag. Measuring it needed `anchor_valid` out of the shared `_backbone_forward`, which meant changing that signature and every caller. DSpark already reports an equivalent `accept_len` computed from the loss mask, so the metric was dropped.
*   **Annealing `base_anchor_weight` toward a floor.** Algorithm-specific logic does not belong in the shared trainer; happy to adopt the general weight scheduler when it lands.
*   **The metric-reduce ordering guard.** Defensive hardening of `dist.reduce` call order, unrelated to XPress.

## Tests

```
# new
pytest tests/unit/models/test_xpress_head.py \
       tests/unit/models/test_denom_decay.py \
       tests/unit/train/config/test_xpress_registration.py

# regression across the models and trainer this PR touches 

pytest tests/unit
make quality
```

The unit tests pin the invariants Jacobi iteration depends on: the mixer being causal across the block (a settled prefix cannot be disturbed by a later slot, which is what makes the fixed point exist), the pass-invariant hidden cache matching the full path, and the training-time mixer `x + (L * tril) x` being the same function as the folded `L * tril + I` an inference engine loads — so an exported checkpoint means the same thing at serving time as it did in training. The registration tests pin the lookup the trainer actually performs, `SpeculatorModel.registry["xpress"]`, and that the `xpress` group is reachable on `TrainConfig` (registering it in `_GROUPS` alone leaves every `--xpress-*` flag silently resolving to nothing).

### Results

```
$ pytest tests/unit/test_package_imports.py tests/unit/models/test_xpress_head.py \
         tests/unit/models/test_denom_decay.py \
         tests/unit/train/config/test_xpress_registration.py -q
12 passed

$ pytest tests/unit/train/config -q
78 passed

$ pytest tests/unit -q   # deselecting the environment failures below
945 passed, 27 deselected

$ make quality
ruff check ..................... All checks passed!
ruff format --check ............ 251 files already formatted
mdformat --check ............... ok
mypy --check-untyped-defs ...... Success: no issues found in 229 source files
sync_provenance --check ........ OK
```

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
