### PR TITLE
fix(train): restore signal handlers on every exit from the decorator

### DIFF
--- a/src/speculators/train/graceful_shutdown.py
+++ b/src/speculators/train/graceful_shutdown.py
@@ -52,25 +52,46 @@ class GracefulShutdownHandler:
         self._original_sigterm: Any = None
         self._timeout = timeout
         self._owner_pid: int | None = None
+        self._installed = False
 
     def install(self):
-        """Register signal handlers for SIGINT and SIGTERM."""
+        """Register signal handlers for SIGINT and SIGTERM.
+
+        Idempotent: a second call while already installed would capture this
+        handler as the "original" and restore() would then reinstall it.
+        """
+        if self._installed:
+            return
         self._owner_pid = os.getpid()
         self._original_sigint = signal.getsignal(signal.SIGINT)
         self._original_sigterm = signal.getsignal(signal.SIGTERM)
         signal.signal(signal.SIGINT, self._handler)
         signal.signal(signal.SIGTERM, self._handler)
+        self._installed = True
 
     def restore(self):
-        """Restore original signal handlers.
+        """Restore the handlers that were active before install().
 
         Called before the checkpoint save attempt so that a deliberate
-        second Ctrl+C during the save causes immediate exit.
+        second Ctrl+C during the save causes immediate exit, and again from
+        the decorator's finally block so the handlers never outlive the call.
+
+        Idempotent, which is what makes calling it from both places safe: the
+        second call must not undo a handler installed in between, such as one
+        set up by maybe_save_checkpoint().
         """
-        if self._original_sigint is not None:
-            signal.signal(signal.SIGINT, self._original_sigint)
-        if self._original_sigterm is not None:
-            signal.signal(signal.SIGTERM, self._original_sigterm)
+        if not self._installed:
+            return
+        # getsignal() returns None when the previous handler was not set from
+        # Python. There is nothing to put back in that case, and leaving this
+        # handler installed is the bug being fixed, so fall back to the default.
+        sigint = self._original_sigint
+        sigterm = self._original_sigterm
+        signal.signal(signal.SIGINT, sigint if sigint is not None else signal.SIG_DFL)
+        signal.signal(
+            signal.SIGTERM, sigterm if sigterm is not None else signal.SIG_DFL
+        )
+        self._installed = False
 
     def _handler(self, signum, frame):  # noqa: ARG002
         # Only handle in the process that installed the handler.
@@ -145,6 +166,13 @@ def with_graceful_shutdown(
                     logger.exception("Failed to save interrupt checkpoint")
                 finally:
                     timer.cancel()
+            finally:
+                # The except branch above restores before the save, but a normal
+                # return or an unrelated exception never reached it, so this
+                # call's handlers stayed installed after it finished. In a
+                # longer-lived process a later interrupt then entered a handler
+                # belonging to a training run that had already ended.
+                handler.restore()
 
         return wrapper
 

--- a/tests/unit/train/test_graceful_shutdown.py
+++ b/tests/unit/train/test_graceful_shutdown.py
@@ -1,0 +1,147 @@
+"""The graceful-shutdown decorator must not leave its handlers installed.
+
+`with_graceful_shutdown()` installs SIGINT/SIGTERM handlers for the duration of
+one training call. It used to restore them only when it caught
+`TrainingInterruptedError`, so a normal return or an unrelated exception left
+this call's handlers in place. In a longer-lived process a later interrupt then
+entered a handler belonging to a training run that had already finished.
+"""
+
+import signal
+from pathlib import Path
+
+import pytest
+
+from speculators.train.graceful_shutdown import (
+    GracefulShutdownHandler,
+    TrainingInterruptedError,
+    with_graceful_shutdown,
+)
+
+
+@pytest.fixture
+def original_handlers():
+    """Snapshot the process handlers and put them back afterwards."""
+    signals = (signal.SIGINT, signal.SIGTERM)
+    before = {sig: signal.getsignal(sig) for sig in signals}
+    yield before
+    for sig, handler in before.items():
+        signal.signal(sig, handler)
+
+
+def _installed(before):
+    """True when the process handlers are the ones from before the call."""
+    return all(signal.getsignal(sig) == handler for sig, handler in before.items())
+
+
+class _Checkpointer:
+    path = Path()
+
+
+class _Trainer:
+    def __init__(self):
+        self.checkpointer = _Checkpointer()
+        self.saved = []
+
+    def maybe_save_checkpoint(self, label):
+        self.saved.append(label)
+
+
+def test_handlers_are_restored_after_a_normal_return(original_handlers):
+    @with_graceful_shutdown()
+    def train(self):
+        # The handlers are this call's while it runs; that part already worked.
+        assert not _installed(original_handlers)
+        return "finished"
+
+    assert train(_Trainer()) == "finished"
+    assert _installed(original_handlers), "handlers outlived a successful call"
+
+
+def test_handlers_are_restored_after_an_unrelated_exception(original_handlers):
+    @with_graceful_shutdown()
+    def train(self):
+        raise ValueError("unrelated")
+
+    with pytest.raises(ValueError, match="unrelated"):
+        train(_Trainer())
+    assert _installed(original_handlers), "handlers outlived a failed call"
+
+
+def test_handlers_are_restored_after_an_interruption(original_handlers):
+    """The path that already restored must keep doing so."""
+
+    @with_graceful_shutdown()
+    def train(self):
+        raise TrainingInterruptedError("SIGINT")
+
+    trainer = _Trainer()
+    train(trainer)
+    assert trainer.saved == ["interrupted"], "the checkpoint save no longer runs"
+    assert _installed(original_handlers)
+
+
+def test_handlers_are_restored_when_the_checkpoint_save_itself_fails(original_handlers):
+    """A save failure is caught and logged, and must not strand the handlers."""
+
+    class Failing(_Trainer):
+        def maybe_save_checkpoint(self, label):
+            raise RuntimeError("disk full")
+
+    @with_graceful_shutdown()
+    def train(self):
+        raise TrainingInterruptedError("SIGTERM")
+
+    train(Failing())
+    assert _installed(original_handlers)
+
+
+def test_nested_calls_unwind_to_the_original_handlers(original_handlers):
+    """Repeated and nested decorated calls must not capture stale handlers."""
+
+    @with_graceful_shutdown()
+    def inner(self):
+        return "inner"
+
+    @with_graceful_shutdown()
+    def outer(self):
+        outer_handlers = {
+            sig: signal.getsignal(sig) for sig in (signal.SIGINT, signal.SIGTERM)
+        }
+        assert inner(self) == "inner"
+        # The inner call restores what it found, which is the outer call's.
+        for sig, handler in outer_handlers.items():
+            assert signal.getsignal(sig) == handler
+        return "outer"
+
+    assert outer(_Trainer()) == "outer"
+    assert _installed(original_handlers)
+
+    # And running the same decorated function twice ends where it started.
+    assert inner(_Trainer()) == "inner"
+    assert _installed(original_handlers)
+
+
+def test_restore_is_idempotent(original_handlers):
+    """The decorator restores in both the except branch and the finally block,
+    so a second restore must not undo a handler installed in between."""
+    handler = GracefulShutdownHandler()
+    handler.install()
+    handler.restore()
+    assert _installed(original_handlers)
+
+    def someone_elses_handler(signum, frame):
+        raise AssertionError("never called")
+
+    signal.signal(signal.SIGINT, someone_elses_handler)
+    handler.restore()
+    assert signal.getsignal(signal.SIGINT) is someone_elses_handler
+
+
+def test_install_is_idempotent(original_handlers):
+    """A second install() must not capture this handler as the original."""
+    handler = GracefulShutdownHandler()
+    handler.install()
+    handler.install()
+    handler.restore()
+    assert _installed(original_handlers)


### PR DESCRIPTION
Closes #1089.

Reproduced with the script from the issue, on `origin/main`:

```
return value: finished
handler restored? {'SIGINT': False, 'SIGTERM': False}
```

`restore()` was reachable only from the `except TrainingInterruptedError` branch, so a normal return or an unrelated exception left the call's handlers installed.

## The change

A `finally` block, so every exit path restores. The `except` branch keeps its own `restore()` — that one has to happen *before* the checkpoint save, so a deliberate second Ctrl+C during the save still forces exit.

That makes `restore()` run twice on the interrupted path, which pulls in two related fixes the issue also points at with "repeated/nested decorated calls can also capture and restore stale handlers":

- **`restore()` is idempotent.** Without it, the second call would undo a handler installed in between — for instance one set up by `maybe_save_checkpoint()`.
- **`install()` is idempotent**, for the mirror-image reason: a second `install()` while already installed would capture *this* handler as the "original", and `restore()` would then put it back rather than remove it.

One more thing found while writing the fix: `restore()` skipped a signal whose original handler was `None`, which `getsignal()` returns when the previous handler was not set from Python. There is nothing to put back in that case, and leaving this handler installed is precisely the bug, so it now falls back to `SIG_DFL`.

## Verification

Seven cases, run against the branch and against `origin/main`:

```
                          with fix    on main
normal return             PASS        FAIL: handlers outlived a successful call
unrelated exception       PASS        FAIL: handlers outlived a failed call
interruption              PASS        PASS
save fails                PASS        PASS
nested calls              PASS        FAIL
restore idempotent        PASS        FAIL
install idempotent        PASS        FAIL
```

The two that pass on `main` are the interruption paths, which already restored — which is the right control, since this must not change them. `interruption` also asserts the checkpoint save still runs (`saved == ["interrupted"]`).

`ruff` 0.15.20 (the pin in `pyproject.toml`) check and format: clean.

### A note on how I ran them

`tests/unit/train/test_graceful_shutdown.py` imports `speculators.train.graceful_shutdown` normally, which is right for CI. It cannot execute on Windows, because importing the package pulls in `hs_connectors.transfer`, which does `import fcntl`:

```
hs_connectors/src/hs_connectors/transfer.py:6: in <module>
    import fcntl
E   ModuleNotFoundError: No module named 'fcntl'
```

That is pre-existing and not specific to this change — `tests/unit/train/test_logger.py` and plain `import speculators` fail the same way here. So I ran the seven test bodies against a directly-loaded module via `runpy.run_path`, the same technique the issue used to avoid unrelated package initialization, which is where the table above comes from. On Linux CI the committed test runs as written.