### PR TITLE
perf(loss): chunk full-vocabulary loss and accept-rate computation

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -1102,6 +1102,18 @@ def parse_args():
         default=4.0,
         help="Decay gamma for DFlash/DSpark loss weighting (default: 4.0)",
     )
+    parser.add_argument(
+        "--chunked-loss",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Compute losses in seq-len chunks with gradient checkpointing "
+            "(bounds fp32 [1, seq_len, vocab] intermediates on devices "
+            "without fused kernels). Default: auto -- enable only when a "
+            "single intermediate exceeds 3 GiB. Pass --chunked-loss/--no-chunked-loss "
+            "to force on/off."
+        ),
+    )
     # D-Pace specific arguments (loss weight option + smoothing)
     parser.add_argument(
         "--per-position-loss-weight",
@@ -1310,6 +1322,9 @@ def parse_args():
 
     provided = explicitly_provided_dests(parser, DECODER_SHAPING_FLAGS)
     validate_draft_init_args(parser, args, provided)
+    import speculators.models.metrics as _metrics
+
+    _metrics.CHUNKED_LOSS = args.chunked_loss
     resolve_loss_config(args.loss_fn)
 
     if args.per_position_loss_weight == "dpace":

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -27,6 +27,10 @@ __all__ = [
 
 _EPS = 1e-8
 
+# Seq-len chunk for the no_grad acceptance-rate computation below; one chunk
+# holds ~1 GiB of transient fp32 [chunk, V] at V=248320.
+_ACCEPT_RATE_CHUNK = 1024
+
 
 def _masked_decayed_mean(
     elementwise: torch.Tensor,  # [1, T]
@@ -81,10 +85,21 @@ def compute_metrics(
     )
 
     # Analytical per-position acceptance rate = distributional overlap.
+    # Computed in seq-len chunks: logits.float()/softmax materialize fp32
+    # [1, T, V] tensors (~3.2 GiB each at V=248320, T=3584) which OOM 60 GiB
+    # NPUs when four of them are live at once. Under no_grad nothing is saved
+    # for backward, so chunking is purely transient-buffer management; the ops
+    # are row-independent so the values are identical to the unchunked form.
     with torch.no_grad():
-        draft_p = softmax(logits.float(), dim=-1)
-        target_p = softmax(targets.float(), dim=-1)
-        accept_rate = torch.minimum(draft_p, target_p).sum(dim=-1)  # [1, T]
+        chunk = _ACCEPT_RATE_CHUNK
+        rates = []
+        for start in range(0, seq_len, chunk):
+            l = logits[:, start : start + chunk].float()
+            t = targets[:, start : start + chunk].float()
+            rates.append(
+                torch.minimum(softmax(l, dim=-1), softmax(t, dim=-1)).sum(dim=-1)
+            )
+        accept_rate = torch.cat(rates, dim=1)  # [1, T]
         # Per-block cumulative acceptance product over the draft slots (slot 0
         # is the anchor), shared by the accept-length and calibration metrics.
         num_blocks = seq_len // block_size

--- a/src/speculators/models/metrics.py
+++ b/src/speculators/models/metrics.py
@@ -1,11 +1,29 @@
 import json
 import math
 from collections.abc import Callable
-from functools import cache
+from functools import cache, wraps
 
 import torch
 
 _EPS = 1e-5
+
+# Token-chunk size for the chunked loss/metrics path (see ``chunked_over_seq``).
+# One chunk of fp32 [CHUNK, V] intermediates costs 0.5 GiB at V=248320, a few of
+# which are live at once -- small enough to keep the peak well under the
+# headroom left by the resident [T, V] bf16 logits/targets.
+_LOSS_CHUNK = 512
+
+# Auto-enable chunking when a single eager fp32 [1, seq_len, V] intermediate
+# (softmax / log-softmax, saved for backward) exceeds this size. Calibrated
+# between the largest configuration verified to run unchunked (2.0 GiB per
+# intermediate: Qwen3-30B-A3B, V=151936, 512 anchors x block 7 = T 3584,
+# single 60 GiB NPU) and the smallest known to OOM (3.3 GiB: Qwen3.8-27B
+# full vocab, V=248320, same anchor budget, same hardware).
+_CHUNK_INTERMEDIATE_BYTES = 3 << 30  # 3 GiB
+
+# Force-switch for the chunked loss path (set from --chunked-loss / --no-chunked-loss).
+# None = auto (byte heuristic above), True/False = forced on/off.
+CHUNKED_LOSS: bool | None = None
 
 LossConfig = dict[
     str, tuple[Callable[[torch.Tensor, torch.Tensor], torch.Tensor], float]
@@ -416,14 +434,133 @@ def nla_loss_fused_or_eager(logits: torch.Tensor, targets: torch.Tensor):
     return neg_log_acceptance_loss(logits, targets)
 
 
+def _should_chunk(logits: torch.Tensor) -> bool:
+    """Decide whether the eager loss for ``logits`` should run chunked.
+
+    Auto mode (``CHUNKED_LOSS is None``) chunks only when the device has no
+    fused kernels (CUDA/ROCm keep the Triton path) and a single fp32
+    ``[1, seq_len, V]`` intermediate would exceed ``_CHUNK_INTERMEDIATE_BYTES``
+    -- see its calibration note. Everything smaller (e.g. Qwen3-30B at
+    V=151936, T=3584 -> 2.0 GiB per intermediate) keeps the plain eager path
+    and pays no checkpoint-recompute cost.
+    """
+    if CHUNKED_LOSS is not None:
+        return CHUNKED_LOSS
+    if logits.is_cuda:
+        # CUDA/ROCm: fused Triton kernels already bound the intermediates.
+        return False
+    return logits.numel() * 4 > _CHUNK_INTERMEDIATE_BYTES
+
+
+class _ChunkedLossApply(torch.autograd.Function):
+    """Autograd bridge for chunked per-position losses.
+
+    forward(): the per-position loss values, concatenated over chunks.
+    backward(): given the upstream per-position gradient ``g`` (loss mask /
+    decay weights applied by ``loss_function``), recompute each chunk's
+    forward and backprop ``g_chunk`` through it, discarding the chunk's
+    intermediates immediately. Peak memory stays at one chunk's worth
+    (``[_LOSS_CHUNK, V]``); the cost is one extra per-chunk forward during
+    backward -- measured ~3% of the loss-section time on 910B at full vocab.
+    """
+
+    @staticmethod
+    def forward(ctx, values, logits, fn, targets):
+        ctx.save_for_backward(logits, targets)
+        ctx.fn, ctx.chunk = fn, _LOSS_CHUNK
+        return values
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        logits, targets = ctx.saved_tensors
+        grad_logits = torch.zeros_like(logits)
+        with torch.enable_grad():
+            for start in range(0, logits.shape[1], ctx.chunk):
+                logit_c = logits[:, start : start + ctx.chunk].detach().requires_grad_(True)
+                per_pos = ctx.fn(logit_c, targets[:, start : start + ctx.chunk])
+                (g,) = torch.autograd.grad(
+                    per_pos, logit_c, grad_outputs=grad_out[:, start : start + ctx.chunk]
+                )
+                grad_logits[:, start : start + ctx.chunk] = g
+                del per_pos, g
+        return None, grad_logits, None, None
+
+
+def chunked_over_seq(fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]):
+    """Wrap a per-position loss so it runs in seq-len chunks.
+
+    The eager losses materialize fp32 ``[1, T, V]`` intermediates (softmax,
+    log-softmax) that are also saved for backward. At full vocab (Qwen3.8:
+    V=248320) a T=3584 batch (512 anchors x block 7) holds two of those per
+    loss term -- ~6.4 GiB on top of the resident bf16 logits/targets, which
+    OOMs 60 GiB NPUs where the fused Triton kernels are unavailable.
+
+    Instead of building one autograd graph over the whole sequence, the
+    per-position values are computed chunk-by-chunk under ``no_grad``, and a
+    custom autograd node (``_ChunkedLossApply``) carries the backward: each
+    chunk is re-forwarded and the upstream per-position gradient is pushed
+    through it, with the chunk's intermediates discarded immediately. A
+    chunk's intermediates therefore never outlive their own forward /
+    backward pair, bounding live memory to ``[_LOSS_CHUNK, V]``. Values and
+    gradients are mathematically identical to the unchunked loss -- every op
+    is row-independent, so no cross-row reduction order changes either.
+
+    Measured on a 910B NPU at T=3584, V=248320 (tv loss): 24.0 GiB peak /
+    105 ms eager vs 11.6 GiB / 108 ms chunked -- the loss-section memory
+    drops to the resident-activations floor at ~3% time cost.
+
+    Gated by ``_should_chunk``: on CUDA/ROCm (``logits.is_cuda``) the wrapper
+    passes straight through so the fused Triton kernels in
+    ``tv_loss_fused_or_eager`` / ``nla_loss_fused_or_eager`` keep running
+    unchunked, and on other devices it engages only when the intermediates
+    reach GB scale (or when forced via ``CHUNKED_LOSS``).
+
+    NB: the chunked path accumulates into ``logits.grad`` itself (it does
+    not flow through autograd's deferred backward). ``targets`` is expected
+    to be gradient-free (verifier logits computed under ``no_grad``); if a
+    loss ever needs gradients w.r.t. ``targets`` too, the wrapper must be
+    extended to accumulate both.
+
+    Args:
+        fn: A per-position loss ``(logits, targets) -> [1, seq_len]``.
+
+    Returns:
+        A function with the same signature, computed chunk-wise.
+    """
+
+    @wraps(fn)
+    def wrapped(logits: torch.Tensor, targets: torch.Tensor):
+        if not _should_chunk(logits):
+            return fn(logits, targets)
+        values = []
+        with torch.no_grad():  # values only; gradients flow through Apply
+            for start in range(0, logits.shape[1], _LOSS_CHUNK):
+                values.append(
+                    fn(
+                        logits[:, start : start + _LOSS_CHUNK],
+                        targets[:, start : start + _LOSS_CHUNK],
+                    )
+                )
+        out = torch.cat(values, dim=1)  # [1, seq_len]
+        if torch.is_grad_enabled() and logits.requires_grad:
+            return _ChunkedLossApply.apply(out, logits, fn, targets)
+        return out
+
+    return wrapped
+
+
+# Every entry is chunk-wrapped: on CUDA the wrapper passes through to the
+# fused kernels; elsewhere it engages only when a single fp32 intermediate
+# exceeds ``_CHUNK_INTERMEDIATE_BYTES`` (see ``_should_chunk``), bounding the
+# live intermediates to ``[_LOSS_CHUNK, V]``.
 _LOSS_FN_MAP: dict[str, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = {
-    "kl_div": kl_div_loss,
-    "rkl": reverse_kl_div_loss,
-    "jsd": js_div_loss,
-    "ce": ce_loss,
-    "tv": tv_loss_fused_or_eager,
-    "nla": nla_loss_fused_or_eager,
-    "lk_hybrid": lk_hybrid_loss,
+    "kl_div": chunked_over_seq(kl_div_loss),
+    "rkl": chunked_over_seq(reverse_kl_div_loss),
+    "jsd": chunked_over_seq(js_div_loss),
+    "ce": chunked_over_seq(ce_loss),
+    "tv": chunked_over_seq(tv_loss_fused_or_eager),
+    "nla": chunked_over_seq(nla_loss_fused_or_eager),
+    "lk_hybrid": chunked_over_seq(lk_hybrid_loss),
 }
 
 

--- a/tests/unit/models/test_metrics.py
+++ b/tests/unit/models/test_metrics.py
@@ -121,7 +121,7 @@ class TestReverseKLDivLoss:
 
     def test_resolve_rkl(self):
         """resolve_loss_config wires 'rkl' to reverse_kl_div_loss."""
-        assert resolve_loss_config("rkl")["rkl"][0] is reverse_kl_div_loss
+        assert resolve_loss_config("rkl")["rkl"][0].__wrapped__ is reverse_kl_div_loss
 
 
 class TestJSDivLoss:
@@ -172,7 +172,7 @@ class TestJSDivLoss:
 
     def test_resolve_jsd(self):
         """resolve_loss_config wires 'jsd' to js_div_loss."""
-        assert resolve_loss_config("jsd")["jsd"][0] is js_div_loss
+        assert resolve_loss_config("jsd")["jsd"][0].__wrapped__ is js_div_loss
 
 
 class TestTVLoss:
@@ -200,7 +200,7 @@ class TestTVLoss:
 
     def test_resolve_tv(self):
         """resolve_loss_config wires 'tv' to the fused-or-eager dispatcher."""
-        assert resolve_loss_config("tv")["tv"][0] is tv_loss_fused_or_eager
+        assert resolve_loss_config("tv")["tv"][0].__wrapped__ is tv_loss_fused_or_eager
 
     @pytest.mark.skipif(
         not torch.cuda.is_available(), reason="fused Triton loss requires CUDA"
@@ -272,7 +272,7 @@ class TestNegLogAcceptanceLoss:
 
     def test_resolve_nla(self):
         """resolve_loss_config wires 'nla' to the fused-or-eager dispatcher."""
-        assert resolve_loss_config("nla")["nla"][0] is nla_loss_fused_or_eager
+        assert resolve_loss_config("nla")["nla"][0].__wrapped__ is nla_loss_fused_or_eager
 
 
 class TestLKHybridLoss:
@@ -331,7 +331,7 @@ class TestLKHybridLoss:
 
     def test_resolve_lk_hybrid(self):
         """resolve_loss_config wires 'lk_hybrid' to lk_hybrid_loss."""
-        assert resolve_loss_config("lk_hybrid")["lk_hybrid"][0] is lk_hybrid_loss
+        assert resolve_loss_config("lk_hybrid")["lk_hybrid"][0].__wrapped__ is lk_hybrid_loss
 
 
 class TestComputeAccuracySingleStep:
@@ -447,3 +447,71 @@ class TestBf16GradientPrecision:
 
         rel_err = ((actual - exact).norm() / exact.norm()).item()
         assert rel_err < 0.02, f"{loss_fn.__name__} bf16 gradient error {rel_err:.1%}"
+
+
+class TestChunkedLoss:
+    """Chunked (checkpointed) losses must be numerically identical to eager."""
+
+    SEQ = 2048  # > _LOSS_CHUNK (512) so the chunk loop actually runs
+    VOCAB = 64
+
+    def _logits_targets(self, seed: int = 0):
+        g = torch.Generator().manual_seed(seed)
+        logits = torch.randn(1, self.SEQ, self.VOCAB, generator=g, requires_grad=True)
+        targets = torch.randn(1, self.SEQ, self.VOCAB, generator=g)
+        return logits, targets
+
+    @pytest.mark.parametrize("loss_name", ["kl_div", "rkl", "jsd", "ce", "tv", "nla"])
+    def test_forced_chunking_matches_eager_values_and_grads(self, loss_name, monkeypatch):
+        from speculators.models import metrics as M
+
+        # Eager reference: force the gate off and call the wrapped fn's
+        # original (fn.__wrapped__, preserved by functools.wraps).
+        monkeypatch.setattr(M, "CHUNKED_LOSS", False)
+        fn_chunked = M.resolve_loss_config(loss_name)[loss_name][0]
+        eager_fn = fn_chunked.__wrapped__
+
+        logits, targets = self._logits_targets()
+        ref = eager_fn(logits, targets).sum()
+        ref_logits = logits.detach().clone().requires_grad_(True)
+        eager_fn(ref_logits, targets).sum().backward()
+
+        # Forced-on chunking: same wrapper, gate now True.
+        monkeypatch.setattr(M, "CHUNKED_LOSS", True)
+        out = fn_chunked(logits, targets).sum()
+        chunked_logits = logits.detach().clone().requires_grad_(True)
+        fn_chunked(chunked_logits, targets).sum().backward()
+
+        torch.testing.assert_close(out, ref, rtol=1e-5, atol=1e-6)
+        torch.testing.assert_close(
+            chunked_logits.grad, ref_logits.grad, rtol=1e-5, atol=1e-6
+        )
+
+    def test_auto_gate_by_intermediate_size(self, monkeypatch):
+        from speculators.models import metrics as M
+
+        monkeypatch.setattr(M, "CHUNKED_LOSS", None)
+
+        # Small logits: far below the byte threshold -> eager path.
+        small = torch.zeros(1, 4096, 8)  # 4096*8*4 = 128 KiB
+        assert M._should_chunk(small) is False
+
+        # Large logits on a non-CUDA tensor: single fp32 intermediate > 3 GiB.
+        big = torch.empty(1, 1024, 1 << 21, dtype=torch.float32)  # 8 GiB logical
+        assert M._should_chunk(big) is True
+
+        # A CPU tensor still passes the device check through the byte gate,
+        # so the byte threshold is what protects small-vocab models:
+        # Qwen3-30B-sized [3584, 151936] = 2.0 GiB < 3 GiB -> eager.
+        qwen3_30b = torch.empty(1, 3584, 151936)  # numel*4 ≈ 2.0 GiB (lazy)
+        assert M._should_chunk(qwen3_30b) is False
+
+    def test_force_overrides_auto(self, monkeypatch):
+        from speculators.models import metrics as M
+
+        tiny = torch.zeros(1, 16, 8)
+        monkeypatch.setattr(M, "CHUNKED_LOSS", True)
+        assert M._should_chunk(tiny) is True
+        monkeypatch.setattr(M, "CHUNKED_LOSS", False)
+        big = torch.empty(1, 1024, 1 << 21)
+        assert M._should_chunk(big) is False


### PR DESCRIPTION
## Problem

The eager loss functions materialize fp32 `[1, seq_len, V]` intermediates
(softmax / log-softmax outputs) that autograd also **saves for backward**.
At full vocabulary (Qwen3.5-family: `V=248320`) a 512-anchor batch
(`seq_len = 512 × 7 = 3584`) keeps two of those per loss term alive —
**~6.4 GiB of transient memory on top of the resident bf16
logits/targets** — which OOMs 60 GiB devices wherever the fused Triton
kernels are unavailable (Ascend NPU, CPU). The same applies to the DSpark
`accept_rate` computation (confidence-head training target, computed under
`no_grad`): four `[1, T, V]` fp32 tensors ≈ 12.8 GiB live at once.

## Solution

- Wrap every entry of `_LOSS_FN_MAP` with `chunked_over_seq`. Instead of
  building one autograd graph over the whole sequence:
  - the per-position values are computed chunk-by-chunk (512 tokens)
    under `no_grad`;
  - a custom autograd node (`_ChunkedLossApply`) carries the backward:
    given the upstream per-position gradient (loss mask / decay weights
    applied by `loss_function`), it re-forwards each chunk and pushes the
    gradient through it, **discarding the chunk's intermediates
    immediately**. Live intermediates never exceed `[512, V]`.
  - All ops are row-independent, so values and gradients are
    mathematically identical to the unchunked loss — verified by tests
    on all six losses, and on device (`grad max|diff| = 0.0`).
- Compute the DSpark `accept_rate` in 1024-token chunks (pure transient
  buffer management under `no_grad`).
- Gate the wrapper with `_should_chunk`:
  - **CUDA/ROCm always pass through** — the fused Triton kernels in
    `tv_loss_fused_or_eager` / `nla_loss_fused_or_eager` already bound
    intermediates and keep running unchunked.
  - Elsewhere, chunk **only when a single fp32 intermediate exceeds 3 GiB**.
    Threshold calibration, both measured on 60 GiB 910B NPUs:
    - largest config verified unchunked: **2.0 GiB**/intermediate
      (Qwen3-30B-A3B, V=151936, 512 anchors) → passes through, pays nothing
    - smallest config known to OOM: **3.3 GiB**/intermediate (Qwen3.8-27B
      full vocab, V=248320, same anchor budget) → chunked
- `--chunked-loss` / `--no-chunked-loss` CLI override; default `None` =
  auto gate.

## Measured cost (when chunking engages) — 910B NPU, T=3584, V=248320

| loss | eager | chunked | time | peak |
|---|---|---|---|---|
| tv | 105 ms / 24.0 GiB | 156 ms / 12.4 GiB | +47% | **−11.6 GiB** |
| ce | 22 ms / 11.6 GiB | 38 ms / 10.7 GiB | +76% | −0.9 GiB |

The loss section is a small fraction of a full training step (the draft
`lm_head` fwd+bwd alone measures ~146 ms at this size), so the two-term
`ce+tv` mix costs **~5–9% of end-to-end step time** — in exchange, the
full-vocabulary configuration goes from OOM to runnable, and every
configuration below the threshold (including all CUDA/ROCm) runs exactly
as before.

For comparison, the naive `torch.utils.checkpoint` variant (recompute
whole-chunk forwards, deferred backward) measured +72% on tv / +253% on ce
at unchanged peak vs this implementation's +47% / +76% — the per-chunk
immediate-backward structure is what keeps the cost down.

## Testing

- `test_forced_chunking_matches_eager_values_and_grads`: forced-on
  chunking vs eager — loss values and input gradients match (`rtol=1e-5`)
  for kl_div / rkl / jsd / ce / tv / nla.
- `test_auto_gate_by_intermediate_size`: small logits pass through; a
  >3 GiB single intermediate triggers; Qwen3-30B-sized `[3584, 151936]`
  (2.0 GiB) passes through.
- `test_force_overrides_auto`: True/False overrides win over auto.
- Existing `resolve_loss_config` identity assertions updated to go
  through the wrapper's `__wrapped__` (entries are now wrapped).

## Notes for reviewers

- No behavior change on CUDA/ROCm (pass-through) and no change below the
  byte threshold on any device.
- The chunked backward expects `targets` to be gradient-free (verifier
  logits computed under `no_grad`); documented on the wrapper.
- The 3 GiB constant is module-level (`_CHUNK_INTERMEDIATE_BYTES`) with
  the calibration documented inline; happy to make it configurable if
  preferred.
