### PR TITLE
feat(eval): long-context acceptance benchmark on a recorded request table

### DIFF
--- a/scripts/evaluate/acceptance_report.py
+++ b/scripts/evaluate/acceptance_report.py
@@ -1,0 +1,244 @@
+"""Speculative-decoding acceptance analysis over a recorded request table.
+
+Pure functions over the generic Parquet table written by ``request_runner``.
+This layer is where all the spec-decode-specific and analysis-specific knowledge
+lives -- how to read per-step acceptance arrays out of the recorded metrics, and
+what context-length buckets to slice by. Crucially, the bucket edges are
+*parameters here*, not constants baked into the runner: the same recording can be
+re-sliced any number of ways (see ``rebin.py``) without touching inference.
+
+Two slicings are produced:
+
+* by prompt length at request start (:func:`bin_by_start_length`)
+* by running token position of each verify step (:func:`bin_by_position`) --
+  prompt length plus everything committed by earlier steps in the same request.
+
+Requests must have been generated against a server started with
+``--per-request-spec-decode-metrics detailed`` so each response carries its own
+``speculative_decoding`` block (including the per-verify-step arrays).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from perf_utils import CsvWriter
+from request_runner import load_table
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger("evaluate")
+
+# Context-length bucket edges (tokens) for the by-start-length report. These are
+# OpenAI MRCR's native power-of-2 bins; they only slice results for reporting.
+DEFAULT_CONTEXT_BIN_EDGES = (
+    0,
+    4096,
+    8192,
+    16384,
+    32768,
+    65536,
+    131072,
+    262144,
+    524288,
+    1048576,
+)
+
+# Bin width (tokens) for the by-token-position report -- finer than the context
+# edges since acceptance can shift noticeably within a single request.
+DEFAULT_POSITION_BIN_SIZE = 256
+
+
+@dataclass
+class SpecRecord:
+    """One generated request's spec-decode stats, projected from the table."""
+
+    prompt_tokens: int
+    spec: dict  # the response's speculative_decoding block
+
+
+def load_spec_records(table_dir: Path) -> list[SpecRecord]:
+    """Project the recorded table down to successfully-generated spec-decode rows."""
+    table = load_table(table_dir)
+    records = []
+    for row in table.to_pylist():
+        if row["status"] != "ok" or not row["metrics_json"]:
+            continue
+        spec = json.loads(row["metrics_json"]).get("speculative_decoding")
+        if not spec:
+            continue
+        records.append(SpecRecord(row["prompt_tokens"], spec))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Binning
+# ---------------------------------------------------------------------------
+
+
+def _bucket_label(n_tokens: int, edges: tuple[int, ...]) -> str:
+    for lo, hi in zip(edges, edges[1:], strict=False):
+        if n_tokens <= hi:
+            return f"{lo}-{hi}"
+    return f"{edges[-1]}+"
+
+
+def _position_bucket_label(n_tokens: int, bin_size: int) -> str:
+    lo = (n_tokens // bin_size) * bin_size
+    return f"{lo}-{lo + bin_size}"
+
+
+def _bucket_sort_key(item: tuple[str, dict]) -> int:
+    return int(item[0].split("-")[0].rstrip("+"))
+
+
+def _finish_bucket(bucket: dict) -> dict:
+    bucket["draft_acceptance_rate"] = (
+        bucket["num_accepted_draft_tokens"] / bucket["num_draft_tokens"]
+        if bucket["num_draft_tokens"]
+        else 0.0
+    )
+    bucket["mean_acceptance_length"] = (
+        1 + bucket["num_accepted_draft_tokens"] / bucket["num_spec_steps"]
+        if bucket["num_spec_steps"]
+        else 0.0
+    )
+    return bucket
+
+
+def bin_by_start_length(
+    records: list[SpecRecord],
+    edges: tuple[int, ...] = DEFAULT_CONTEXT_BIN_EDGES,
+) -> list[dict]:
+    """Aggregate whole-request acceptance by prompt length at request start."""
+    buckets: dict[str, dict] = {}
+    for r in records:
+        label = _bucket_label(r.prompt_tokens, edges)
+        b = buckets.setdefault(
+            label,
+            {
+                "bucket": label,
+                "num_requests": 0,
+                "num_spec_steps": 0,
+                "num_draft_tokens": 0,
+                "num_accepted_draft_tokens": 0,
+            },
+        )
+        b["num_requests"] += 1
+        b["num_spec_steps"] += r.spec["num_spec_steps"]
+        b["num_draft_tokens"] += r.spec["num_draft_tokens"]
+        b["num_accepted_draft_tokens"] += r.spec["num_accepted_draft_tokens"]
+    return [_finish_bucket(b) for _, b in sorted(buckets.items(), key=_bucket_sort_key)]
+
+
+def bin_by_position(
+    records: list[SpecRecord],
+    bin_size: int = DEFAULT_POSITION_BIN_SIZE,
+) -> list[dict]:
+    """Aggregate per-verify-step acceptance by the running token position.
+
+    Each step's position is the prompt length plus everything committed by
+    earlier steps in that same request (accepted draft tokens plus the
+    always-accepted bonus token).
+    """
+    buckets: dict[str, dict] = {}
+    for r in records:
+        accepted = r.spec.get("per_step_accepted")
+        drafted = r.spec.get("per_step_drafted")
+        if not accepted or not drafted:
+            continue
+        pos = r.prompt_tokens
+        for a, d in zip(accepted, drafted, strict=True):
+            label = _position_bucket_label(pos, bin_size)
+            b = buckets.setdefault(
+                label,
+                {
+                    "bucket": label,
+                    "num_spec_steps": 0,
+                    "num_draft_tokens": 0,
+                    "num_accepted_draft_tokens": 0,
+                },
+            )
+            b["num_spec_steps"] += 1
+            b["num_draft_tokens"] += d
+            b["num_accepted_draft_tokens"] += a
+            pos += a + 1
+    return [_finish_bucket(b) for _, b in sorted(buckets.items(), key=_bucket_sort_key)]
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _print_bucket_table(title: str, rows: list[dict]) -> None:
+    print(f"\n=== {title} ===\n")
+    has_requests = "num_requests" in rows[0]
+    header = f"  {'Bucket':<18}"
+    if has_requests:
+        header += f" {'Requests':>9}"
+    header += f" {'Steps':>8} {'Accept Rate':>12} {'Mean Len':>9}"
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    for row in rows:
+        line = f"  {row['bucket']:<18}"
+        if has_requests:
+            line += f" {row['num_requests']:>9}"
+        line += (
+            f" {row['num_spec_steps']:>8} {row['draft_acceptance_rate']:>12.4f}"
+            f" {row['mean_acceptance_length']:>9.4f}"
+        )
+        print(line)
+    print()
+
+
+def write_report(
+    output_dir: Path,
+    records: list[SpecRecord],
+    *,
+    context_bin_edges: tuple[int, ...] = DEFAULT_CONTEXT_BIN_EDGES,
+    position_bin_size: int = DEFAULT_POSITION_BIN_SIZE,
+) -> None:
+    """Print and write both acceptance CSVs from projected spec records."""
+    if not records:
+        logger.error("No spec-decode records to report on")
+        return
+
+    by_start = bin_by_start_length(records, context_bin_edges)
+    _print_bucket_table("Acceptance by context length at request start", by_start)
+    CsvWriter(
+        output_dir / "acceptance_by_start_length.csv",
+        [
+            "bucket",
+            "num_requests",
+            "num_spec_steps",
+            "num_draft_tokens",
+            "num_accepted_draft_tokens",
+            "draft_acceptance_rate",
+            "mean_acceptance_length",
+        ],
+    ).append_rows(by_start)
+
+    by_position = bin_by_position(records, position_bin_size)
+    if not by_position:
+        logger.warning(
+            "No per-step data; skipping by-position report (was the server "
+            "started with --per-request-spec-decode-metrics detailed?)"
+        )
+        return
+    _print_bucket_table("Acceptance by context length at token position", by_position)
+    CsvWriter(
+        output_dir / "acceptance_by_position.csv",
+        [
+            "bucket",
+            "num_spec_steps",
+            "num_draft_tokens",
+            "num_accepted_draft_tokens",
+            "draft_acceptance_rate",
+            "mean_acceptance_length",
+        ],
+    ).append_rows(by_position)

--- a/scripts/evaluate/acceptance_report.py
+++ b/scripts/evaluate/acceptance_report.py
@@ -210,6 +210,8 @@ def write_report(
 
     by_start = bin_by_start_length(records, context_bin_edges)
     _print_bucket_table("Acceptance by context length at request start", by_start)
+    # overwrite: a report is written whole each run (e.g. re-binning the same
+    # table into the same output_dir), so replace it rather than append.
     CsvWriter(
         output_dir / "acceptance_by_start_length.csv",
         [
@@ -221,6 +223,7 @@ def write_report(
             "draft_acceptance_rate",
             "mean_acceptance_length",
         ],
+        overwrite=True,
     ).append_rows(by_start)
 
     by_position = bin_by_position(records, position_bin_size)
@@ -241,4 +244,5 @@ def write_report(
             "draft_acceptance_rate",
             "mean_acceptance_length",
         ],
+        overwrite=True,
     ).append_rows(by_position)

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -91,6 +91,20 @@ _SPEEDBENCH_COLUMN_MAPPER = (
 )
 
 
+def _positive_int(value: str) -> int:
+    """argparse type: accept only integers >= 1.
+
+    Guards flags whose non-positive values fail late and expensively -- e.g. a
+    negative --samples-per-bin becomes a negative list slice that runs nearly the
+    whole dataset, and a non-positive --position-bin-size only blows up at the
+    reporting step, after the entire inference run.
+    """
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1, got {parsed}")
+    return parsed
+
+
 def _fetch_model_info(target: str) -> dict | None:
     """Return the first ``/v1/models`` entry (has ``id`` and ``max_model_len``)."""
     base = target.rstrip("/")
@@ -505,7 +519,7 @@ def main() -> None:
     lc_group = parser.add_argument_group("long-context mode")
     lc_group.add_argument(
         "--samples-per-bin",
-        type=int,
+        type=_positive_int,
         default=DEFAULT_SAMPLES_PER_BIN,
         help=(
             "long-context: records to run per native MRCR token bin. Larger "
@@ -525,7 +539,7 @@ def main() -> None:
     )
     lc_group.add_argument(
         "--position-bin-size",
-        type=int,
+        type=_positive_int,
         default=DEFAULT_POSITION_BIN_SIZE,
         help=(
             "long-context: token-position bin width for the by-position report "

--- a/scripts/evaluate/evaluate.py
+++ b/scripts/evaluate/evaluate.py
@@ -4,12 +4,22 @@
 Modes:
     throughput   Max throughput run for acceptance rates
     sweep        Full pipeline (gen-len, sweep, CSV)
+    long-context Per-request acceptance vs. context length via OpenAI's MRCR
+                 dataset. Deterministically samples a superset-monotonic set
+                 stratified across MRCR's native token bins, records every
+                 request to a Parquet table, and reports acceptance binned by
+                 context length. Requires the server started with
+                 --per-request-spec-decode-metrics detailed and the render
+                 endpoint enabled (VLLM_ENABLE_SCALE_OUT_ENDPOINTS=1).
 
 Examples:
     python evaluate.py --target http://localhost:8000/v1 throughput
     python evaluate.py --target http://localhost:8000/v1 sweep
     python evaluate.py --target http://localhost:8000/v1 sweep \\
         --subsets "HumanEval,qa" --gen-kwargs '{"temperature":0.6}'
+
+    python evaluate.py --target http://localhost:8000/v1 long-context \\
+        --samples-per-bin 20
 
     # SPEED-Bench (run prepare_speedbench.py once first to split data):
     python evaluate.py --target http://localhost:8000/v1 throughput \\
@@ -63,6 +73,9 @@ DEFAULT_SUBSETS = (
 )
 DEFAULT_MAX_CONCURRENCY = 128
 DEFAULT_MAX_REQUESTS = 200
+# long-context: records selected per native MRCR token bin (density/cost knob).
+DEFAULT_SAMPLES_PER_BIN = 20
+DEFAULT_POSITION_BIN_SIZE = 256
 DEFAULT_GEN_LEN_RATE = 128
 DEFAULT_SWEEP_RATE = 10
 DEFAULT_DATA_COLUMN_MAPPER = (
@@ -78,7 +91,8 @@ _SPEEDBENCH_COLUMN_MAPPER = (
 )
 
 
-def _fetch_model_name(target: str) -> str | None:
+def _fetch_model_info(target: str) -> dict | None:
+    """Return the first ``/v1/models`` entry (has ``id`` and ``max_model_len``)."""
     base = target.rstrip("/")
     if not base.endswith("/v1"):
         base += "/v1"
@@ -88,10 +102,15 @@ def _fetch_model_name(target: str) -> str | None:
             data = json.loads(resp.read())
         models = data.get("data", [])
         if models:
-            return models[0].get("id")
+            return models[0]
     except (URLError, json.JSONDecodeError, OSError) as e:
-        logger.warning("Could not fetch model name from %s: %s", url, e)
+        logger.warning("Could not fetch model info from %s: %s", url, e)
     return None
+
+
+def _fetch_model_name(target: str) -> str | None:
+    info = _fetch_model_info(target)
+    return info.get("id") if info else None
 
 
 def _sanitize_dir_name(name: str) -> str:
@@ -281,16 +300,41 @@ def _run_subset(
     return acceptance_csv, perf_csv, max_tokens if is_sweep else None
 
 
+def _run_long_context(args: argparse.Namespace, output_dir: Path) -> None:
+    # Imported lazily so throughput/sweep runs don't pull the long-context deps
+    # (pandas, pyarrow, huggingface_hub).
+    from mrcr import run_mrcr  # noqa: PLC0415
+
+    run_mrcr(
+        target=args.target,
+        model_info=_fetch_model_info(args.target),
+        output_dir=output_dir,
+        max_concurrency=args.max_concurrency,
+        samples_per_bin=args.samples_per_bin,
+        selection_seed=args.selection_seed,
+        position_bin_size=args.position_bin_size,
+    )
+
+
 def run_benchmark(args: argparse.Namespace) -> None:
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    save_eval_provenance(output_dir)
+
+    if args.mode == "long-context":
+        _run_long_context(args, output_dir)
+    else:
+        _run_guidellm_modes(args, output_dir)
+    logger.info("Benchmarking complete! Results: %s", output_dir)
+
+
+def _run_guidellm_modes(args: argparse.Namespace, output_dir: Path) -> None:
     check_dependencies()
     is_sweep = args.mode == "sweep"
 
     metrics_url = args.target.rstrip("/").removesuffix("/v1") + "/metrics"
-    output_dir = Path(args.output_dir)
     artifacts_dir = output_dir / "artifacts"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
-
-    save_eval_provenance(output_dir)
 
     if not (output_dir / "vllm_command.txt").exists():
         logger.info(
@@ -365,8 +409,6 @@ def run_benchmark(args: argparse.Namespace) -> None:
         with (output_dir / "max_tokens.json").open("w") as f:
             json.dump(all_max_tokens, f, indent=2)
 
-    logger.info("Benchmarking complete! Results: %s", output_dir)
-
 
 def main() -> None:
     logging.basicConfig(
@@ -389,10 +431,11 @@ def main() -> None:
     )
     parser.add_argument(
         "mode",
-        choices=["throughput", "sweep"],
+        choices=["throughput", "sweep", "long-context"],
         help=(
             "throughput: max-rate run for acceptance rates; "
-            "sweep: full benchmarking pipeline"
+            "sweep: full benchmarking pipeline; "
+            "long-context: per-request acceptance vs. context length via MRCR"
         ),
     )
     parser.add_argument(
@@ -457,6 +500,36 @@ def main() -> None:
         help=(
             "Path to directory produced by SPEED-Bench prepare.py. "
             "Required when --dataset is a speedbench/ spec."
+        ),
+    )
+    lc_group = parser.add_argument_group("long-context mode")
+    lc_group.add_argument(
+        "--samples-per-bin",
+        type=int,
+        default=DEFAULT_SAMPLES_PER_BIN,
+        help=(
+            "long-context: records to run per native MRCR token bin. Larger "
+            "context windows fill more bins, so a run at a bigger --max-model-len "
+            f"is a superset of a smaller one (default: {DEFAULT_SAMPLES_PER_BIN})"
+        ),
+    )
+    lc_group.add_argument(
+        "--selection-seed",
+        type=int,
+        default=0,
+        help=(
+            "long-context: seed mixed into the per-record content hash used to "
+            "rank within each bin; changing it picks a different deterministic "
+            "sample (default: 0)"
+        ),
+    )
+    lc_group.add_argument(
+        "--position-bin-size",
+        type=int,
+        default=DEFAULT_POSITION_BIN_SIZE,
+        help=(
+            "long-context: token-position bin width for the by-position report "
+            f"(default: {DEFAULT_POSITION_BIN_SIZE})"
         ),
     )
     args = parser.parse_args()

--- a/scripts/evaluate/mrcr.py
+++ b/scripts/evaluate/mrcr.py
@@ -1,0 +1,170 @@
+"""MRCR long-context benchmark: a set of requests + an ordering + a stop rule.
+
+This is a thin adapter. It knows only how to turn OpenAI's ``openai/mrcr``
+dataset into a deterministically-selected, length-ordered set of chat requests;
+the generic runner (``request_runner``) sends them and records everything, and
+the analysis layer (``acceptance_report``) turns the recording into reports.
+Nothing about inference, persistence, or binning lives here.
+
+Deterministic superset selection
+---------------------------------
+Records are stratified into MRCR's native power-of-2 token bins and, within each
+bin, ranked by a stable content hash; the lowest-ranked ``samples_per_bin`` per
+bin are kept. Bin assignment uses ``n_chars / EST_CHARS_PER_TOKEN`` (MRCR carries
+no token count, and this ratio is ~4.9 with <=2% spread across the whole dataset
+-- validated offline against o200k -- so it matches exact tokenization for bin
+assignment at zero runtime cost). The candidate set is independent of the
+server's ``max_model_len``; the only context-dependent step is the render
+fit-test in the runner, which is monotonic, so a larger-context run selects a
+superset of a smaller one. Batches are handed to the runner smallest-bin-first
+with a stop rule that halts once an entire bin renders oversized.
+
+Correctness is intentionally not graded: MRCR is used purely as a source of
+long, multi-turn prompts to study how acceptance holds up as context grows.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from typing import TYPE_CHECKING
+
+import pandas as pd
+from acceptance_report import (
+    DEFAULT_CONTEXT_BIN_EDGES,
+    DEFAULT_POSITION_BIN_SIZE,
+    load_spec_records,
+    write_report,
+)
+from huggingface_hub import hf_hub_download
+from request_runner import (
+    TABLE_DIRNAME,
+    Request,
+    run_requests,
+    select_stratified,
+    stable_hash,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger("evaluate")
+
+MRCR_REPO = "openai/mrcr"
+MRCR_SHARDS = ("2needle/2needle_0.parquet", "2needle/2needle_1.parquet")
+
+# Chars-per-token ratio for MRCR content, used only to estimate a record's native
+# token bin (exact length comes from the render endpoint). 4.9 +/- 0.1 across the
+# full 20k-490k token range measured with OpenAI's o200k tokenizer.
+EST_CHARS_PER_TOKEN = 4.9
+
+# Native token bins for selection: MRCR's power-of-2 edges minus the leading 0,
+# since every record is far larger than 4096 tokens.
+SELECTION_BIN_EDGES = tuple(e for e in DEFAULT_CONTEXT_BIN_EDGES if e > 0)
+
+# Requested generation budget; the render endpoint clips this to whatever fits.
+MAX_NEW_TOKENS = 512
+# Drop candidates left with less than this much room -- too few steps to measure.
+MIN_GENERATION_ROOM = 32
+
+
+def _load_records() -> list[dict]:
+    frames = [
+        pd.read_parquet(hf_hub_download(MRCR_REPO, shard, repo_type="dataset"))
+        for shard in MRCR_SHARDS
+    ]
+    return pd.concat(frames, ignore_index=True).to_dict("records")
+
+
+def _to_request(index: int, record: dict) -> Request:
+    return Request(
+        messages=json.loads(record["prompt"]),
+        max_tokens=MAX_NEW_TOKENS,
+        request_id=f"mrcr-{index}",
+        metadata={
+            "index": index,
+            "n_chars": int(record["n_chars"]),
+            "est_tokens": round(record["n_chars"] / EST_CHARS_PER_TOKEN),
+            "n_needles": int(record["n_needles"]),
+            "total_messages": int(record["total_messages"]),
+        },
+    )
+
+
+def _all_oversized(rows: list[dict]) -> bool:
+    """Stop rule: an entire bin rendered oversized (all larger bins are bigger).
+
+    Keyed on real render outcomes, never the length estimate. A transport error
+    leaves fit unknown, so it does not count as oversized and won't stop the run.
+    """
+    return bool(rows) and all(r["status"] == "oversized" for r in rows)
+
+
+def run_mrcr(
+    target: str,
+    model_info: dict | None,
+    output_dir: Path,
+    max_concurrency: int,
+    *,
+    samples_per_bin: int,
+    selection_seed: int = 0,
+    position_bin_size: int = DEFAULT_POSITION_BIN_SIZE,
+) -> None:
+    """Select MRCR records, run them through the generic harness, and report."""
+    if model_info is None:
+        logger.error("Could not determine served model info from %s/models", target)
+        sys.exit(1)
+    model_name = model_info["id"]
+    logger.info(
+        "Server reports model=%s max_model_len=%s",
+        model_name,
+        model_info.get("max_model_len"),
+    )
+    root_url = target.rstrip("/").removesuffix("/v1")
+
+    logger.info("Loading MRCR 2-needle dataset...")
+    records = _load_records()
+    if not records:
+        logger.error("MRCR dataset returned no records")
+        sys.exit(1)
+    logger.info("Loaded %d MRCR records", len(records))
+
+    indexed = list(enumerate(records))
+    selected = select_stratified(
+        indexed,
+        bin_edges=SELECTION_BIN_EDGES,
+        samples_per_bin=samples_per_bin,
+        key_fn=lambda ir: stable_hash(f"{selection_seed}:{ir[1]['prompt']}"),
+        length_fn=lambda ir: ir[1]["n_chars"] / EST_CHARS_PER_TOKEN,
+    )
+    batches = [[_to_request(i, rec) for i, rec in group] for group in selected]
+    n_selected = sum(len(b) for b in batches)
+    logger.info(
+        "Selected %d candidate records across %d bins (%d per bin)",
+        n_selected,
+        len(batches),
+        samples_per_bin,
+    )
+
+    table_dir = run_requests(
+        root_url,
+        model_name,
+        batches,
+        output_dir / TABLE_DIRNAME,
+        max_concurrency=max_concurrency,
+        fit_test=True,
+        min_generation_room=MIN_GENERATION_ROOM,
+        should_stop=_all_oversized,
+    )
+
+    records_out = load_spec_records(table_dir)
+    if not records_out:
+        logger.error("No usable spec-decode results were recorded")
+        sys.exit(1)
+    write_report(
+        output_dir,
+        records_out,
+        context_bin_edges=DEFAULT_CONTEXT_BIN_EDGES,
+        position_bin_size=position_bin_size,
+    )

--- a/scripts/evaluate/mrcr.py
+++ b/scripts/evaluate/mrcr.py
@@ -168,3 +168,9 @@ def run_mrcr(
         context_bin_edges=DEFAULT_CONTEXT_BIN_EDGES,
         position_bin_size=position_bin_size,
     )
+    logger.info(
+        "Render the acceptance figure with:\n"
+        "  python plot.py acceptance --table %s --output %s",
+        table_dir,
+        output_dir / "acceptance.png",
+    )

--- a/scripts/evaluate/perf_utils.py
+++ b/scripts/evaluate/perf_utils.py
@@ -458,12 +458,21 @@ def parse_sweep_results(
 
 
 class CsvWriter:
-    """Append rows incrementally to a CSV file, writing the header on first row."""
+    """Append rows incrementally to a CSV file, writing the header on first row.
 
-    def __init__(self, path: Path, columns: list[str]) -> None:
+    Pass ``overwrite=True`` for a report written in full each run: the first
+    write then truncates any existing file (and re-emits the header) instead of
+    appending, so regenerating a fixed-name report replaces it rather than
+    accumulating stale rows across runs. Subsequent writes on the same instance
+    still append.
+    """
+
+    def __init__(
+        self, path: Path, columns: list[str], *, overwrite: bool = False
+    ) -> None:
         self.path = path
         self.columns = columns
-        self._started = self.path.exists()
+        self._started = False if overwrite else self.path.exists()
 
     def append(self, row: dict) -> None:
         self.append_rows([row])

--- a/scripts/evaluate/plot.py
+++ b/scripts/evaluate/plot.py
@@ -4,6 +4,7 @@
 Subcommands:
     compare     Multi-version comparison plots (overlay smoothed curves)
     speedup     Pairwise speedup visualization (gradient-shaded region)
+    acceptance  Long-context acceptance-length heatmap from a recorded table
 
 Examples:
     python plot.py compare \\
@@ -15,11 +16,16 @@ Examples:
         --baseline "No Spec=nospec/results.csv" \\
         --target "Eagle3=eagle3/results.csv" \\
         --metric latency --title "Qwen3-8B"
+
+    python plot.py acceptance \\
+        --table long_context/raw_table \\
+        --output long_context/acceptance.png
 """
 
 from __future__ import annotations
 
 import argparse
+import math
 import sys
 from collections import defaultdict
 from pathlib import Path
@@ -28,6 +34,7 @@ import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.cm import ScalarMappable
+from matplotlib.gridspec import GridSpec
 from perf_utils import (
     METRICS,
     load_data,
@@ -368,6 +375,220 @@ def run_speedup(args: argparse.Namespace) -> None:
 
 
 # ============================================================================
+# Acceptance (long-context spec-decode)
+# ============================================================================
+
+ACCEPT_ACCENT = "#1f4e79"  # mean-length line
+ACCEPT_BAR = "#3b6fb0"  # tokens-generated bars
+INK = "#1a1a1a"
+MUTED = "#666666"
+TOKENS_PER_K = 1000  # threshold for "k"-suffixed axis labels
+MIN_CELL_SHARE = 0.005  # heatmap cells below this share are left blank
+
+
+def _steps_from_records(records: list) -> tuple[np.ndarray, np.ndarray]:
+    """Flatten spec records into (context position, committed length) per step.
+
+    Each verify step is placed at the *running* context length at the moment it
+    ran -- the prompt length plus everything committed by earlier steps in that
+    same request -- and commits ``accepted drafts + 1`` (the bonus) tokens.
+    """
+    positions: list[int] = []
+    accepts: list[int] = []
+    for r in records:
+        per_step = r.spec.get("per_step_accepted")
+        if not per_step:
+            continue
+        pos = r.prompt_tokens
+        for a in per_step:
+            positions.append(pos)
+            accepts.append(a + 1)
+            pos += a + 1
+    return np.array(positions), np.array(accepts)
+
+
+def _auto_log2_edges(positions: np.ndarray) -> np.ndarray:
+    """~2 bins per octave spanning the observed context range."""
+    lo, hi = positions.min(), positions.max()
+    n_bins = max(4, int(round(math.log2(hi / lo) * 2)))
+    return np.logspace(math.log2(lo), math.log2(hi), n_bins + 1, base=2)
+
+
+def _context_label(v: float) -> str:
+    return f"{v / TOKENS_PER_K:.0f}k" if v >= TOKENS_PER_K else f"{v:.0f}"
+
+
+def _acceptance_grid(
+    positions: np.ndarray,
+    accepts: np.ndarray,
+    edges: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, int]:
+    """Bin steps by context length; return per-bin (frac, tokens, mean_len, ymax).
+
+    ``frac`` is column-normalized: within each context bin, the share of verify
+    steps at each acceptance length (columns sum to 1). ``tokens`` is committed
+    tokens per bin (decoupled from acceptance -> a clean sample-size measure) and
+    ``mean_len`` is committed tokens per step per bin.
+    """
+    n_bins = len(edges) - 1
+    xidx = np.clip(np.digitize(positions, edges) - 1, 0, n_bins - 1)
+    ymax = int(accepts.max())
+    counts = np.zeros((ymax, n_bins))
+    tokens = np.zeros(n_bins)
+    for xi, a in zip(xidx, accepts, strict=True):
+        counts[a - 1, xi] += 1
+        tokens[xi] += a
+    steps = counts.sum(axis=0)
+    frac = np.divide(counts, steps, out=np.zeros_like(counts), where=steps > 0)
+    mean_len = np.divide(tokens, steps, out=np.zeros_like(tokens), where=steps > 0)
+    return frac, tokens, mean_len, ymax
+
+
+def _annotate_cells(ax: plt.Axes, frac: np.ndarray, ymax: int, n_bins: int) -> None:
+    vmax = frac.max()
+    for yi in range(ymax):
+        for xi in range(n_bins):
+            v = frac[yi, xi]
+            if v >= MIN_CELL_SHARE:
+                ax.text(
+                    xi,
+                    yi,
+                    f"{v * 100:.0f}",
+                    ha="center",
+                    va="center",
+                    fontsize=8,
+                    color="white" if v > vmax * 0.55 else INK,
+                )
+
+
+def _draw_acceptance(
+    frac: np.ndarray,
+    tokens: np.ndarray,
+    mean_len: np.ndarray,
+    ymax: int,
+    edges: np.ndarray,
+    *,
+    title: str | None,
+) -> plt.Figure:
+    """Three x-aligned panels sharing one context-length axis.
+
+    A dedicated colorbar column (only under the heatmap) keeps all three left
+    panels the same width, so the line, bars, and heatmap columns line up.
+    """
+    n_bins = len(edges) - 1
+    fig = plt.figure(figsize=(11, 8.5))
+    gs = GridSpec(
+        3,
+        2,
+        width_ratios=[1, 0.025],
+        height_ratios=[1.1, 1.1, 4],
+        hspace=0.08,
+        wspace=0.02,
+    )
+
+    # panel 1: mean acceptance length (summary of the heatmap below)
+    ax_line = fig.add_subplot(gs[0, 0])
+    ax_line.plot(
+        range(n_bins), mean_len, "-o", color=ACCEPT_ACCENT, lw=2, ms=7, zorder=3
+    )
+    for i, v in enumerate(mean_len):
+        if v:
+            ax_line.text(
+                i, v, f"{v:.2f}", ha="center", va="bottom", fontsize=8, color=MUTED
+            )
+    ax_line.set_ylabel("Mean\naccept len", color=INK)
+    ax_line.grid(axis="y", color="#e6e6e6", lw=0.8)
+    ax_line.set_axisbelow(True)
+    ax_line.margins(y=0.28)
+    ax_line.set_title(
+        title or "Speculative-decoding acceptance vs context length",
+        fontsize=13,
+        fontweight="bold",
+        color=INK,
+        pad=10,
+    )
+    for s in ("top", "right"):
+        ax_line.spines[s].set_visible(False)
+
+    # panel 2: committed tokens generated per bin (how much data backs each column)
+    ax_bar = fig.add_subplot(gs[1, 0], sharex=ax_line)
+    ax_bar.bar(
+        range(n_bins),
+        tokens,
+        width=1.0,
+        color=ACCEPT_BAR,
+        edgecolor="white",
+        linewidth=1.2,
+    )
+    ax_bar.set_ylabel("Tokens\ngenerated", color=INK)
+    ax_bar.margins(y=0.18)
+    for s in ("top", "right"):
+        ax_bar.spines[s].set_visible(False)
+
+    # panel 3: acceptance-length distribution within each context bin
+    ax = fig.add_subplot(gs[2, 0], sharex=ax_line)
+    im = ax.imshow(
+        frac, origin="lower", aspect="auto", cmap="Blues", vmin=0, vmax=frac.max()
+    )
+    _annotate_cells(ax, frac, ymax, n_bins)
+    ax.set_yticks(range(ymax))
+    ax.set_yticklabels(range(1, ymax + 1))
+    ax.set_ylabel("Acceptance length (committed tokens/step)", color=INK)
+    ax.set_xticks(range(n_bins))
+    ax.set_xticklabels(
+        [
+            f"{_context_label(edges[i])}–{_context_label(edges[i + 1])}"
+            for i in range(n_bins)
+        ],
+        fontsize=8,
+    )
+    ax.set_xlabel("Context length at token position (tokens)", color=INK)
+    for shared in (ax_line, ax_bar):  # sharex re-adds labels; keep on heatmap only
+        shared.tick_params(labelbottom=False)
+
+    cax = fig.add_subplot(gs[2, 1])
+    cbar = fig.colorbar(im, cax=cax)
+    cbar.set_label("Share of steps within context bin", color=INK)
+    return fig
+
+
+def run_acceptance(args: argparse.Namespace) -> None:
+    from acceptance_report import load_spec_records  # noqa: PLC0415
+
+    records = load_spec_records(args.table)
+    if not records:
+        print(f"[ERROR] No spec-decode records in {args.table}", file=sys.stderr)
+        sys.exit(1)
+
+    positions, accepts = _steps_from_records(records)
+    if positions.size == 0:
+        print(
+            "[ERROR] No per-step data. Start the server with "
+            "--per-request-spec-decode-metrics detailed",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if args.context_bin_edges:
+        edges = np.array(
+            sorted(int(e) for e in args.context_bin_edges.split(",") if e.strip())
+        )
+    else:
+        edges = _auto_log2_edges(positions)
+
+    frac, tokens, mean_len, ymax = _acceptance_grid(positions, accepts, edges)
+    fig = _draw_acceptance(frac, tokens, mean_len, ymax, edges, title=args.title)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(args.output, dpi=args.dpi, bbox_inches="tight")
+    plt.close(fig)
+    print(
+        f"[INFO] Saved {args.output} "
+        f"({len(accepts)} steps, {len(edges) - 1} context bins)"
+    )
+
+
+# ============================================================================
 # CLI
 # ============================================================================
 
@@ -473,6 +694,37 @@ def main() -> None:
         help="Optional title prefix for plots (e.g. model name)",
     )
     spd.set_defaults(func=run_speedup)
+
+    # --- acceptance ---
+    acc = sub.add_parser(
+        "acceptance",
+        help="Long-context spec-decode acceptance heatmap",
+        description=(
+            "Render a 3-panel figure from a recorded request table: mean "
+            "acceptance length, tokens generated, and the acceptance-length "
+            "distribution -- all sharing one context-length axis."
+        ),
+    )
+    acc.add_argument(
+        "--table",
+        type=Path,
+        required=True,
+        help="raw_table directory produced by the long-context runner",
+    )
+    acc.add_argument(
+        "--output",
+        type=Path,
+        default=Path("acceptance.png"),
+        help="Output PNG path (default: acceptance.png)",
+    )
+    acc.add_argument(
+        "--context-bin-edges",
+        default=None,
+        help="Comma-separated token edges (default: ~2 log2 bins per octave)",
+    )
+    acc.add_argument("--title", default=None, help="Optional plot title")
+    acc.add_argument("--dpi", type=int, default=130, help="Output DPI (default: 130)")
+    acc.set_defaults(func=run_acceptance)
 
     args = parser.parse_args()
 

--- a/scripts/evaluate/rebin.py
+++ b/scripts/evaluate/rebin.py
@@ -64,17 +64,29 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    # Validate bin arguments up front, before any file I/O -- _bucket_label
+    # assumes strictly ascending edges, so sort + de-duplicate the user's input
+    # and require at least two distinct edges; otherwise unordered or too-few
+    # edges silently misaggregate the report.
+    context_bin_edges = DEFAULT_CONTEXT_BIN_EDGES
+    if args.context_bin_edges:
+        try:
+            edges = sorted(
+                {int(e) for e in args.context_bin_edges.split(",") if e.strip()}
+            )
+        except ValueError:
+            parser.error("--context-bin-edges must be comma-separated integers")
+        if len(edges) < 2:  # noqa: PLR2004
+            parser.error("--context-bin-edges needs at least two distinct edges")
+        context_bin_edges = tuple(edges)
+    if args.position_bin_size < 1:
+        parser.error("--position-bin-size must be at least 1")
+
     records = load_spec_records(args.table)
     if not records:
         logger.error("No spec-decode records found in %s", args.table)
         sys.exit(1)
     logger.info("Loaded %d spec-decode records from %s", len(records), args.table)
-
-    context_bin_edges = DEFAULT_CONTEXT_BIN_EDGES
-    if args.context_bin_edges:
-        context_bin_edges = tuple(
-            int(e) for e in args.context_bin_edges.split(",") if e.strip()
-        )
 
     write_report(
         args.output_dir or args.table.parent,

--- a/scripts/evaluate/rebin.py
+++ b/scripts/evaluate/rebin.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Rebuild acceptance reports from a recorded request table, with no server.
+
+The long-context runner streams every request's raw result (identity, exact
+prompt length, response, and full server metrics) to a Parquet table -- the
+source of truth. The aggregated CSVs are just one slicing of it. This script
+re-slices that table with different bucket edges, so changing how results are
+binned never requires re-running inference.
+
+Usage:
+    python rebin.py --table <output_dir>/raw_table
+    python rebin.py --table <dir>/raw_table --position-bin-size 512
+    python rebin.py --table <dir>/raw_table --context-bin-edges 0,8192,32768,131072
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from acceptance_report import (
+    DEFAULT_CONTEXT_BIN_EDGES,
+    DEFAULT_POSITION_BIN_SIZE,
+    load_spec_records,
+    write_report,
+)
+
+logger = logging.getLogger("evaluate")
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO, format="[%(levelname)s] %(message)s", stream=sys.stderr
+    )
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--table",
+        type=Path,
+        required=True,
+        help="Path to a raw_table directory produced by the long-context runner",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Where to write the re-bucketed CSVs (default: the table's parent)",
+    )
+    parser.add_argument(
+        "--context-bin-edges",
+        default=None,
+        help=(
+            "Comma-separated token edges for the by-start-length report "
+            f"(default: {','.join(map(str, DEFAULT_CONTEXT_BIN_EDGES))})"
+        ),
+    )
+    parser.add_argument(
+        "--position-bin-size",
+        type=int,
+        default=DEFAULT_POSITION_BIN_SIZE,
+        help=f"By-position bin width in tokens (default: {DEFAULT_POSITION_BIN_SIZE})",
+    )
+    args = parser.parse_args()
+
+    records = load_spec_records(args.table)
+    if not records:
+        logger.error("No spec-decode records found in %s", args.table)
+        sys.exit(1)
+    logger.info("Loaded %d spec-decode records from %s", len(records), args.table)
+
+    context_bin_edges = DEFAULT_CONTEXT_BIN_EDGES
+    if args.context_bin_edges:
+        context_bin_edges = tuple(
+            int(e) for e in args.context_bin_edges.split(",") if e.strip()
+        )
+
+    write_report(
+        args.output_dir or args.table.parent,
+        records,
+        context_bin_edges=context_bin_edges,
+        position_bin_size=args.position_bin_size,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate/request_runner.py
+++ b/scripts/evaluate/request_runner.py
@@ -1,0 +1,309 @@
+"""Generic request runner: send a set of chat requests, record everything.
+
+This layer is deliberately benchmark- and metric-agnostic. A caller supplies an
+ordered sequence of :class:`Request` objects -- each just chat messages, a
+sampling budget, and an opaque ``metadata`` dict -- and, optionally, a stop
+predicate evaluated after each batch. The runner renders every request through
+the server's own ``/v1/chat/completions/render`` endpoint (which doubles as an
+exact-length + context fit-test), generates whatever fits, and streams one flat
+row per request to a Parquet dataset. Each row carries the request identity and
+metadata, the exact prompt length, the response text, and the *raw* server
+metrics blob -- all untouched.
+
+The runner does not know what a "bin", a "context length", or "speculative
+decoding" is. Interpreting the recorded table -- binning, acceptance math,
+plots -- is the job of a separate analysis layer (see ``acceptance_report.py``),
+so the same recording can be re-analysed any number of ways without re-running
+inference, and other benchmarks can reuse this runner unchanged.
+
+A benchmark, in this design, is just "a set of requests to make, in some order,
+with an optional early-stop rule" -- produced by a thin adapter (see ``mrcr.py``).
+
+Durability: each batch is written as its own Parquet part file
+(``part-00000.parquet`` ...) under the table directory. A completed batch is a
+complete, readable file, so a crash only loses the batch in flight; the table is
+the whole directory, read back with :func:`load_table`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, TypeVar
+from urllib.error import HTTPError, URLError
+from urllib.request import Request as UrlRequest
+from urllib.request import urlopen
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+    from pathlib import Path
+
+logger = logging.getLogger("evaluate")
+
+T = TypeVar("T")
+
+RowStatus = Literal["ok", "oversized", "error"]
+
+_RENDER_TIMEOUT_S = 180
+_GENERATE_TIMEOUT_S = 1200
+
+# Flat, stable schema for the recorded table. The two ``*_json`` columns keep the
+# runner generic: it never interprets server metrics or caller metadata, it just
+# records them verbatim for the analysis layer to parse.
+TABLE_SCHEMA = pa.schema(
+    [
+        ("request_id", pa.string()),
+        ("status", pa.string()),  # ok | oversized | error
+        ("prompt_tokens", pa.int64()),
+        ("granted_max_tokens", pa.int64()),
+        ("completion_tokens", pa.int64()),
+        ("finish_reason", pa.string()),
+        ("response_text", pa.string()),
+        ("metrics_json", pa.string()),  # verbatim response["metrics"]
+        ("metadata_json", pa.string()),  # verbatim Request.metadata
+    ]
+)
+
+TABLE_DIRNAME = "raw_table"
+
+
+@dataclass
+class Request:
+    """One chat request to send, plus opaque metadata echoed into the table."""
+
+    messages: list[dict]
+    max_tokens: int = 512
+    sampling: dict = field(default_factory=dict)  # temperature, top_p, seed, ...
+    metadata: dict = field(default_factory=dict)  # echoed verbatim into the row
+    request_id: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Generic request-set helpers (produce/order the batches a runner consumes)
+# ---------------------------------------------------------------------------
+
+
+def stable_hash(value: str) -> str:
+    """A stable, process-independent hash usable as a deterministic sort key."""
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _bin_index(length: float, bin_edges: Sequence[float]) -> int:
+    for i, edge in enumerate(bin_edges):
+        if length <= edge:
+            return i
+    return len(bin_edges)
+
+
+def select_stratified(
+    items: Iterable[T],
+    *,
+    bin_edges: Sequence[float],
+    samples_per_bin: int,
+    key_fn: Callable[[T], str],
+    length_fn: Callable[[T], float],
+) -> list[list[T]]:
+    """Deterministically pick up to *samples_per_bin* items per length bin.
+
+    Items are placed into fixed absolute bins by ``length_fn`` and, within each
+    bin, ranked by ``key_fn`` (a stable content hash); the lowest-ranked
+    ``samples_per_bin`` per bin are kept. The result is grouped by bin and
+    ordered by ascending bin, ready to hand to :func:`run_requests` as batches
+    -- render smallest-first and stop once a whole bin no longer fits. The
+    selection depends only on the items and these arguments, never on the
+    server, so a larger-context run is a superset of a smaller one.
+    """
+    bins: dict[int, list[T]] = defaultdict(list)
+    for item in items:
+        bins[_bin_index(length_fn(item), bin_edges)].append(item)
+    return [sorted(bins[b], key=key_fn)[:samples_per_bin] for b in sorted(bins)]
+
+
+# ---------------------------------------------------------------------------
+# HTTP
+# ---------------------------------------------------------------------------
+
+
+def _post(root_url: str, path: str, body: dict, timeout: int) -> dict:
+    req = UrlRequest(  # noqa: S310
+        f"{root_url}{path}",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return json.loads(resp.read())
+
+
+def _render(root_url: str, model: str, req: Request) -> tuple[int, int] | RowStatus:
+    """Return ``(prompt_tokens, granted_max_tokens)`` or a failure status.
+
+    An HTTP error from the render endpoint means the prompt doesn't fit the
+    model's context window -- reported as ``"oversized"``.
+    """
+    try:
+        rendered = _post(
+            root_url,
+            "/v1/chat/completions/render",
+            {"model": model, "messages": req.messages, "max_tokens": req.max_tokens},
+            timeout=_RENDER_TIMEOUT_S,
+        )
+        return len(rendered["token_ids"]), rendered["sampling_params"]["max_tokens"]
+    except HTTPError:
+        return "oversized"
+    except (URLError, OSError, json.JSONDecodeError, KeyError, TypeError) as e:
+        logger.warning("Render failed for %s: %s", req.request_id, e)
+        return "error"
+
+
+def _row(req: Request, status: RowStatus, **fields) -> dict:
+    return {
+        "request_id": req.request_id,
+        "status": status,
+        "prompt_tokens": None,
+        "granted_max_tokens": None,
+        "completion_tokens": None,
+        "finish_reason": None,
+        "response_text": None,
+        "metrics_json": None,
+        "metadata_json": json.dumps(req.metadata),
+        **fields,
+    }
+
+
+def _execute(
+    root_url: str, model: str, req: Request, *, fit_test: bool, min_room: int
+) -> dict:
+    """Render (optional), generate, and return one flat table row."""
+    max_tokens = req.max_tokens
+    prompt_tokens: int | None = None
+    granted: int | None = None
+
+    if fit_test:
+        rendered = _render(root_url, model, req)
+        if isinstance(rendered, str):  # "oversized" | "error"
+            return _row(req, rendered)
+        prompt_tokens, granted = rendered
+        if granted < min_room:
+            # Fits, but too little generation room left to be worth measuring.
+            return _row(req, "oversized", prompt_tokens=prompt_tokens)
+        max_tokens = granted
+
+    try:
+        resp = _post(
+            root_url,
+            "/v1/chat/completions",
+            {
+                "model": model,
+                "messages": req.messages,
+                "max_tokens": max_tokens,
+                **req.sampling,
+            },
+            timeout=_GENERATE_TIMEOUT_S,
+        )
+    except (HTTPError, URLError, OSError, json.JSONDecodeError) as e:
+        logger.warning("Generation failed for %s: %s", req.request_id, e)
+        return _row(req, "error", prompt_tokens=prompt_tokens)
+
+    choice = (resp.get("choices") or [{}])[0]
+    usage = resp.get("usage") or {}
+    return _row(
+        req,
+        "ok",
+        prompt_tokens=prompt_tokens or usage.get("prompt_tokens"),
+        granted_max_tokens=granted,
+        completion_tokens=usage.get("completion_tokens"),
+        finish_reason=choice.get("finish_reason"),
+        response_text=(choice.get("message") or {}).get("content"),
+        metrics_json=json.dumps(resp.get("metrics") or {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def run_requests(
+    root_url: str,
+    model: str,
+    batches: Iterable[Sequence[Request]],
+    table_dir: Path,
+    *,
+    max_concurrency: int,
+    fit_test: bool = True,
+    min_generation_room: int = 0,
+    should_stop: Callable[[list[dict]], bool] | None = None,
+) -> Path:
+    """Send *batches* of requests concurrently and record every result.
+
+    Batches are processed in order; within a batch requests run concurrently.
+    After each batch the (list of) rows is written as a Parquet part file and,
+    if *should_stop* returns True for that batch's rows, the run halts (used by
+    ordered benchmarks to stop once a whole batch is oversized). Returns the
+    table directory, readable via :func:`load_table`.
+    """
+    table_dir.mkdir(parents=True, exist_ok=True)
+    n_ok = n_oversized = n_error = 0
+
+    with ThreadPoolExecutor(max_workers=max_concurrency) as pool:
+        for part_idx, batch in enumerate(batches):
+            if not batch:
+                continue
+            futures = [
+                pool.submit(
+                    _execute,
+                    root_url,
+                    model,
+                    req,
+                    fit_test=fit_test,
+                    min_room=min_generation_room,
+                )
+                for req in batch
+            ]
+            rows = [f.result() for f in as_completed(futures)]
+
+            pq.write_table(
+                pa.Table.from_pylist(rows, schema=TABLE_SCHEMA),
+                table_dir / f"part-{part_idx:05d}.parquet",
+                compression="zstd",
+            )
+            n_ok += sum(r["status"] == "ok" for r in rows)
+            n_oversized += sum(r["status"] == "oversized" for r in rows)
+            n_error += sum(r["status"] == "error" for r in rows)
+            logger.info(
+                "Batch %d: %d ok, %d oversized, %d error (cumulative %d/%d/%d)",
+                part_idx,
+                sum(r["status"] == "ok" for r in rows),
+                sum(r["status"] == "oversized" for r in rows),
+                sum(r["status"] == "error" for r in rows),
+                n_ok,
+                n_oversized,
+                n_error,
+            )
+            if should_stop is not None and should_stop(rows):
+                logger.info(
+                    "Stop predicate satisfied after batch %d; halting.", part_idx
+                )
+                break
+
+    logger.info(
+        "Run complete: %d ok, %d oversized, %d error. Table: %s",
+        n_ok,
+        n_oversized,
+        n_error,
+        table_dir,
+    )
+    return table_dir
+
+
+def load_table(table_dir: Path) -> pa.Table:
+    """Read a recorded table (a directory of Parquet part files) back in."""
+    return pq.read_table(table_dir, schema=TABLE_SCHEMA)

--- a/scripts/evaluate/request_runner.py
+++ b/scripts/evaluate/request_runner.py
@@ -54,6 +54,11 @@ RowStatus = Literal["ok", "oversized", "error"]
 _RENDER_TIMEOUT_S = 180
 _GENERATE_TIMEOUT_S = 1200
 
+# HTTP statuses the render endpoint uses to reject a prompt that exceeds the
+# model's context window (vLLM: 400; some proxies: 413). Every other status is a
+# genuine failure, not an oversized prompt.
+_CONTEXT_LIMIT_STATUSES = frozenset({400, 413})
+
 # Flat, stable schema for the recorded table. The two ``*_json`` columns keep the
 # runner generic: it never interprets server metrics or caller metadata, it just
 # records them verbatim for the analysis layer to parse.
@@ -145,8 +150,12 @@ def _post(root_url: str, path: str, body: dict, timeout: int) -> dict:
 def _render(root_url: str, model: str, req: Request) -> tuple[int, int] | RowStatus:
     """Return ``(prompt_tokens, granted_max_tokens)`` or a failure status.
 
-    An HTTP error from the render endpoint means the prompt doesn't fit the
-    model's context window -- reported as ``"oversized"``.
+    Only a context-limit rejection means the prompt genuinely doesn't fit --
+    reported as ``"oversized"``. The render endpoint returns 400/413 for that.
+    Any other HTTP status (a missing route, or a transient 5xx) is a *failure*,
+    not an oversized prompt, and must be reported as ``"error"`` -- otherwise an
+    ordered benchmark's ``_all_oversized`` stop rule can halt the whole run on a
+    blip and the table would blame prompt length for a server fault.
     """
     try:
         rendered = _post(
@@ -156,8 +165,13 @@ def _render(root_url: str, model: str, req: Request) -> tuple[int, int] | RowSta
             timeout=_RENDER_TIMEOUT_S,
         )
         return len(rendered["token_ids"]), rendered["sampling_params"]["max_tokens"]
-    except HTTPError:
-        return "oversized"
+    except HTTPError as e:
+        if e.code in _CONTEXT_LIMIT_STATUSES:
+            return "oversized"
+        logger.warning(
+            "Render endpoint returned HTTP %s for %s: %s", e.code, req.request_id, e
+        )
+        return "error"
     except (URLError, OSError, json.JSONDecodeError, KeyError, TypeError) as e:
         logger.warning("Render failed for %s: %s", req.request_id, e)
         return "error"
@@ -251,6 +265,11 @@ def run_requests(
     table directory, readable via :func:`load_table`.
     """
     table_dir.mkdir(parents=True, exist_ok=True)
+    # Start from a clean table: a reuse of this directory by a shorter run would
+    # otherwise leave stale higher-index part files that load_table() reads back,
+    # silently mixing the previous run's rows into this one's reports.
+    for stale in table_dir.glob("part-*.parquet"):
+        stale.unlink()
     n_ok = n_oversized = n_error = 0
 
     with ThreadPoolExecutor(max_workers=max_concurrency) as pool:

--- a/scripts/evaluate/requirements.txt
+++ b/scripts/evaluate/requirements.txt
@@ -8,3 +8,9 @@ matplotlib
 numpy
 scikit-learn
 scipy
+
+# long-context mode: MRCR dataset loading + recorded request table. Requests go
+# straight to the target server's HTTP API, so no separate eval harness is needed.
+pandas
+pyarrow
+huggingface_hub


### PR DESCRIPTION
## Summary

Adds a **`long-context`** evaluation mode that measures speculative-decoding acceptance as context length grows, using [OpenAI's MRCR dataset](https://huggingface.co/datasets/openai/mrcr) as a source of long, multi-turn prompts.

The design principle: **a benchmark is just a set of requests to make (in some order, with an optional stop rule); everything is recorded to a table, and reports are pure functions over that table.** So the pieces are decoupled into three layers, none of which is MRCR-specific except the last:

1. **`request_runner.py` — generic runner.** Given an ordered set of requests (chat messages + sampling budget + opaque `metadata`) and an optional per-batch stop predicate, it renders each request through the server's own render endpoint (exact prompt length + context fit-test), generates whatever fits, and streams one flat row per request to a **Parquet table**: request identity, metadata, exact prompt length, response text, and the *raw* server metrics blob — all verbatim. It knows nothing about bins, context length, or spec-decode. Each batch is a separate Parquet part file, so a crash only loses the batch in flight.
2. **`acceptance_report.py` — spec-decode analysis over the table.** Context-length bucket edges live here as *analysis parameters*, not harness constants. Reports acceptance (a) by prompt length at request start and (b) by running token position within each request.
3. **`mrcr.py` — thin MRCR adapter.** Loads the dataset and turns it into a deterministically-selected, length-ordered request set.

Because the raw table is the source of truth, reports can be re-sliced with different bin edges and **no server** via `rebin.py`, and plotted with `plot.py acceptance`.

Correctness is intentionally not graded — MRCR is used only for its long prompts.

### Deterministic superset selection

Records are stratified into MRCR's native power-of-2 token bins and, within each bin, ranked by a stable content hash (`sha256(seed + prompt)`); the lowest-ranked `--samples-per-bin` per bin form the candidate set. Bin assignment uses `n_chars / 4.9` (MRCR carries no token count; the ratio is 4.9 ± 0.1 across the whole dataset, validated offline against o200k) — zero runtime cost, no `tiktoken` dependency. The candidate set is independent of `max_model_len`; the only context-dependent step is the render fit-test, which is monotonic, so `Kept(ctx1) ⊆ Kept(ctx2)` for `ctx1 ≤ ctx2`. Batches run smallest-first and stop once a whole bin renders oversized.

### CLI

```bash
# Server must expose the render endpoint and per-request detailed metrics:
VLLM_ENABLE_SCALE_OUT_ENDPOINTS=1 vllm serve <model> \
    --per-request-spec-decode-metrics detailed \
    --speculative-config '{"model":"<draft>","num_speculative_tokens":N}'

python evaluate.py --target http://localhost:8000/v1 long-context --samples-per-bin 20

# Re-slice results offline with different bins (no server):
python rebin.py --table <out>/raw_table --context-bin-edges 0,8192,32768,131072

# Plot the acceptance figure offline (no server):
python plot.py acceptance --table <out>/raw_table --output <out>/acceptance.png
```

New flags (long-context only): `--samples-per-bin`, `--selection-seed`, `--position-bin-size`. `throughput`/`sweep` are unchanged and don't import the long-context deps.

### Visualization

`plot.py` gains an **`acceptance`** subcommand that renders the recorded table into one figure — another pure slicing of the same source of truth as the CSVs, so it needs no server:

![Long-context acceptance plot](https://raw.githubusercontent.com/reed-meyerson/speculators/pr-assets/acceptance_example.png)

Three panels share one context-length x-axis (example: Qwen3-8B + a DFlash speculator, 7 speculative tokens, MRCR 2-needle):

- **Mean accept len** (line) — mean committed tokens per verify step in each context bin; the headline trend.
- **Tokens generated** (bars) — committed tokens per bin, i.e. how much data backs each column. Deliberately *decoupled* from acceptance (a step-count bar would inflate low-acceptance bins), so it reads cleanly as sample size.
- **Acceptance-length distribution** (heatmap) — within each context bin, the share of verify **steps** that committed exactly *k* tokens (each column sums to ~100%). The integer in a cell is just the precise readout of its color.

The x-axis is the *running* context length at each verify step (prompt length + everything committed so far), not per-request — so it stays meaningful even when generation is long relative to the bin width. Bins default to ~2 log2 bins per octave and can be overridden with `--context-bin-edges`.

Reading the example: acceptance degrades monotonically as context grows — mean length falls 2.73 → 1.68 tokens/step from ~4k to ~26k, and the share of single-token steps climbs 28% → 52%.

### Dependencies

Long-context mode adds `pandas`, `pyarrow`, `huggingface_hub` (dataset loading + Parquet table); requests go straight to the target server's HTTP API, so there's no separate eval harness. Plotting reuses the existing `matplotlib`/`numpy` deps — nothing new.

### Validation

Ran end-to-end against Qwen3-8B + a DFlash speculator at `--max-model-len 40960`: deterministic bounded selection with the bin early-stop firing, a Parquet table written (one part file per bin), both acceptance reports produced, detailed per-step metrics flowing through, `rebin.py` reproducing the reports offline with different bin edges, and `plot.py acceptance` rendering the figure above from the recorded table. Recording is small — a full MRCR run is single-digit MB (the raw prompts are *not* stored, only a reference; the per-step arrays are bounded by the generation cap, not the context length).

### Note

Supersedes #1064 — this replaces the earlier Inspect-AI-based MRCR mode with the recorded-table architecture. Opening fresh rather than force-pushing that branch so the two approaches can be compared. Draft while I gather more validation.

The example image is hosted on the fork's `pr-assets` branch (kept out of this PR's diff), since `gh` can't upload to GitHub's attachment CDN directly.

---

Reusability: `throughput`/`sweep` could later adopt `request_runner` + `acceptance_report` to get the same per-request table and reporting (out of scope here).
