### PR TITLE
add chunk loss for dspark

### DIFF
--- a/src/speculators/models/dspark/core.py
+++ b/src/speculators/models/dspark/core.py
@@ -106,6 +106,7 @@ class DSparkDraftModel(DFlashDraftModel):
             "per_position_loss_weight", "fixed-exp-decay"
         )
         dpace_alpha = kwargs.get("dpace_alpha", 0.5)
+        anchor_chunk_size = kwargs.get("anchor_chunk_size", 0)
         shared = {
             "loss_config": loss_config,
             "tv_loss_fn": tv_loss_fn,
@@ -114,6 +115,7 @@ class DSparkDraftModel(DFlashDraftModel):
             "confidence_head_alpha": confidence_head_alpha,
             "per_position_loss_weight": per_position_loss_weight,
             "dpace_alpha": dpace_alpha,
+            "anchor_chunk_size": anchor_chunk_size,
         }
         return dict(shared), dict(shared)
 
@@ -133,6 +135,7 @@ class DSparkDraftModel(DFlashDraftModel):
         confidence_head_alpha: float = 1.0,
         per_position_loss_weight: str = "fixed-exp-decay",
         dpace_alpha: float = 0.5,
+        anchor_chunk_size: int = 0,
         **kwargs,
     ):
         hidden, logits, targets, aligned_loss_mask, anchored_block_indices = (
@@ -208,5 +211,6 @@ class DSparkDraftModel(DFlashDraftModel):
             per_position_loss_weight=per_position_loss_weight,
             dpace_alpha=dpace_alpha,
             sample_from_anchor=self.config.sample_from_anchor,
+            anchor_chunk_size=anchor_chunk_size,
         )
         return None, loss, metrics

