### PR TITLE
Unstyle cli command output for more stable comparisons

### DIFF
--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -1,5 +1,6 @@
 """Smoke tests for the speculators CLI."""
 
+import click
 from typer.testing import CliRunner
 
 from speculators.cli import app
@@ -7,49 +8,56 @@ from speculators.cli import app
 runner = CliRunner()
 
 
+def unstyled_output(result):
+    """Return CLI output without terminal styling for stable assertions."""
+    return click.unstyle(result.output)
+
+
 class TestRootApp:
     def test_no_args_shows_help(self):
         result = runner.invoke(app, [])
-        assert "Usage" in result.output
+        assert "Usage" in unstyled_output(result)
 
     def test_help(self):
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert "Pipeline" in result.output
-        assert "Tools" in result.output
+        assert "Pipeline" in unstyled_output(result)
+        assert "Tools" in unstyled_output(result)
 
     def test_version(self):
         result = runner.invoke(app, ["--version"])
         assert result.exit_code == 0
-        assert "speculators version:" in result.output
+        assert "speculators version:" in unstyled_output(result)
 
     def test_pipeline_commands_in_help(self):
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert "prepare-data" in result.output
-        assert "stitch-mtp" in result.output
-        assert "generate-offline-data" in result.output
-        assert "regenerate-responses" in result.output
-        assert "train" in result.output
+        output = unstyled_output(result)
+        assert "prepare-data" in output
+        assert "stitch-mtp" in output
+        assert "generate-offline-data" in output
+        assert "regenerate-responses" in output
+        assert "train" in output
 
     def test_tools_commands_in_help(self):
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert "convert" in result.output
+        assert "convert" in unstyled_output(result)
 
 
 class TestConvertCommand:
     def test_help(self):
         result = runner.invoke(app, ["convert", "--help"])
         assert result.exit_code == 0
-        assert "--verifier" in result.output
-        assert "--algorithm" in result.output
+        output = unstyled_output(result)
+        assert "--verifier" in output
+        assert "--algorithm" in output
 
     def test_algorithm_choices_in_help(self):
         result = runner.invoke(app, ["convert", "--help"])
         assert result.exit_code == 0
         for algo in ("eagle3", "mtp", "dflash"):
-            assert algo in result.output
+            assert algo in unstyled_output(result)
 
     def test_missing_required_args(self):
         result = runner.invoke(app, ["convert"])
@@ -60,10 +68,11 @@ class TestPrepareDataCommand:
     def test_help(self):
         result = runner.invoke(app, ["prepare-data", "--help"])
         assert result.exit_code == 0
-        assert "--model" in result.output
-        assert "--data" in result.output
-        assert "--output" in result.output
-        assert "--seq-length" in result.output
+        output = unstyled_output(result)
+        assert "--model" in output
+        assert "--data" in output
+        assert "--output" in output
+        assert "--seq-length" in output
 
     def test_missing_required_args(self):
         result = runner.invoke(app, ["prepare-data"])
@@ -72,25 +81,26 @@ class TestPrepareDataCommand:
     def test_allow_empty_output_in_help(self):
         result = runner.invoke(app, ["prepare-data", "--help"])
         assert result.exit_code == 0
-        assert "--allow-empty-output" in result.output
+        assert "--allow-empty-output" in unstyled_output(result)
 
     def test_overwrite_in_help(self):
         result = runner.invoke(app, ["prepare-data", "--help"])
         assert result.exit_code == 0
-        assert "--overwrite" in result.output
+        assert "--overwrite" in unstyled_output(result)
 
     def test_render_endpoint_in_help(self):
         result = runner.invoke(app, ["prepare-data", "--help"])
         assert result.exit_code == 0
-        assert "--render-endpoint" in result.output
+        assert "--render-endpoint" in unstyled_output(result)
 
 
 class TestStitchCommand:
     def test_help(self):
         result = runner.invoke(app, ["stitch-mtp", "--help"])
         assert result.exit_code == 0
-        assert "finetuned_checkpoint" in result.output
-        assert "verifier_path" in result.output
+        output = unstyled_output(result)
+        assert "finetuned_checkpoint" in output
+        assert "verifier_path" in output
 
     def test_missing_required_args(self):
         result = runner.invoke(app, ["stitch-mtp"])
@@ -101,18 +111,20 @@ class TestGenerateOfflineDataCommand:
     def test_help(self):
         result = runner.invoke(app, ["generate-offline-data", "--help"])
         assert result.exit_code == 0
-        assert "--endpoint" in result.output
-        assert "--preprocessed-data" in result.output
-        assert "--concurrency" in result.output
-        assert "--world-size" in result.output
-        assert "--rank" in result.output
+        output = unstyled_output(result)
+        assert "--endpoint" in output
+        assert "--preprocessed-data" in output
+        assert "--concurrency" in output
+        assert "--world-size" in output
+        assert "--rank" in output
 
     def test_fail_on_error_in_help(self):
         result = runner.invoke(app, ["generate-offline-data", "--help"])
         assert result.exit_code == 0
-        assert "--fail-on-error" in result.output
-        assert "--max-retries" in result.output
-        assert "--validate-outputs" in result.output
+        output = unstyled_output(result)
+        assert "--fail-on-error" in output
+        assert "--max-retries" in output
+        assert "--validate-outputs" in output
 
     def test_invalid_rank(self):
         result = runner.invoke(
@@ -129,10 +141,11 @@ class TestRegenerateResponsesCommand:
     def test_help(self):
         result = runner.invoke(app, ["regenerate-responses", "--help"])
         assert result.exit_code == 0
-        assert "--endpoint" in result.output
-        assert "--dataset" in result.output
-        assert "--concurrency" in result.output
-        assert "--max-tokens" in result.output
+        output = unstyled_output(result)
+        assert "--endpoint" in output
+        assert "--dataset" in output
+        assert "--concurrency" in output
+        assert "--max-tokens" in output
 
     def test_invalid_max_retries(self):
         result = runner.invoke(app, ["regenerate-responses", "--max-retries", "-1"])
@@ -164,7 +177,7 @@ class TestRegenerateResponsesCommand:
             ],
         )
         assert result.exit_code != 0
-        assert "only apply to dataset presets" in result.output
+        assert "only apply to dataset presets" in unstyled_output(result)
 
     def test_invalid_temperature_cycle(self):
         result = runner.invoke(
@@ -177,11 +190,12 @@ class TestTrainCommand:
     def test_help(self):
         result = runner.invoke(app, ["train", "--help"])
         assert result.exit_code == 0
-        assert "--verifier-name-or-path" in result.output
-        assert "--config" in result.output
-        assert "--speculator-type" in result.output
+        output = unstyled_output(result)
+        assert "--verifier-name-or-path" in output
+        assert "--config" in output
+        assert "--speculator-type" in output
 
     def test_train_appears_in_pipeline_panel(self):
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert "train" in result.output
+        assert "train" in unstyled_output(result)


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Currently some of the cli tests are checking if certain strings like `--verifier` are in the cli help output. However, depending on the running environment, there maybe be ansi styling characters inserted into that output which can break up the target string (e.g. `-\x1b[0m\x1b[1;2;36m-verifier`). This pr adds an "unstyling" step which strips color styling. 

## Tests

Reproduced CI failure locally using 

```
env -u NO_COLOR GITHUB_ACTIONS=true \
    python -m pytest -q tests/unit/cli/test_cli.py
```

and then confirmed this change fixes the issue. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
