### PR TITLE
add gradient checkpointing for dflash/dspark

### DIFF
--- a/docs/cli/train.md
+++ b/docs/cli/train.md
@@ -104,6 +104,8 @@ torchrun --standalone --nproc_per_node=4 -m speculators.train \
 
 - **`--fsdp-shard`** (flag) Shard model parameters across GPUs with FSDP. By default, parameters are fully replicated (DDP-like). Enable this when the model does not fit in a single GPU's memory.
 
+- **`--gradient-checkpointing`** (flag) Enable gradient checkpointing on decoder layers to save activation memory at the cost of ~30-50% slower backward. Each decoder layer's forward is checkpointed: only the layer input is saved for backward; intermediate activations (MLP, attention) are recomputed. Saves ~10 GB for a 5-layer DSpark model with 32K sequence length. Recommended for 32K+ sequence lengths or large `--max-anchors`.
+
 ### Training Arguments
 
 - **`--save-path`** (str, default: `"./checkpoints"`) Directory to save model checkpoints.

--- a/src/speculators/models/dflash/core.py
+++ b/src/speculators/models/dflash/core.py
@@ -37,6 +37,7 @@ _compiled_create_block_mask = torch.compile(create_block_mask)
 @SpeculatorModel.register("dflash")
 class DFlashDraftModel(DraftVocabMixin, SpeculatorModel):
     config_class: ClassVar[type[DFlashSpeculatorConfig]] = DFlashSpeculatorConfig  # type: ignore[misc]
