### PR TITLE
Add job checks for Unit, Integration, and Smoke tests

### DIFF
--- a/.buildkite/gpu-tests/gpu-tests-H100.yml
+++ b/.buildkite/gpu-tests/gpu-tests-H100.yml
@@ -1,5 +1,8 @@
 steps:
   - group: ":test_tube: Unit Tests (H100)"
+    notify:
+      - github_commit_status:
+          context: "buildkite/speculators/unit-tests"
     steps:
       - label: ":python: Unit Tests py{{matrix.python}} / transformers {{matrix.transformers}}"
         agents:
@@ -69,6 +72,9 @@ steps:
             transformers: ["latest"]
 
   - group: ":test_tube: Integration Tests (H100)"
+    notify:
+      - github_commit_status:
+          context: "buildkite/speculators/integration-tests"
     steps:
       - label: ":python: Integration Tests py{{matrix.python}} / transformers {{matrix.transformers}}"
         agents:
@@ -144,6 +150,9 @@ steps:
 
   - group: ":test_tube: Smoke Tests (H100)"
     depends_on: "block-smoke-tests-h100"
+    notify:
+      - github_commit_status:
+          context: "buildkite/speculators/smoke-tests"
     steps:
       - label: ":python: Smoke Tests py{{matrix.python}}"
         agents:

--- a/.buildkite/gpu-tests/gpu-tests-L4.yml
+++ b/.buildkite/gpu-tests/gpu-tests-L4.yml
@@ -1,5 +1,8 @@
 steps:
   - group: ":test_tube: Unit Tests (L4)"
+    notify:
+      - github_commit_status:
+          context: "buildkite/speculators/unit-tests"
     steps:
       - label: ":python: Unit Tests py{{matrix.python}} / transformers {{matrix.transformers}}"
         agents:
@@ -58,6 +61,9 @@ steps:
             transformers: ["latest"]
 
   - group: ":test_tube: Integration Tests (L4)"
+    notify:
+      - github_commit_status:
+          context: "buildkite/speculators/integration-tests"
     steps:
       - label: ":python: Integration Tests py{{matrix.python}} / transformers {{matrix.transformers}}"
         agents:
@@ -122,6 +128,9 @@ steps:
 
   - group: ":test_tube: Smoke Tests (L4)"
     depends_on: "block-smoke-tests-l4"
+    notify:
+      - github_commit_status:
+          context: "buildkite/speculators/smoke-tests"
     steps:
       - label: ":python: Smoke Tests py{{matrix.python}}"
         agents:


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

This adds status results for each subclass of tests (unit, integration, smoke) which should appear in the github ui.

I've intentionally used the same context key (e.g. "buildkite/speculators/unit-tests") for both the H100 and L4 tests. This will allow more seamless switching between runner types (since we won't have to update branch protection rules). However, it also means that we should make sure we don't run both the L4 and H100 tests together. 

## Tests

Will check if this runs in the pr, but I'm guessing it will have to land first to go into effect. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
