### PR TITLE
feat(eval): add MRCR mode for long-context acceptance rate benchmarks

### DIFF
--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -4,7 +4,7 @@
 Modes:
     throughput   Max throughput run for acceptance rates
     sweep        Full pipeline (gen-len, sweep, CSV)
-    mrcr         Long-context acceptance rates via OpenAI's MRCR dataset,
+    long-context Long-context acceptance rates via OpenAI's MRCR dataset,
                  bucketed by context length (uses Inspect AI as the harness)
 
 Examples:
@@ -21,8 +21,8 @@ Examples:
         --dataset speedbench/qualitative/coding \\
         --speedbench-data-dir ./speedbench_data
 
-    # MRCR (long-context acceptance rate by bucket, capped at 128k tokens):
-    python evaluate.py --target http://localhost:8000/v1 mrcr \\
+    # Long-context (acceptance rate by context-length bucket, capped at 128k tokens):
+    python evaluate.py --target http://localhost:8000/v1 long-context \\
         --mrcr-max-context 131072 --mrcr-max-samples-per-bucket 20
 """
 
@@ -303,7 +303,7 @@ def run_benchmark(args: argparse.Namespace) -> None:
 
     save_eval_provenance(output_dir)
 
-    if args.mode == "mrcr":
+    if args.mode == "long-context":
         from mrcr_bench import run_mrcr
         model_info = _fetch_model_info(args.target)
         run_mrcr(
@@ -412,11 +412,11 @@ def main() -> None:
     )
     parser.add_argument(
         "mode",
-        choices=["throughput", "sweep", "mrcr"],
+        choices=["throughput", "sweep", "long-context"],
         help=(
             "throughput: max-rate run for acceptance rates; "
             "sweep: full benchmarking pipeline; "
-            "mrcr: long-context acceptance rates via OpenAI's MRCR dataset"
+            "long-context: acceptance rates across context-length buckets"
         ),
     )
     parser.add_argument(

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -293,85 +293,6 @@ def _run_subset(
     return acceptance_csv, perf_csv, max_tokens if is_sweep else None
 
 
-def _run_mrcr(args: argparse.Namespace, metrics_url: str, output_dir: Path) -> None:
-    """Drive MRCR long-context prompts through the target server, bucket by
-    bucket, diffing spec-decode Prometheus counters around each bucket's run.
-
-    Uses Inspect AI as the eval harness (dataset loading + concurrent
-    generation against the target's OpenAI-compatible endpoint via the
-    ``vllm`` model provider). Correctness is not graded here — only
-    acceptance metrics are collected.
-    """
-    from inspect_ai import eval as inspect_eval
-
-    from mrcr_bench import build_task, load_mrcr_buckets, warn_if_oversized
-
-    model_info = _fetch_model_info(args.target)
-    if model_info is None:
-        logger.error("Could not determine served model info from %s/models", args.target)
-        sys.exit(1)
-    model_name = model_info["id"]
-    max_model_len = model_info.get("max_model_len")
-    logger.info(
-        "Server reports model=%s max_model_len=%s", model_name, max_model_len
-    )
-    logger.info(
-        "Loading MRCR 2-needle dataset (max_context=%d, max_samples_per_bucket=%s)...",
-        args.mrcr_max_context,
-        args.mrcr_max_samples_per_bucket,
-    )
-    buckets = load_mrcr_buckets(
-        max_context=args.mrcr_max_context,
-        max_samples_per_bucket=args.mrcr_max_samples_per_bucket,
-    )
-    if not buckets:
-        logger.error(
-            "No MRCR buckets available at or below --mrcr-max-context=%d",
-            args.mrcr_max_context,
-        )
-        sys.exit(1)
-
-    root_url = args.target.rstrip("/").removesuffix("/v1")
-    log_dir = output_dir / "artifacts" / "mrcr_logs"
-    acceptance_csv: CsvWriter | None = None
-
-    for label, samples in buckets.items():
-        subset = f"mrcr/2needle/{label}"
-        logger.info("[%s] Starting (%d samples)", subset, len(samples))
-
-        if max_model_len is not None:
-            warn_if_oversized(root_url, model_name, subset, samples, max_model_len)
-
-        baseline = _require_metrics(metrics_url)
-        inspect_eval(
-            build_task(samples),
-            model=f"vllm/{model_name}",
-            model_base_url=args.target,
-            max_connections=args.max_concurrency,
-            log_dir=str(log_dir / label.replace("-", "_")),
-            display="none",
-            fail_on_error=False,
-        )
-        current = _require_metrics(metrics_url)
-
-        spec = extract_spec_decode_metrics(current, baseline_metrics=baseline)
-        if not spec or spec.get("num_drafts", 0) <= 0:
-            logger.warning("[%s] No speculative decoding metrics found", subset)
-            continue
-
-        spec["subset"] = subset
-        print_acceptance_report(spec)
-        if acceptance_csv is None:
-            acceptance_csv = CsvWriter(
-                output_dir / "acceptance.csv",
-                ["subset"] + acceptance_csv_columns(spec),
-            )
-        acceptance_csv.append(spec)
-        logger.info("[%s] Complete", subset)
-
-    if acceptance_csv is None:
-        logger.error("No acceptance metrics collected from any MRCR bucket")
-        sys.exit(1)
 
 
 def run_benchmark(args: argparse.Namespace) -> None:
@@ -383,7 +304,17 @@ def run_benchmark(args: argparse.Namespace) -> None:
     save_eval_provenance(output_dir)
 
     if args.mode == "mrcr":
-        _run_mrcr(args, metrics_url, output_dir)
+        from mrcr_bench import run_mrcr
+        run_mrcr(
+            target=args.target,
+            metrics_url=metrics_url,
+            output_dir=output_dir,
+            max_concurrency=args.max_concurrency,
+            max_context=args.mrcr_max_context,
+            max_samples_per_bucket=args.mrcr_max_samples_per_bucket,
+            fetch_model_info=_fetch_model_info,
+            require_metrics=_require_metrics,
+        )
         logger.info("Benchmarking complete! Results: %s", output_dir)
         return
 

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -4,6 +4,8 @@
 Modes:
     throughput   Max throughput run for acceptance rates
     sweep        Full pipeline (gen-len, sweep, CSV)
+    mrcr         Long-context acceptance rates via OpenAI's MRCR dataset,
+                 bucketed by context length (uses Inspect AI as the harness)
 
 Examples:
     python evaluate.py --target http://localhost:8000/v1 throughput
@@ -18,6 +20,10 @@ Examples:
     python evaluate.py --target http://localhost:8000/v1 throughput \\
         --dataset speedbench/qualitative/coding \\
         --speedbench-data-dir ./speedbench_data
+
+    # MRCR (long-context acceptance rate by bucket, capped at 128k tokens):
+    python evaluate.py --target http://localhost:8000/v1 mrcr \\
+        --mrcr-max-context 131072 --mrcr-max-samples-per-bucket 20
 """
 
 from __future__ import annotations
@@ -78,7 +84,8 @@ _SPEEDBENCH_COLUMN_MAPPER = (
 )
 
 
-def _fetch_model_name(target: str) -> str | None:
+def _fetch_model_info(target: str) -> dict | None:
+    """Return the first entry of ``/v1/models`` (includes ``id`` and ``max_model_len``)."""
     base = target.rstrip("/")
     if not base.endswith("/v1"):
         base += "/v1"
@@ -88,10 +95,15 @@ def _fetch_model_name(target: str) -> str | None:
             data = json.loads(resp.read())
         models = data.get("data", [])
         if models:
-            return models[0].get("id")
+            return models[0]
     except (URLError, json.JSONDecodeError, OSError) as e:
-        logger.warning("Could not fetch model name from %s: %s", url, e)
+        logger.warning("Could not fetch model info from %s: %s", url, e)
     return None
+
+
+def _fetch_model_name(target: str) -> str | None:
+    info = _fetch_model_info(target)
+    return info.get("id") if info else None
 
 
 def _sanitize_dir_name(name: str) -> str:
