### PR TITLE
enable vLLM render endpoints

### DIFF
--- a/scripts/launch_vllm.py
+++ b/scripts/launch_vllm.py
@@ -135,6 +135,11 @@ def _set_render_thread_defaults() -> None:
         os.environ.setdefault(name, value)
 
 
+def _enable_scale_out_endpoints() -> None:
+    """Enable vLLM's render route while preserving an explicit user setting."""
+    os.environ.setdefault("VLLM_ENABLE_SCALE_OUT_ENDPOINTS", "1")
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description="Launch vLLM for hidden states extraction",
@@ -437,6 +442,7 @@ def main():
     if not args.dry_run:
         if "--headless" not in vllm_args:
             _set_render_thread_defaults()
+            _enable_scale_out_endpoints()
         os.execvp(cmd[0], cmd)  # noqa: S606
 
 

--- a/tests/unit/scripts/test_launch_vllm.py
+++ b/tests/unit/scripts/test_launch_vllm.py
@@ -2,6 +2,7 @@ import os
 
 from scripts.launch_vllm import (
     DEFAULT_RENDERER_NUM_WORKERS,
+    _enable_scale_out_endpoints,
     _preprocessing_workers,
     _set_render_thread_defaults,
     _with_render_defaults,
@@ -53,6 +54,18 @@ def test_render_thread_defaults_are_bounded_and_overrideable(monkeypatch):
     monkeypatch.setenv("RAYON_NUM_THREADS", "8")
     _set_render_thread_defaults()
     assert os.environ["RAYON_NUM_THREADS"] == "8"
+
+
+def test_scale_out_endpoints_enabled_by_default(monkeypatch):
+    monkeypatch.delenv("VLLM_ENABLE_SCALE_OUT_ENDPOINTS", raising=False)
+    _enable_scale_out_endpoints()
+    assert os.environ["VLLM_ENABLE_SCALE_OUT_ENDPOINTS"] == "1"
+
+
+def test_explicit_scale_out_endpoint_setting_is_preserved(monkeypatch):
+    monkeypatch.setenv("VLLM_ENABLE_SCALE_OUT_ENDPOINTS", "0")
+    _enable_scale_out_endpoints()
+    assert os.environ["VLLM_ENABLE_SCALE_OUT_ENDPOINTS"] == "0"
 
 
 def test_sizing_respects_the_combined_budget():


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
vLLM nightly now disables scale-out endpoints by default, including `/v1/chat/completions/render`. This caused render requests to return HTTP 404, leaving preprocessing with empty datasets and failing four E2E tests.
The fix sets `VLLM_ENABLE_SCALE_OUT_ENDPOINTS=1` when launching vLLM, restoring the render endpoint. Older vLLM releases safely ignore this setting, while explicit user configuration remains preserved.

## Tests
Rerun the four failed tests locally 
```
======================================================================================= warnings summary =======================================================================================
.venv/lib64/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /home/shanjiaz/speculators/.venv/lib64/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/e2e/smoke/test_render_boundary.py::test_render_boundary_masks_against_live_vllm
tests/e2e/smoke/test_render_boundary.py::test_render_boundary_masks_against_live_vllm
  /home/shanjiaz/speculators/.venv/lib64/python3.12/site-packages/multiprocess/popen_fork.py:66: DeprecationWarning: This process (pid=1932483) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================== 4 passed, 16 warnings in 625.68s (0:10:25) ==========================================================================
```

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