--- a/src/speculators/models/dspark/metrics.py
+++ b/src/speculators/models/dspark/metrics.py
@@ -23,6 +23,7 @@ from speculators.losses import (
     compound_loss,
     dflash_loss_decay,
     dpace_loss_decay,
+    loss_function,
     tv_loss,
 )
 from speculators.models.metrics import (
@@ -35,6 +36,92 @@ __all__ = [
 ]
 
 _EPS = 1e-8
+
+
+@torch.compiler.disable
+def _chunked_accept_rate(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    block_size: int,
+    anchor_chunk_size: int = 64,
+    tv_loss_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] = tv_loss,
+) -> torch.Tensor:
+    """Per-position acceptance rate computed in anchor chunks.
+
+    Numerically identical to::
+
+        accept_rate = 1.0 - tv_loss_fn(logits, targets)
+
+    but processes *anchor_chunk_size* anchors at a time to bound peak memory.
+    Each chunk's loss function (e.g. tv_loss) operates per-position along the
+    vocab dimension, so chunking along the sequence dimension has zero
+    precision impact.
+
+    Inspired by DeepSpec's ``chunked_gather_target_hidden`` which uses the
+    same ``anchor_chunk_size`` pattern with ``@torch.compiler.disable``.
+    """
+    chunk_tokens = anchor_chunk_size * block_size
+    parts: list[torch.Tensor] = []
+    for i in range(0, logits.shape[1], chunk_tokens):
+        end = min(i + chunk_tokens, logits.shape[1])
+        ar = 1.0 - tv_loss_fn(logits[:, i:end], targets[:, i:end])
+        parts.append(ar)
+    return torch.cat(parts, dim=1)
+
+
+@torch.compiler.disable
+def _chunked_compound_loss(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    loss_mask: torch.Tensor,
+    pos_idx: torch.Tensor,
+    loss_config: LossConfig,
+    decay_fn: Callable[..., torch.Tensor] | None,
+    block_size: int,
+    anchor_chunk_size: int = 64,
+) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+    """Compute compound loss in anchor chunks to bound forward and backward peak memory.
+
+    Numerically identical to ``compound_loss(logits, targets, ...)`` but processes
+    *anchor_chunk_size* anchors at a time. Each chunk's loss function (e.g. tv_loss)
+    creates [1, chunk_tokens, vocab] fp32 intermediates instead of [1, Q, vocab],
+    reducing both forward and backward peak memory.
+
+    The weighted average is preserved: each chunk's contribution is weighted by
+    its mask proportion, so the result equals the full computation.
+    """
+    chunk_tokens = anchor_chunk_size * block_size
+    total = torch.tensor(0.0, device=logits.device, dtype=torch.float32)
+    term_losses: dict[str, torch.Tensor] = {}
+    multi = len(loss_config) > 1
+    total_mask = loss_mask.sum().clamp_min(_EPS)
+
+    for i in range(0, logits.shape[1], chunk_tokens):
+        end = min(i + chunk_tokens, logits.shape[1])
+        chunk_logits = logits[:, i:end, :]
+        chunk_targets = targets[:, i:end, :]
+        chunk_mask = loss_mask[:, i:end]
+        chunk_pos = pos_idx[:, i:end]
+        chunk_weight = chunk_mask.sum() / total_mask
+
+        for name, (fn, weight) in loss_config.items():
+            term = loss_function(
+                chunk_logits,
+                chunk_targets,
+                chunk_mask,
+                chunk_pos,
+                loss_fn=fn,
+                decay_fn=decay_fn,
+            )
+            if multi:
+                key = f"{name}_loss"
+                if key not in term_losses:
+                    term_losses[key] = (term * chunk_weight).detach()
+                else:
+                    term_losses[key] = term_losses[key] + (term * chunk_weight).detach()
+            total = total + weight * term * chunk_weight
+
+    return total, term_losses
 
 
 def _masked_decayed_mean(
@@ -67,8 +154,14 @@ def compute_metrics(
     per_position_loss_weight: str = "fixed-exp-decay",
     dpace_alpha: float = 0.5,
     sample_from_anchor: bool = True,
+    anchor_chunk_size: int = 0,
 ) -> tuple[torch.Tensor, dict]:
-    """Compute the DSpark loss and a metrics dict (``*_sum``/``*_total`` pairs)."""
+    """Compute the DSpark loss and a metrics dict (``*_sum``/``*_total`` pairs).
+
+    Args:
+        anchor_chunk_size: Number of anchors per chunk for memory-efficient
+            computation. 0 disables chunking (uses full computation).
+    """
 
     device = logits.device
     seq_len = logits.shape[1]
@@ -86,14 +179,28 @@ def compute_metrics(
             dflash_loss_decay, gamma=gamma, sample_from_anchor=sample_from_anchor
         )
 
-    loss, term_losses = compound_loss(
-        logits, targets, loss_mask, pos_idx, loss_config=loss_config, decay_fn=decay_fn
-    )
+    if anchor_chunk_size > 0:
+        loss, term_losses = _chunked_compound_loss(
+            logits, targets, loss_mask, pos_idx,
+            loss_config=loss_config, decay_fn=decay_fn,
+            block_size=block_size, anchor_chunk_size=anchor_chunk_size,
+        )
+    else:
+        loss, term_losses = compound_loss(
+            logits, targets, loss_mask, pos_idx,
+            loss_config=loss_config, decay_fn=decay_fn,
+        )
 
     # Analytical per-position acceptance rate = distributional overlap
     # = 1 - TV; the fused kernel avoids the two full-vocab fp32 softmaxes.
     with torch.no_grad():
-        accept_rate = 1.0 - tv_loss_fn(logits, targets)  # [1, T]
+        if anchor_chunk_size > 0:
+            accept_rate = _chunked_accept_rate(
+                logits, targets, block_size,
+                anchor_chunk_size=anchor_chunk_size, tv_loss_fn=tv_loss_fn,
+            )
+        else:
+            accept_rate = 1.0 - tv_loss_fn(logits, targets)  # [1, T]
         # Per-block cumulative acceptance product over the draft slots (slot 0
         # is the anchor), shared by the accept-length and calibration metrics.
         num_blocks = seq_len // block_size

--- a/src/speculators/train/config/schema.py
+++ b/src/speculators/train/config/schema.py
@@ -524,6 +524,14 @@ class DSparkArgs(_Group):
     confidence_head_alpha: float = Field(
         default=1.0, description="DSpark: weight of the confidence-head BCE term."
     )
+    anchor_chunk_size: int = Field(
+        default=0,
+        ge=0,
+        description="DSpark: chunk size (in anchors) for memory-efficient loss "
+        "and acceptance-rate computation in DSpark metrics. Processes this "
+        "many anchors at a time to bound peak memory. Set to 0 to disable "
+        "chunking (use full computation, higher memory). (default: 0)",
+    )
 
 
 class PEagleArgs(_Group):

--- a/tests/unit/models/test_dspark_metrics.py
+++ b/tests/unit/models/test_dspark_metrics.py
@@ -234,3 +234,103 @@ class TestComputeMetrics:
             assert key in metrics
         # all metric values must be tensors (so dist.reduce works in the trainer)
         assert all(torch.is_tensor(v) for v in metrics.values())
+
+    def test_chunked_loss_matches_non_chunked(self):
+        """anchor_chunk_size>0 produces the same loss as the full computation."""
+        torch.manual_seed(42)
+        logits = torch.randn(1, 8, 32, requires_grad=True)
+        targets = torch.randn(1, 8, 32)
+        loss_mask = torch.ones(1, 8, dtype=torch.float32)
+
+        loss_full, metrics_full = compute_metrics(
+            logits, targets, None, loss_mask, 2, loss_config=_DEFAULT_LOSS,
+        )
+        loss_chunked, metrics_chunked = compute_metrics(
+            logits, targets, None, loss_mask, 2, loss_config=_DEFAULT_LOSS,
+            anchor_chunk_size=2,
+        )
+        assert torch.allclose(loss_full, loss_chunked, atol=1e-4)
+        for key in metrics_full:
+            assert key in metrics_chunked, f"missing key {key} in chunked metrics"
+            assert torch.allclose(
+                metrics_full[key], metrics_chunked[key], atol=1e-4
+            ), f"mismatch for {key}"
+
+    def test_chunked_accept_rate_matches_non_chunked(self):
+        """Chunked accept_rate equals the full tv_loss_fn computation."""
+        torch.manual_seed(7)
+        logits = torch.randn(1, 12, 64) * 3
+        targets = torch.randn(1, 12, 64) * 3
+        loss_mask = torch.ones(1, 12, dtype=torch.float32)
+
+        _, metrics_full = compute_metrics(
+            logits, targets, None, loss_mask, 3, loss_config=_DEFAULT_LOSS,
+        )
+        _, metrics_chunked = compute_metrics(
+            logits, targets, None, loss_mask, 3, loss_config=_DEFAULT_LOSS,
+            anchor_chunk_size=2,
+        )
+        assert torch.allclose(
+            metrics_full["accept_rate_sum"], metrics_chunked["accept_rate_sum"],
+            atol=1e-5,
+        )
+        assert torch.allclose(
+            metrics_full["accept_len_sum"], metrics_chunked["accept_len_sum"],
+            atol=1e-4,
+        )
+
+    def test_chunked_with_confidence_head_matches(self):
+        """Chunked computation with confidence head matches non-chunked."""
+        torch.manual_seed(99)
+        logits = torch.randn(1, 8, 32, requires_grad=True)
+        targets = torch.randn(1, 8, 32)
+        confidence_logits = torch.randn(1, 8, requires_grad=True)
+        loss_mask = torch.tensor([[1, 0, 1, 0, 1, 1, 0, 1]], dtype=torch.float32)
+
+        loss_full, metrics_full = compute_metrics(
+            logits, targets, confidence_logits, loss_mask, 2,
+            loss_config=_DEFAULT_LOSS,
+        )
+        loss_chunked, metrics_chunked = compute_metrics(
+            logits, targets, confidence_logits, loss_mask, 2,
+            loss_config=_DEFAULT_LOSS, anchor_chunk_size=1,
+        )
+        assert torch.allclose(loss_full, loss_chunked, atol=1e-4)
+        for key in metrics_full:
+            assert key in metrics_chunked
+            assert torch.allclose(
+                metrics_full[key], metrics_chunked[key], atol=1e-4
+            ), f"mismatch for {key}"
+
+    def test_chunk_size_zero_equals_default(self):
+        """anchor_chunk_size=0 (explicit) matches the default (no arg)."""
+        torch.manual_seed(13)
+        logits = torch.randn(1, 6, 16)
+        targets = torch.randn(1, 6, 16)
+        loss_mask = torch.ones(1, 6, dtype=torch.float32)
+
+        loss_default, metrics_default = compute_metrics(
+            logits, targets, None, loss_mask, 2, loss_config=_DEFAULT_LOSS,
+        )
+        loss_zero, metrics_zero = compute_metrics(
+            logits, targets, None, loss_mask, 2, loss_config=_DEFAULT_LOSS,
+            anchor_chunk_size=0,
+        )
+        assert torch.equal(loss_default, loss_zero)
+        for key in metrics_default:
+            assert torch.equal(metrics_default[key], metrics_zero[key])
+
+    def test_chunked_backward_graph_preserved(self):
+        """Chunked loss keeps the backward graph and produces gradients."""
+        torch.manual_seed(55)
+        logits = torch.randn(1, 8, 32, requires_grad=True)
+        targets = torch.randn(1, 8, 32)
+        loss_mask = torch.ones(1, 8, dtype=torch.float32)
+
+        loss, _ = compute_metrics(
+            logits, targets, None, loss_mask, 2, loss_config=_DEFAULT_LOSS,
+            anchor_chunk_size=1,
+        )
+        loss.backward()
+        assert logits.grad is not None
+        assert torch.count_nonzero(logits.grad) > 0


### PR DESCRIPTION
## Purpose
DSpark training materializes full [1, Q, V] fp32 intermediates during loss and acceptance-rate computation, where Q = num_anchors × block_size and V = vocab_size. For long sequences this drives peak memory to O(Q×V), limiting the maximum trainable sequence length.
This PR ports the chunk-loss optimization : loss and accept_rate are computed in anchor_chunk_size-sized chunks along the sequence dimension, reducing peak memory from O(Q×V) to O(chunk×V) while remaining numerically identical to the full computation.
Default is anchor_chunk_size=0 (disabled, unchanged behavior); users opt in via --anchor-chunk-size 64.

## Tests
Testing on the qwen3-8b model, with a sequence length of 8k and a max-anchor of 2048, the GPU memory usage decreased from 50G to 45G.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
