### PR TITLE
fix(train): fix regression from #971 - keep Muon-excluded matrices at Muon's LR

### DIFF
--- a/src/speculators/train/optimizers.py
+++ b/src/speculators/train/optimizers.py
@@ -3,9 +3,12 @@
 Provides a single entry point, :func:`build_optimizers`, that returns the list of
 optimizers the trainer should drive. The default ("adamw") returns a single AdamW
 optimizer over all parameters, preserving the historical behavior. The "muon" option
-returns two optimizers: ``torch.optim.Muon`` over the 2D weight matrices (which is all
-Muon supports) and ``torch.optim.AdamW`` over everything else (norms, biases, and the
-embedding / LM-head matrices, following standard Muon practice).
+returns three optimizers: ``torch.optim.Muon`` over the 2D weight matrices (which is
+all Muon supports), ``torch.optim.AdamW`` over the norms and biases, and a second
+``AdamW`` at ``muon_lr`` over the 2D matrices Muon skips (embeddings, LM heads, and
+other vocabulary-indexed tables). Those are skipped for their shape, not because they
+want a smaller step, so folding them into the base group would cut their LR and weight
+decay 10x under the default ``muon_lr = 10 * lr``.
 
 Muon works transparently for both single-GPU and multi-GPU (FSDP2) training: when the
 model is sharded with ``fully_shard`` the parameters become ``DTensor``s and Muon's
@@ -38,32 +41,35 @@ _MATRIX_NDIM = 2
 
 def split_named_params_for_muon(
     model: Module,
-) -> tuple[list[tuple[str, Tensor]], list[tuple[str, Tensor]]]:
-    """Split a model's trainable parameters into Muon and AdamW groups.
+) -> tuple[
+    list[tuple[str, Tensor]], list[tuple[str, Tensor]], list[tuple[str, Tensor]]
+]:
+    """Split a model's trainable parameters into Muon, AdamW, and excluded-matrix
+    groups.
 
     A parameter goes to Muon iff it requires gradients, is a 2D matrix with both
-    dimensions > 1, and is not an embedding, codebook, or vocabulary-output weight;
-    everything else goes to AdamW. Degenerate 2D weights (``[1, N]`` / ``[N, 1]``
-    vectors) route to AdamW -- Muon orthogonalizes matrices, not vectors, and crashes
-    on them under FSDP2.
+    dimensions > 1, and is not an embedding, codebook, or vocabulary-output weight. A
+    2D matrix that *is* one of those goes to ``excluded_matrix_params``, which keeps
+    Muon's LR. Everything else -- norms, biases, and degenerate 2D weights (``[1, N]``
+    / ``[N, 1]`` vectors) -- goes to AdamW; Muon orthogonalizes matrices, not vectors,
+    and crashes on them under FSDP2.
 
     :param model: The model whose parameters should be partitioned.
-    :return: A ``(muon_params, adamw_params)`` tuple of named parameter lists.
+    :return: A ``(muon_params, adamw_params, excluded_matrix_params)`` tuple.
     """
     muon_params: list[tuple[str, Tensor]] = []
     adamw_params: list[tuple[str, Tensor]] = []
+    excluded_matrix_params: list[tuple[str, Tensor]] = []
     for name, param in model.named_parameters():
         if not param.requires_grad:
             continue
-        if (
-            param.ndim == _MATRIX_NDIM
-            and min(param.shape) > 1  # exclude degenerate [1, N] / [N, 1] vectors
-            and not any(hint in name for hint in _ADAMW_NAME_HINTS)
-        ):
-            muon_params.append((name, param))
-        else:
+        if param.ndim != _MATRIX_NDIM or min(param.shape) == 1:
             adamw_params.append((name, param))
-    return muon_params, adamw_params
+        elif any(hint in name for hint in _ADAMW_NAME_HINTS):
+            excluded_matrix_params.append((name, param))
+        else:
+            muon_params.append((name, param))
+    return muon_params, adamw_params, excluded_matrix_params
 
 
 def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
@@ -72,7 +78,8 @@ def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
     :param model: The model to optimize.
     :param config: A ``TrainerConfig`` holding the optimizer hyperparameters.
     :return: A list of optimizers for the trainer to step in tandem. The default
-        "adamw" returns a single optimizer; "muon" returns ``[Muon, AdamW]``.
+        "adamw" returns a single optimizer; "muon" returns ``[Muon, AdamW]``, plus
+        an AdamW for the matrices Muon excludes when the model has any.
     """
     if config.optimizer == "adamw":
         return [
@@ -84,11 +91,13 @@ def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
         ]
 
     if config.optimizer == "muon":
