### PR TITLE
Link to multi-node training and python api reference

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -2,5 +2,7 @@
 
 This section contains the auto-generated Python API documentation for Speculators.
 
+Browse the [generated Python API reference](../reference/speculators/).
+
 !!! warning
     Using the Python API directly is **not officially supported** at this time and there are **no guarantees of backward compatibility** between releases. We recommend using the [CLI commands](../cli/index.md) as the primary entrypoints for interacting with Speculators.

--- a/docs/user_guide/tutorials/index.md
+++ b/docs/user_guide/tutorials/index.md
@@ -6,6 +6,10 @@ Step-by-step tutorials to guide you through complete workflows, from data prepar
 
 The main end-to-end walkthrough: prepare data, generate hidden states, train, and serve. Covers Eagle-3, P-EAGLE, DFlash, DSpark, and MTP, in online, offline, or hybrid mode -- pick your algorithm and mode at the top of the page.
 
+## [Multi-Node Training](multi_node_training.md)
+
+Stream hidden states between separate extraction and training nodes with the Mooncake backend when the target model does not fit on one node or shared storage is unavailable.
+
 ## [Response Regeneration](response_regeneration.md)
 
 Regenerate dataset responses using your target model for improved drafter alignment. Recommended before training.


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Currently the python API reference and multi-node training tutorial can only be accessed through the nav bar / sidebar and aren't linked in the docs. This can make it harder to find/access these pages, especially on devices with smaller screens where the nav bar may be hidden. 

This pr fixes that by linking to the pages. 

## Tests

~~Will verify links appear as expected on the generated pr site.~~ Verified!

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