@@ -281,16 +293,102 @@ def _run_subset(
     return acceptance_csv, perf_csv, max_tokens if is_sweep else None
 
 
-def run_benchmark(args: argparse.Namespace) -> None:
-    check_dependencies()
-    is_sweep = args.mode == "sweep"
+def _run_mrcr(args: argparse.Namespace, metrics_url: str, output_dir: Path) -> None:
+    """Drive MRCR long-context prompts through the target server, bucket by
+    bucket, diffing spec-decode Prometheus counters around each bucket's run.
 
+    Uses Inspect AI as the eval harness (dataset loading + concurrent
+    generation against the target's OpenAI-compatible endpoint via the
+    ``vllm`` model provider). Correctness is not graded here — only
+    acceptance metrics are collected.
+    """
+    from inspect_ai import eval as inspect_eval
+
+    from mrcr_bench import build_task, load_mrcr_buckets, warn_if_oversized
+
+    model_info = _fetch_model_info(args.target)
+    if model_info is None:
+        logger.error("Could not determine served model info from %s/models", args.target)
+        sys.exit(1)
+    model_name = model_info["id"]
+    max_model_len = model_info.get("max_model_len")
+    logger.info(
+        "Server reports model=%s max_model_len=%s", model_name, max_model_len
+    )
+    logger.info(
+        "Loading MRCR 2-needle dataset (max_context=%d, max_samples_per_bucket=%s)...",
+        args.mrcr_max_context,
+        args.mrcr_max_samples_per_bucket,
+    )
+    buckets = load_mrcr_buckets(
+        max_context=args.mrcr_max_context,
+        max_samples_per_bucket=args.mrcr_max_samples_per_bucket,
+    )
+    if not buckets:
+        logger.error(
+            "No MRCR buckets available at or below --mrcr-max-context=%d",
+            args.mrcr_max_context,
+        )
+        sys.exit(1)
+
+    root_url = args.target.rstrip("/").removesuffix("/v1")
+    log_dir = output_dir / "artifacts" / "mrcr_logs"
+    acceptance_csv: CsvWriter | None = None
+
+    for label, samples in buckets.items():
+        subset = f"mrcr/2needle/{label}"
+        logger.info("[%s] Starting (%d samples)", subset, len(samples))
+
+        if max_model_len is not None:
+            warn_if_oversized(root_url, model_name, subset, samples, max_model_len)
+
+        baseline = _require_metrics(metrics_url)
+        inspect_eval(
+            build_task(samples),
+            model=f"vllm/{model_name}",
+            model_base_url=args.target,
+            max_connections=args.max_concurrency,
+            log_dir=str(log_dir / label.replace("-", "_")),
+            display="none",
+            fail_on_error=False,
+        )
+        current = _require_metrics(metrics_url)
+
+        spec = extract_spec_decode_metrics(current, baseline_metrics=baseline)
+        if not spec or spec.get("num_drafts", 0) <= 0:
+            logger.warning("[%s] No speculative decoding metrics found", subset)
+            continue
+
+        spec["subset"] = subset
+        print_acceptance_report(spec)
+        if acceptance_csv is None:
+            acceptance_csv = CsvWriter(
+                output_dir / "acceptance.csv",
+                ["subset"] + acceptance_csv_columns(spec),
+            )
+        acceptance_csv.append(spec)
+        logger.info("[%s] Complete", subset)
+
+    if acceptance_csv is None:
+        logger.error("No acceptance metrics collected from any MRCR bucket")
+        sys.exit(1)
+
+
+def run_benchmark(args: argparse.Namespace) -> None:
     metrics_url = args.target.rstrip("/").removesuffix("/v1") + "/metrics"
     output_dir = Path(args.output_dir)
     artifacts_dir = output_dir / "artifacts"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 
     save_eval_provenance(output_dir)
+
+    if args.mode == "mrcr":
+        _run_mrcr(args, metrics_url, output_dir)
+        logger.info("Benchmarking complete! Results: %s", output_dir)
+        return
+
+    check_dependencies()
+    is_sweep = args.mode == "sweep"
 
     acceptance_csv = None
     perf_csv = None
@@ -382,10 +480,11 @@ def main() -> None:
     )
     parser.add_argument(
         "mode",
-        choices=["throughput", "sweep"],
+        choices=["throughput", "sweep", "mrcr"],
         help=(
             "throughput: max-rate run for acceptance rates; "
-            "sweep: full benchmarking pipeline"
+            "sweep: full benchmarking pipeline; "
+            "mrcr: long-context acceptance rates via OpenAI's MRCR dataset"
         ),
     )
     parser.add_argument(
@@ -442,6 +541,23 @@ def main() -> None:
         default=DEFAULT_DATA_COLUMN_MAPPER,
         help="Column mapping for guidellm in typed key=value format"
         f" (default: {DEFAULT_DATA_COLUMN_MAPPER})",
+    )
+    parser.add_argument(
+        "--mrcr-max-context",
+        type=int,
+        default=131072,
+        dest="mrcr_max_context",
+        help=(
+            "Skip MRCR buckets whose lower token-count edge exceeds this; "
+            "keep at or below the target server's max_model_len (default: 131072)"
+        ),
+    )
+    parser.add_argument(
+        "--mrcr-max-samples-per-bucket",
+        type=int,
+        default=20,
+        dest="mrcr_max_samples_per_bucket",
+        help="Cap samples per context-length bucket to bound eval cost (default: 20)",
     )
     parser.add_argument(
         "--speedbench-data-dir",

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -305,14 +305,15 @@ def run_benchmark(args: argparse.Namespace) -> None:
 
     if args.mode == "mrcr":
         from mrcr_bench import run_mrcr
+        model_info = _fetch_model_info(args.target)
         run_mrcr(
             target=args.target,
+            model_info=model_info,
             metrics_url=metrics_url,
             output_dir=output_dir,
             max_concurrency=args.max_concurrency,
             max_context=args.mrcr_max_context,
             max_samples_per_bucket=args.mrcr_max_samples_per_bucket,
-            fetch_model_info=_fetch_model_info,
             require_metrics=_require_metrics,
         )
         logger.info("Benchmarking complete! Results: %s", output_dir)

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -4,8 +4,11 @@
 Modes:
     throughput   Max throughput run for acceptance rates
     sweep        Full pipeline (gen-len, sweep, CSV)
-    long-context Long-context acceptance rates via OpenAI's MRCR dataset,
-                 bucketed by context length (uses Inspect AI as the harness)
+    long-context Long-context acceptance rates via OpenAI's MRCR dataset. Runs a
+                 deterministic sample stratified across MRCR's native token bins
+                 (larger --max-model-len => superset) and bins acceptance by
+                 context length after the fact (requires
+                 --per-request-spec-decode-metrics detailed on the server)
 
 Examples:
     python evaluate.py --target http://localhost:8000/v1 throughput
@@ -21,9 +24,9 @@ Examples:
         --dataset speedbench/qualitative/coding \\
         --speedbench-data-dir ./speedbench_data
 
-    # Long-context (acceptance rate by context-length bucket, capped at 128k tokens):
+    # Long-context: deterministic MRCR sample, ~samples-per-bin per token bin.
     python evaluate.py --target http://localhost:8000/v1 long-context \\
-        --mrcr-max-context 131072 --mrcr-max-samples-per-bucket 20
+        --samples-per-bin 20
 """
 
 from __future__ import annotations
@@ -69,6 +72,9 @@ DEFAULT_SUBSETS = (
 )
 DEFAULT_MAX_CONCURRENCY = 128
 DEFAULT_MAX_REQUESTS = 200
+# long-context: records selected per native MRCR token bin (density/cost knob).
+DEFAULT_SAMPLES_PER_BIN = 20
+DEFAULT_POSITION_BIN_SIZE = 256
 DEFAULT_GEN_LEN_RATE = 128
 DEFAULT_SWEEP_RATE = 10
 DEFAULT_DATA_COLUMN_MAPPER = (
@@ -85,7 +91,7 @@ _SPEEDBENCH_COLUMN_MAPPER = (
 
 
 def _fetch_model_info(target: str) -> dict | None:
-    """Return the first entry of ``/v1/models`` (includes ``id`` and ``max_model_len``)."""
+    """Return the first ``/v1/models`` entry (has ``id`` and ``max_model_len``)."""
     base = target.rstrip("/")
     if not base.endswith("/v1"):
         base += "/v1"
@@ -293,8 +299,6 @@ def _run_subset(
     return acceptance_csv, perf_csv, max_tokens if is_sweep else None
 
 
-
-
 def run_benchmark(args: argparse.Namespace) -> None:
     metrics_url = args.target.rstrip("/").removesuffix("/v1") + "/metrics"
     output_dir = Path(args.output_dir)
@@ -304,17 +308,19 @@ def run_benchmark(args: argparse.Namespace) -> None:
     save_eval_provenance(output_dir)
 
     if args.mode == "long-context":
-        from mrcr_bench import run_mrcr
+        # Imported lazily so throughput/sweep runs don't pull the long-context
+        # deps (pandas, pyarrow, huggingface_hub).
+        from mrcr_bench import run_mrcr  # noqa: PLC0415
+
         model_info = _fetch_model_info(args.target)
         run_mrcr(
             target=args.target,
             model_info=model_info,
-            metrics_url=metrics_url,
             output_dir=output_dir,
             max_concurrency=args.max_concurrency,
-            max_context=args.mrcr_max_context,
-            max_samples_per_bucket=args.mrcr_max_samples_per_bucket,
-            require_metrics=_require_metrics,
+            samples_per_bin=args.samples_per_bin,
+            selection_seed=args.selection_seed,
+            position_bin_size=args.position_bin_size,
         )
         logger.info("Benchmarking complete! Results: %s", output_dir)
         return
@@ -416,7 +422,7 @@ def main() -> None:
         help=(
             "throughput: max-rate run for acceptance rates; "
             "sweep: full benchmarking pipeline; "
-            "long-context: acceptance rates across context-length buckets"
+            "long-context: acceptance rates across the MRCR long-context dataset"
         ),
     )
     parser.add_argument(
@@ -475,29 +481,43 @@ def main() -> None:
         f" (default: {DEFAULT_DATA_COLUMN_MAPPER})",
     )
     parser.add_argument(
-        "--mrcr-max-context",
-        type=int,
-        default=131072,
-        dest="mrcr_max_context",
-        help=(
-            "Skip MRCR buckets whose lower token-count edge exceeds this; "
-            "keep at or below the target server's max_model_len (default: 131072)"
-        ),
-    )
-    parser.add_argument(
-        "--mrcr-max-samples-per-bucket",
-        type=int,
-        default=20,
-        dest="mrcr_max_samples_per_bucket",
-        help="Cap samples per context-length bucket to bound eval cost (default: 20)",
-    )
-    parser.add_argument(
         "--speedbench-data-dir",
         default=None,
         dest="speedbench_data_dir",
         help=(
             "Path to directory produced by SPEED-Bench prepare.py. "
             "Required when --dataset is a speedbench/ spec."
+        ),
+    )
+    lc_group = parser.add_argument_group("long-context mode")
+    lc_group.add_argument(
+        "--samples-per-bin",
+        type=int,
+        default=DEFAULT_SAMPLES_PER_BIN,
+        help=(
+            "long-context: records to run per native MRCR token bin. Larger "
+            "context windows fill more bins, so the selected set at a bigger "
+            f"--max-model-len is a superset of a smaller one (default: "
+            f"{DEFAULT_SAMPLES_PER_BIN})"
+        ),
+    )
+    lc_group.add_argument(
+        "--selection-seed",
+        type=int,
+        default=0,
+        help=(
+            "long-context: seed mixed into the per-record content hash used to "
+            "rank within each bin; changing it picks a different deterministic "
+            "sample (default: 0)"
+        ),
+    )
+    lc_group.add_argument(
+        "--position-bin-size",
+        type=int,
+        default=DEFAULT_POSITION_BIN_SIZE,
+        help=(
+            "long-context: token-position bin width for the by-position report "
+            f"(default: {DEFAULT_POSITION_BIN_SIZE})"
         ),
     )
     args = parser.parse_args()

--- a/scripts/evaluate/mrcr_bench.py
+++ b/scripts/evaluate/mrcr_bench.py
@@ -1,0 +1,168 @@
+"""MRCR long-context prompt source for speculative-decoding acceptance benchmarking.
+
+Loads OpenAI's ``openai/mrcr`` 2-needle dataset and buckets samples by
+prompt+answer token count, using the same bin edges and ``o200k_base``
+tiktoken encoding OpenAI uses for its own leaderboard. Each bucket becomes an
+Inspect AI ``Task`` that ``evaluate.py`` runs against the target server to
+drive realistic long-context requests.
+
+Correctness is intentionally not graded: MRCR is used here purely as a source
+of long, multi-turn prompts to see how spec-decode acceptance holds up as
+context length grows, not to measure retrieval accuracy.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+import pandas as pd
+import tiktoken
+from huggingface_hub import hf_hub_download
+
+from inspect_ai import Task
+from inspect_ai.dataset import MemoryDataset, Sample
+from inspect_ai.model import ChatMessageAssistant, ChatMessageSystem, ChatMessageUser
+from inspect_ai.solver import generate
+
+logger = logging.getLogger("evaluate")
+
+MRCR_REPO = "openai/mrcr"
+MRCR_ENCODING = "o200k_base"
+MRCR_SHARDS = ("2needle/2needle_0.parquet", "2needle/2needle_1.parquet")
+
+# OpenAI's own bin edges, in tokens: first bin is closed on both ends,
+# remaining bins are left-open/right-closed.
+MRCR_BIN_EDGES = (4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576)
+
+_ROLE_TO_MESSAGE = {
+    "system": ChatMessageSystem,
+    "user": ChatMessageUser,
+    "assistant": ChatMessageAssistant,
+}
+
+
+def _bucket_label(n_tokens: int) -> str | None:
+    lo0, hi0 = MRCR_BIN_EDGES[0], MRCR_BIN_EDGES[1]
+    if lo0 <= n_tokens <= hi0:
+        return f"{lo0}-{hi0}"
+    for lo, hi in zip(MRCR_BIN_EDGES[1:], MRCR_BIN_EDGES[2:]):
+        if lo < n_tokens <= hi:
+            return f"{lo}-{hi}"
+    return None
+
+
+def _count_tokens(enc: tiktoken.Encoding, messages: list[dict], answer: str) -> int:
+    total = sum(len(enc.encode(m["content"])) for m in messages)
+    return total + len(enc.encode(answer))
+
+
+def _iter_records():
+    for shard in MRCR_SHARDS:
+        path = hf_hub_download(MRCR_REPO, shard, repo_type="dataset")
+        yield from pd.read_parquet(path).to_dict("records")
+
+
+def load_mrcr_buckets(
+    max_context: int,
+    max_samples_per_bucket: int | None = None,
+) -> dict[str, list[Sample]]:
+    """Download the MRCR 2-needle dataset and group samples into context-length buckets.
+
+    Buckets whose lower edge exceeds *max_context* are dropped entirely, since
+    those prompts would exceed a server started with a smaller max context.
+    """
+    enc = tiktoken.get_encoding(MRCR_ENCODING)
+    buckets: dict[str, list[Sample]] = {}
+
+    for record in _iter_records():
+        messages = json.loads(record["prompt"])
+        n_tokens = _count_tokens(enc, messages, record["answer"])
+        if n_tokens > max_context:
+            continue
+        label = _bucket_label(n_tokens)
+        if label is None:
+            continue
+
+        bucket = buckets.setdefault(label, [])
+        if max_samples_per_bucket is not None and len(bucket) >= max_samples_per_bucket:
+            continue
+
+        bucket.append(
+            Sample(
+                input=[_ROLE_TO_MESSAGE[m["role"]](content=m["content"]) for m in messages],
+                target="",
+                metadata={
+                    "bucket": label,
+                    "n_tokens": n_tokens,
+                    "random_string_to_prepend": record["random_string_to_prepend"],
+                },
+            )
+        )
+
+    for label, samples in buckets.items():
+        logger.info("  mrcr/2needle/%s: %d samples", label, len(samples))
+
+    return dict(sorted(buckets.items(), key=lambda kv: int(kv[0].split("-")[0])))
+
+
+def build_task(samples: list[Sample]) -> Task:
+    return Task(dataset=MemoryDataset(samples), solver=[generate()])
+
+
+def real_token_count(root_url: str, model: str, sample: Sample) -> int:
+    """Tokenize *sample* through the target server's own ``/tokenize`` endpoint.
+
+    Unlike the o200k_base counts used for bucketing, this reflects the actual
+    tokenizer and chat template the server will use, and (unlike the
+    ``/v1/chat/completions/render`` endpoint) doesn't reject oversized prompts —
+    it just reports how long they really are.
+    """
+    messages = [{"role": m.role, "content": m.content} for m in sample.input]
+    body = json.dumps({"model": model, "messages": messages}).encode()
+    req = Request(
+        f"{root_url.rstrip('/')}/tokenize",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urlopen(req, timeout=180) as resp:  # noqa: S310
+        return json.loads(resp.read())["count"]
+
+
+def warn_if_oversized(
+    root_url: str,
+    model: str,
+    subset: str,
+    samples: list[Sample],
+    max_model_len: int,
+) -> None:
+    """Log a warning for any sample whose real tokenized length exceeds *max_model_len*.
+
+    MRCR's own bucket labels are based on OpenAI's o200k_base tokenizer, which
+    can undercount relative to the model actually being served (different
+    vocab, plus chat-template overhead) — this checks against the real count.
+    """
+    oversized = []
+    for sample in samples:
+        try:
+            n_tokens = real_token_count(root_url, model, sample)
+        except (URLError, OSError, KeyError) as e:
+            logger.warning("[%s] Could not tokenize sample for length check: %s", subset, e)
+            continue
+        if n_tokens > max_model_len:
+            oversized.append(n_tokens)
+
+    if oversized:
+        logger.warning(
+            "[%s] %d/%d samples exceed the server's max_model_len=%d once "
+            "tokenized by the real model (largest: %d tokens, bucket label "
+            "was computed with o200k_base and may undercount)",
+            subset,
+            len(oversized),
+            len(samples),
+            max_model_len,
+            max(oversized),
+        )

--- a/scripts/evaluate/mrcr_bench.py
+++ b/scripts/evaluate/mrcr_bench.py
@@ -3,8 +3,8 @@
 Loads OpenAI's ``openai/mrcr`` 2-needle dataset and buckets samples by
 prompt+answer token count, using the same bin edges and ``o200k_base``
 tiktoken encoding OpenAI uses for its own leaderboard. Each bucket becomes an
-Inspect AI ``Task`` that ``evaluate.py`` runs against the target server to
-drive realistic long-context requests.
+Inspect AI ``Task`` that is run against the target server to drive realistic
+long-context requests.
 
 Correctness is intentionally not graded: MRCR is used here purely as a source
 of long, multi-turn prompts to see how spec-decode acceptance holds up as
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
+from pathlib import Path
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
@@ -22,10 +24,12 @@ import pandas as pd
 import tiktoken
 from huggingface_hub import hf_hub_download
 
-from inspect_ai import Task
+from inspect_ai import Task, eval as inspect_eval
 from inspect_ai.dataset import MemoryDataset, Sample
 from inspect_ai.model import ChatMessageAssistant, ChatMessageSystem, ChatMessageUser
 from inspect_ai.solver import generate
+
+from perf_utils import CsvWriter, acceptance_csv_columns, extract_spec_decode_metrics, print_acceptance_report
 
 logger = logging.getLogger("evaluate")
 
@@ -166,3 +170,86 @@ def warn_if_oversized(
             max_model_len,
             max(oversized),
         )
+
+
+def run_mrcr(
+    target: str,
+    metrics_url: str,
+    output_dir: Path,
+    max_concurrency: int,
+    max_context: int,
+    max_samples_per_bucket: int,
+    fetch_model_info,
+    require_metrics,
+) -> None:
+    """Run MRCR long-context evaluation.
+
+    Drives MRCR prompts through the target server bucket-by-bucket, diffing
+    spec-decode Prometheus counters around each bucket's run.
+    """
+    model_info = fetch_model_info(target)
+    if model_info is None:
+        logger.error("Could not determine served model info from %s/models", target)
+        sys.exit(1)
+    model_name = model_info["id"]
+    max_model_len = model_info.get("max_model_len")
+    logger.info(
+        "Server reports model=%s max_model_len=%s", model_name, max_model_len
+    )
+    logger.info(
+        "Loading MRCR 2-needle dataset (max_context=%d, max_samples_per_bucket=%s)...",
+        max_context,
+        max_samples_per_bucket,
+    )
+    buckets = load_mrcr_buckets(
+        max_context=max_context,
+        max_samples_per_bucket=max_samples_per_bucket,
+    )
+    if not buckets:
+        logger.error(
+            "No MRCR buckets available at or below --mrcr-max-context=%d",
+            max_context,
+        )
+        sys.exit(1)
+
+    root_url = target.rstrip("/").removesuffix("/v1")
+    log_dir = output_dir / "artifacts" / "mrcr_logs"
+    acceptance_csv: CsvWriter | None = None
+
+    for label, samples in buckets.items():
+        subset = f"mrcr/2needle/{label}"
+        logger.info("[%s] Starting (%d samples)", subset, len(samples))
+
+        if max_model_len is not None:
+            warn_if_oversized(root_url, model_name, subset, samples, max_model_len)
+
+        baseline = require_metrics(metrics_url)
+        inspect_eval(
+            build_task(samples),
+            model=f"vllm/{model_name}",
+            model_base_url=target,
+            max_connections=max_concurrency,
+            log_dir=str(log_dir / label.replace("-", "_")),
+            display="none",
+            fail_on_error=False,
+        )
+        current = require_metrics(metrics_url)
+
+        spec = extract_spec_decode_metrics(current, baseline_metrics=baseline)
+        if not spec or spec.get("num_drafts", 0) <= 0:
+            logger.warning("[%s] No speculative decoding metrics found", subset)
+            continue
+
+        spec["subset"] = subset
+        print_acceptance_report(spec)
+        if acceptance_csv is None:
+            acceptance_csv = CsvWriter(
+                output_dir / "acceptance.csv",
+                ["subset"] + acceptance_csv_columns(spec),
+            )
+        acceptance_csv.append(spec)
+        logger.info("[%s] Complete", subset)
+
+    if acceptance_csv is None:
+        logger.error("No acceptance metrics collected from any MRCR bucket")
+        sys.exit(1)

--- a/scripts/evaluate/mrcr_bench.py
+++ b/scripts/evaluate/mrcr_bench.py
@@ -1,10 +1,10 @@
-"""MRCR long-context prompt source for speculative-decoding acceptance benchmarking.
+"""Long-context acceptance benchmarking via OpenAI's MRCR dataset.
 
-Loads OpenAI's ``openai/mrcr`` 2-needle dataset and buckets samples by
+Loads the ``openai/mrcr`` 2-needle dataset and buckets samples by
 prompt+answer token count, using the same bin edges and ``o200k_base``
 tiktoken encoding OpenAI uses for its own leaderboard. Each bucket becomes an
 Inspect AI ``Task`` that is run against the target server to drive realistic
-long-context requests.
+long-context requests and measure acceptance rates across context lengths.
 
 Correctness is intentionally not graded: MRCR is used here purely as a source
 of long, multi-turn prompts to see how spec-decode acceptance holds up as

--- a/scripts/evaluate/mrcr_bench.py
+++ b/scripts/evaluate/mrcr_bench.py
@@ -174,12 +174,12 @@ def warn_if_oversized(
 
 def run_mrcr(
     target: str,
+    model_info: dict | None,
     metrics_url: str,
     output_dir: Path,
     max_concurrency: int,
     max_context: int,
     max_samples_per_bucket: int,
-    fetch_model_info,
     require_metrics,
 ) -> None:
     """Run MRCR long-context evaluation.
@@ -187,7 +187,6 @@ def run_mrcr(
     Drives MRCR prompts through the target server bucket-by-bucket, diffing
     spec-decode Prometheus counters around each bucket's run.
     """
-    model_info = fetch_model_info(target)
     if model_info is None:
         logger.error("Could not determine served model info from %s/models", target)
         sys.exit(1)

--- a/scripts/evaluate/mrcr_bench.py
+++ b/scripts/evaluate/mrcr_bench.py
@@ -1,14 +1,25 @@
 """Long-context acceptance benchmarking via OpenAI's MRCR dataset.
 
-Loads the ``openai/mrcr`` 2-needle dataset and buckets samples by
-prompt+answer token count, using the same bin edges and ``o200k_base``
-tiktoken encoding OpenAI uses for its own leaderboard. Each bucket becomes an
-Inspect AI ``Task`` that is run against the target server to drive realistic
-long-context requests and measure acceptance rates across context lengths.
+Thin dataset adapter over the generic per-request spec-decode acceptance
+harness in ``spec_acceptance``. This module knows only how to load the
+``openai/mrcr`` 2-needle dataset and turn a record into chat messages / a
+selection key / a length proxy; the harness does the rendering, generation,
+persistence, binning and reporting.
+
+Sample selection is deterministic and monotonic in ``max_model_len`` (see
+``spec_acceptance.select_stratified``): records are stratified into MRCR's
+native power-of-2 token bins and, within each bin, the lowest-ranked
+``samples_per_bin`` by a stable content hash are chosen. The bin a record lands
+in is estimated from its ``n_chars`` metadata -- MRCR carries no per-record
+token count, but ``n_chars / tokens`` is empirically ~4.9 with <=2% spread
+across the whole dataset (validated offline against OpenAI's o200k tokenizer),
+so the estimate matches exact tokenization for bin assignment at zero runtime
+cost. Exact prompt length and the context fit-test always come from the
+server's render endpoint, never the estimate.
 
 Correctness is intentionally not graded: MRCR is used here purely as a source
 of long, multi-turn prompts to see how spec-decode acceptance holds up as
-context length grows, not to measure retrieval accuracy.
+context length grows and generation proceeds, not to measure retrieval accuracy.
 """
 
 from __future__ import annotations
@@ -16,51 +27,36 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from pathlib import Path
-from urllib.error import URLError
-from urllib.request import Request, urlopen
+from typing import TYPE_CHECKING
 
 import pandas as pd
-import tiktoken
 from huggingface_hub import hf_hub_download
+from spec_acceptance import (
+    DEFAULT_CONTEXT_BIN_EDGES,
+    DEFAULT_POSITION_BIN_SIZE,
+    run_acceptance,
+    select_stratified,
+    stable_hash,
+)
 
-from inspect_ai import Task, eval as inspect_eval
-from inspect_ai.dataset import MemoryDataset, Sample
-from inspect_ai.model import ChatMessageAssistant, ChatMessageSystem, ChatMessageUser
-from inspect_ai.solver import generate
-
-from perf_utils import CsvWriter, acceptance_csv_columns, extract_spec_decode_metrics, print_acceptance_report
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger("evaluate")
 
 MRCR_REPO = "openai/mrcr"
-MRCR_ENCODING = "o200k_base"
 MRCR_SHARDS = ("2needle/2needle_0.parquet", "2needle/2needle_1.parquet")
 
-# OpenAI's own bin edges, in tokens: first bin is closed on both ends,
-# remaining bins are left-open/right-closed.
-MRCR_BIN_EDGES = (4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576)
+# Empirical chars-per-token ratio for MRCR content, used only to estimate which
+# native token bin a record falls in (exact length comes from the render
+# endpoint). Measured at 4.9 +/- 0.1 across the full 20k-490k token range with
+# OpenAI's o200k tokenizer, so bin assignment matches exact tokenization.
+EST_CHARS_PER_TOKEN = 4.9
 
-_ROLE_TO_MESSAGE = {
-    "system": ChatMessageSystem,
-    "user": ChatMessageUser,
-    "assistant": ChatMessageAssistant,
-}
-
-
-def _bucket_label(n_tokens: int) -> str | None:
-    lo0, hi0 = MRCR_BIN_EDGES[0], MRCR_BIN_EDGES[1]
-    if lo0 <= n_tokens <= hi0:
-        return f"{lo0}-{hi0}"
-    for lo, hi in zip(MRCR_BIN_EDGES[1:], MRCR_BIN_EDGES[2:]):
-        if lo < n_tokens <= hi:
-            return f"{lo}-{hi}"
-    return None
-
-
-def _count_tokens(enc: tiktoken.Encoding, messages: list[dict], answer: str) -> int:
-    total = sum(len(enc.encode(m["content"])) for m in messages)
-    return total + len(enc.encode(answer))
+# MRCR's native context-length bins (tokens); shared with the harness so
+# selection and the report use one bin definition. Drop the leading 0 edge for
+# selection -- every record is far larger than 4096 tokens.
+SELECTION_BIN_EDGES = tuple(e for e in DEFAULT_CONTEXT_BIN_EDGES if e > 0)
 
 
 def _iter_records():
@@ -69,186 +65,67 @@ def _iter_records():
         yield from pd.read_parquet(path).to_dict("records")
 
 
-def load_mrcr_buckets(
-    max_context: int,
-    max_samples_per_bucket: int | None = None,
-) -> dict[str, list[Sample]]:
-    """Download the MRCR 2-needle dataset and group samples into context-length buckets.
-
-    Buckets whose lower edge exceeds *max_context* are dropped entirely, since
-    those prompts would exceed a server started with a smaller max context.
-    """
-    enc = tiktoken.get_encoding(MRCR_ENCODING)
-    buckets: dict[str, list[Sample]] = {}
-
-    for record in _iter_records():
-        messages = json.loads(record["prompt"])
-        n_tokens = _count_tokens(enc, messages, record["answer"])
-        if n_tokens > max_context:
-            continue
-        label = _bucket_label(n_tokens)
-        if label is None:
-            continue
-
-        bucket = buckets.setdefault(label, [])
-        if max_samples_per_bucket is not None and len(bucket) >= max_samples_per_bucket:
-            continue
-
-        bucket.append(
-            Sample(
-                input=[_ROLE_TO_MESSAGE[m["role"]](content=m["content"]) for m in messages],
-                target="",
-                metadata={
-                    "bucket": label,
-                    "n_tokens": n_tokens,
-                    "random_string_to_prepend": record["random_string_to_prepend"],
-                },
-            )
-        )
-
-    for label, samples in buckets.items():
-        logger.info("  mrcr/2needle/%s: %d samples", label, len(samples))
-
-    return dict(sorted(buckets.items(), key=lambda kv: int(kv[0].split("-")[0])))
-
-
-def build_task(samples: list[Sample]) -> Task:
-    return Task(dataset=MemoryDataset(samples), solver=[generate()])
-
-
-def real_token_count(root_url: str, model: str, sample: Sample) -> int:
-    """Tokenize *sample* through the target server's own ``/tokenize`` endpoint.
-
-    Unlike the o200k_base counts used for bucketing, this reflects the actual
-    tokenizer and chat template the server will use, and (unlike the
-    ``/v1/chat/completions/render`` endpoint) doesn't reject oversized prompts —
-    it just reports how long they really are.
-    """
-    messages = [{"role": m.role, "content": m.content} for m in sample.input]
-    body = json.dumps({"model": model, "messages": messages}).encode()
-    req = Request(
-        f"{root_url.rstrip('/')}/tokenize",
-        data=body,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    with urlopen(req, timeout=180) as resp:  # noqa: S310
-        return json.loads(resp.read())["count"]
-
-
-def warn_if_oversized(
-    root_url: str,
-    model: str,
-    subset: str,
-    samples: list[Sample],
-    max_model_len: int,
-) -> None:
-    """Log a warning for any sample whose real tokenized length exceeds *max_model_len*.
-
-    MRCR's own bucket labels are based on OpenAI's o200k_base tokenizer, which
-    can undercount relative to the model actually being served (different
-    vocab, plus chat-template overhead) — this checks against the real count.
-    """
-    oversized = []
-    for sample in samples:
-        try:
-            n_tokens = real_token_count(root_url, model, sample)
-        except (URLError, OSError, KeyError) as e:
-            logger.warning("[%s] Could not tokenize sample for length check: %s", subset, e)
-            continue
-        if n_tokens > max_model_len:
-            oversized.append(n_tokens)
-
-    if oversized:
-        logger.warning(
-            "[%s] %d/%d samples exceed the server's max_model_len=%d once "
-            "tokenized by the real model (largest: %d tokens, bucket label "
-            "was computed with o200k_base and may undercount)",
-            subset,
-            len(oversized),
-            len(samples),
-            max_model_len,
-            max(oversized),
-        )
+def _record_messages(record: dict) -> list[dict]:
+    return json.loads(record["prompt"])
 
 
 def run_mrcr(
     target: str,
     model_info: dict | None,
-    metrics_url: str,
     output_dir: Path,
     max_concurrency: int,
-    max_context: int,
-    max_samples_per_bucket: int,
-    require_metrics,
+    *,
+    samples_per_bin: int,
+    selection_seed: int = 0,
+    position_bin_size: int = DEFAULT_POSITION_BIN_SIZE,
 ) -> None:
-    """Run MRCR long-context evaluation.
+    """Run the MRCR long-context evaluation.
 
-    Drives MRCR prompts through the target server bucket-by-bucket, diffing
-    spec-decode Prometheus counters around each bucket's run.
+    Deterministically selects up to *samples_per_bin* records per native token
+    bin, then renders + generates them against *target* and reports acceptance
+    binned by context length two ways (see module docstring).
     """
     if model_info is None:
         logger.error("Could not determine served model info from %s/models", target)
         sys.exit(1)
     model_name = model_info["id"]
-    max_model_len = model_info.get("max_model_len")
     logger.info(
-        "Server reports model=%s max_model_len=%s", model_name, max_model_len
+        "Server reports model=%s max_model_len=%s",
+        model_name,
+        model_info.get("max_model_len"),
     )
-    logger.info(
-        "Loading MRCR 2-needle dataset (max_context=%d, max_samples_per_bucket=%s)...",
-        max_context,
-        max_samples_per_bucket,
-    )
-    buckets = load_mrcr_buckets(
-        max_context=max_context,
-        max_samples_per_bucket=max_samples_per_bucket,
-    )
-    if not buckets:
-        logger.error(
-            "No MRCR buckets available at or below --mrcr-max-context=%d",
-            max_context,
-        )
-        sys.exit(1)
 
     root_url = target.rstrip("/").removesuffix("/v1")
-    log_dir = output_dir / "artifacts" / "mrcr_logs"
-    acceptance_csv: CsvWriter | None = None
 
-    for label, samples in buckets.items():
-        subset = f"mrcr/2needle/{label}"
-        logger.info("[%s] Starting (%d samples)", subset, len(samples))
-
-        if max_model_len is not None:
-            warn_if_oversized(root_url, model_name, subset, samples, max_model_len)
-
-        baseline = require_metrics(metrics_url)
-        inspect_eval(
-            build_task(samples),
-            model=f"vllm/{model_name}",
-            model_base_url=target,
-            max_connections=max_concurrency,
-            log_dir=str(log_dir / label.replace("-", "_")),
-            display="none",
-            fail_on_error=False,
-        )
-        current = require_metrics(metrics_url)
-
-        spec = extract_spec_decode_metrics(current, baseline_metrics=baseline)
-        if not spec or spec.get("num_drafts", 0) <= 0:
-            logger.warning("[%s] No speculative decoding metrics found", subset)
-            continue
-
-        spec["subset"] = subset
-        print_acceptance_report(spec)
-        if acceptance_csv is None:
-            acceptance_csv = CsvWriter(
-                output_dir / "acceptance.csv",
-                ["subset"] + acceptance_csv_columns(spec),
-            )
-        acceptance_csv.append(spec)
-        logger.info("[%s] Complete", subset)
-
-    if acceptance_csv is None:
-        logger.error("No acceptance metrics collected from any MRCR bucket")
+    logger.info("Loading MRCR 2-needle dataset...")
+    records = list(_iter_records())
+    if not records:
+        logger.error("MRCR dataset returned no records")
         sys.exit(1)
+    logger.info("Loaded %d MRCR records", len(records))
+
+    candidate_bins = select_stratified(
+        records,
+        bin_edges=SELECTION_BIN_EDGES,
+        samples_per_bin=samples_per_bin,
+        key_fn=lambda r: stable_hash(f"{selection_seed}:{r['prompt']}"),
+        length_fn=lambda r: r["n_chars"] / EST_CHARS_PER_TOKEN,
+    )
+    n_selected = sum(len(b) for b in candidate_bins)
+    logger.info(
+        "Selected %d candidate records across %d bins (%d per bin)",
+        n_selected,
+        len(candidate_bins),
+        samples_per_bin,
+    )
+
+    run_acceptance(
+        root_url,
+        model_name,
+        candidate_bins,
+        _record_messages,
+        output_dir,
+        max_concurrency=max_concurrency,
+        context_bin_edges=DEFAULT_CONTEXT_BIN_EDGES,
+        position_bin_size=position_bin_size,
+    )

--- a/scripts/evaluate/plot.py
+++ b/scripts/evaluate/plot.py
@@ -4,6 +4,8 @@
 Subcommands:
     compare     Multi-version comparison plots (overlay smoothed curves)
     speedup     Pairwise speedup visualization (gradient-shaded region)
+    mrcr        MRCR long-context acceptance length, by request start length
+                and by token position (output of `evaluate.py long-context`)
 
 Examples:
     python plot.py compare \\
@@ -15,19 +17,23 @@ Examples:
         --baseline "No Spec=nospec/results.csv" \\
         --target "Eagle3=eagle3/results.csv" \\
         --metric latency --title "Qwen3-8B"
+
+    python plot.py mrcr --results-dir Qwen3-8B_20260904_143700
 """
 
 from __future__ import annotations
 
 import argparse
+import csv
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
 from pathlib import Path
 
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.cm import ScalarMappable
+from matplotlib.ticker import FixedLocator, FuncFormatter, NullFormatter
 from perf_utils import (
     METRICS,
     load_data,
@@ -35,6 +41,7 @@ from perf_utils import (
     pretty_subset,
     smooth_curve,
 )
+from spec_acceptance import RAW_LOG_FILENAME, load_results
 
 COLOR_CYCLE = [
     "#1f77b4",
@@ -368,6 +375,273 @@ def run_speedup(args: argparse.Namespace) -> None:
 
 
 # ============================================================================
+# MRCR long-context acceptance
+# ============================================================================
+
+# Two-hue small-multiples pair (validated for adjacent CVD separation):
+# request-start-length panel in blue, token-position panel in orange.
+_MRCR_START_COLOR = "#2a78d6"
+_MRCR_POSITION_COLOR = "#eb6834"
+
+
+def _read_bucket_csv(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    with path.open(newline="") as f:
+        return list(csv.DictReader(f))
+
+
+_MAX_LABELED_BARS = 40
+
+
+def _plot_acceptance_bars(ax, rows: list[dict], color: str, title: str) -> None:
+    labels = [row["bucket"] for row in rows]
+    values = [float(row["mean_acceptance_length"]) for row in rows]
+    x = range(len(labels))
+    dense = len(labels) > _MAX_LABELED_BARS
+
+    bars = ax.bar(x, values, color=color, width=1.0 if dense else 0.6, zorder=3)
+    if not dense:
+        for bar, value in zip(bars, values, strict=True):
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                bar.get_height(),
+                f"{value:.2f}",
+                ha="center",
+                va="bottom",
+                fontsize=9,
+            )
+
+    # Too many buckets to label every tick -- thin them out instead of
+    # letting them overlap into an unreadable smear.
+    tick_step = max(1, -(-len(labels) // 24)) if dense else 1
+    tick_idx = list(x)[::tick_step]
+    ax.set_xticks(tick_idx)
+    ax.set_xticklabels(
+        [labels[i] for i in tick_idx],
+        rotation=35 if not dense else 90,
+        ha="right" if not dense else "center",
+        fontsize=9 if not dense else 7,
+    )
+    ax.set_title(title, fontsize=13, fontweight="bold")
+    ax.set_xlabel("Context length (tokens)", fontsize=11)
+    ax.set_ylabel("Mean acceptance length", fontsize=11)
+    ax.grid(True, axis="y", alpha=0.3, zorder=0)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+
+def _load_position_scatter(
+    raw_log: Path, bin_size: int
+) -> tuple[list[int], list[int], list[int], list[float], list[float]]:
+    """Reconstruct per-verify-step (position, acceptance length) data from a raw log.
+
+    Returns ``(bubble_x, bubble_y, bubble_count, line_x, line_y)``: the bubble
+    arrays aggregate steps into ``(position // bin_size, acceptance_length)``
+    counts (one disk per combination); the line arrays are the raw, unbinned
+    per-step pairs used for the mean trend line.
+    """
+    counter: Counter[tuple[int, int]] = Counter()
+    line_x: list[float] = []
+    line_y: list[float] = []
+    for result in load_results(raw_log):
+        accepted = result.metrics.get("per_step_accepted")
+        drafted = result.metrics.get("per_step_drafted")
+        if not accepted or not drafted:
+            continue
+        pos = result.prompt_tokens
+        for accepted_count, _ in zip(accepted, drafted, strict=True):
+            acceptance_length = accepted_count + 1
+            line_x.append(pos)
+            line_y.append(acceptance_length)
+            binned_pos = (pos // bin_size) * bin_size
+            counter[(binned_pos, acceptance_length)] += 1
+            pos += accepted_count + 1
+
+    bubble_x = [key[0] for key in counter]
+    bubble_y = [key[1] for key in counter]
+    bubble_count = [counter[key] for key in counter]
+    return bubble_x, bubble_y, bubble_count, line_x, line_y
+
+
+def _binned_mean_curve(
+    x: list[float], y: list[float], n_bins: int = 40
+) -> tuple[np.ndarray, np.ndarray] | None:
+    """Plain per-bin mean of y over log-spaced bins of x. No model, no error bars."""
+    x_arr = np.asarray(x, dtype=float)
+    y_arr = np.asarray(y, dtype=float)
+    if len(x_arr) < 10:  # noqa: PLR2004
+        return None
+
+    log_x = np.log(x_arr)
+    edges = np.linspace(log_x.min(), log_x.max(), n_bins + 1)
+    bin_idx = np.clip(np.digitize(log_x, edges) - 1, 0, n_bins - 1)
+
+    centers, means = [], []
+    for b in range(n_bins):
+        mask = bin_idx == b
+        if not mask.any():
+            continue
+        centers.append(np.exp(log_x[mask].mean()))
+        means.append(y_arr[mask].mean())
+    return np.array(centers), np.array(means)
+
+
+def _set_log2_ticks(ax) -> None:
+    """Label the (already log-scale) x-axis with powers of 2, e.g. "2^12" for 4096.
+
+    Context lengths are naturally thought of in powers of 2 (MRCR's own
+    bucket edges double each step); matplotlib's default log-scale ticks
+    (4x10^3, 10^4, ...) don't line up with that.
+    """
+    xmin, xmax = ax.get_xlim()
+    if xmin <= 0:
+        return
+    lo_exp = int(np.floor(np.log2(xmin)))
+    hi_exp = int(np.ceil(np.log2(xmax)))
+    ticks = [2**e for e in range(lo_exp, hi_exp + 1) if xmin <= 2**e <= xmax]
+    if not ticks:
+        return
+    ax.xaxis.set_major_locator(FixedLocator(ticks))
+    ax.xaxis.set_major_formatter(
+        FuncFormatter(lambda val, _pos: f"2^{round(np.log2(val))}")
+    )
+    ax.xaxis.set_minor_formatter(NullFormatter())
+
+
+_BUBBLE_JITTER_SEED = 0
+
+
+def _plot_position_scatter(
+    ax,
+    raw_log: Path,
+    *,
+    bin_size: int,
+    alpha: float,
+    min_area: float,
+    max_area: float,
+    y_jitter: float,
+    title: str,
+) -> None:
+    """Disk-per-(position, acceptance length) scatter, sized by step count.
+
+    Disk *area* -- not radius -- scales with count, so the size comparison
+    a reader makes (area) matches the encoded quantity. Bubbles at the same
+    integer acceptance length would otherwise sit on an exact horizontal
+    line and stack directly on top of each other; a small fixed-seed random
+    y-jitter (uniform within +/- `y_jitter`) spreads them out so overlapping
+    disks are still visually distinguishable. The trend line below is fit
+    on the un-jittered values, so jitter never affects the reported mean.
+    """
+    bubble_x, bubble_y, bubble_count, line_x, line_y = _load_position_scatter(
+        raw_log, bin_size
+    )
+    if not bubble_x:
+        ax.axis("off")
+        return
+
+    rng = np.random.default_rng(_BUBBLE_JITTER_SEED)
+    jittered_y = [
+        y + rng.uniform(-y_jitter, y_jitter) if y_jitter else y for y in bubble_y
+    ]
+
+    max_count = max(bubble_count)
+    sizes = [min_area + (max_area - min_area) * (c / max_count) for c in bubble_count]
+    ax.scatter(
+        bubble_x,
+        jittered_y,
+        s=sizes,
+        color=_MRCR_POSITION_COLOR,
+        alpha=alpha,
+        edgecolors="none",
+        zorder=3,
+    )
+
+    trend_result = _binned_mean_curve(line_x, line_y)
+    if trend_result is not None:
+        x_smooth, mean_pred = trend_result
+        ax.plot(
+            x_smooth,
+            mean_pred,
+            color="#0d366b",
+            linewidth=2.5,
+            zorder=4,
+            label="Mean acceptance length",
+        )
+        ax.legend(loc="upper right", framealpha=0.9, fontsize=9)
+
+    ax.set_xscale("log")
+    _set_log2_ticks(ax)
+    ax.set_title(title, fontsize=13, fontweight="bold")
+    ax.set_xlabel("Context length (tokens, token position)", fontsize=11)
+    ax.set_ylabel("Acceptance length", fontsize=11)
+    ax.grid(True, alpha=0.3, zorder=0)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+
+def run_mrcr(args: argparse.Namespace) -> None:
+    start_rows = _read_bucket_csv(args.results_dir / "acceptance_by_start_length.csv")
+    raw_log = args.raw_log or (args.results_dir / RAW_LOG_FILENAME)
+    has_raw_log = raw_log.exists()
+    position_rows = (
+        []
+        if has_raw_log
+        else _read_bucket_csv(args.results_dir / "acceptance_by_position.csv")
+    )
+
+    if not start_rows and not has_raw_log and not position_rows:
+        print(
+            f"[ERROR] No acceptance data found in {args.results_dir}", file=sys.stderr
+        )
+        sys.exit(1)
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5))
+
+    if start_rows:
+        _plot_acceptance_bars(
+            axes[0], start_rows, _MRCR_START_COLOR, "By context length at request start"
+        )
+    else:
+        axes[0].axis("off")
+
+    if has_raw_log:
+        _plot_position_scatter(
+            axes[1],
+            raw_log,
+            bin_size=args.position_bin_size,
+            alpha=args.bubble_alpha,
+            min_area=args.bubble_min_area,
+            max_area=args.bubble_max_area,
+            y_jitter=args.bubble_y_jitter,
+            title="By context length at token position",
+        )
+    elif position_rows:
+        _plot_acceptance_bars(
+            axes[1],
+            position_rows,
+            _MRCR_POSITION_COLOR,
+            "By context length at token position",
+        )
+    else:
+        axes[1].axis("off")
+
+    fig.suptitle(
+        args.title or "MRCR long-context acceptance length",
+        fontsize=14,
+        fontweight="bold",
+    )
+    fig.tight_layout(rect=(0, 0, 1, 0.95))
+
+    output_dir = args.output_dir or args.results_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+    outpath = output_dir / "mrcr_acceptance_length.png"
+    fig.savefig(outpath, dpi=150)
+    plt.close(fig)
+    print(f"[INFO] Saved {outpath}")
+
+
+# ============================================================================
 # CLI
 # ============================================================================
 
@@ -473,6 +747,89 @@ def main() -> None:
         help="Optional title prefix for plots (e.g. model name)",
     )
     spd.set_defaults(func=run_speedup)
+
+    # --- mrcr ---
+    mrcr = sub.add_parser(
+        "mrcr",
+        help="MRCR long-context acceptance length bar charts",
+        description=(
+            "Bar charts of mean acceptance length by context length, both at "
+            "request start and at token position (output of "
+            "`evaluate.py long-context`)."
+        ),
+    )
+    mrcr.add_argument(
+        "--results-dir",
+        type=Path,
+        required=True,
+        help=(
+            "Directory containing acceptance_by_start_length.csv and "
+            "acceptance_by_position.csv"
+        ),
+    )
+    mrcr.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory for the output PNG (default: --results-dir)",
+    )
+    mrcr.add_argument(
+        "--title",
+        type=str,
+        default=None,
+        help="Optional figure title (e.g. model name)",
+    )
+    mrcr.add_argument(
+        "--raw-log",
+        type=Path,
+        default=None,
+        help=(
+            "Path to raw_requests.jsonl for the per-token-position disk scatter "
+            "(default: <results-dir>/raw_requests.jsonl; falls back to the "
+            "coarser acceptance_by_position.csv bar chart if not found)"
+        ),
+    )
+    mrcr.add_argument(
+        "--position-bin-size",
+        type=int,
+        default=32,
+        help=(
+            "Token width to group positions into for the scatter (default: 32). "
+            "At 1 (exact positions), the model's frequent 1-token-per-step "
+            "advances in the low-acceptance regime mean adjacent same-row "
+            "disks touch and merge into solid bands regardless of opacity; "
+            "coarser bins give real, separable count variation."
+        ),
+    )
+    mrcr.add_argument(
+        "--bubble-alpha",
+        type=float,
+        default=0.12,
+        help="Disk opacity in the per-token-position scatter (default: 0.12)",
+    )
+    mrcr.add_argument(
+        "--bubble-y-jitter",
+        type=float,
+        default=0.25,
+        help=(
+            "Random +/- jitter added to each disk's y-position (acceptance "
+            "length) so disks at the same integer value don't stack exactly "
+            "on top of each other (default: 0.25; 0 disables)"
+        ),
+    )
+    mrcr.add_argument(
+        "--bubble-min-area",
+        type=float,
+        default=10.0,
+        help="Disk area (points^2) for a count-1 cell (default: 10)",
+    )
+    mrcr.add_argument(
+        "--bubble-max-area",
+        type=float,
+        default=280.0,
+        help="Disk area (points^2) for the most frequent cell (default: 280)",
+    )
+    mrcr.set_defaults(func=run_mrcr)
 
     args = parser.parse_args()
 

--- a/scripts/evaluate/rebin_mrcr.py
+++ b/scripts/evaluate/rebin_mrcr.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Rebuild long-context acceptance reports from a raw results log.
+
+`evaluate.py long-context` streams every raw per-request result (prompt length +
+full spec-decode metrics) to ``raw_requests.jsonl`` in its output directory as
+it runs. That file is the source of truth -- the aggregated CSVs are just one
+slicing of it. This script re-slices it with different bucket edges, so changing
+how results are binned doesn't require re-running inference against the server.
+
+Usage:
+    python rebin_mrcr.py --raw-log <output_dir>/raw_requests.jsonl
+    python rebin_mrcr.py --raw-log <dir>/raw_requests.jsonl --position-bin-size 512
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from spec_acceptance import (
+    DEFAULT_CONTEXT_BIN_EDGES,
+    DEFAULT_POSITION_BIN_SIZE,
+    load_results,
+    write_report,
+)
+
+logger = logging.getLogger("evaluate")
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO, format="[%(levelname)s] %(message)s", stream=sys.stderr
+    )
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--raw-log",
+        type=Path,
+        required=True,
+        help="Path to a raw_requests.jsonl produced by `evaluate.py long-context`",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Where to write the re-bucketed CSVs (default: alongside --raw-log)",
+    )
+    parser.add_argument(
+        "--context-bin-edges",
+        type=str,
+        default=None,
+        help=(
+            "Comma-separated token edges for the by-start-length report "
+            f"(default: {','.join(map(str, DEFAULT_CONTEXT_BIN_EDGES))})"
+        ),
+    )
+    parser.add_argument(
+        "--position-bin-size",
+        type=int,
+        default=DEFAULT_POSITION_BIN_SIZE,
+        help=(
+            "Token-position bin width for the by-position report "
+            f"(default: {DEFAULT_POSITION_BIN_SIZE})"
+        ),
+    )
+    args = parser.parse_args()
+
+    results = load_results(args.raw_log)
+    if not results:
+        logger.error("No results found in %s", args.raw_log)
+        sys.exit(1)
+    logger.info("Loaded %d raw results from %s", len(results), args.raw_log)
+
+    context_bin_edges = DEFAULT_CONTEXT_BIN_EDGES
+    if args.context_bin_edges:
+        context_bin_edges = tuple(
+            int(e) for e in args.context_bin_edges.split(",") if e.strip()
+        )
+
+    write_report(
+        args.output_dir or args.raw_log.parent,
+        results,
+        context_bin_edges=context_bin_edges,
+        position_bin_size=args.position_bin_size,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate/requirements.txt
+++ b/scripts/evaluate/requirements.txt
@@ -7,3 +7,11 @@ matplotlib
 numpy
 scikit-learn
 scipy
+
+# MRCR mode: Inspect AI harness + dataset loading
+inspect-ai
+openai>=3.1.0  # inspect-ai's vllm provider requires this; older pins from guidellm are too low
+pandas
+pyarrow
+tiktoken
+huggingface_hub

--- a/scripts/evaluate/requirements.txt
+++ b/scripts/evaluate/requirements.txt
@@ -6,13 +6,10 @@ speculators>0.7.1
 # Visualization dependencies
 matplotlib
 numpy
-scikit-learn
 scipy
 
-# MRCR mode: Inspect AI harness + dataset loading
-inspect-ai
-openai>=3.1.0  # inspect-ai's vllm provider requires this; older pins from guidellm are too low
+# long-context mode: MRCR dataset loading (requests go straight to the
+# target server's own HTTP API, no separate eval harness needed)
 pandas
 pyarrow
-tiktoken
 huggingface_hub

--- a/scripts/evaluate/spec_acceptance.py
+++ b/scripts/evaluate/spec_acceptance.py
@@ -1,0 +1,535 @@
+"""Generic per-request speculative-decoding acceptance harness.
+
+Dataset-agnostic machinery for measuring how spec-decode acceptance holds up as
+context length grows. A caller supplies an iterable of "items" plus small
+adapter callables (``item -> chat messages``, ``item -> stable key``,
+``item -> length proxy``); everything else -- deterministic stratified
+selection, rendering, generation, raw-result persistence, binning and
+reporting -- lives here so future benchmarks can reuse it.
+
+For each selected item the harness first renders it through the target server's
+own ``/v1/chat/completions/render`` endpoint. That applies the chat template and
+tokenizes exactly as the server would, giving an exact prompt length and
+naturally rejecting anything that doesn't fit the model's context window -- no
+separate approximate tokenizer or pre-run bucketing needed. Everything that
+fits is then generated with ``--per-request-spec-decode-metrics detailed``
+required, so each response carries its own acceptance stats plus per-verify-step
+arrays. Every raw per-request result is streamed to ``raw_requests.jsonl`` as it
+completes -- that's the source of truth; the aggregated CSVs are just one
+slicing of it, rebuildable after the fact with different bin edges via
+``load_results`` + ``write_report`` (see ``rebin_mrcr.py``) without re-running
+inference.
+
+Results are sliced into context-length buckets two ways:
+
+* by the prompt length at the start of the request (``bin_by_start_length``)
+* by the running token position of each verify step (``bin_by_position``) --
+  prompt length plus however much has been generated so far.
+
+Deterministic superset selection
+---------------------------------
+``select_stratified`` chooses which items to run as a pure function of the
+items, the caller's flags, and (through the render fit-test) the server's
+``max_model_len`` -- never of run order or wall-clock. Items are placed into
+fixed absolute length bins by a caller-supplied length proxy and, within each
+bin, ranked by a stable content hash; the lowest-ranked ``samples_per_bin`` per
+bin form the candidate set. That set is independent of ``max_model_len``, so the
+only context-dependent step is the render fit-test, which is monotonic: raising
+``max_model_len`` can only let *more* candidates through. The kept set at a
+smaller context is therefore always a subset of the kept set at a larger one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sys
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, TypeVar
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from perf_utils import CsvWriter
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+logger = logging.getLogger("evaluate")
+
+T = TypeVar("T")
+
+# Default context-length bucket edges (tokens) for the by-request-start-length
+# report. These are OpenAI MRCR's native power-of-2 bins; they only slice
+# results for reporting, they don't gate which requests get sent.
+DEFAULT_CONTEXT_BIN_EDGES = (
+    0,
+    4096,
+    8192,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+    524288,
+    1048576,
+)
+
+# Default bin width (tokens) for the by-token-position report -- much finer than
+# the context edges since acceptance can shift noticeably within one request as
+# generation proceeds.
+DEFAULT_POSITION_BIN_SIZE = 256
+
+# Default requested generation length; the render endpoint clips this per-sample
+# to whatever actually fits under the server's max_model_len.
+DEFAULT_MAX_NEW_TOKENS = 512
+# Skip samples left with less than this much generation room -- too few verify
+# steps to say anything about acceptance.
+MIN_GENERATION_ROOM = 32
+
+_RENDER_TIMEOUT_S = 180
+_GENERATE_TIMEOUT_S = 1200
+
+RAW_LOG_FILENAME = "raw_requests.jsonl"
+
+_Failure = Literal["oversized", "error"]
+
+
+@dataclass
+class AcceptanceResult:
+    prompt_tokens: int
+    metrics: dict
+
+
+# ---------------------------------------------------------------------------
+# Raw-result persistence
+# ---------------------------------------------------------------------------
+
+
+def append_result(f, result: AcceptanceResult) -> None:
+    """Append *result* to an open ``raw_requests.jsonl`` file, flushing immediately.
+
+    Flushing per line means a killed or crashed run still leaves every completed
+    request's data on disk.
+    """
+    f.write(
+        json.dumps({"prompt_tokens": result.prompt_tokens, "metrics": result.metrics})
+    )
+    f.write("\n")
+    f.flush()
+
+
+def load_results(path: Path) -> list[AcceptanceResult]:
+    """Reload results previously written with :func:`append_result`."""
+    results = []
+    with path.open() as f:
+        for raw_line in f:
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            obj = json.loads(stripped)
+            results.append(AcceptanceResult(obj["prompt_tokens"], obj["metrics"]))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# HTTP: render + generate
+# ---------------------------------------------------------------------------
+
+
+def _post(root_url: str, path: str, body: dict, timeout: int) -> dict:
+    data = json.dumps(body).encode()
+    req = Request(  # noqa: S310
+        f"{root_url}{path}",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return json.loads(resp.read())
+
+
+def render(
+    root_url: str,
+    model: str,
+    messages: list[dict],
+    max_new_tokens: int = DEFAULT_MAX_NEW_TOKENS,
+) -> tuple[int, int] | _Failure:
+    """Render *messages*, returning ``(prompt_tokens, granted_max_tokens)``.
+
+    Doubles as the context-length fit-test: a render failure (or too little
+    generation room left after clipping) means the prompt doesn't fit the model,
+    so the caller should drop the sample rather than send it for real.
+    """
+    try:
+        rendered = _post(
+            root_url,
+            "/v1/chat/completions/render",
+            {"model": model, "messages": messages, "max_tokens": max_new_tokens},
+            timeout=_RENDER_TIMEOUT_S,
+        )
+        prompt_tokens = len(rendered["token_ids"])
+        granted = rendered["sampling_params"]["max_tokens"]
+    except HTTPError:
+        return "oversized"
+    except (URLError, OSError, json.JSONDecodeError, KeyError, TypeError) as e:
+        logger.warning("Render failed, skipping sample: %s", e)
+        return "error"
+
+    if granted < MIN_GENERATION_ROOM:
+        return "oversized"
+    return prompt_tokens, granted
+
+
+def render_and_generate(
+    root_url: str,
+    model: str,
+    messages: list[dict],
+    max_new_tokens: int = DEFAULT_MAX_NEW_TOKENS,
+) -> AcceptanceResult | _Failure:
+    """Render *messages* through the target server, then (if it fits) generate."""
+    rendered = render(root_url, model, messages, max_new_tokens)
+    if isinstance(rendered, str):
+        return rendered
+    prompt_tokens, granted = rendered
+
+    try:
+        response = _post(
+            root_url,
+            "/v1/chat/completions",
+            {"model": model, "messages": messages, "max_tokens": granted},
+            timeout=_GENERATE_TIMEOUT_S,
+        )
+        spec = (response.get("metrics") or {}).get("speculative_decoding")
+    except (HTTPError, URLError, OSError, json.JSONDecodeError) as e:
+        logger.warning("Generation request failed, skipping sample: %s", e)
+        return "error"
+
+    if not spec:
+        return "error"
+    return AcceptanceResult(prompt_tokens, spec)
+
+
+def _has_detailed_metrics(result: AcceptanceResult) -> bool:
+    return bool(result.metrics.get("per_step_accepted"))
+
+
+def _fail_missing_detailed_metrics() -> None:
+    logger.error(
+        "Server did not return detailed per-request spec-decode metrics for a "
+        "test request. Relaunch it with --per-request-spec-decode-metrics "
+        "detailed and a --speculative-config."
+    )
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic stratified selection
+# ---------------------------------------------------------------------------
+
+
+def stable_hash(value: str) -> str:
+    """A stable, process-independent hash usable as a deterministic sort key."""
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _bin_index(length: float, bin_edges: tuple[int, ...]) -> int:
+    """Return the index of the first edge >= *length* (last index for overflow)."""
+    for i, edge in enumerate(bin_edges):
+        if length <= edge:
+            return i
+    return len(bin_edges)
+
+
+def select_stratified(
+    items: list[T],
+    *,
+    bin_edges: tuple[int, ...],
+    samples_per_bin: int,
+    key_fn: Callable[[T], str],
+    length_fn: Callable[[T], float],
+) -> list[list[T]]:
+    """Deterministically pick up to *samples_per_bin* items per length bin.
+
+    Items are placed into fixed absolute bins by ``length_fn`` and, within each
+    bin, ranked by ``key_fn`` (a stable content hash); the lowest-ranked
+    ``samples_per_bin`` per bin are kept. The result is grouped by bin and
+    ordered by ascending bin, so callers can render smallest-first and stop once
+    a whole bin no longer fits. The selection depends only on the items and the
+    arguments here -- never on ``max_model_len`` -- which is what makes a
+    larger-context run a superset of a smaller one.
+    """
+    bins: dict[int, list[T]] = defaultdict(list)
+    for item in items:
+        bins[_bin_index(length_fn(item), bin_edges)].append(item)
+    grouped = []
+    for b in sorted(bins):
+        ranked = sorted(bins[b], key=key_fn)
+        grouped.append(ranked[:samples_per_bin])
+    return grouped
+
+
+# ---------------------------------------------------------------------------
+# Binning / reporting
+# ---------------------------------------------------------------------------
+
+
+def _bucket_label(n_tokens: int, edges: tuple[int, ...]) -> str:
+    for lo, hi in zip(edges, edges[1:], strict=False):
+        if n_tokens <= hi:
+            return f"{lo}-{hi}"
+    return f"{edges[-1]}+"
+
+
+def _position_bucket_label(n_tokens: int, bin_size: int) -> str:
+    lo = (n_tokens // bin_size) * bin_size
+    return f"{lo}-{lo + bin_size}"
+
+
+def _bucket_sort_key(item: tuple[str, dict]) -> int:
+    return int(item[0].split("-")[0].rstrip("+"))
+
+
+def _finish_bucket(bucket: dict) -> dict:
+    bucket["draft_acceptance_rate"] = (
+        bucket["num_accepted_draft_tokens"] / bucket["num_draft_tokens"]
+        if bucket["num_draft_tokens"]
+        else 0.0
+    )
+    bucket["mean_acceptance_length"] = (
+        1 + bucket["num_accepted_draft_tokens"] / bucket["num_spec_steps"]
+        if bucket["num_spec_steps"]
+        else 0.0
+    )
+    return bucket
+
+
+def bin_by_start_length(
+    results: list[AcceptanceResult],
+    edges: tuple[int, ...] = DEFAULT_CONTEXT_BIN_EDGES,
+) -> list[dict]:
+    """Aggregate whole-request acceptance stats by prompt length at request start."""
+    buckets: dict[str, dict] = {}
+    for r in results:
+        label = _bucket_label(r.prompt_tokens, edges)
+        bucket = buckets.setdefault(
+            label,
+            {
+                "bucket": label,
+                "num_requests": 0,
+                "num_spec_steps": 0,
+                "num_draft_tokens": 0,
+                "num_accepted_draft_tokens": 0,
+            },
+        )
+        bucket["num_requests"] += 1
+        bucket["num_spec_steps"] += r.metrics["num_spec_steps"]
+        bucket["num_draft_tokens"] += r.metrics["num_draft_tokens"]
+        bucket["num_accepted_draft_tokens"] += r.metrics["num_accepted_draft_tokens"]
+    return [_finish_bucket(b) for _, b in sorted(buckets.items(), key=_bucket_sort_key)]
+
+
+def bin_by_position(
+    results: list[AcceptanceResult],
+    bin_size: int = DEFAULT_POSITION_BIN_SIZE,
+) -> list[dict]:
+    """Aggregate per-verify-step acceptance stats by the running token position.
+
+    Each step's position is the prompt length plus everything committed by
+    earlier steps in that same request (accepted draft tokens plus the
+    always-accepted bonus token).
+    """
+    buckets: dict[str, dict] = {}
+    for r in results:
+        accepted = r.metrics.get("per_step_accepted")
+        drafted = r.metrics.get("per_step_drafted")
+        if not accepted or not drafted:
+            continue
+        pos = r.prompt_tokens
+        for a, d in zip(accepted, drafted, strict=True):
+            label = _position_bucket_label(pos, bin_size)
+            bucket = buckets.setdefault(
+                label,
+                {
+                    "bucket": label,
+                    "num_spec_steps": 0,
+                    "num_draft_tokens": 0,
+                    "num_accepted_draft_tokens": 0,
+                },
+            )
+            bucket["num_spec_steps"] += 1
+            bucket["num_draft_tokens"] += d
+            bucket["num_accepted_draft_tokens"] += a
+            pos += a + 1
+    return [_finish_bucket(b) for _, b in sorted(buckets.items(), key=_bucket_sort_key)]
+
+
+def _print_bucket_table(title: str, rows: list[dict]) -> None:
+    print(f"\n=== {title} ===\n")
+    has_requests = "num_requests" in rows[0]
+    header = f"  {'Bucket':<18}"
+    if has_requests:
+        header += f" {'Requests':>9}"
+    header += f" {'Steps':>8} {'Accept Rate':>12} {'Mean Len':>9}"
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for row in rows:
+        line = f"  {row['bucket']:<18}"
+        if has_requests:
+            line += f" {row['num_requests']:>9}"
+        line += (
+            f" {row['num_spec_steps']:>8} {row['draft_acceptance_rate']:>12.4f}"
+            f" {row['mean_acceptance_length']:>9.4f}"
+        )
+        print(line)
+    print()
+
+
+def write_report(
+    output_dir: Path,
+    results: list[AcceptanceResult],
+    *,
+    context_bin_edges: tuple[int, ...] = DEFAULT_CONTEXT_BIN_EDGES,
+    position_bin_size: int = DEFAULT_POSITION_BIN_SIZE,
+) -> None:
+    by_start = bin_by_start_length(results, context_bin_edges)
+    _print_bucket_table("Acceptance by context length at request start", by_start)
+    CsvWriter(
+        output_dir / "acceptance_by_start_length.csv",
+        [
+            "bucket",
+            "num_requests",
+            "num_spec_steps",
+            "num_draft_tokens",
+            "num_accepted_draft_tokens",
+            "draft_acceptance_rate",
+            "mean_acceptance_length",
+        ],
+    ).append_rows(by_start)
+
+    by_position = bin_by_position(results, position_bin_size)
+    if not by_position:
+        logger.warning(
+            "No per-step data available; skipping acceptance-by-position report"
+        )
+        return
+    _print_bucket_table("Acceptance by context length at token position", by_position)
+    CsvWriter(
+        output_dir / "acceptance_by_position.csv",
+        [
+            "bucket",
+            "num_spec_steps",
+            "num_draft_tokens",
+            "num_accepted_draft_tokens",
+            "draft_acceptance_rate",
+            "mean_acceptance_length",
+        ],
+    ).append_rows(by_position)
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def run_acceptance(
+    root_url: str,
+    model: str,
+    candidate_bins: list[list[T]],
+    to_messages: Callable[[T], list[dict]],
+    output_dir: Path,
+    *,
+    max_concurrency: int,
+    context_bin_edges: tuple[int, ...] = DEFAULT_CONTEXT_BIN_EDGES,
+    position_bin_size: int = DEFAULT_POSITION_BIN_SIZE,
+    max_new_tokens: int = DEFAULT_MAX_NEW_TOKENS,
+) -> None:
+    """Render + generate every candidate, stream raw results, and write reports.
+
+    *candidate_bins* is the ascending-by-length grouping returned by
+    :func:`select_stratified`. Each bin is rendered/generated as a concurrent
+    batch; once a whole bin renders oversized the run stops, since all larger
+    bins are strictly bigger and cannot fit. The stop decision keys off actual
+    render results, never a length estimate, so a fitting candidate is never
+    dropped.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    raw_log_path = output_dir / RAW_LOG_FILENAME
+    results: list[AcceptanceResult] = []
+    n_oversized = 0
+    n_failed = 0
+    checked_detailed = False
+    n_candidates = sum(len(b) for b in candidate_bins)
+
+    with (
+        raw_log_path.open("w") as raw_log,
+        ThreadPoolExecutor(max_workers=max_concurrency) as pool,
+    ):
+        for bin_items in candidate_bins:
+            if not bin_items:
+                continue
+            futures = [
+                pool.submit(
+                    render_and_generate,
+                    root_url,
+                    model,
+                    to_messages(item),
+                    max_new_tokens,
+                )
+                for item in bin_items
+            ]
+            bin_all_oversized = True
+            for future in as_completed(futures):
+                result = future.result()
+                if isinstance(result, AcceptanceResult):
+                    bin_all_oversized = False
+                    if not checked_detailed:
+                        if not _has_detailed_metrics(result):
+                            _fail_missing_detailed_metrics()
+                        checked_detailed = True
+                    results.append(result)
+                    append_result(raw_log, result)
+                elif result == "oversized":
+                    n_oversized += 1
+                else:
+                    # A transport error leaves this sample's fit unknown, so it
+                    # must not trigger the oversized early-stop.
+                    bin_all_oversized = False
+                    n_failed += 1
+            logger.info(
+                "Progress: %d/%d candidates done (%d kept, %d oversized, %d fail)",
+                len(results) + n_oversized + n_failed,
+                n_candidates,
+                len(results),
+                n_oversized,
+                n_failed,
+            )
+            if bin_all_oversized:
+                logger.info(
+                    "A full length bin rendered oversized; stopping "
+                    "(all larger bins are strictly bigger)."
+                )
+                break
+
+    logger.info(
+        "Run complete: %d/%d candidates kept (%d exceeded max context, %d failed). "
+        "Raw per-request results: %s",
+        len(results),
+        n_candidates,
+        n_oversized,
+        n_failed,
+        raw_log_path,
+    )
+    if not results:
+        logger.error("No usable results collected")
+        sys.exit(1)
+
+    write_report(
+        output_dir,
+        results,
+        context_bin_edges=context_bin_edges,
+        position_bin_size=position_bin_size,
+    )


### PR DESCRIPTION
## Summary

Adds a **`long-context`** evaluation mode that measures speculative-decoding acceptance as context length grows, using [OpenAI's MRCR dataset](https://huggingface.co/datasets/openai/mrcr) as a source of long, multi-turn prompts. Selection is **deterministic** and **monotonic in `max_model_len`** (a larger context window runs a superset of a smaller one), cost is bounded by construction, and the per-request machinery is factored into a dataset-agnostic harness that future benchmarks can reuse.

Correctness is intentionally not graded — MRCR is used only for its long prompts, not to measure retrieval accuracy.

### How it works

- **Deterministic superset selection.** Records are stratified into MRCR's native power-of-2 token bins and, within each bin, ranked by a stable content hash (`sha256(seed + prompt)`); the lowest-ranked `--samples-per-bin` per bin form the candidate set. Bin assignment uses an `n_chars / 4.9` token estimate (MRCR carries no token count; the ratio is 4.9 ± 0.1 across the whole dataset, validated offline against o200k) — zero runtime cost, no `tiktoken` dependency. The candidate set is independent of `max_model_len`; the only context-dependent step is the exact render fit-test, which is monotonic, so `Kept(ctx1) ⊆ Kept(ctx2)` for `ctx1 ≤ ctx2`.
- **Exact lengths + fit via the server's own render endpoint.** Each candidate is rendered through `/v1/chat/completions/render`, applying the chat template and tokenizing exactly as the server would — giving an exact prompt length and naturally rejecting anything that doesn't fit, with no separate tokenizer. Requires the server started with `VLLM_ENABLE_SCALE_OUT_ENDPOINTS=1`.
- **Bounded cost.** Rendering is capped to ~`samples_per_bin × n_bins`, done concurrently smallest-first, and stops early once a whole bin renders oversized (all larger bins are strictly bigger). Generation runs only on what fits.
- **Per-request detailed metrics.** Generation uses `--per-request-spec-decode-metrics detailed`, so each response carries its own acceptance stats plus per-verify-step arrays. Every raw result is streamed to `raw_requests.jsonl` as the source of truth; the aggregated CSVs are one slicing of it, rebuildable offline with different bin edges (no re-inference).
- **Two report slicings.** Acceptance by prompt length at request start, and by running token position within each request.

### Code organization

- **`spec_acceptance.py`** (new) — dataset-agnostic per-request acceptance harness: stratified selection, render/generate, raw-log persistence, binning, reporting. Reusable by `throughput`/`sweep` in a future PR.
- **`mrcr_bench.py`** — thin MRCR adapter (record → messages / selection key / length proxy); all inference/binning/IO delegates to the harness.
- **`rebin_mrcr.py`** — re-slice a saved `raw_requests.jsonl` with different `--context-bin-edges` / `--position-bin-size`, no server needed.
- **`evaluate.py`** — dispatch + new flags; `throughput`/`sweep` unchanged.
- **`plot.py`** — MRCR acceptance-vs-length scatter/binned-mean plot.
- **`_fetch_model_info()`** — returns `id` + `max_model_len` from `/v1/models`.

### CLI args (long-context mode)

- `--samples-per-bin` (default 20) — records per native token bin; density/cost knob
- `--selection-seed` (default 0) — mixed into the content hash to pick a different deterministic sample
- `--position-bin-size` (default 256) — token-position bin width for the by-position report

### Dependencies

Long-context mode needs only `pandas`, `pyarrow`, `huggingface_hub` (dataset loading); requests go straight to the target server's HTTP API. Drops the previous `inspect-ai`, `openai`, `tiktoken`, and `scikit-learn` requirements.

### Usage

\`\`\`bash
# Server must expose the render endpoint and per-request detailed metrics:
VLLM_ENABLE_SCALE_OUT_ENDPOINTS=1 vllm serve <model> \
    --per-request-spec-decode-metrics detailed \
    --speculative-config '{"model":"<draft>","num_speculative_tokens":N}'

python evaluate.py --target http://localhost:8000/v1 long-context --samples-per-bin 20

# Re-slice results offline with different bins (no server):
python rebin_mrcr.py --raw-log <out>/raw_requests.jsonl --position-bin-size 512
\`\`\`