-        muon_params, adamw_params = split_named_params_for_muon(model)
+        muon_params, adamw_params, excluded = split_named_params_for_muon(model)
         logger.info(
-            "Muon optimizer: %d 2D params via Muon, %d params via AdamW.",
+            "Muon optimizer: %d via Muon, %d via AdamW, %d excluded matrices "
+            "via AdamW at muon_lr.",
             len(muon_params),
             len(adamw_params),
+            len(excluded),
         )
 
         optimizers: list[torch.optim.Optimizer] = []
@@ -109,6 +118,15 @@ def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
                     adamw_params,
                     lr=config.lr,
                     weight_decay=config.weight_decay,
+                )
+            )
+        if excluded:
+            # Skipped by Muon for their shape, not to be trained more slowly.
+            optimizers.append(
+                torch.optim.AdamW(
+                    excluded,
+                    lr=config.muon_lr,
+                    weight_decay=config.muon_weight_decay,
                 )
             )
         if not optimizers:

--- a/src/speculators/train/optimizers.py
+++ b/src/speculators/train/optimizers.py
@@ -3,12 +3,11 @@
 Provides a single entry point, :func:`build_optimizers`, that returns the list of
 optimizers the trainer should drive. The default ("adamw") returns a single AdamW
 optimizer over all parameters, preserving the historical behavior. The "muon" option
-returns three optimizers: ``torch.optim.Muon`` over the 2D weight matrices (which is
-all Muon supports), ``torch.optim.AdamW`` over the norms and biases, and a second
-``AdamW`` at ``muon_lr`` over the 2D matrices Muon skips (embeddings, LM heads, and
-other vocabulary-indexed tables). Those are skipped for their shape, not because they
-want a smaller step, so folding them into the base group would cut their LR and weight
-decay 10x under the default ``muon_lr = 10 * lr``.
+returns two optimizers: ``torch.optim.Muon`` over the supported 2D weight matrices and
+``torch.optim.AdamW`` over everything else. The AdamW optimizer has a separate
+parameter group at ``muon_lr`` for the 2D matrices Muon excludes (embeddings, LM
+heads, and other vocabulary-indexed tables), preserving their larger learning rate
+without requiring another optimizer.
 
 Muon works transparently for both single-GPU and multi-GPU (FSDP2) training: when the
 model is sharded with ``fully_shard`` the parameters become ``DTensor``s and Muon's
@@ -44,32 +43,32 @@ def split_named_params_for_muon(
 ) -> tuple[
     list[tuple[str, Tensor]], list[tuple[str, Tensor]], list[tuple[str, Tensor]]
 ]:
-    """Split a model's trainable parameters into Muon, AdamW, and excluded-matrix
-    groups.
+    """Split trainable parameters by optimizer and AdamW hyperparameters.
 
     A parameter goes to Muon iff it requires gradients, is a 2D matrix with both
     dimensions > 1, and is not an embedding, codebook, or vocabulary-output weight. A
-    2D matrix that *is* one of those goes to ``excluded_matrix_params``, which keeps
-    Muon's LR. Everything else -- norms, biases, and degenerate 2D weights (``[1, N]``
-    / ``[N, 1]`` vectors) -- goes to AdamW; Muon orthogonalizes matrices, not vectors,
-    and crashes on them under FSDP2.
+    semantically excluded 2D matrix goes to ``muon_excluded_params`` so AdamW can
+    update it with Muon's learning rate and weight decay. Everything else -- norms,
+    biases, and degenerate 2D weights (``[1, N]`` / ``[N, 1]`` vectors) -- goes to the
+    base AdamW group; Muon orthogonalizes matrices, not vectors, and crashes on them
+    under FSDP2.
 
     :param model: The model whose parameters should be partitioned.
