### PR TITLE
perf(eagle3): skip unused teacher projections while preserving metrics

### DIFF
--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -189,6 +189,33 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
                 f" match draft hidden size {self.hidden_size}."
             )
 
+    def _compute_training_targets(
+        self,
+        hidden_states: torch.Tensor,
+        loss_mask: torch.Tensor | None,
+        ttt_steps: int,
+    ) -> torch.Tensor:
+        """Project rows needed by either loss or the evolving accuracy history."""
+        if loss_mask is None:
+            return self.verifier_lm_head(self.verifier_norm(hidden_states))
+
+        # prev_correct starts at loss_mask and follows draft starts. At depth t,
+        # start r compares with teacher row r+t even if that row has no loss.
+        supervised = loss_mask.to(torch.bool)
+        needed = supervised.clone()
+        for step in range(1, min(ttt_steps, hidden_states.shape[1])):
+            needed[:, step:] |= supervised[:, :-step]
+        indices = needed.any(dim=0).nonzero(as_tuple=True)[0]
+        if indices.numel() == hidden_states.shape[1]:
+            return self.verifier_lm_head(self.verifier_norm(hidden_states))
+
+        selected = hidden_states.index_select(1, indices)
+        projected = self.verifier_lm_head(self.verifier_norm(selected))
+        targets = projected.new_zeros(
+            hidden_states.shape[0], hidden_states.shape[1], projected.shape[-1]
+        )
+        return targets.index_copy_(1, indices, projected)
+
     @conditional_torch_compile
     def forward(  # noqa: C901
         self,
@@ -248,8 +275,8 @@ class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
         return_loss = verifier_last_hidden_states is not None
         if return_loss:
             with torch.no_grad():
-                targets = self.verifier_lm_head(
-                    self.verifier_norm(verifier_last_hidden_states)
+                targets = self._compute_training_targets(
+                    verifier_last_hidden_states, loss_mask, ttt_steps
                 )
                 # shape: [1, total_seq_len, draft_vocab_size]
             loss = torch.tensor(0.0, device=device)

--- a/tests/integration/models/test_eagle3_target_projection.py
+++ b/tests/integration/models/test_eagle3_target_projection.py
@@ -1,0 +1,124 @@
+"""Teacher row selection must preserve loss and cross-depth accuracy history."""
+
+from types import MethodType
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from speculators.losses import eager
+from speculators.models.eagle3.metrics import compute_metrics
+from tests.integration.conftest import make_eagle3_model
+
+
+@pytest.mark.parametrize(
+    "mask_bits",
+    [[0, 1, 0, 0, 0, 1, 0, 0, 0, 1], [0] * 6 + [1] * 4, [1] * 10, [0] * 10, None],
+    ids=["sparse", "suffix", "all", "empty", "none"],
+)
+@pytest.mark.parametrize("depth", [1, 3, 4])
+@pytest.mark.parametrize(
+    "loss_name",
+    [
+        "kl_div_loss",
+        "reverse_kl_div_loss",
+        "js_div_loss",
+        "ce_loss",
+        "tv_loss",
+        "neg_log_acceptance_loss",
+        "lk_hybrid_loss",
+    ],
+)
+def test_teacher_projection_preserves_training(mask_bits, depth, loss_name):
+    torch.manual_seed(17)
+    model = make_eagle3_model(
+        device="cpu", dtype=torch.float32, draft_attn_impl="eager"
+    )
+    seq = 10
+    mask = (
+        torch.tensor([mask_bits], dtype=torch.bool) if mask_bits is not None else None
+    )
+    teacher_hs = torch.randn(1, seq, 64)
+    # Independent oracle: enumerate every teacher row inspected by a chain
+    # whose initial prev_correct is true, across all requested depths.
+    required = set()
+    for row in range(seq):
+        if mask is None or mask[0, row]:
+            required.update(range(row, min(seq, row + depth)))
+    with patch.object(
+        model.verifier_lm_head, "forward", wraps=model.verifier_lm_head.forward
+    ) as head:
+        selected = model._compute_training_targets(teacher_hs, mask, depth)
+    assert head.call_args.args[0].shape[1] == len(required)
+    dense = model.verifier_lm_head(model.verifier_norm(teacher_hs))
+    torch.testing.assert_close(
+        selected[:, sorted(required)], dense[:, sorted(required)]
+    )
+
+    inputs = {
+        "hidden_states": torch.randn(1, seq, 192),
+        "input_ids": torch.randint(0, 128, (1, seq)),
+        "document_ids": torch.tensor([[0] * 5 + [1] * 5]),
+        "verifier_last_hidden_states": teacher_hs,
+        "loss_mask": mask,
+        "ttt_steps": depth,
+        "loss_config": {loss_name: (getattr(eager, loss_name), 1.0)},
+    }
+
+    def dense_targets(self, hidden, _mask, _depth):
+        return self.verifier_lm_head(self.verifier_norm(hidden))
+
+    outputs, grads = [], []
+    with torch.compiler.set_stance("force_eager"):
+        for use_dense in [True, False]:
+            model.zero_grad(set_to_none=True)
+            if use_dense:
+                with patch.object(
+                    model, "_compute_training_targets", MethodType(dense_targets, model)
+                ):
+                    output = model(**inputs)
+            else:
+                output = model(**inputs)
+            output[1].backward()
+            outputs.append(output)
+            grads.append(
+                {
+                    n: p.grad.clone()
+                    for n, p in model.named_parameters()
+                    if p.grad is not None
+                }
+            )
+    torch.testing.assert_close(outputs[0], outputs[1])
+    assert grads[0].keys() == grads[1].keys()
+    for name in grads[0]:
+        torch.testing.assert_close(grads[0][name], grads[1][name])
+
+
+def test_mask_only_projection_changes_accuracy_history():
+    # Row 1 has no loss, but chain 0 reads it at depth 1. Replacing its
+    # argmax changes the metrics when that chain reaches supervised row 2.
+    mask = torch.tensor([[True, False, True]])
+    logits = torch.tensor([[[0.0, 2.0]] * 3], requires_grad=True)
+    targets = logits.detach().clone()
+    masked_targets = targets.clone()
+    masked_targets[:, 1] = 0
+    runs = []
+    for teacher in [targets, masked_targets]:
+        previous = mask.clone()
+        runs.append(
+            [
+                compute_metrics(
+                    logits,
+                    teacher,
+                    mask,
+                    previous,
+                    step,
+                    1.0,
+                    loss_config={"kl_div": (eager.kl_div_loss, 1.0)},
+                )
+                for step in range(3)
+            ]
+        )
+    for original, masked in zip(*runs, strict=True):
+        torch.testing.assert_close(original[0], masked[0])
+    assert runs[0][2][1]["cond_acc_2_sum"] != runs[1][2][1]["cond_acc_2_sum"]


### PR DESCRIPTION
EAGLE3 currently normalizes/projects every verifier hidden row before applying the loss mask. This draft projects only the rows required by the loss and the existing cross-depth accuracy history, then scatters into the unchanged dense targets layout. The draft backbone, draft logits/tokens, and metric definitions are unchanged.

**Draft because the performance benefit is workload-dependent:** contiguous prompt/response masks benefit, but dense masks and some short dispersed masks regress. This is not yet a recommendation to enable the change for every workload.

The important correctness constraint is that `loss_mask` alone is insufficient. `prev_correct` begins at supervised draft starts and compares start r against teacher row r+t at depth t, including masked intermediate targets. Keep the union of those positions for t in [0, ttt_steps). A three-position [1,0,1] regression test shows that zeroing masked targets alone preserves loss but changes later accuracy counts. The implementation preserves that existing behavior rather than changing metrics as part of a performance patch. With no mask or all rows needed, it retains dense projection (the latter still pays mask-analysis overhead).

Validation on base `3419401a380db305ed6493ba4680ad8a3c3e0e45`:

- `CUDA_VISIBLE_DEVICES='' python -m pytest tests/integration/models/test_eagle3_target_projection.py -q -o addopts=''`: **106 passed**. Seven built-in eager losses, five mask layouts, depths 1/3/4, packed documents; real model loss, complete output metrics, draft tokens, and parameter gradients compared against dense teacher projection. Includes the mask-only negative control.
- `CUDA_VISIBLE_DEVICES=2 python -m pytest tests/integration/models/test_eagle3_target_projection.py tests/integration/models/test_model_forward.py -k 'eagle3 or Eagle3' -q -o addopts=''`: **50 passed, 100 deselected**, before expanding the new loss parameterization from KL to all seven losses. Includes existing compiled CUDA EAGLE3 forward/backward and attention-backend checks.
- `CUDA_VISIBLE_DEVICES='' python -m pytest tests/unit/models/test_metrics.py tests/unit/models/test_eagle3_attention.py -q -o addopts=''`: **46 passed**.
- Repository-pinned Ruff 0.15.20 check/format and `git diff --check` passed for changed files.

Benchmark scope: **teacher norm/projection/selection/scatter only**, not complete training. RTX 6000 Ada; PyTorch 2.11.0+cu130; BF16; B=1, H=1024, V=32768, TTT=7. Each arm wrapped with `torch.compile`, three warmup calls, four alternating AB/BA pairs, five calls per arm, synchronized host wall timing without profiler. Compilation is outside timing. Dense zero-filled targets remain allocated. All required-row logits were bit-identical in these sampled eager BF16 checks and argmax agreed; this is not a universal bitwise-equivalence claim.

| Rows | Layout | Supervised rows | Retained teacher rows | Baseline ms | Candidate ms | Time change / baseline |
|---|---|---|---|---|---|---|
| 2048 | suffix | 204 | 204 | 0.687 | 0.412 | -39.99% |
| 2048 | dispersed | 204 | 1025 | 0.803 | 0.832 | +3.60% |
| 2048 | all | 2048 | 2048 | 0.685 | 0.740 | +8.02% |
| 2048 | empty | 0 | 0 | 0.691 | 0.237 | -65.73% |
| 8192 | suffix | 819 | 819 | 2.792 | 1.049 | -62.41% |
| 8192 | dispersed | 819 | 4183 | 3.320 | 3.177 | -4.31% |
| 8192 | all | 8192 | 8192 | 3.701 | 3.983 | +7.62% |
| 8192 | empty | 0 | 0 | 2.748 | 0.701 | -74.50% |

The mask's future-position union explains why ~10% dispersed supervision can require ~50% of teacher rows. Nonzero/dynamic selection adds synchronization and compiled graph boundaries, so the full-mask fallback is not free. Eager function measurements also showed a short dispersed-mask slowdown (~13%). Full training throughput, distributed training, and serving/quality metrics have not been measured.

Related: #1088 replaces the metrics contract; if it lands first, the required-row rule and its tests need to be revisited. This PR targets current main and does not duplicate the metric-definition changes in #1088, #624, or #902.

<details>
<summary>Reproduce the function-only benchmark from the PR checkout</summary>

Save as a Python file and run with the desired `CUDA_VISIBLE_DEVICES`. It writes timing JSON, environment/base identity, and a working-tree patch into `teacher-projection-benchmark/`. The PR diff supplies the committed patch.

```python
import json
import platform
import subprocess
import time
from pathlib import Path
import torch
from speculators.models.eagle3.core import Eagle3DraftModel

root=Path('teacher-projection-benchmark')
root.mkdir(exist_ok=True)
repo=Path.cwd()
class Head(torch.nn.Module):
    _compute_training_targets=Eagle3DraftModel._compute_training_targets
    def __init__(self):
        super().__init__()
        self.verifier_norm=torch.nn.RMSNorm(1024)
        self.verifier_lm_head=torch.nn.Linear(1024,32768,bias=False)
    def dense(self,h,m,t):
        return self.verifier_lm_head(self.verifier_norm(h))

provenance={'base':subprocess.check_output(['git','rev-parse','HEAD'],cwd=repo,text=True).strip(),'torch':torch.__version__,'gpu':torch.cuda.get_device_name(),'python':platform.python_version(),'scope':'torch.compile teacher norm/projection/gather/scatter function only; no complete training throughput','warmup':3,'pairs':4,'iterations_per_arm':5,'dtype':'bfloat16','H':1024,'V':32768,'depth':7}
(root/'provenance.json').write_text(json.dumps(provenance,indent=2))
(root/'speculators.patch').write_bytes(subprocess.check_output(['git','diff'],cwd=repo))
torch.manual_seed(42)
head=Head().cuda().bfloat16();results=[]
with torch.no_grad():
 for seq in [2048,8192]:
  h=torch.randn(1,seq,1024,device='cuda',dtype=torch.bfloat16)
  for layout in ['suffix','dispersed','all','empty']:
   mask=torch.zeros(1,seq,device='cuda',dtype=torch.bool)
   if layout=='suffix':mask[:,-int(seq*0.1):]=True
   if layout=='dispersed':mask[:,torch.randperm(seq,device='cuda')[:int(seq*0.1)]]=True
   if layout=='all':mask[:]=True
   needed=mask.clone()
   for t in range(1,7):needed[:,t:] |= mask[:,:-t]
   a=head.dense(h,mask,7);b=head._compute_training_targets(h,mask,7)
   av=a[needed];bv=b[needed];relative=float(torch.linalg.vector_norm(av.float()-bv.float())/torch.linalg.vector_norm(av.float()).clamp_min(1e-20))
   torch.testing.assert_close(av,bv,atol=0.02,rtol=0.02)
   assert torch.equal(av.argmax(-1),bv.argmax(-1))
   del a,b,av,bv
   torch.compiler.reset()
   funcs={'baseline':torch.compile(head.dense),'candidate':torch.compile(head._compute_training_targets)}
   for fn in funcs.values():
    for _ in range(3):fn(h,mask,7)
   measurements=[]
   for pair in range(4):
    for arm in (['baseline','candidate'] if pair%2==0 else ['candidate','baseline']):
     torch.cuda.synchronize();torch.cuda.reset_peak_memory_stats();start=time.perf_counter()
     for _ in range(5):out=funcs[arm](h,mask,7);del out
     torch.cuda.synchronize()
     measurements.append({'pair':pair,'arm':arm,'ms':(time.perf_counter()-start)*1000/5,'peak_allocated':torch.cuda.max_memory_allocated()})
   row={'seq':seq,'layout':layout,'loss_rows':int(mask.sum()),'required_rows':int(needed.sum()),'relative_L2':relative,'measurements':measurements};results.append(row)
   (root/'benchmark.json').write_text(json.dumps(results,indent=2))
   print({k:v for k,v in row.items() if k!='measurements'}, {a:sum(v['ms'] for v in measurements if v['arm']==a)/4 for a in funcs},flush=True)

```

</details>
