### PR TITLE
fix(train): use max_steps as scheduler total when set

### DIFF
--- a/src/speculators/train/trainer.py
+++ b/src/speculators/train/trainer.py
@@ -150,9 +150,13 @@ def _resolve_scheduler_steps(
     Explicit ``scheduler_warmup_steps`` wins; otherwise ``scheduler_warmup_ratio``
     (a fraction of total steps, validated to ``[0, 1]``) is used; otherwise the
     default of 1% of the resolved total steps. ``scheduler_total_steps`` defaults
-    to ``num_epochs * train_loader_len``.
+    to ``max_steps`` when set, else ``num_epochs * train_loader_len``.
     """
     default_total_steps = config.num_epochs * train_loader_len
+    # max_steps bounds the training loop, so the LR schedule must decay over the
+    # same horizon; otherwise the LR endpoint is never reached.
+    if config.max_steps is not None:
+        default_total_steps = config.max_steps
     scheduler_total_steps = (
         config.scheduler_total_steps
         if config.scheduler_total_steps is not None

--- a/tests/unit/train/test_trainer_scheduler.py
+++ b/tests/unit/train/test_trainer_scheduler.py
@@ -40,6 +40,28 @@ def test_scheduler_total_steps_only_defaults_warmup_to_one_percent_of_total():
     assert warmup_steps == 10
 
 
+def test_max_steps_sets_scheduler_total_steps():
+    # max_steps stops the training loop early; the scheduler must decay over the
+    # same horizon (30), not num_epochs * loader_len (100).
+    warmup_steps, total_steps = _resolve_scheduler_steps(
+        make_config(max_steps=30),
+        20,
+    )
+
+    assert total_steps == 30
+    assert warmup_steps == 0  # 1% of 30
+
+
+def test_scheduler_total_steps_override_wins_over_max_steps():
+    warmup_steps, total_steps = _resolve_scheduler_steps(
+        make_config(max_steps=30, scheduler_total_steps=250),
+        20,
+    )
+
+    assert total_steps == 250
+    assert warmup_steps == 2  # 1% of 250
+
+
 def test_scheduler_warmup_ratio_uses_scheduler_total_steps():
     warmup_steps, total_steps = _resolve_scheduler_steps(
         make_config(scheduler_total_steps=200, scheduler_warmup_ratio=0.1),


### PR DESCRIPTION
## Purpose

When `max_steps` is set, `Trainer.train_epoch` stops the run early
(`src/speculators/train/trainer.py:547-551`), but `_resolve_scheduler_steps`
still computed the LR scheduler's total steps as
`num_epochs * len(train_loader)` (`src/speculators/train/trainer.py:155`).
Cosine/linear schedules therefore never reached their decay endpoint within
the actual run — the LR stayed higher than intended for the whole training.

This PR resolves the scheduler's total steps with the priority:

1. explicit `scheduler_total_steps` (unchanged)
2. `max_steps`, when set (new)
3. `num_epochs * len(train_loader)` (previous default)

The docstring of `_resolve_scheduler_steps` is updated accordingly.

Note: #898 (closed, unmerged) addressed a different `max_steps` concern —
stopping the outer epoch loop and persisting the final checkpoint segment.
This PR only fixes the scheduler's total step count and does not touch
stopping or checkpointing logic.

Small bug fix (< 20 lines), so no tracking issue was opened first, per
CONTRIBUTING.md.

## Tests

Added two unit tests to `tests/unit/train/test_trainer_scheduler.py`:

- `test_max_steps_sets_scheduler_total_steps`
- `test_scheduler_total_steps_override_wins_over_max_steps`

Command and result:

```
python -m pytest tests/unit/train/test_trainer_scheduler.py -v
======================== 9 passed, 14 warnings in 0.23s ========================
```

Quality gates (pinned `ruff~=0.15.20`):

```
ruff check                    # All checks passed!
ruff format --check           # 247 files already formatted
mypy --check-untyped-defs     # Success: no issues found in 224 source files
```

## Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.