-    :return: A ``(muon_params, adamw_params, excluded_matrix_params)`` tuple.
+    :return: A ``(muon_params, adamw_params, muon_excluded_params)`` tuple.
     """
     muon_params: list[tuple[str, Tensor]] = []
     adamw_params: list[tuple[str, Tensor]] = []
-    excluded_matrix_params: list[tuple[str, Tensor]] = []
+    muon_excluded_params: list[tuple[str, Tensor]] = []
     for name, param in model.named_parameters():
         if not param.requires_grad:
             continue
         if param.ndim != _MATRIX_NDIM or min(param.shape) == 1:
             adamw_params.append((name, param))
         elif any(hint in name for hint in _ADAMW_NAME_HINTS):
-            excluded_matrix_params.append((name, param))
+            muon_excluded_params.append((name, param))
         else:
             muon_params.append((name, param))
-    return muon_params, adamw_params, excluded_matrix_params
+    return muon_params, adamw_params, muon_excluded_params
 
 
 def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
@@ -78,8 +77,8 @@ def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
     :param model: The model to optimize.
     :param config: A ``TrainerConfig`` holding the optimizer hyperparameters.
     :return: A list of optimizers for the trainer to step in tandem. The default
-        "adamw" returns a single optimizer; "muon" returns ``[Muon, AdamW]``, plus
-        an AdamW for the matrices Muon excludes when the model has any.
+        "adamw" returns a single optimizer; "muon" returns ``[Muon, AdamW]`` when
+        both parameter types are present.
     """
     if config.optimizer == "adamw":
         return [
@@ -91,13 +90,15 @@ def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
         ]
 
     if config.optimizer == "muon":
-        muon_params, adamw_params, excluded = split_named_params_for_muon(model)
+        muon_params, adamw_params, muon_excluded_params = split_named_params_for_muon(
+            model
+        )
         logger.info(
             "Muon optimizer: %d via Muon, %d via AdamW, %d excluded matrices "
-            "via AdamW at muon_lr.",
+            "via the AdamW muon_lr group.",
             len(muon_params),
             len(adamw_params),
-            len(excluded),
+            len(muon_excluded_params),
         )
 
         optimizers: list[torch.optim.Optimizer] = []
@@ -112,21 +113,23 @@ def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
                     adjust_lr_fn=config.muon_adjust_lr_fn,
                 )
             )
+        adamw_param_groups = []
         if adamw_params:
+            adamw_param_groups.append({"params": adamw_params})
+        if muon_excluded_params:
+            adamw_param_groups.append(
+                {
+                    "params": muon_excluded_params,
+                    "lr": config.muon_lr,
+                    "weight_decay": config.muon_weight_decay,
+                }
+            )
+        if adamw_param_groups:
             optimizers.append(
                 torch.optim.AdamW(
-                    adamw_params,
+                    adamw_param_groups,
                     lr=config.lr,
                     weight_decay=config.weight_decay,
-                )
-            )
-        if excluded:
-            # Skipped by Muon for their shape, not to be trained more slowly.
-            optimizers.append(
-                torch.optim.AdamW(
-                    excluded,
-                    lr=config.muon_lr,
-                    weight_decay=config.muon_weight_decay,
                 )
             )
         if not optimizers:

--- a/src/speculators/train/optimizers.py
+++ b/src/speculators/train/optimizers.py
@@ -4,10 +4,9 @@ Provides a single entry point, :func:`build_optimizers`, that returns the list o
 optimizers the trainer should drive. The default ("adamw") returns a single AdamW
 optimizer over all parameters, preserving the historical behavior. The "muon" option
 returns two optimizers: ``torch.optim.Muon`` over the supported 2D weight matrices and
-``torch.optim.AdamW`` over everything else. The AdamW optimizer has a separate
-parameter group at ``muon_lr`` for the 2D matrices Muon excludes (embeddings, LM
-heads, and other vocabulary-indexed tables), preserving their larger learning rate
-without requiring another optimizer.
+``torch.optim.AdamW`` over everything else. Fresh, output-adjacent token-transition
+factors use a dedicated AdamW parameter group at ``muon_lr``; other Muon exclusions
+retain the base AdamW hyperparameters.
 
 Muon works transparently for both single-GPU and multi-GPU (FSDP2) training: when the
 model is sharded with ``fully_shard`` the parameters become ``DTensor``s and Muon's
