### PR TITLE
fix(data): skip chat template check when render endpoint is set

### DIFF
--- a/src/speculators/data_generation/preprocessing.py
+++ b/src/speculators/data_generation/preprocessing.py
@@ -854,11 +854,18 @@ def load_and_preprocess_dataset(
             )
 
         pretokenized = {"input_ids", "loss_mask"} <= set(raw_dataset.column_names)
-        if not pretokenized and not processor_has_chat_template:
+        # With a render endpoint the chat template is applied server-side, so a
+        # local processor without a chat_template attribute is fine.
+        if (
+            not pretokenized
+            and not processor_has_chat_template
+            and render_endpoint is None
+        ):
             raise ValueError(
                 f"Processor for {target_model_path} does not support chat templates. "
-                "Please use a model with a pre-configured chat template or provide "
-                "pre-tokenized input_ids and loss_mask columns."
+                "Please use a model with a pre-configured chat template, provide "
+                "pre-tokenized input_ids and loss_mask columns, or pass "
+                "--render-endpoint so vLLM renders conversations server-side."
             )
 
         log.info(f"Loaded {len(raw_dataset)} samples")

--- a/tests/unit/train/test_prepare_data.py
+++ b/tests/unit/train/test_prepare_data.py
@@ -149,6 +149,8 @@ def test_pretokenized_data_does_not_require_chat_template(
 def test_conversation_data_still_requires_chat_template(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
+    """Without a render endpoint, conversation data still fails fast when the
+    processor exposes no chat template."""
     raw = HFDataset.from_dict(
         {
             "conversations": [
@@ -176,3 +178,56 @@ def test_conversation_data_still_requires_chat_template(
             build_dataset_num_proc=1,
             token_freq_path=tmp_path / "token_freq.pt",
         )
+
+
+def test_render_endpoint_bypasses_chat_template_requirement(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    """Server-side rendering needs no local chat template: the processor's
+    template is never used when a render endpoint is provided."""
+    raw = HFDataset.from_dict(
+        {
+            "conversations": [
+                [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "hi"},
+                ]
+            ]
+        }
+    )
+    monkeypatch.setattr(
+        preprocessing_module,
+        "load_processor",
+        lambda *a, **k: _NoChatTemplateProcessor(),
+    )
+    monkeypatch.setattr(
+        preprocessing_module, "load_raw_dataset", lambda _path: (raw, None)
+    )
+    processed = HFDataset.from_dict(
+        {
+            "input_ids": [[1, 2, 3]],
+            "loss_mask": [[0, 1, 1]],
+            "seq_len": [3],
+        }
+    )
+    processed.set_format(type="torch")
+    monkeypatch.setattr(
+        preprocessing_module,
+        "build_speculator_training_dataset",
+        lambda *a, **k: processed,
+    )
+    monkeypatch.setattr(
+        preprocessing_module, "save_token_frequency_distribution", lambda **k: None
+    )
+    monkeypatch.setattr(preprocessing_module, "_visualize_sample", lambda *a, **k: None)
+
+    dataset, _ = load_and_preprocess_dataset(
+        "custom-model",
+        ["conversations.jsonl"],
+        seq_length=8,
+        build_dataset_num_proc=1,
+        token_freq_path=tmp_path / "token_freq.pt",
+        render_endpoint="http://localhost:8000",
+    )
+
+    assert len(dataset) == 1


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

`prepare-data` rejects natural-language conversation datasets when the target
model's processor has no `chat_template` attribute — even when
`--render-endpoint` is provided and templating happens entirely server-side.

This breaks models whose chat template is not a Jinja string. Kimi-K3, for
example, implements `apply_chat_template()` programmatically in its remote
code (`tokenization_kimi.py`), and neither the `KimiK3Processor` nor its inner
tokenizer exposes a `chat_template` attribute, so
`load_and_preprocess_dataset()` raises:

```
ValueError: Processor for ... does not support chat templates. ...
```

even though the vLLM render endpoint renders conversations correctly.

Reproduction:
```
 speculators prepare-data \
  --model /pathto/Kimi-K3 \
  --trust-remote-code \
  --data /pathto/test.jsonl \
  --render-endpoint http://host:port \
  --output ./data \
  --seq-length 8192 \
  --num-preprocessing-workers 48 \
  --minimum-valid-tokens 16
```

This PR skips the local chat-template precondition when a render endpoint is
set, since the processor's template is never used on that path. The check is
unchanged when no render endpoint is given. Pretokenized
(`input_ids`/`loss_mask`) inputs continue to bypass the check entirely.

## Tests

Added `test_render_endpoint_bypasses_chat_template_requirement` covering the
new path (conversations + render endpoint + template-less processor passes),
while `test_conversation_data_still_requires_chat_template` keeps covering the
no-endpoint rejection.

```
$ python -m pytest tests/unit/train/test_prepare_data.py -q
8 passed in 0.09s
```

Also validated end-to-end against a live Kimi-K3 vLLM server
(`--render-endpoint http://<host>:60000`): 96k ShareGPT-style conversations
rendered via `/v1/chat/completions/render` and preprocessed into 235k training
rows without error.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [x] (Optional) The necessary documentation update. — No docs change needed; behavior only relaxes an over-strict precondition.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.