### PR TITLE
fix(models): resolve verifier_norm class by verifier family

### DIFF
--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -124,9 +124,6 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             config.transformer_layer_config.hidden_size,
             eps=config.transformer_layer_config.rms_norm_eps,  # type: ignore[arg-type]
         )
-        # Must apply the verifier's own final-norm convention (`x * (1 + w)`
-        # for the Gemma/Qwen3.5 families, `x * w` otherwise) or the
-        # reconstructed verifier targets are silently mis-scaled.
         self.verifier_norm = resolve_verifier_norm_class(config)(
             config.transformer_layer_config.hidden_size,
             eps=config.transformer_layer_config.rms_norm_eps,  # type: ignore[arg-type]

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -25,6 +25,7 @@ from speculators.models.utils import (
     conditional_torch_compile,
     flatten_rope_parameters,
     resolve_target_layer_ids,
+    resolve_verifier_norm_class,
 )
 
 logger = logging.getLogger(__name__)
@@ -123,7 +124,10 @@ class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
             config.transformer_layer_config.hidden_size,
             eps=config.transformer_layer_config.rms_norm_eps,  # type: ignore[arg-type]
         )
-        self.verifier_norm = Qwen3RMSNorm(
+        # Must apply the verifier's own final-norm convention (`x * (1 + w)`
+        # for the Gemma/Qwen3.5 families, `x * w` otherwise) or the
+        # reconstructed verifier targets are silently mis-scaled.
+        self.verifier_norm = resolve_verifier_norm_class(config)(
             config.transformer_layer_config.hidden_size,
             eps=config.transformer_layer_config.rms_norm_eps,  # type: ignore[arg-type]
         )

--- a/src/speculators/models/utils.py
+++ b/src/speculators/models/utils.py
@@ -1,9 +1,7 @@
-import json
 import logging
 import warnings
 from copy import deepcopy
-from functools import partial
-from pathlib import Path
+from functools import lru_cache, partial
 
 import torch
 from transformers import AutoConfig, PretrainedConfig
@@ -13,50 +11,57 @@ from transformers.models.qwen3.modeling_qwen3 import Qwen3RMSNorm
 logger = logging.getLogger(__name__)
 
 # Verifier families whose final norm follows the Gemma convention
-# `x_norm * (1 + w)` instead of the plain RMSNorm `x_norm * w`. Matched as a
-# prefix against the verifier's HF `model_type` / `text_config.model_type`
-# (read from its config.json when resolvable) with a fallback to lowercased
-# `architectures`. Qwen3.5 is in here because `Qwen3_5RMSNorm` is an alias of
-# vLLM's `GemmaRMSNorm` (see vllm/model_executor/models/qwen3_5.py) and
-# transformers' `Qwen3_5RMSNorm.forward` computes `output * (1.0 + weight)`.
-GEMMA_STYLE_FINAL_NORM_PREFIXES = ("gemma", "qwen3_5")
+# `x_norm * (1 + w)` instead of the plain RMSNorm `x_norm * w`. Matched
+# exactly against the verifier's effective `model_type` (after text_config
+# extraction) — gemma3n and gemma4 dropped this convention, so prefix
+# matching would over-include. Qwen3.5 is in here because transformers'
+# Qwen3_5RMSNorm computes `output * (1.0 + weight)` and vLLM's is an alias
+# of GemmaRMSNorm.
+GEMMA_STYLE_FINAL_NORM_MODEL_TYPES = frozenset(
+    (
+        "gemma",
+        "gemma2",
+        "gemma3",
+        "gemma3_text",
+        "qwen3_5",
+        "qwen3_5_text",
+        "recurrent_gemma",
+    )
+)
+
+
+@lru_cache(maxsize=None)
+def _verifier_model_type(name_or_path: str) -> str | None:
+    """The verifier's effective model_type, or None when unresolvable."""
+    try:
+        verifier_config = get_verifier_config(name_or_path)
+    except (KeyError, OSError, ValueError):
+        logger.warning(
+            "Could not resolve a config for verifier %s; assuming the plain "
+            "final-norm convention (x * w).",
+            name_or_path,
+        )
+        return None
+    return str(getattr(verifier_config, "model_type", "") or "").lower()
 
 
 def uses_gemma_style_final_norm(config) -> bool:  # noqa: ANN001
     """Whether the verifier's final norm is `x_norm * (1 + w)` rather than `x_norm * w`."""
     verifier = getattr(getattr(config, "speculators_config", None), "verifier", None)
-    if verifier is None:
-        return False
-
-    candidates: list[str] = []
-
-    # Prefer the verifier's own config.json (model_type is the reliable signal,
-    # and the multimodal wrapper keeps the family under text_config).
     name_or_path = getattr(verifier, "name_or_path", None)
-    if name_or_path:
-        config_file = Path(name_or_path) / "config.json"
-        if config_file.is_file():
-            try:
-                hf_config = json.loads(config_file.read_text())
-            except (OSError, ValueError):
-                hf_config = {}
-            candidates.append(str(hf_config.get("model_type", "")))
-            candidates.append(str(hf_config.get("text_config", {}).get("model_type", "")))
-
-    # Fall back to the architectures recorded in the speculator config.
-    candidates.extend(str(a) for a in (getattr(verifier, "architectures", None) or []))
-
-    return any(
-        c.lower().startswith(GEMMA_STYLE_FINAL_NORM_PREFIXES) for c in candidates if c
-    )
+    if not name_or_path:
+        return False
+    model_type = _verifier_model_type(name_or_path)
+    return model_type is not None and model_type in GEMMA_STYLE_FINAL_NORM_MODEL_TYPES
 
 
 def resolve_verifier_norm_class(config) -> type:  # noqa: ANN001
     """The RMSNorm class matching the verifier's final-norm weight convention.
 
-    Generalizes #892's Gemma3 selection: the frozen ``verifier_norm`` must
-    apply the same gain convention the verifier was trained under, or the
-    reconstructed targets are silently mis-scaled.
+    The frozen ``verifier_norm`` must apply the same gain convention the
+    verifier was trained under (`x * (1 + w)` for the Gemma/Qwen3.5
+    families, `x * w` otherwise), or the reconstructed verifier targets
+    are silently mis-scaled.
     """
     if uses_gemma_style_final_norm(config):
         return Gemma3RMSNorm

--- a/src/speculators/models/utils.py
+++ b/src/speculators/models/utils.py
@@ -1,12 +1,66 @@
+import json
 import logging
 import warnings
 from copy import deepcopy
 from functools import partial
+from pathlib import Path
 
 import torch
 from transformers import AutoConfig, PretrainedConfig
+from transformers.models.gemma3.modeling_gemma3 import Gemma3RMSNorm
+from transformers.models.qwen3.modeling_qwen3 import Qwen3RMSNorm
 
 logger = logging.getLogger(__name__)
+
+# Verifier families whose final norm follows the Gemma convention
+# `x_norm * (1 + w)` instead of the plain RMSNorm `x_norm * w`. Matched as a
+# prefix against the verifier's HF `model_type` / `text_config.model_type`
+# (read from its config.json when resolvable) with a fallback to lowercased
+# `architectures`. Qwen3.5 is in here because `Qwen3_5RMSNorm` is an alias of
+# vLLM's `GemmaRMSNorm` (see vllm/model_executor/models/qwen3_5.py) and
+# transformers' `Qwen3_5RMSNorm.forward` computes `output * (1.0 + weight)`.
+GEMMA_STYLE_FINAL_NORM_PREFIXES = ("gemma", "qwen3_5")
+
+
+def uses_gemma_style_final_norm(config) -> bool:  # noqa: ANN001
+    """Whether the verifier's final norm is `x_norm * (1 + w)` rather than `x_norm * w`."""
+    verifier = getattr(getattr(config, "speculators_config", None), "verifier", None)
+    if verifier is None:
+        return False
+
+    candidates: list[str] = []
+
+    # Prefer the verifier's own config.json (model_type is the reliable signal,
+    # and the multimodal wrapper keeps the family under text_config).
+    name_or_path = getattr(verifier, "name_or_path", None)
+    if name_or_path:
+        config_file = Path(name_or_path) / "config.json"
+        if config_file.is_file():
+            try:
+                hf_config = json.loads(config_file.read_text())
+            except (OSError, ValueError):
+                hf_config = {}
+            candidates.append(str(hf_config.get("model_type", "")))
+            candidates.append(str(hf_config.get("text_config", {}).get("model_type", "")))
+
+    # Fall back to the architectures recorded in the speculator config.
+    candidates.extend(str(a) for a in (getattr(verifier, "architectures", None) or []))
+
+    return any(
+        c.lower().startswith(GEMMA_STYLE_FINAL_NORM_PREFIXES) for c in candidates if c
+    )
+
+
+def resolve_verifier_norm_class(config) -> type:  # noqa: ANN001
+    """The RMSNorm class matching the verifier's final-norm weight convention.
+
+    Generalizes #892's Gemma3 selection: the frozen ``verifier_norm`` must
+    apply the same gain convention the verifier was trained under, or the
+    reconstructed targets are silently mis-scaled.
+    """
+    if uses_gemma_style_final_norm(config):
+        return Gemma3RMSNorm
+    return Qwen3RMSNorm
 
 
 def conditional_torch_compile(func=None, *args, **kwargs):

--- a/src/speculators/models/utils.py
+++ b/src/speculators/models/utils.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from copy import deepcopy
-from functools import lru_cache, partial
+from functools import cache, partial
 
 import torch
 from transformers import AutoConfig, PretrainedConfig
@@ -30,7 +30,7 @@ GEMMA_STYLE_FINAL_NORM_MODEL_TYPES = frozenset(
 )
 
 
-@lru_cache(maxsize=None)
+@cache
 def _verifier_model_type(name_or_path: str) -> str | None:
     """The verifier's effective model_type, or None when unresolvable."""
     try:
@@ -45,8 +45,8 @@ def _verifier_model_type(name_or_path: str) -> str | None:
     return str(getattr(verifier_config, "model_type", "") or "").lower()
 
 
-def uses_gemma_style_final_norm(config) -> bool:  # noqa: ANN001
-    """Whether the verifier's final norm is `x_norm * (1 + w)` rather than `x_norm * w`."""
+def uses_gemma_style_final_norm(config) -> bool:
+    """Whether the verifier's final norm applies gain ``1 + w`` (not ``w``)."""
     verifier = getattr(getattr(config, "speculators_config", None), "verifier", None)
     name_or_path = getattr(verifier, "name_or_path", None)
     if not name_or_path:
@@ -55,7 +55,7 @@ def uses_gemma_style_final_norm(config) -> bool:  # noqa: ANN001
     return model_type is not None and model_type in GEMMA_STYLE_FINAL_NORM_MODEL_TYPES
 
 
-def resolve_verifier_norm_class(config) -> type:  # noqa: ANN001
+def resolve_verifier_norm_class(config) -> type:
     """The RMSNorm class matching the verifier's final-norm weight convention.
 
     The frozen ``verifier_norm`` must apply the same gain convention the

--- a/tests/unit/models/test_verifier_norm_convention.py
+++ b/tests/unit/models/test_verifier_norm_convention.py
@@ -25,49 +25,58 @@ from speculators.models.utils import resolve_verifier_norm_class, uses_gemma_sty
 from .test_checkpoint_key_ownership import _fake_verifier, _make_fake_loader, _make_model
 
 
-def _point_at_fake_verifier(
-    model, tmp_path, model_type: str, architectures: list[str], text_model_type: str = ""
-):
-    verifier_dir = tmp_path / model_type / text_model_type / "_".join(architectures)
+def _point_at_fake_verifier(model, tmp_path, model_type: str, text_model_type: str = ""):
+    """Point the model's verifier at a fake checkpoint dir with this model_type."""
+    verifier_dir = tmp_path / model_type / text_model_type
     verifier_dir.mkdir(parents=True)
-    raw = {"model_type": model_type, "architectures": architectures}
+    raw = {"model_type": model_type}
     if text_model_type:  # multimodal wrapper carrying the family in text_config
         raw["text_config"] = {"model_type": text_model_type}
     (verifier_dir / "config.json").write_text(json.dumps(raw))
     model.config.speculators_config.verifier.name_or_path = str(verifier_dir)
-    model.config.speculators_config.verifier.architectures = architectures
 
 
 @pytest.mark.parametrize(
-    ("model_type", "text_model_type", "architectures", "expected"),
+    ("model_type", "text_model_type", "expected"),
     [
-        ("qwen3_5", "", ["Qwen3_5ForConditionalGeneration"], True),
-        ("qwen3", "qwen3_5_text", ["Qwen3_5ForConditionalGeneration"], True),
-        ("gemma3_text", "", ["Gemma3ForConditionalGeneration"], True),
-        ("qwen3", "", ["Gemma3ForCausalLM"], True),  # architectures fallback
-        ("qwen3", "", ["Qwen3ForCausalLM"], False),
-        ("llama", "", ["LlamaForCausalLM"], False),
+        ("qwen3_5", "", True),
+        ("qwen3_5", "qwen3_5_text", True),
+        ("gemma3_text", "", True),
+        ("gemma2", "", True),
+        ("gemma3n", "", False),  # dropped the (1 + w) convention
+        ("gemma4", "gemma4_text", False),  # dropped the (1 + w) convention
+        ("qwen3", "", False),
+        ("llama", "", False),
     ],
     ids=[
         "qwen3_5",
         "qwen3_5_text_nested",
-        "gemma3",
-        "gemma3_arch_fallback",
+        "gemma3_text",
+        "gemma2",
+        "gemma3n_negative",
+        "gemma4_negative",
         "qwen3_negative",
         "llama_negative",
     ],
 )
-def test_detection_by_model_type_and_architectures(
-    tmp_path, model_type: str, text_model_type: str, architectures: list[str], expected: bool
+def test_detection_by_verifier_model_type(
+    tmp_path, model_type: str, text_model_type: str, expected: bool
 ):
     model = _make_model(DFlashDraftModel, draft_vocab_size=64)
-    _point_at_fake_verifier(model, tmp_path, model_type, architectures, text_model_type)
+    _point_at_fake_verifier(model, tmp_path, model_type, text_model_type)
     assert uses_gemma_style_final_norm(model.config) is expected
-    assert (
-        resolve_verifier_norm_class(model.config) is Gemma3RMSNorm
-        if expected
-        else resolve_verifier_norm_class(model.config) is Qwen3RMSNorm
+    assert (resolve_verifier_norm_class(model.config) is Gemma3RMSNorm) is expected
+
+
+def test_unresolvable_verifier_defaults_to_plain(monkeypatch: pytest.MonkeyPatch):
+    """A verifier config AutoConfig cannot resolve keeps the plain convention."""
+    monkeypatch.setattr(
+        "speculators.models.utils.AutoConfig.from_pretrained",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("cannot resolve")),
     )
+    model = _make_model(DFlashDraftModel, draft_vocab_size=64)  # verifier name_or_path="dummy"
+    assert uses_gemma_style_final_norm(model.config) is False
+    assert isinstance(model.verifier_norm, Qwen3RMSNorm)
 
 
 def test_plain_construction_unchanged():
@@ -83,7 +92,7 @@ def test_gemma_style_construction_swaps_class(
     """Gemma-convention verifiers construct verifier_norm as Gemma3RMSNorm
     and load the raw checkpoint weight unchanged (the +1 lives in forward)."""
     model = _make_model(DFlashDraftModel, draft_vocab_size=64)
-    _point_at_fake_verifier(model, tmp_path, model_type, ["XForCausalLM"])
+    _point_at_fake_verifier(model, tmp_path, model_type)
     rebuilt = DFlashDraftModel(model.config)
     assert isinstance(rebuilt.verifier_norm, Gemma3RMSNorm)
 

--- a/tests/unit/models/test_verifier_norm_convention.py
+++ b/tests/unit/models/test_verifier_norm_convention.py
@@ -1,0 +1,120 @@
+"""Verifier final-norm class resolution.
+
+Some verifier families store the final RMSNorm weight in the Gemma
+convention — the applied gain is ``1 + w`` — while a plain ``Qwen3RMSNorm``
+applies gain ``w``. This family includes Gemma itself and the Qwen3.5/Qwen3.8
+models, whose ``Qwen3_5RMSNorm`` is an alias of vLLM's ``GemmaRMSNorm``.
+The frozen ``verifier_norm`` must therefore be constructed from the class
+matching the verifier's convention, or the reconstructed verifier targets
+are silently mis-scaled.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+import pytest
+import torch
+from transformers.models.gemma3.modeling_gemma3 import Gemma3RMSNorm
+from transformers.models.qwen3.modeling_qwen3 import Qwen3RMSNorm
+
+from speculators.models.dflash.core import DFlashDraftModel
+from speculators.models.utils import resolve_verifier_norm_class, uses_gemma_style_final_norm
+
+from .test_checkpoint_key_ownership import _fake_verifier, _make_fake_loader, _make_model
+
+
+def _point_at_fake_verifier(
+    model, tmp_path, model_type: str, architectures: list[str], text_model_type: str = ""
+):
+    verifier_dir = tmp_path / model_type / text_model_type / "_".join(architectures)
+    verifier_dir.mkdir(parents=True)
+    raw = {"model_type": model_type, "architectures": architectures}
+    if text_model_type:  # multimodal wrapper carrying the family in text_config
+        raw["text_config"] = {"model_type": text_model_type}
+    (verifier_dir / "config.json").write_text(json.dumps(raw))
+    model.config.speculators_config.verifier.name_or_path = str(verifier_dir)
+    model.config.speculators_config.verifier.architectures = architectures
+
+
+@pytest.mark.parametrize(
+    ("model_type", "text_model_type", "architectures", "expected"),
+    [
+        ("qwen3_5", "", ["Qwen3_5ForConditionalGeneration"], True),
+        ("qwen3", "qwen3_5_text", ["Qwen3_5ForConditionalGeneration"], True),
+        ("gemma3_text", "", ["Gemma3ForConditionalGeneration"], True),
+        ("qwen3", "", ["Gemma3ForCausalLM"], True),  # architectures fallback
+        ("qwen3", "", ["Qwen3ForCausalLM"], False),
+        ("llama", "", ["LlamaForCausalLM"], False),
+    ],
+    ids=[
+        "qwen3_5",
+        "qwen3_5_text_nested",
+        "gemma3",
+        "gemma3_arch_fallback",
+        "qwen3_negative",
+        "llama_negative",
+    ],
+)
+def test_detection_by_model_type_and_architectures(
+    tmp_path, model_type: str, text_model_type: str, architectures: list[str], expected: bool
+):
+    model = _make_model(DFlashDraftModel, draft_vocab_size=64)
+    _point_at_fake_verifier(model, tmp_path, model_type, architectures, text_model_type)
+    assert uses_gemma_style_final_norm(model.config) is expected
+    assert (
+        resolve_verifier_norm_class(model.config) is Gemma3RMSNorm
+        if expected
+        else resolve_verifier_norm_class(model.config) is Qwen3RMSNorm
+    )
+
+
+def test_plain_construction_unchanged():
+    """A plain-convention verifier (the default dummy) keeps Qwen3RMSNorm."""
+    model = _make_model(DFlashDraftModel, draft_vocab_size=64)
+    assert isinstance(model.verifier_norm, Qwen3RMSNorm)
+
+
+@pytest.mark.parametrize("model_type", ["qwen3_5", "gemma3_text"], ids=["qwen3_5", "gemma3"])
+def test_gemma_style_construction_swaps_class(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, model_type: str
+):
+    """Gemma-convention verifiers construct verifier_norm as Gemma3RMSNorm
+    and load the raw checkpoint weight unchanged (the +1 lives in forward)."""
+    model = _make_model(DFlashDraftModel, draft_vocab_size=64)
+    _point_at_fake_verifier(model, tmp_path, model_type, ["XForCausalLM"])
+    rebuilt = DFlashDraftModel(model.config)
+    assert isinstance(rebuilt.verifier_norm, Gemma3RMSNorm)
+
+    # The weight must load verbatim: the convention is applied in forward,
+    # not baked into the parameter.
+    fake = _fake_verifier()
+    fake["model.norm.weight"] = torch.randn(16)
+    rebuilt.save_pretrained(tmp_path / "draft")
+    monkeypatch.setattr(
+        "speculators.utils.loading.load_model_layers",
+        _make_fake_loader(fake),
+    )
+    loaded = cast(
+        "DFlashDraftModel",
+        DFlashDraftModel.from_pretrained(tmp_path / "draft", local_files_only=True),
+    )
+    assert isinstance(loaded.verifier_norm, Gemma3RMSNorm)
+    assert torch.equal(loaded.verifier_norm.weight, fake["model.norm.weight"])
+
+
+def test_gemma3_rmsnorm_matches_folded_qwen3_rmsnorm():
+    """Reference equivalence: Gemma3RMSNorm(w) == Qwen3RMSNorm(w + 1).
+
+    The two fix mechanisms for the convention mismatch (class swap vs
+    folding +1 into the loaded weight) must produce the same function.
+    """
+    torch.manual_seed(0)
+    w = torch.randn(16)
+    x = torch.randn(8, 16)
+    gemma = Gemma3RMSNorm(16, eps=1e-6)
+    gemma.weight.data = w.clone()
+    qwen_folded = Qwen3RMSNorm(16, eps=1e-6)
+    qwen_folded.weight.data = w + 1.0
+    torch.testing.assert_close(gemma(x), qwen_folded(x), rtol=1e-5, atol=1e-5)

--- a/tests/unit/models/test_verifier_norm_convention.py
+++ b/tests/unit/models/test_verifier_norm_convention.py
@@ -20,12 +20,21 @@ from transformers.models.gemma3.modeling_gemma3 import Gemma3RMSNorm
 from transformers.models.qwen3.modeling_qwen3 import Qwen3RMSNorm
 
 from speculators.models.dflash.core import DFlashDraftModel
-from speculators.models.utils import resolve_verifier_norm_class, uses_gemma_style_final_norm
+from speculators.models.utils import (
+    resolve_verifier_norm_class,
+    uses_gemma_style_final_norm,
+)
 
-from .test_checkpoint_key_ownership import _fake_verifier, _make_fake_loader, _make_model
+from .test_checkpoint_key_ownership import (
+    _fake_verifier,
+    _make_fake_loader,
+    _make_model,
+)
 
 
-def _point_at_fake_verifier(model, tmp_path, model_type: str, text_model_type: str = ""):
+def _point_at_fake_verifier(
+    model, tmp_path, model_type: str, text_model_type: str = ""
+):
     """Point the model's verifier at a fake checkpoint dir with this model_type."""
     verifier_dir = tmp_path / model_type / text_model_type
     verifier_dir.mkdir(parents=True)
@@ -70,11 +79,15 @@ def test_detection_by_verifier_model_type(
 
 def test_unresolvable_verifier_defaults_to_plain(monkeypatch: pytest.MonkeyPatch):
     """A verifier config AutoConfig cannot resolve keeps the plain convention."""
+
+    def _raise(*args, **kwargs):
+        raise OSError("cannot resolve")
+
     monkeypatch.setattr(
         "speculators.models.utils.AutoConfig.from_pretrained",
-        lambda *args, **kwargs: (_ for _ in ()).throw(OSError("cannot resolve")),
+        _raise,
     )
-    model = _make_model(DFlashDraftModel, draft_vocab_size=64)  # verifier name_or_path="dummy"
+    model = _make_model(DFlashDraftModel, draft_vocab_size=64)
     assert uses_gemma_style_final_norm(model.config) is False
     assert isinstance(model.verifier_norm, Qwen3RMSNorm)
 
@@ -85,7 +98,9 @@ def test_plain_construction_unchanged():
     assert isinstance(model.verifier_norm, Qwen3RMSNorm)
 
 
-@pytest.mark.parametrize("model_type", ["qwen3_5", "gemma3_text"], ids=["qwen3_5", "gemma3"])
+@pytest.mark.parametrize(
+    "model_type", ["qwen3_5", "gemma3_text"], ids=["qwen3_5", "gemma3"]
+)
 def test_gemma_style_construction_swaps_class(
     tmp_path, monkeypatch: pytest.MonkeyPatch, model_type: str
 ):

--- a/tests/unit/models/test_verifier_norm_convention.py
+++ b/tests/unit/models/test_verifier_norm_convention.py
@@ -19,7 +19,7 @@ import torch
 from transformers.models.gemma3.modeling_gemma3 import Gemma3RMSNorm
 from transformers.models.qwen3.modeling_qwen3 import Qwen3RMSNorm
 
-from speculators.models.dflash.core import DFlashDraftModel
+from speculators.models.dflash.core import DFlashDraftModel, DFlashSpeculatorConfig
 from speculators.models.utils import (
     resolve_verifier_norm_class,
     uses_gemma_style_final_norm,
@@ -38,7 +38,7 @@ def _point_at_fake_verifier(
     """Point the model's verifier at a fake checkpoint dir with this model_type."""
     verifier_dir = tmp_path / model_type / text_model_type
     verifier_dir.mkdir(parents=True)
-    raw = {"model_type": model_type}
+    raw: dict = {"model_type": model_type}
     if text_model_type:  # multimodal wrapper carrying the family in text_config
         raw["text_config"] = {"model_type": text_model_type}
     (verifier_dir / "config.json").write_text(json.dumps(raw))
@@ -108,7 +108,7 @@ def test_gemma_style_construction_swaps_class(
     and load the raw checkpoint weight unchanged (the +1 lives in forward)."""
     model = _make_model(DFlashDraftModel, draft_vocab_size=64)
     _point_at_fake_verifier(model, tmp_path, model_type)
-    rebuilt = DFlashDraftModel(model.config)
+    rebuilt = DFlashDraftModel(cast("DFlashSpeculatorConfig", model.config))
     assert isinstance(rebuilt.verifier_norm, Gemma3RMSNorm)
 
     # The weight must load verbatim: the convention is applied in forward,


### PR DESCRIPTION
Some verifier families store the final RMSNorm weight in the Gemma convention — applied gain is (1 + w) — while verifier_norm was always constructed as a plain Qwen3RMSNorm (gain w). This includes the Gemma models (as covered for Gemma3 by #892) and the Qwen3.5/Qwen3.8 family, whose Qwen3_5RMSNorm is an alias of vLLM's GemmaRMSNorm (vllm/model_executor/models/qwen3_5.py); transformers' Qwen3_5RMSNorm.forward likewise computes output * (1.0 + weight).

The mismatch silently mis-scales the reconstructed verifier targets: on a Qwen3.8-27B verifier (V=248320), feeding real model.norm.weight and real lm_head rows through both variants gives rel-L2 0.51 vs the verifier's own final hidden state (KL ~0.48 nat on the reconstructed target distribution, top-1 prob 0.008 vs 0.071 true). Training converges regardless — argmax mostly survives the ~2x scale error — so nothing flags it. Likely (part of) what #797 observed as "DFlash performs worse on Qwen3.5 than Qwen3".

Generalizes #892's Gemma3 norm-class selection into a shared resolve_verifier_norm_class helper: detection keys off the verifier's model_type / text_config.model_type (read from its config.json when resolvable) with an architectures fallback — not weight statistics, since in the Qwen3.8 checkpoint per-layer norm weights sit near zero (gemma-style storage) while the final norm weight sits near 1.0, so value-based heuristics would misfire on exactly the layer that matters. The checkpoint weight loads verbatim; the convention is applied in the norm class's forward, matching the verifier's own numerics.

Verified end-to-end on the DSpark-on-Qwen3.8 pipeline (hidden-states extraction through serving) with the equivalent weight-fold variant of this fix; a unit test asserts Gemma3RMSNorm(w) == Qwen3RMSNorm(w+1).

Refs #892, #797.

