### PR TITLE
fix(eval): support spline smoothing for small sweeps

### DIFF
--- a/scripts/evaluate/perf_utils.py
+++ b/scripts/evaluate/perf_utils.py
@@ -212,7 +212,15 @@ def smooth_curve(
     if len(x) < 2:  # noqa: PLR2004
         return x, y
 
-    spline = UnivariateSpline(x, y, s=len(x) * np.var(y))
+    # SciPy's default cubic spline requires at least four data points (m > k).
+    # Small sweeps can legitimately produce only two or three successful points,
+    # so lower the spline degree to fit the available data.
+    spline = UnivariateSpline(
+        x,
+        y,
+        k=min(3, len(x) - 1),
+        s=len(x) * np.var(y),
+    )
     x_dense = np.linspace(x.min(), x.max(), n_dense)
     y_dense = spline(x_dense)
 

--- a/tests/unit/scripts/test_perf_utils.py
+++ b/tests/unit/scripts/test_perf_utils.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 
 _SCRIPT_DIR = Path(__file__).resolve().parents[3] / "scripts" / "evaluate"
@@ -153,6 +154,11 @@ def test_smooth_curve_supports_small_sweeps(perf_utils, point_count):
 
     assert len(x_smooth) == 300
     assert len(y_smooth) == 300
+    assert np.all(np.isfinite(x_smooth))
+    assert np.all(np.isfinite(y_smooth))
+    assert np.all(np.diff(x_smooth) > 0)
+    assert x_smooth[[0, -1]] == pytest.approx([x[0], x[-1]])
+    assert y_smooth[[0, -1]] == pytest.approx([y[0], y[-1]])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/scripts/test_perf_utils.py
+++ b/tests/unit/scripts/test_perf_utils.py
@@ -140,6 +140,22 @@ class TestParseGenKwargs:
 
 
 # ---------------------------------------------------------------------------
+# smooth_curve
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("point_count", [2, 3])
+def test_smooth_curve_supports_small_sweeps(perf_utils, point_count):
+    x = list(range(point_count))
+    y = [float(value**2) for value in x]
+
+    x_smooth, y_smooth = perf_utils.smooth_curve(x, y)
+
+    assert len(x_smooth) == 300
+    assert len(y_smooth) == 300
+
+
+# ---------------------------------------------------------------------------
 # run_guidellm — command construction
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

  ## Purpose

  Fix performance plotting when a sweep has only two or three successful data points. SciPy's default cubic
  `UnivariateSpline` requires at least four points and otherwise raises `ValueError: m must be > k`.

  ## Tests

  - `tests/unit/scripts/test_perf_utils.py` — 26 passed
  - Verified 2-, 3-, and 4-point inputs on Python 3.10 / SciPy 1.8

  ## Checklist

  - [x] Purpose and test results are provided.
  - [x] No documentation update is necessary.
  - [x] I have reviewed the change.

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
