### PR TITLE
Update kv cache extraction following restructure

### DIFF
--- a/hs_connectors/src/hs_connectors/mooncake_hidden_states_connector.py
+++ b/hs_connectors/src/hs_connectors/mooncake_hidden_states_connector.py
@@ -42,10 +42,28 @@ logger = init_logger(__name__)
 
 
 def extract_from_kv_cache(
-    kv_cache: torch.Tensor, slot_mapping: torch.Tensor, num_tokens: int
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    num_tokens: int,
+    *,
+    block_size: int,
+    num_hidden_states: int,
 ) -> torch.Tensor:
-    block_size = kv_cache.shape[1]
-    return kv_cache[slot_mapping // block_size, slot_mapping % block_size][:num_tokens]
+    dimensions = kv_cache.shape[1:3]
+    if dimensions == (num_hidden_states, block_size):
+        return kv_cache[slot_mapping // block_size, :, slot_mapping % block_size][
+            :num_tokens
+        ]
+    if dimensions == (block_size, num_hidden_states):
+        return kv_cache[slot_mapping // block_size, slot_mapping % block_size][
+            :num_tokens
+        ]
+    raise ValueError(
+        "Unexpected hidden-state cache dimensions: "
+        f"got {tuple(dimensions)}, expected either "
+        f"({num_hidden_states}, {block_size}) or "
+        f"({block_size}, {num_hidden_states})"
+    )
 
 
 def sanitize_key(key: str) -> str:
@@ -133,6 +151,9 @@ class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
         self._block_size = self._get_cache_block_size(
             vllm_config, kv_cache_config, self._hs_group_idx
         )
+        self._num_hidden_states = kv_cache_config.kv_cache_groups[
+            self._hs_group_idx
+        ].kv_cache_spec.num_kv_heads
 
         if (
             self._vllm_config.speculative_config is None
@@ -241,7 +262,11 @@ class MooncakeHiddenStatesConnector(KVConnectorBase_V1, SupportsHMA):
             with torch.cuda.stream(copy_stream):
                 slot_mapping = slot_mapping.to(self._kv_cache.device, non_blocking=True)
                 hidden_states = extract_from_kv_cache(
-                    self._kv_cache, slot_mapping, num_tokens
+                    self._kv_cache,
+                    slot_mapping,
+                    num_tokens,
+                    block_size=self._block_size,
+                    num_hidden_states=self._num_hidden_states,
                 )
                 assert_finite("hidden_states", hidden_states)
                 # Async DtoH copy into pinned host memory.

--- a/tests/unit/hs_connectors/test_mooncake_connector.py
+++ b/tests/unit/hs_connectors/test_mooncake_connector.py
@@ -1,0 +1,40 @@
+"""Tests for the vLLM cache extraction used by the Mooncake connector."""
+
+import pytest
+import torch
+
+pytest.importorskip("vllm")
+
+from hs_connectors.mooncake_hidden_states_connector import (
+    extract_from_kv_cache,
+)
+
+
+@pytest.mark.parametrize("legacy_layout", [False, True])
+def test_extract_from_kv_cache_preserves_hidden_state_slots(legacy_layout):
+    """Extract token slots from both supported cache layouts."""
+    num_blocks, num_hidden_states, block_size, hidden_size = (2, 4, 3, 2)
+    logical_cache = torch.arange(
+        num_blocks * num_hidden_states * block_size * hidden_size
+    ).reshape(num_blocks, num_hidden_states, block_size, hidden_size)
+    kv_cache = logical_cache.transpose(1, 2) if legacy_layout else logical_cache
+    slot_mapping = torch.tensor([0, 1, 2, 3, 5])
+
+    actual = extract_from_kv_cache(
+        kv_cache,
+        slot_mapping,
+        num_tokens=4,
+        block_size=block_size,
+        num_hidden_states=num_hidden_states,
+    )
+    expected = torch.stack(
+        [
+            logical_cache[0, :, 0],
+            logical_cache[0, :, 1],
+            logical_cache[0, :, 2],
+            logical_cache[1, :, 0],
+        ]
+    )
+
+    assert actual.shape == (4, num_hidden_states, hidden_size)
+    assert torch.equal(actual, expected)


### PR DESCRIPTION


<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Following https://github.com/vllm-project/vllm/pull/51718, which changed the kv cache layout the connector uses, hidden states extraction (using mooncake connector) was failing with a shape issue. This pr updates the `extract_from_kv_cache` function to handle both kv cache layout options (since the new one is only on the nightly release). 

## Tests

Added tests for both layout structures. Will validate with CI + smoke tests. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