+    supports_gradient_checkpointing = True  # noqa: D003  # Qwen3DFlashDecoderLayer inherits GradientCheckpointingLayer
     _no_split_modules = ["Qwen3DFlashDecoderLayer"]
     _keys_to_ignore_on_load_missing: ClassVar[list[str]] = [  # type: ignore[misc]
         "embed_tokens.weight",

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -28,6 +28,7 @@ from speculators.proposals.greedy import GreedyTokenProposalConfig
 @SpeculatorModel.register("eagle3")
 class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
     config_class: ClassVar[type[Eagle3SpeculatorConfig]] = Eagle3SpeculatorConfig  # type: ignore[misc]
+    supports_gradient_checkpointing = True  # noqa: D003  # Llama/Qwen3 DecoderLayer inherits GradientCheckpointingLayer
     _keys_to_ignore_on_load_missing: ClassVar[list[str]] = [  # type: ignore[misc]
         "embed_tokens.weight",
         "verifier_norm.weight",

--- a/src/speculators/models/eagle3/core.py
+++ b/src/speculators/models/eagle3/core.py
@@ -28,7 +28,6 @@ from speculators.proposals.greedy import GreedyTokenProposalConfig
 @SpeculatorModel.register("eagle3")
 class Eagle3DraftModel(DraftVocabMixin, SpeculatorModel):
     config_class: ClassVar[type[Eagle3SpeculatorConfig]] = Eagle3SpeculatorConfig  # type: ignore[misc]
-    supports_gradient_checkpointing = True  # noqa: D003  # Llama/Qwen3 DecoderLayer inherits GradientCheckpointingLayer
     _keys_to_ignore_on_load_missing: ClassVar[list[str]] = [  # type: ignore[misc]
         "embed_tokens.weight",
         "verifier_norm.weight",

--- a/src/speculators/models/peagle/core.py
+++ b/src/speculators/models/peagle/core.py
@@ -27,6 +27,7 @@ class PEagleDraftModel(Eagle3DraftModel):
     """
 
     config_class: ClassVar[type[PEagleSpeculatorConfig]] = PEagleSpeculatorConfig  # type: ignore[misc]
+    supports_gradient_checkpointing = True  # noqa: D003  # Llama/Qwen3 DecoderLayer inherits GradientCheckpointingLayer
     _keys_to_ignore_on_load_missing: ClassVar[list[str]] = [  # type: ignore[misc]
         *Eagle3DraftModel._keys_to_ignore_on_load_missing,  # noqa: SLF001
         "mask_hidden",

--- a/src/speculators/train/cli.py
+++ b/src/speculators/train/cli.py
@@ -732,6 +732,7 @@ def main(cfg: TrainConfig):  # noqa: C901
         hidden_states_dtype=hidden_states_dtype,
         log_freq=args.log_freq,
         fsdp_shard=args.fsdp_shard,
+        gradient_checkpointing=args.gradient_checkpointing,
         max_steps=args.max_steps,
     )
     trainer = Trainer(draft_model, trainer_config, train_loader, val_loader)

--- a/src/speculators/train/config/schema.py
+++ b/src/speculators/train/config/schema.py
@@ -416,6 +416,12 @@ class TrainerArgs(_Group):
         "parameters are fully replicated (DDP-like). Enable when the model does not "
         "fit in a single GPU's memory.",
     )
+    gradient_checkpointing: bool = Field(
+        default=False,
+        description="Enable gradient checkpointing on decoder layers to save "
+        "activation memory at the cost of ~30-50 percent slower backward. "
+        "Recommended for 32K+ sequence lengths or large max_anchors.",
+    )
     max_steps: int | None = Field(
         default=None,
         ge=1,

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -138,6 +138,7 @@ class TrainerConfig(NamedTuple):
     hidden_states_dtype: torch.dtype = torch.bfloat16
     log_freq: int = 1
     fsdp_shard: bool = False
+    gradient_checkpointing: bool = False
     max_steps: int | None = None
 
 
@@ -296,6 +297,15 @@ class Trainer:
     def setup_model(self):
         # Verify model is compatible with training infrastructure
         SpeculatorModel.verify_training_compatible(self.model)
+
+        # Enable gradient checkpointing BEFORE FSDP/DDP wrapping to save
+        # activation memory at the cost of recomputation during backward.
+        # Each decoder layer's forward is checkpointed: only the layer input
+        # is saved for backward; intermediate activations (MLP, attention)
+        # are recomputed. Saves ~10 GB for 5-layer DSpark with 32K seq.
+        if self.config.gradient_checkpointing:
+            self.model.gradient_checkpointing_enable()
+            root_logger.info("Gradient checkpointing enabled")
 
         load_checkpoint = (
             self.resume_from_checkpoint and self.checkpointer.previous_epoch != -1

--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -304,6 +304,11 @@ class Trainer:
         # is saved for backward; intermediate activations (MLP, attention)
         # are recomputed. Saves ~10 GB for 5-layer DSpark with 32K seq.
         if self.config.gradient_checkpointing:
+            if not self.model.supports_gradient_checkpointing:
+                raise ValueError(
+                    f"{type(self.model).__name__} does not support "
+                    "gradient checkpointing"
+                )
             self.model.gradient_checkpointing_enable()
             root_logger.info("Gradient checkpointing enabled")
 


### PR DESCRIPTION
## Purpose
DSpark/DFlash training on long sequences (32K+) consumes excessive activation memory — intermediate MLP and attention activations for all decoder layers are retained for backward, driving peak memory beyond NPU limits.
This PR enables gradient checkpointing: each decoder layer's forward is checkpointed so only the layer input is saved for backward, and intermediate activations are recomputed during the backward pass. This reduces activation memory by ~10 GB for a 5-layer DSpark model at 32K sequence length, at the cost of ~30-50% slower backward.
Two changes were required: (1) setting supports_gradient_checkpointing = True on DFlashDraftModel (the class-level gate that was missing — Qwen3DFlashDecoderLayer already inherits GradientCheckpointingLayer, so the mechanism was always available, only the flag was absent), and (2) wiring gradient_checkpointing through TrainerConfig, the trainer's setup_model(), and the CLI schema so users can opt in via --gradient-checkpointing.

## Tests
Testing on the qwen3-8b model, with a sequence length of 8k and a max-anchor of 2048, the GPU memory usage decreased from 50G to 25G.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
