### PR TITLE
fix(eval): sum per-position acceptance counters across engines

### DIFF
--- a/scripts/evaluate/perf_utils.py
+++ b/scripts/evaluate/perf_utils.py
@@ -301,7 +301,7 @@ def parse_prometheus_metrics(raw_text: str) -> list[Metric]:
         pos_values.sort()
         values = [0.0] * (pos_values[-1][0] + 1)
         for pos, val in pos_values:
-            values[pos] = val
+            values[pos] += val
         metrics.append(Vector(name=name, values=values))
 
     return metrics

--- a/tests/unit/scripts/test_perf_utils.py
+++ b/tests/unit/scripts/test_perf_utils.py
@@ -42,8 +42,88 @@ def perf_utils():
 
 
 # ---------------------------------------------------------------------------
+# Prometheus metrics aggregation
+# ---------------------------------------------------------------------------
+
+
+def _engine_metrics(engine: int, drafts: int, counts: list[int]) -> str:
+    """Build one engine's consistent cumulative speculative counters."""
+    prefix = "vllm:spec_decode_"
+    labels = f'engine="{engine}"'
+    rows = [
+        f"{prefix}num_drafts_total{{{labels}}} {drafts}",
+        f"{prefix}num_draft_tokens_total{{{labels}}} {drafts * len(counts)}",
+        f"{prefix}num_accepted_tokens_total{{{labels}}} {sum(counts)}",
+    ]
+    rows.extend(
+        f"{prefix}num_accepted_tokens_per_pos_total"
+        f'{{{labels},position="{pos}"}} {value}'
+        for pos, value in enumerate(counts)
+    )
+    return "\n".join(rows)
+
+
+@pytest.mark.parametrize("engines", [1, 2])
+@pytest.mark.parametrize("reverse", [False, True])
+def test_per_position_metrics_sum_engines(perf_utils, engines, reverse):
+    """All positions use the same engine aggregation as the scalar counters."""
+    text = _engine_metrics(0, 10, [8, 4])
+    if engines == 2:
+        text += "\n" + _engine_metrics(1, 20, [18, 6])
+    if reverse:
+        text = "\n".join(reversed(text.splitlines()))
+    result = perf_utils.extract_spec_decode_metrics(
+        perf_utils.parse_prometheus_metrics(text)
+    )
+    drafts = 10 if engines == 1 else 30
+    counts = [8, 4] if engines == 1 else [26, 10]
+    assert result["num_drafts"] == drafts
+    assert result["num_accepted_tokens"] == sum(counts)
+    for pos, count in enumerate(counts):
+        assert result[f"acceptance_at_pos_{pos}"] == pytest.approx(count / drafts)
+    assert result["acceptance_length"] == pytest.approx(
+        1 + sum(result[f"acceptance_at_pos_{pos}"] for pos in range(len(counts)))
+    )
+
+
+def test_per_position_metrics_sum_before_baseline_subtraction(perf_utils):
+    """Subtract aggregate snapshots rather than the largest engine samples."""
+    baseline = _engine_metrics(0, 10, [8, 4]) + "\n" + _engine_metrics(1, 20, [18, 6])
+    current = _engine_metrics(0, 20, [17, 9]) + "\n" + _engine_metrics(1, 30, [27, 10])
+    result = perf_utils.extract_spec_decode_metrics(
+        perf_utils.parse_prometheus_metrics(current),
+        perf_utils.parse_prometheus_metrics(baseline),
+    )
+    assert result["num_drafts"] == 20
+    assert result["num_accepted_tokens"] == 27
+    assert result["acceptance_at_pos_0"] == pytest.approx(18 / 20)
+    assert result["acceptance_at_pos_1"] == pytest.approx(9 / 20)
+    assert result["acceptance_length"] == pytest.approx(1 + 27 / 20)
+
+
+# ---------------------------------------------------------------------------
 # parse_gen_kwargs
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("drafts", [0, 10])
+def test_per_position_metrics_keep_sparse_positions(perf_utils, drafts):
+    """Missing positions stay zero while duplicate series are aggregated."""
+    text = f"vllm:spec_decode_num_drafts_total {drafts}\n" + "\n".join(
+        [
+            "vllm:spec_decode_num_accepted_tokens_per_pos_total"
+            '{engine="0",position="2"} 3',
+            "vllm:spec_decode_num_accepted_tokens_per_pos_total"
+            '{position="2",engine="1"} 4',
+        ]
+    )
+    metrics = perf_utils.parse_prometheus_metrics(text)
+    vector = next(metric for metric in metrics if isinstance(metric, perf_utils.Vector))
+    assert vector.values == [0.0, 0.0, 7.0]
+    result = perf_utils.extract_spec_decode_metrics(metrics)
+    assert result["acceptance_at_pos_0"] == 0
+    assert result["acceptance_at_pos_1"] == 0
+    assert result["acceptance_at_pos_2"] == pytest.approx(7 / drafts if drafts else 0)
 
 
 class TestParseGenKwargs:


### PR DESCRIPTION
## Purpose

Fixes #1095.

Sum per-position speculative acceptance counters across engine-labeled
Prometheus series, consistently with the existing scalar-counter aggregation.
Previously the parser sorted `(position, value)` pairs and overwrote each
position, retaining the largest engine value rather than the total. Dividing
that value by the aggregate draft count underestimates per-position acceptance.

For example, engine counts of 8 and 18 with draft counts of 10 and 20 should
produce `26 / 30`, not `18 / 30`. The production change replaces assignment
with addition; extraction formulas and single-engine behavior are unchanged.

## Tests

Tested source base: `3419401a380db305ed6493ba4680ad8a3c3e0e45`, with the two-file
patch, on Linux CPU / Python 3.12. Locally built Speculators and hs-connectors
were installed into an isolated target directory without changing the shared
runtime's packages.

```sh
PYTHONPATH=/tmp/speculators-1095.Fcs78o/installed \
  /home/minimind/codex-builds/omni-benchmark.jyMJ1k/venv/bin/python \
  -m pytest tests/unit/scripts -q --tb=short -o addopts= --maxfail=1
```

- 164 passed, 19 warnings, including all 31 tests in `test_perf_utils.py`.
- Added single-engine controls, unequal two-engine counters, reversed scrape
  order, aggregate snapshot subtraction, sparse positions and zero drafts.
- Before the production fix, the initial regression batch produced 3 failures
  and 26 passes; the same batch passed after the fix. Two boundary cases were
  subsequently added.
- Pinned Ruff 0.15.20 lint and formatting checks passed on both changed files.
- Targeted Mypy 2.1.0 passed with import following skipped. **Full configured
  Mypy and `make quality` are not passing validation claims**: both the patched
  and clean-base runs stopped on missing dependency stubs and an installed
  librosa syntax-parsing error. Full checking did not complete.
  A supplemental Python-3.12 checker/target run completed traversal on both
  trees with the same 15 diagnostics in 12 files (missing stubs, hs_connectors
  exports, and an attention Tensor/tuple type mismatch). This does not replace
  the configured Python-3.10 gate or establish full type correctness.

**September 8 follow-up on signed head `2cfe086`:** after isolating
`types-tqdm==4.70.0.20260906`, `types-PyYAML==6.0.12.20260906` and
`librosa==0.11.0` in a separate dependency target, configured Mypy 2.1.0 with
`--check-untyped-defs` and the original Python-3.10 target completed all
**220 selected source files**. It reports one error in unchanged
`src/speculators/models/attention.py:64` (Torch flex_attention's Tensor/tuple
return annotation). The clean base completed 219 files with the identical
single diagnostic. This supersedes the earlier incomplete traversal in this
explicit diagnostic environment, not the earlier environment or the
non-passing full gate. No source edits, ignore rules, shared-environment package
replacements or new signatures were made. Full `make quality` is still not a
passing claim.

This validates CPU metric parsing and extraction, not the reported live
multi-GPU vLLM workload. No throughput or model-quality improvement is claimed.
The complete repository test suite was not run.

AI assistance: Codex assisted with implementation and local verification.

## Checklist

- [x] The purpose of the PR, including the related issue.
- [x] The test plan/results and validation limitations.
- [ ] (Optional) The necessary documentation update. No public API changes.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