@@ -18,24 +17,37 @@ import logging
 
 import torch
 from torch import Tensor
-from torch.nn import Module
+from torch.nn import Embedding, Module
 
 logger = logging.getLogger("speculators")
 
-# Names of parameters that are 2D but should still be optimized with AdamW rather than
-# Muon, following the convention from Keller Jordan's Muon (embeddings, embedding-like
-# codebooks, Markov vocabulary factors, and output heads are excluded from the
-# orthogonalized update).
+# Muon is intended for feature-to-feature matrices, not vocabulary-indexed tables.
+# Embeddings are also detected structurally; these hints cover output heads and custom
+# codebooks implemented as raw parameters.
 _ADAMW_NAME_HINTS = (
     "embed_tokens",
     "lm_head",
     "codebook",
-    "markov_w1",
-    "markov_w2",
+)
+
+# Fresh, output-adjacent token-transition factors use AdamW for their vocabulary axes
+# but keep Muon's larger learning rate and weight decay. Match complete suffixes so
+# unrelated embeddings and codebooks remain in the base AdamW group.
+_TRANSITION_PARAM_SUFFIXES = (
+    "markov_w1.weight",
+    "markov_w2.weight",
+    "predecessor_codebook",
+    "predecessor_codebook.weight",
+    "successor_codebook",
+    "successor_codebook.weight",
 )
 
 # Muon only orthogonalizes 2D weight matrices.
 _MATRIX_NDIM = 2
+
+
+def _matches_param_suffix(name: str, suffixes: tuple[str, ...]) -> bool:
+    return any(name == suffix or name.endswith(f".{suffix}") for suffix in suffixes)
 
 
 def split_named_params_for_muon(
@@ -45,30 +57,41 @@ def split_named_params_for_muon(
 ]:
     """Split trainable parameters by optimizer and AdamW hyperparameters.
 
-    A parameter goes to Muon iff it requires gradients, is a 2D matrix with both
-    dimensions > 1, and is not an embedding, codebook, or vocabulary-output weight. A
-    semantically excluded 2D matrix goes to ``muon_excluded_params`` so AdamW can
-    update it with Muon's learning rate and weight decay. Everything else -- norms,
-    biases, and degenerate 2D weights (``[1, N]`` / ``[N, 1]`` vectors) -- goes to the
-    base AdamW group; Muon orthogonalizes matrices, not vectors, and crashes on them
-    under FSDP2.
+    Fresh token-transition factors go to ``transition_params`` so AdamW can update
+    them with Muon's learning rate and weight decay. Other embeddings, codebooks, and
+    vocabulary-output weights use the base AdamW group. A remaining parameter goes to
+    Muon iff it is a 2D matrix with both dimensions > 1; norms, biases, and degenerate
+    2D weights (``[1, N]`` / ``[N, 1]`` vectors) use base AdamW because Muon
+    orthogonalizes matrices, not vectors, and crashes on them under FSDP2.
 
     :param model: The model whose parameters should be partitioned.
-    :return: A ``(muon_params, adamw_params, muon_excluded_params)`` tuple.
+    :return: A ``(muon_params, adamw_params, transition_params)`` tuple.
     """
+    embedding_param_ids = {
+        id(param)
+        for module in model.modules()
+        if isinstance(module, Embedding)
+        for param in module.parameters(recurse=False)
+    }
+
     muon_params: list[tuple[str, Tensor]] = []
     adamw_params: list[tuple[str, Tensor]] = []
-    muon_excluded_params: list[tuple[str, Tensor]] = []
+    transition_params: list[tuple[str, Tensor]] = []
     for name, param in model.named_parameters():
         if not param.requires_grad:
             continue
-        if param.ndim != _MATRIX_NDIM or min(param.shape) == 1:
+        if _matches_param_suffix(name, _TRANSITION_PARAM_SUFFIXES):
+            transition_params.append((name, param))
+        elif (
+            param.ndim != _MATRIX_NDIM
+            or min(param.shape) == 1
+            or id(param) in embedding_param_ids
+            or any(hint in name for hint in _ADAMW_NAME_HINTS)
+        ):
             adamw_params.append((name, param))
-        elif any(hint in name for hint in _ADAMW_NAME_HINTS):
-            muon_excluded_params.append((name, param))
         else:
             muon_params.append((name, param))
-    return muon_params, adamw_params, muon_excluded_params
+    return muon_params, adamw_params, transition_params
 
 
 def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
@@ -90,15 +113,15 @@ def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
         ]
 
     if config.optimizer == "muon":
