### PR TITLE
Support truncating on the vLLM server during rendering

### DIFF
--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -373,12 +373,18 @@ def _append_boundary_rows(
     max_length: int,
     minimum_valid_tokens: int | None,
 ) -> tuple[int, int, int]:
-    """Append rendered rows and return kept, unsupervised, and clipped counts."""
+    """Append rendered rows and return kept, unsupervised, and
+    maybe-truncated counts.
+    """
     num_kept = 0
     num_unsupervised = 0
-    num_clipped = 0
+    num_maybe_truncated = 0
 
     for row in rows:
+        # vLLM applies the requested right-side truncation before returning the
+        # render. A row at the limit may therefore have been truncated, but the
+        # render response does not expose the original length.
+        maybe_truncated = len(row["input_ids"]) >= max_length
         status = _append_row(
             results,
             row["input_ids"],
@@ -387,18 +393,20 @@ def _append_boundary_rows(
             minimum_valid_tokens,
         )
         num_unsupervised += status == "unsupervised"
-        # Kept-but-truncated only: a row clipped past its boundary reports
-        # as unsupervised above, and would otherwise be counted twice.
-        num_clipped += status == "kept" and len(row["input_ids"]) > max_length
+        num_maybe_truncated += maybe_truncated and status == "kept"
         if status == "kept":
             num_kept += 1
             if "messages" in results:
                 results["messages"].append(_adapt_conv_for_vllm(row["conv"]))
 
-    return num_kept, num_unsupervised, num_clipped
+    return num_kept, num_unsupervised, num_maybe_truncated
 
 
-def _warn_seq_length(num_unsupervised: int, num_clipped: int) -> None:
+def _warn_seq_length(
+    num_unsupervised: int,
+    num_maybe_truncated: int,
+    max_length: int,
+) -> None:
     """Warn when ``--seq-length`` cost supervision: all of it, or just the tail."""
     if num_unsupervised:
         log.warning(
@@ -406,13 +414,11 @@ def _warn_seq_length(num_unsupervised: int, num_clipped: int) -> None:
             f"If unexpected, consider increasing --seq-length to avoid "
             f"truncating assistant responses."
         )
-    if num_clipped:
+    if num_maybe_truncated:
         log.warning(
-            f"Clipped {num_clipped} rows at --seq-length: the assistant turn is "
-            f"cut mid-response, so its tail and closing tokens are never "
-            f"supervised. These rows are kept and look healthy. Raise "
-            f"--seq-length to supervise responses whole -- reasoning traces "
-            f"routinely exceed 2048 tokens."
+            f"{num_maybe_truncated} rows may have been truncated because "
+            f"their seq_length==max_seq_length ({max_length}). The assistant "
+            "turn may be cut mid-response. Raise --seq-length to reduce truncation."
         )
 
 
@@ -426,7 +432,7 @@ def _passthrough_pretokenized(
     """
     results: dict[str, list] = {"input_ids": [], "loss_mask": [], "seq_len": []}
     num_unsupervised = 0
-    num_clipped = 0
+    num_maybe_truncated = 0
     for ids, mask in zip(examples["input_ids"], examples["loss_mask"], strict=True):
         # A per-row length skew survives strict= column pairing; the collator
         # packs each key independently and would shift the mask silently.
@@ -439,8 +445,8 @@ def _passthrough_pretokenized(
         num_unsupervised += status == "unsupervised"
         # Kept-but-truncated only: a row clipped past its boundary reports as
         # unsupervised above, and would otherwise be counted twice.
-        num_clipped += status == "kept" and len(ids) > max_length
-    _warn_seq_length(num_unsupervised, num_clipped)
+        num_maybe_truncated += status == "kept" and len(ids) > max_length
+    _warn_seq_length(num_unsupervised, num_maybe_truncated, max_length)
     return results
 
 
@@ -485,7 +491,7 @@ def _preprocess_batch(
         tools_col = None
 
     num_unsupervised = 0
-    num_clipped = 0
+    num_maybe_truncated = 0
     num_convs_in = 0
     num_convs_empty = 0
 
@@ -502,17 +508,21 @@ def _preprocess_batch(
             continue
 
         num_convs_in += 1
-        num_kept, row_unsupervised, row_clipped = _append_boundary_rows(
+        num_kept, row_unsupervised, row_maybe_truncated = _append_boundary_rows(
             results,
             rows,
             max_length,
             minimum_valid_tokens,
         )
         num_unsupervised += row_unsupervised
-        num_clipped += row_clipped
+        num_maybe_truncated += row_maybe_truncated
         num_convs_empty += num_kept == 0
 
-    _warn_seq_length(num_unsupervised, num_clipped)
+    _warn_seq_length(
+        num_unsupervised,
+        num_maybe_truncated,
+        max_length,
+    )
     if num_convs_empty:
         log.warning(
             f"{num_convs_empty}/{num_convs_in} conversations produced no training "

--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -184,15 +184,18 @@ def _encode_render(
     render_endpoint: str,
     *,
     add_generation_prompt: bool,
+    max_length: int,
     tools: list[dict] | None = None,
 ) -> list[int]:
-    """Render a conversation prefix via the vLLM ``/render`` endpoint; return ids."""
+    """Render a conversation prefix via vLLM, bounded to the training window."""
     messages = _adapt_conv_for_vllm(conv_prefix)
     return render_conversation(
         render_endpoint,
         messages,
         add_generation_prompt=add_generation_prompt,
         tools=tools,
+        truncate_prompt_tokens=max_length,
+        truncation_side="right",
     )
 
 
@@ -240,6 +243,7 @@ def _render_boundary_rows(
             normalized_conv[:j],
             render_endpoint,
             add_generation_prompt=True,
+            max_length=max_length,
             tools=tools,
         )
         if len(prompt_ids) >= max_length:
@@ -251,6 +255,7 @@ def _render_boundary_rows(
             normalized_conv[: j + 1],
             render_endpoint,
             add_generation_prompt=False,
+            max_length=max_length,
             tools=tools,
         )
         if full_ids[: len(prompt_ids)] == prompt_ids:
@@ -263,6 +268,7 @@ def _render_boundary_rows(
                 normalized_conv[:j],
                 render_endpoint,
                 add_generation_prompt=False,
+                max_length=max_length,
                 tools=tools,
             )
             if full_ids[: len(hist_ids)] != hist_ids or boundary < len(hist_ids):

--- a/src/speculators/data_generation/render_client.py
+++ b/src/speculators/data_generation/render_client.py
@@ -8,6 +8,7 @@ already runs, so one tokenizer feeds the mask, hidden states, and serving.
 
 import logging
 from http import HTTPStatus
+from typing import Literal
 
 import httpx
 
@@ -35,12 +36,15 @@ def render_conversation(
     add_generation_prompt: bool,
     tools: list[dict] | None = None,
     chat_template_kwargs: dict | None = None,
+    truncate_prompt_tokens: int | None = None,
+    truncation_side: Literal["left", "right"] | None = None,
     timeout: float = DEFAULT_RENDER_TIMEOUT,
 ) -> list[int]:
     """POST to ``/v1/chat/completions/render`` and return the token ids.
 
-    No truncation: boundary detection needs full lengths; over-length rows are
-    clipped downstream.
+    ``truncate_prompt_tokens`` and ``truncation_side`` are optional so callers
+    that need the complete render can omit them. Preprocessing uses right-side
+    truncation to keep the rendered prefix and assistant boundary in-window.
     """
     url = f"{endpoint.rstrip('/')}/v1/chat/completions/render"
 
@@ -52,6 +56,10 @@ def render_conversation(
         body["tools"] = tools
     if chat_template_kwargs is not None:
         body["chat_template_kwargs"] = chat_template_kwargs
+    if truncate_prompt_tokens is not None:
+        body["truncate_prompt_tokens"] = truncate_prompt_tokens
+    if truncation_side is not None:
+        body["truncation_side"] = truncation_side
 
     resp = httpx.post(url, json=body, timeout=timeout)
 

--- a/tests/integration/datagen/test_render_boundary.py
+++ b/tests/integration/datagen/test_render_boundary.py
@@ -48,7 +48,7 @@ def _patch_encode(monkeypatch, renders: dict[tuple[int, bool], list[int]]):
 
 
 def test_encode_render_sends_training_window(monkeypatch):
-    request = {}
+    request: dict[str, object] = {}
 
     def fake_render(
         endpoint,
@@ -163,6 +163,19 @@ def test_append_row_statuses():
     assert preprocessing._append_row(results, [1, 2, 3], [0, 1, 1], 10, 1) == "kept"
     assert len(results["input_ids"]) == 1
     assert results["seq_len"] == [3]
+
+
+def test_append_boundary_rows_counts_rows_at_limit_as_maybe_truncated():
+    results: dict[str, list] = {"input_ids": [], "loss_mask": [], "seq_len": []}
+    rows: list[preprocessing.BoundaryRow] = [
+        {
+            "input_ids": [1, 2, 3, 4],
+            "loss_mask": [0, 1, 1, 1],
+            "conv": _conv(2),
+        }
+    ]
+
+    assert preprocessing._append_boundary_rows(results, rows, 4, None) == (1, 0, 1)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/integration/datagen/test_render_boundary.py
+++ b/tests/integration/datagen/test_render_boundary.py
@@ -34,10 +34,51 @@ def _conv(n: int) -> list[dict]:
 def _patch_encode(monkeypatch, renders: dict[tuple[int, bool], list[int]]):
     """Stub ``_encode_render`` to return crafted ids keyed by (prefix_len, gen)."""
 
-    def fake(conv_prefix, render_endpoint, *, add_generation_prompt, tools=None):
+    def fake(
+        conv_prefix,
+        render_endpoint,
+        *,
+        add_generation_prompt,
+        max_length=None,
+        tools=None,
+    ):
         return renders[(len(conv_prefix), add_generation_prompt)]
 
     monkeypatch.setattr(preprocessing, "_encode_render", fake)
+
+
+def test_encode_render_sends_training_window(monkeypatch):
+    request = {}
+
+    def fake_render(
+        endpoint,
+        messages,
+        *,
+        add_generation_prompt,
+        tools=None,
+        truncate_prompt_tokens=None,
+        truncation_side=None,
+    ):
+        request.update(
+            truncate_prompt_tokens=truncate_prompt_tokens,
+            truncation_side=truncation_side,
+        )
+        return [1, 2]
+
+    monkeypatch.setattr(preprocessing, "render_conversation", fake_render)
+
+    result = preprocessing._encode_render(
+        [{"role": "user", "content": "hi"}],
+        "http://x",
+        add_generation_prompt=True,
+        max_length=10,
+    )
+
+    assert result == [1, 2]
+    assert request == {
+        "truncate_prompt_tokens": 10,
+        "truncation_side": "right",
+    }
 
 
 # --------------------------------------------------------------------------- #
@@ -135,6 +176,28 @@ class _Resp:
 
     def json(self):
         return self._payload
+
+
+def test_render_conversation_sends_truncation_options(monkeypatch):
+    request_body = {}
+
+    def post(url, *, json, timeout):
+        request_body.update(json)
+        return _Resp(200, {"token_ids": [1, 2]})
+
+    monkeypatch.setattr(render_client.httpx, "post", post)
+    result = render_client.render_conversation(
+        "http://x",
+        [],
+        add_generation_prompt=False,
+        truncate_prompt_tokens=10,
+        truncation_side="right",
+        max_retries=0,
+    )
+
+    assert result == [1, 2]
+    assert request_body["truncate_prompt_tokens"] == 10
+    assert request_body["truncation_side"] == "right"
 
 
 def test_render_conversation_missing_token_ids_raises(monkeypatch):


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Currently our calls to the render endpoint during preprocessing don't include right truncation. Therefore, if we send a sequence that is longer than `max_model_len` (which happens in nightly CI) the request fails, the sample is skipped entirely, and a warning is printed.

This pr, changes the logic so that vLLM performs the right truncation for us instead. So instead of dropping these samples, they will simply be truncated.

We can't tell which requests were truncated exactly, so instead we consider sequences who's encoded `seq_len==max_seq_len` as `maybe_truncated` and log this to console. 

## Tests

CI tests. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
