### PR TITLE
Patch Qwen3.5 3D M-Rope handling

### DIFF
--- a/src/speculators/models/mtp/core.py
+++ b/src/speculators/models/mtp/core.py
@@ -24,6 +24,49 @@ logger = logging.getLogger(__name__)
 __all__ = ["MTPDraftModel", "compute_step_weights"]
 
 _IGNORE_INDEX = -100
+_QWEN3_5_MODEL_TYPES = {"qwen3_5_text", "qwen3_5_moe_text"}
+_QWEN3_5_MROPE_POSITION_ID_RANK = 3
+_QWEN3_5_MROPE_SECTIONS = 3
+
+
+def _prepare_mtp_position_ids(
+    position_ids: torch.Tensor,
+    valid_len: int,
+    model_type: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Prepare mask/layer and rotary position IDs for an MTP step.
+
+    Released transformers versions expand Qwen3.5's 2-D position IDs inside
+    the rotary embedding. Newer versions expect the caller to provide the
+    three MRoPE sections explicitly. Keep the 2-D text positions for mask
+    construction and the decoder layer, while providing the 3-D form to the
+    rotary embedding when needed.
+
+    Returns:
+        A pair of ``(text_position_ids, rotary_position_ids)``.
+    """
+    if position_ids.ndim == _QWEN3_5_MROPE_POSITION_ID_RANK:
+        if model_type not in _QWEN3_5_MODEL_TYPES:
+            raise ValueError(
+                "3-D position_ids are only supported for Qwen3.5 MTP models; "
+                f"got model type {model_type!r}."
+            )
+        if position_ids.shape[0] != _QWEN3_5_MROPE_SECTIONS:
+            raise ValueError(
+                "Qwen3.5 MTP position_ids must have shape [3, batch, seq_len]; "
+                f"got {tuple(position_ids.shape)}."
+            )
+        rotary_position_ids = position_ids[:, :, :valid_len]
+        return rotary_position_ids[0], rotary_position_ids
+
+    step_position_ids = position_ids[:, :valid_len]
+    if model_type in _QWEN3_5_MODEL_TYPES:
+        rotary_position_ids = step_position_ids.unsqueeze(0).expand(
+            _QWEN3_5_MROPE_SECTIONS, -1, -1
+        )
+    else:
+        rotary_position_ids = step_position_ids
+    return step_position_ids, rotary_position_ids
 
 
 def compute_step_weights(beta: float = 0.6, num_steps: int = 3) -> list[float]:
@@ -138,7 +181,8 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
             embedding source and the prediction target (offset by step+2).
         :param hidden_states: Hidden states from verifier [1, seq_len, hidden_size]
         :param attention_mask: Optional attention mask [1, seq_len]
-        :param position_ids: Optional position IDs [1, seq_len]
+        :param position_ids: Optional position IDs [batch, seq_len]. Qwen3.5
+            also accepts the explicit MRoPE layout [3, batch, seq_len].
         :param loss_mask: Optional binary mask [1, seq_len]; 1=compute loss,
             0=ignore.
         :param step_weights: Per-step loss weights (None = uniform). Training only.
@@ -178,7 +222,11 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
             metrics["loss_total"] = torch.tensor(1.0, device=device)
             return (all_logits, total_loss, metrics)
 
-        step_pos_ids = position_ids[:, :valid_len]
+        step_pos_ids, rotary_step_pos_ids = _prepare_mtp_position_ids(
+            position_ids,
+            valid_len,
+            self.config.transformer_layer_config.model_type,
+        )
         causal_mask = create_causal_mask(
             config=self.config.transformer_layer_config,
             inputs_embeds=hidden_states[:, :valid_len],
@@ -193,7 +241,7 @@ class MTPDraftModel(DraftVocabMixin, SpeculatorModel):
             step_embeds = self.embed_tokens(
                 input_ids[:, step + 1 : step + 1 + valid_len]
             )
-            step_pos_emb = self.rotary_emb(step_hidden, step_pos_ids)
+            step_pos_emb = self.rotary_emb(step_hidden, rotary_step_pos_ids)
 
             mtp_output = self.mtp_layers[0](
                 hidden_states=step_hidden,

--- a/tests/unit/models/test_mtp_model.py
+++ b/tests/unit/models/test_mtp_model.py
@@ -4,8 +4,46 @@ import math
 
 import torch
 
+from speculators.models.mtp.core import _prepare_mtp_position_ids
+
 BATCH = 1
 SEQ_LEN = 10
+
+
+def test_qwen35_position_ids_are_expanded_for_new_transformers():
+    position_ids = torch.arange(8).unsqueeze(0)
+
+    text_position_ids, rotary_position_ids = _prepare_mtp_position_ids(
+        position_ids, valid_len=6, model_type="qwen3_5_text"
+    )
+
+    assert text_position_ids.shape == (1, 6)
+    assert rotary_position_ids.shape == (3, 1, 6)
+    assert torch.equal(rotary_position_ids[0], text_position_ids)
+    assert torch.equal(rotary_position_ids[1], text_position_ids)
+    assert torch.equal(rotary_position_ids[2], text_position_ids)
+
+
+def test_qwen35_position_ids_accept_existing_mrope_layout():
+    position_ids = torch.arange(24).reshape(3, 2, 4)
+
+    text_position_ids, rotary_position_ids = _prepare_mtp_position_ids(
+        position_ids, valid_len=3, model_type="qwen3_5_moe_text"
+    )
+
+    assert torch.equal(text_position_ids, position_ids[0, :, :3])
+    assert torch.equal(rotary_position_ids, position_ids[:, :, :3])
+
+
+def test_non_qwen35_position_ids_remain_2d():
+    position_ids = torch.arange(8).unsqueeze(0)
+
+    text_position_ids, rotary_position_ids = _prepare_mtp_position_ids(
+        position_ids, valid_len=6, model_type="qwen3"
+    )
+
+    assert torch.equal(text_position_ids, position_ids[:, :6])
+    assert torch.equal(rotary_position_ids, position_ids[:, :6])
 
 
 # ===== Forward output structure =====


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose

Our nightly job is failing due to changes that recently landed on transformers main:

> Upstream's qwen3_5 model gives its rotary embedding a 3-section/mRoPE signature expecting a 3-D position_ids; speculators' MTP still passes a 2-D position_ids from speculators/models/mtp/core.py, so position_ids[:, :, None, :] over-indexes → IndexError: too many indices for tensor of dimension 2. The pinned-transformers lanes (3.10/3.11/3.13) are unaffected. On the e2e 3.13-main lane this also surfaces via test_mtp_finetuning_smoke (train.py fails with the same IndexError) and test_mtp_roundtrip.

This pr updates the mtp code, to handle either 2D or 3D position ids, and reshape them as needed for the MRope module. 

## Tests

Added tests to check backwards compat. 

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