-        muon_params, adamw_params, muon_excluded_params = split_named_params_for_muon(
+        muon_params, adamw_params, transition_params = split_named_params_for_muon(
             model
         )
         logger.info(
-            "Muon optimizer: %d via Muon, %d via AdamW, %d excluded matrices "
-            "via the AdamW muon_lr group.",
+            "Muon optimizer: %d via Muon, %d via base AdamW, %d transition factors "
+            "via AdamW at muon_lr.",
             len(muon_params),
             len(adamw_params),
-            len(muon_excluded_params),
+            len(transition_params),
         )
 
         optimizers: list[torch.optim.Optimizer] = []
@@ -116,10 +139,10 @@ def build_optimizers(model: Module, config) -> list[torch.optim.Optimizer]:
         adamw_param_groups = []
         if adamw_params:
             adamw_param_groups.append({"params": adamw_params})
-        if muon_excluded_params:
+        if transition_params:
             adamw_param_groups.append(
                 {
-                    "params": muon_excluded_params,
+                    "params": transition_params,
                     "lr": config.muon_lr,
                     "weight_decay": config.muon_weight_decay,
                 }

--- a/tests/unit/models/test_dflash2_model_definitions.py
+++ b/tests/unit/models/test_dflash2_model_definitions.py
@@ -225,12 +225,11 @@ def test_candidate_codebooks_use_adamw_under_muon_optimizer():
         top_k=3,
     )
 
-    muon, adamw = split_named_params_for_muon(selector)
-    muon_names = {name for name, _ in muon}
-    adamw_names = {name for name, _ in adamw}
+    muon, adamw, excluded = split_named_params_for_muon(selector)
 
-    assert muon_names == {"hidden_projection.weight"}
-    assert adamw_names == {
+    assert {name for name, _ in muon} == {"hidden_projection.weight"}
+    assert not adamw
+    assert {name for name, _ in excluded} == {
         "predecessor_codebook",
         "successor_codebook",
     }

--- a/tests/unit/models/test_dflash2_model_definitions.py
+++ b/tests/unit/models/test_dflash2_model_definitions.py
@@ -225,11 +225,11 @@ def test_candidate_codebooks_use_adamw_under_muon_optimizer():
         top_k=3,
     )
 
-    muon, adamw, muon_excluded = split_named_params_for_muon(selector)
+    muon, adamw, transition = split_named_params_for_muon(selector)
 
     assert {name for name, _ in muon} == {"hidden_projection.weight"}
     assert not adamw
-    assert {name for name, _ in muon_excluded} == {
+    assert {name for name, _ in transition} == {
         "predecessor_codebook",
         "successor_codebook",
     }

--- a/tests/unit/models/test_dflash2_model_definitions.py
+++ b/tests/unit/models/test_dflash2_model_definitions.py
@@ -225,11 +225,11 @@ def test_candidate_codebooks_use_adamw_under_muon_optimizer():
         top_k=3,
     )
 
-    muon, adamw, excluded = split_named_params_for_muon(selector)
+    muon, adamw, muon_excluded = split_named_params_for_muon(selector)
 
     assert {name for name, _ in muon} == {"hidden_projection.weight"}
     assert not adamw
-    assert {name for name, _ in excluded} == {
+    assert {name for name, _ in muon_excluded} == {
         "predecessor_codebook",
         "successor_codebook",
     }

--- a/tests/unit/models/test_dspark_model_definitions.py
+++ b/tests/unit/models/test_dspark_model_definitions.py
@@ -1,10 +1,15 @@
 """Unit tests for DSpark Markov and confidence heads."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 from speculators.models.dspark.model_definitions import ConfidenceHead, MarkovHead
-from speculators.train.optimizers import split_named_params_for_muon
+from speculators.train.optimizers import (
+    build_optimizers,
+    split_named_params_for_muon,
+)
 
 
 class TestMarkovHead:
@@ -55,16 +60,41 @@ class TestMarkovHead:
     def test_vocab_factors_use_adamw_under_muon_optimizer(self):
         head = self._head("gated")
 
-        muon, adamw = split_named_params_for_muon(head)
-        muon_names = {name for name, _ in muon}
-        adamw_names = {name for name, _ in adamw}
+        muon, adamw, excluded = split_named_params_for_muon(head)
 
-        assert muon_names == {"gate_proj.weight"}
-        assert adamw_names == {
+        assert {name for name, _ in muon} == {"gate_proj.weight"}
+        assert {name for name, _ in adamw} == {"gate_proj.bias"}
+        assert {name for name, _ in excluded} == {
             "markov_w1.weight",
             "markov_w2.weight",
-            "gate_proj.bias",
         }
+
+    def test_vocab_factors_keep_muon_lr_not_the_base_lr(self):
+        """The Markov factors are skipped by Muon because a vocabulary index is not a
+        feature axis -- not because they want a 10x smaller step than their neighbours.
+        """
+        head = self._head("vanilla")
+        config = SimpleNamespace(
+            optimizer="muon",
+            lr=3e-4,
+            weight_decay=0.01,
+            muon_lr=3e-3,
+            muon_momentum=0.95,
+            muon_weight_decay=0.1,
+            muon_ns_steps=5,
+            muon_adjust_lr_fn="match_rms_adamw",
+        )
+
+        groups = {
+            name: group
+            for opt in build_optimizers(head, config)
+            for group in opt.param_groups
+            for name in group.get("param_names") or []
+        }
+
+        for name in ("markov_w1.weight", "markov_w2.weight"):
+            assert groups[name]["lr"] == config.muon_lr
+            assert groups[name]["weight_decay"] == config.muon_weight_decay
 
     def test_invalid_rank_raises(self):
         with pytest.raises(ValueError):

--- a/tests/unit/models/test_dspark_model_definitions.py
+++ b/tests/unit/models/test_dspark_model_definitions.py
@@ -60,11 +60,11 @@ class TestMarkovHead:
     def test_vocab_factors_use_adamw_under_muon_optimizer(self):
         head = self._head("gated")
 
-        muon, adamw, muon_excluded = split_named_params_for_muon(head)
+        muon, adamw, transition = split_named_params_for_muon(head)
 
         assert {name for name, _ in muon} == {"gate_proj.weight"}
         assert {name for name, _ in adamw} == {"gate_proj.bias"}
-        assert {name for name, _ in muon_excluded} == {
+        assert {name for name, _ in transition} == {
             "markov_w1.weight",
             "markov_w2.weight",
         }

--- a/tests/unit/models/test_dspark_model_definitions.py
+++ b/tests/unit/models/test_dspark_model_definitions.py
@@ -60,11 +60,11 @@ class TestMarkovHead:
     def test_vocab_factors_use_adamw_under_muon_optimizer(self):
         head = self._head("gated")
 
-        muon, adamw, excluded = split_named_params_for_muon(head)
+        muon, adamw, muon_excluded = split_named_params_for_muon(head)
 
         assert {name for name, _ in muon} == {"gate_proj.weight"}
         assert {name for name, _ in adamw} == {"gate_proj.bias"}
-        assert {name for name, _ in excluded} == {
+        assert {name for name, _ in muon_excluded} == {
             "markov_w1.weight",
             "markov_w2.weight",
         }
@@ -73,7 +73,7 @@ class TestMarkovHead:
         """The Markov factors are skipped by Muon because a vocabulary index is not a
         feature axis -- not because they want a 10x smaller step than their neighbours.
         """
-        head = self._head("vanilla")
+        head = self._head("gated")
         config = SimpleNamespace(
             optimizer="muon",
             lr=3e-4,
@@ -85,13 +85,20 @@ class TestMarkovHead:
             muon_adjust_lr_fn="match_rms_adamw",
         )
 
+        muon, adamw = build_optimizers(head, config)
+
+        assert isinstance(muon, torch.optim.Muon)
+        assert isinstance(adamw, torch.optim.AdamW)
+        assert len(adamw.param_groups) == 2
+
         groups = {
             name: group
-            for opt in build_optimizers(head, config)
-            for group in opt.param_groups
+            for group in adamw.param_groups
             for name in group.get("param_names") or []
         }
 
+        assert groups["gate_proj.bias"]["lr"] == config.lr
+        assert groups["gate_proj.bias"]["weight_decay"] == config.weight_decay
         for name in ("markov_w1.weight", "markov_w2.weight"):
             assert groups[name]["lr"] == config.muon_lr
             assert groups[name]["weight_decay"] == config.muon_weight_decay

--- a/tests/unit/train/test_optimizers.py
+++ b/tests/unit/train/test_optimizers.py
@@ -1,0 +1,24 @@
+"""Tests for optimizer parameter partitioning."""
+
+import torch
+from torch import nn
+
+from speculators.train.optimizers import split_named_params_for_muon
+
+
+def test_generic_embeddings_heads_and_codebooks_use_base_adamw():
+    model = nn.Module()
+    model.token_lookup = nn.Embedding(32, 8)
+    model.lm_head = nn.Linear(8, 32, bias=False)
+    model.aux_codebook = nn.Parameter(torch.empty(32, 8))
+    model.projection = nn.Linear(8, 16, bias=False)
+
+    muon, adamw, transition = split_named_params_for_muon(model)
+
+    assert {name for name, _ in muon} == {"projection.weight"}
+    assert {name for name, _ in adamw} == {
+        "token_lookup.weight",
+        "lm_head.weight",
+        "aux_codebook",
+    }
+    assert not transition


### PR DESCRIPTION
## Purpose

Fixes a regression introduced by #971.

* See the DSpark x Markov head report: https://claude.ai/code/artifact/124e424c-9db1-42bd-a724-7d5657f59df7
* See the DFlash2 codebook report: https://claude.ai/code/artifact/380c43b0-5609-4676-bc2f-68c338b2def5


#971 correctly routed DSpark's Markov factors (`markov_w1`, `markov_w2`) out of Muon — they are vocabulary-indexed tables, and orthogonalizing one is meaningless. But `build_optimizers` has a single AdamW group, at `lr`. So the factors silently dropped from `muon_lr` / `muon_weight_decay` to `lr` / `weight_decay` — **10x lower on both**, given `muon_lr = 10 * lr` by default. Nothing in the diff said so.

The head then barely trains. Over 10 epochs its logit bias moves from 0.006 to 0.027, against 0.587 before #971 — it isn't learning something worse, it isn't learning.

## Change

The 2D matrices excluded from Muon for semantic reasons share a single AdamW optimizer with the base parameters, using a dedicated parameter group at `muon_lr` / `muon_weight_decay`.

This covers `markov_w1` / `markov_w2` and the DFlash2 codebooks. `embed_tokens` / `lm_head` are frozen in every speculator type, so no other model changes. Everything else from #971 is untouched — the `std=0.01` init stays, and both factors stay excluded from Muon.

## Results

Qwen3-8B, `tutorial_regen` (4993 rows), 6xH100, 10 epochs, single seed. Peak validation acceptance length:

|  | peak val EAL | Δ |
|---|---|---|
| pre-#971 | 2.552 | — |
| `main` (#971) | 2.497 | **−0.055** |
| this PR | 2.552 | recovered |

`main` is below pre-#971 at all ten epochs, by 0.049 to 0.072.

## Test

`test_vocab_factors_keep_muon_lr_not_the_base_lr` fails on `main` with `assert 0.0003 == 0.003` and passes here. Partitioning tests also cover the DFlash2 transition codebooks and verify that generic embeddings, LM heads, and unrelated codebooks retain base AdamW hyperparameters. Full unit suite shows no new failures.

## Note on resuming older checkpoints

The AdamW parameter-group layout changes, so checkpoints written before this PR are not guaranteed to resume. This is deliberate: those checkpoints come from runs whose Markov head was inert, and any incompatibility fails loudly rather than silently mis-mapping optimizer state.

Fresh runs and `--optimizer adamw` are unaffected.

## Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.

