### PR TITLE
perf(losses): autotune the fused-loss tile instead of a fixed 131072 block

### DIFF
--- a/src/speculators/losses/fused.py
+++ b/src/speculators/losses/fused.py
@@ -30,37 +30,40 @@ import torch
 import triton
 import triton.language as tl
 
+from speculators.utils.util import is_npu_available
+
 # Ascend NPU's Unified Buffer (~192 KB) cannot fit the double-row load these
 # kernels perform (logits + targets per block) beyond 4096 elements per block;
 # triton-ascend raises "ub overflow" at BLOCK_SIZE >= 8192. CE is single-row
 # but shares the same cap so all _FusedLoss OPs use one path.
 MAX_FUSED_SIZE_NPU = 4096
 
-# CUDA tile selection. Each program holds several fp32 vectors of
-# BLOCK_SIZE / threads elements live at once, so what bounds the tile is
-# elements *per thread*, not BLOCK_SIZE. Past ~32 the working set exceeds the
-# 255-register budget and Triton spills to local memory; measured spill bytes
-# per thread for the forward kernel at V=151936 on an A100:
+# Search space for the row-per-program tile, autotuned per (vocab, OP) on the
+# first launch. Each program keeps several fp32 vectors of BLOCK_SIZE / threads
+# elements live at once, so what bounds the tile is elements *per thread*, not
+# BLOCK_SIZE: register use grows at roughly two per element, exhausting the
+# 255-register budget around 128, after which Triton spills to local memory.
+# Measured registers/spill-bytes per thread, forward kernel, V=151936, A100:
 #
-#     BLOCK_SIZE   warps=8   warps=16   warps=32
-#       131072        1162        532        234
-#        65536         152         38         38
-#        32768           0          0          0
-#         8192           0          0          0
+#     BLOCK_SIZE     warps=4      warps=8     warps=16     warps=32
+#          4096     54/0         32/0         31/0         27/0
+#          8192     96/6         48/0         32/0         31/0
+#         16384    253/0        127/0         64/0         32/0
+#         32768    255/126      254/0         97/0         53/0
+#         65536     32/1222     255/152      128/38        64/38
+#        131072     32/3748      32/1162      32/532       32/234
 #
-# A fixed BLOCK_SIZE of 131072 (the previous behaviour, hit by any vocab
-# > 65536) spilled 234 B/thread and ran the forward at 98 GB/s -- 6% of HBM
-# peak, and 17x slower than the same kernel with a register-resident tile.
-ELEMS_PER_THREAD = 32
-
-# Cap the tile so a full-vocab row is streamed in several register-resident
-# passes rather than one spilling pass. 8192 measured fastest at the shapes
-# training actually uses (>=1024 rows); a wider tile only helps when there are
-# too few rows to fill the device, where the kernel costs <0.3 ms anyway.
-MAX_FUSED_SIZE = 8192
-
-# num_warps=4 measured slower than 8 at every shape tried.
-MIN_THREADS_PER_PROGRAM = 256
+# A spilling tile is never competitive -- the fixed BLOCK_SIZE=131072 this file
+# used to select for any vocab > 65536 spilled 234 B/thread and ran the forward
+# at 98 GB/s, 6% of A100 HBM peak -- so the space is bounded to the
+# register-resident region up front rather than rediscovered at every startup.
+# Which tile *within* that region wins is machine-dependent, which is what the
+# autotuner is for; on an A100 it lands on 8192/8 warps at a 151936 vocab and
+# 16384/16 at 32000.
+_MAX_ELEMS_PER_THREAD = 128
+_MIN_ELEMS_PER_THREAD = 4
+_BLOCK_SIZES = (1024, 2048, 4096, 8192, 16384, 32768)
+_THREADS_PER_PROGRAM = (128, 256, 512, 1024)
 
 # tl.constexpr instances: Triton kernels may only read globals wrapped this way.
 _LOG2 = tl.constexpr(0.6931471805599453)
@@ -81,24 +84,47 @@ _OP_TV = tl.constexpr(4)
 _N_STATS = 5
 
 
-def _calculate_settings(n, device):
-    """Pick (BLOCK_SIZE, num_warps) for a row-per-program launch over ``n`` cols.
+def _tile_configs():
+    """Register-resident (BLOCK_SIZE, num_warps) candidates for the autotuner."""
+    if is_npu_available():
+        # triton-ascend is Unified-Buffer bound rather than register bound:
+        # exactly one tile fits, so there is nothing to search.
+        return [triton.Config({"BLOCK_SIZE": MAX_FUSED_SIZE_NPU}, num_warps=4)]
 
-    Sized so each program's working set stays in registers: the thread count
-    scales with the tile so elements-per-thread is pinned at
-    ``ELEMS_PER_THREAD`` regardless of vocab size.
+    # AMD wavefronts are 64-wide, so a thread count is half as many warps.
+    warp_size = 64 if getattr(torch.version, "hip", None) is not None else 32
+    return [
+        triton.Config({"BLOCK_SIZE": block}, num_warps=threads // warp_size)
+        for threads in _THREADS_PER_PROGRAM
+        for block in _BLOCK_SIZES
+        if _MIN_ELEMS_PER_THREAD <= block // threads <= _MAX_ELEMS_PER_THREAD
+    ]
+
+
+def _prune_oversized_tiles(configs, nargs, **_):
+    """Drop tiles wider than the vocabulary; those only add masked-off lanes.
+
+    Dynamo traces this callback when the launch is inside a compiled region, so
+    it has to stay to simple list operations -- a ``min(..., key=...)`` here
+    fails to trace.
     """
-    if device.type == "npu":
-        # triton-ascend is Unified-Buffer bound, not register bound, and does
-        # not require extra num_warps tuning.
-        return min(triton.next_power_of_2(n), MAX_FUSED_SIZE_NPU), 4
+    cap = triton.next_power_of_2(nargs["n_cols"])
+    keep = [config for config in configs if config.kwargs["BLOCK_SIZE"] <= cap]
+    if keep:
+        return keep
+    # Every tile is oversized for a very narrow vocab. They all still mask
+    # correctly, but only the narrowest are worth compiling.
+    floor = min(config.kwargs["BLOCK_SIZE"] for config in configs)
+    return [config for config in configs if config.kwargs["BLOCK_SIZE"] == floor]
 
-    BLOCK_SIZE = min(triton.next_power_of_2(n), MAX_FUSED_SIZE)
-    threads = max(BLOCK_SIZE // ELEMS_PER_THREAD, MIN_THREADS_PER_PROGRAM)
-    num_warps = threads // 32
-    if getattr(torch.version, "hip", None) is not None:  # AMD wavefronts are 64-wide
-        num_warps //= 2
-    return BLOCK_SIZE, num_warps
+
+# Keyed on OP as well as the vocab: CE streams the row once where the
+# distribution losses stream it three times, so they do not share an optimum.
+_autotune_tile = triton.autotune(
+    configs=_tile_configs(),
+    key=["n_cols", "OP"],
+    prune_configs_by={"early_config_prune": _prune_oversized_tiles},
+)
 
 
 @triton.jit
@@ -124,6 +150,7 @@ def _log_mix(ldp, ltp):
     return mx + tl.log(tl.exp(ldp - mx) + tl.exp(ltp - mx)) - _LOG2
 
 
+@_autotune_tile
 @triton.jit
 def loss_forward_kernel(  # noqa: C901 -- constexpr OP branches, pruned per instance
     logits_ptr,
@@ -210,6 +237,7 @@ def loss_forward_kernel(  # noqa: C901 -- constexpr OP branches, pruned per inst
             tl.store(stats_ptr + 4 * stats_row + pid, extra)
 
 
+@_autotune_tile
 @triton.jit
 def loss_backward_kernel(
     logits_ptr,
@@ -285,7 +313,6 @@ class _FusedLoss(torch.autograd.Function):
         targets_flat = targets.contiguous().view(B * T, V)
         loss = torch.empty(B * T, device=logits.device, dtype=torch.float32)
         stats = torch.empty(_N_STATS, B * T, device=logits.device, dtype=torch.float32)
-        BLOCK_SIZE, num_warps = _calculate_settings(V, logits_flat.device)
         loss_forward_kernel[(B * T,)](
             logits_flat,
             targets_flat,
@@ -294,8 +321,6 @@ class _FusedLoss(torch.autograd.Function):
             stats.stride(0),
             V,
             OP=op,
-            BLOCK_SIZE=BLOCK_SIZE,
-            num_warps=num_warps,
         )
         # CE backward only needs the target argmax cached in stats.
         ctx.save_for_backward(
@@ -303,14 +328,12 @@ class _FusedLoss(torch.autograd.Function):
         )
         ctx.op = op
         ctx.shape = (B, T, V)
-        ctx.settings = (BLOCK_SIZE, num_warps)
         return loss.view(B, T)
 
     @staticmethod
     def backward(ctx, grad_output):
         logits_flat, targets_flat, stats = ctx.saved_tensors
         B, T, V = ctx.shape
-        BLOCK_SIZE, num_warps = ctx.settings
         grad_in = torch.empty_like(logits_flat)
         loss_backward_kernel[(B * T,)](
             logits_flat,
@@ -321,8 +344,6 @@ class _FusedLoss(torch.autograd.Function):
             stats.stride(0),
             V,
             OP=ctx.op,
-            BLOCK_SIZE=BLOCK_SIZE,
-            num_warps=num_warps,
         )
         return grad_in.view(B, T, V), None, None
 

--- a/src/speculators/losses/fused.py
+++ b/src/speculators/losses/fused.py
@@ -62,7 +62,7 @@ MAX_FUSED_SIZE_NPU = 4096
 # 16384/16 at 32000.
 _MAX_ELEMS_PER_THREAD = 128
 _MIN_ELEMS_PER_THREAD = 4
-_BLOCK_SIZES = (1024, 2048, 4096, 8192, 16384, 32768)
+_BLOCK_SIZES = (512, 1024, 2048, 4096, 8192, 16384, 32768)
 _THREADS_PER_PROGRAM = (128, 256, 512, 1024)
 
 # tl.constexpr instances: Triton kernels may only read globals wrapped this way.

--- a/src/speculators/losses/fused.py
+++ b/src/speculators/losses/fused.py
@@ -22,20 +22,45 @@ lineage); TV gradient sign convention matches Liger ops/tvd.py.
 """
 
 # Triton kernels idiomatically use uppercase constexpr/dim names (B, T, V,
-# BLOCK_SIZE) and inline block-size tuning thresholds; exempt this file from the
-# pep8-naming and magic-value lints rather than fight those conventions.
-# ruff: noqa: N803, N806, PLR2004
+# BLOCK_SIZE); exempt this file from the pep8-naming lints rather than fight
+# that convention.
+# ruff: noqa: N803, N806
 
 import torch
 import triton
 import triton.language as tl
 
-MAX_FUSED_SIZE = 131072
 # Ascend NPU's Unified Buffer (~192 KB) cannot fit the double-row load these
 # kernels perform (logits + targets per block) beyond 4096 elements per block;
 # triton-ascend raises "ub overflow" at BLOCK_SIZE >= 8192. CE is single-row
 # but shares the same cap so all _FusedLoss OPs use one path.
 MAX_FUSED_SIZE_NPU = 4096
+
+# CUDA tile selection. Each program holds several fp32 vectors of
+# BLOCK_SIZE / threads elements live at once, so what bounds the tile is
+# elements *per thread*, not BLOCK_SIZE. Past ~32 the working set exceeds the
+# 255-register budget and Triton spills to local memory; measured spill bytes
+# per thread for the forward kernel at V=151936 on an A100:
+#
+#     BLOCK_SIZE   warps=8   warps=16   warps=32
+#       131072        1162        532        234
+#        65536         152         38         38
+#        32768           0          0          0
+#         8192           0          0          0
+#
+# A fixed BLOCK_SIZE of 131072 (the previous behaviour, hit by any vocab
+# > 65536) spilled 234 B/thread and ran the forward at 98 GB/s -- 6% of HBM
+# peak, and 17x slower than the same kernel with a register-resident tile.
+ELEMS_PER_THREAD = 32
+
+# Cap the tile so a full-vocab row is streamed in several register-resident
+# passes rather than one spilling pass. 8192 measured fastest at the shapes
+# training actually uses (>=1024 rows); a wider tile only helps when there are
+# too few rows to fill the device, where the kernel costs <0.3 ms anyway.
+MAX_FUSED_SIZE = 8192
+
+# num_warps=4 measured slower than 8 at every shape tried.
+MIN_THREADS_PER_PROGRAM = 256
 
 # tl.constexpr instances: Triton kernels may only read globals wrapped this way.
 _LOG2 = tl.constexpr(0.6931471805599453)
@@ -57,16 +82,20 @@ _N_STATS = 5
 
 
 def _calculate_settings(n, device):
-    max_size = MAX_FUSED_SIZE_NPU if device.type == "npu" else MAX_FUSED_SIZE
-    BLOCK_SIZE = min(triton.next_power_of_2(n), max_size)
-    # triton-ascend does not require extra num_warps tuning
-    num_warps = 4
-    if BLOCK_SIZE >= 32768:
-        num_warps = 32
-    elif BLOCK_SIZE >= 8192:
-        num_warps = 16
-    elif BLOCK_SIZE >= 2048:
-        num_warps = 8
+    """Pick (BLOCK_SIZE, num_warps) for a row-per-program launch over ``n`` cols.
+
+    Sized so each program's working set stays in registers: the thread count
+    scales with the tile so elements-per-thread is pinned at
+    ``ELEMS_PER_THREAD`` regardless of vocab size.
+    """
+    if device.type == "npu":
+        # triton-ascend is Unified-Buffer bound, not register bound, and does
+        # not require extra num_warps tuning.
+        return min(triton.next_power_of_2(n), MAX_FUSED_SIZE_NPU), 4
+
+    BLOCK_SIZE = min(triton.next_power_of_2(n), MAX_FUSED_SIZE)
+    threads = max(BLOCK_SIZE // ELEMS_PER_THREAD, MIN_THREADS_PER_PROGRAM)
+    num_warps = threads // 32
     if getattr(torch.version, "hip", None) is not None:  # AMD wavefronts are 64-wide
         num_warps //= 2
     return BLOCK_SIZE, num_warps

--- a/tests/unit/models/test_fused_losses.py
+++ b/tests/unit/models/test_fused_losses.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+import triton
 
 from speculators.losses import eager, resolve_loss_config
 from speculators.utils.util import is_npu_available
@@ -187,13 +188,11 @@ def test_eager_implementation_supports_differentiable_targets():
         assert targets.grad is not None, name
 
 
-def test_calculate_settings_respects_device_cap():
-    """`_calculate_settings` picks the right BLOCK_SIZE for each device without
-    needing NPU or CUDA hardware -- the helper only reads ``device.type``.
+def test_calculate_settings_respects_npu_cap():
+    """The NPU branch keeps its fixed Unified-Buffer cap at every vocab size.
 
-    Exercises the NPU cap (MAX_FUSED_SIZE_NPU = 4096) and the CUDA cap
-    (MAX_FUSED_SIZE = 131072) at vocab sizes that span the boundaries, so
-    upstream CI (which typically has no NPU) still covers the NPU branch.
+    Runs without NPU hardware -- the helper only reads ``device.type`` -- so
+    upstream CI still covers the branch.
     """
     fused_losses = pytest.importorskip("speculators.losses.fused")
 
@@ -211,15 +210,49 @@ def test_calculate_settings_respects_device_cap():
             f"NPU cap: vocab={vocab} -> BLOCK_SIZE={block}, expected {expected}"
         )
 
+
+def test_calculate_settings_tile_stays_register_resident():
+    """CUDA tiles never exceed ELEMS_PER_THREAD elements per thread.
+
+    This is the invariant that matters. A wider tile spills to local memory:
+    the previous fixed BLOCK_SIZE=131072 spilled 234 bytes/thread and ran the
+    forward kernel ~17x slower at vocab sizes above 65536. The helper only
+    reads ``device.type``, so this runs without CUDA hardware.
+    """
+    fused_losses = pytest.importorskip("speculators.losses.fused")
+    device = SimpleNamespace(type="cuda")
+
+    for vocab in (512, 4096, 8192, 32000, 131072, 151936, 262144):
+        block, warps = fused_losses._calculate_settings(vocab, device)
+        threads = warps * 32
+        assert block <= triton.next_power_of_2(vocab)
+        assert block <= fused_losses.MAX_FUSED_SIZE
+        assert block <= threads * fused_losses.ELEMS_PER_THREAD, (
+            f"vocab={vocab}: BLOCK_SIZE={block} exceeds "
+            f"{fused_losses.ELEMS_PER_THREAD} elements/thread at {threads} threads"
+        )
+        assert threads >= fused_losses.MIN_THREADS_PER_PROGRAM
+
+
+def test_calculate_settings_cuda_cases():
+    """The tile stops growing with the vocab once it hits MAX_FUSED_SIZE.
+
+    8192/8 warps is the configuration measured fastest on an A100 at the row
+    counts training uses, for both a 32k draft vocab and a full 152k vocab.
+    """
+    fused_losses = pytest.importorskip("speculators.losses.fused")
+    device = SimpleNamespace(type="cuda")
+
     cuda_cases = (
-        (512, 512),
-        (4096, 4096),
-        (8192, 8192),
-        (131072, 131072),
-        (151936, 131072),
+        (512, (512, 256 // 32)),
+        (4096, (4096, 256 // 32)),
+        (8192, (8192, 256 // 32)),
+        (32000, (8192, 256 // 32)),
+        (131072, (8192, 256 // 32)),
+        (151936, (8192, 256 // 32)),
     )
     for vocab, expected in cuda_cases:
-        block, _ = fused_losses._calculate_settings(vocab, SimpleNamespace(type="cuda"))
-        assert block == expected, (
-            f"CUDA cap: vocab={vocab} -> BLOCK_SIZE={block}, expected {expected}"
+        assert fused_losses._calculate_settings(vocab, device) == expected, (
+            f"vocab={vocab} -> {fused_losses._calculate_settings(vocab, device)}, "
+            f"expected {expected}"
         )

--- a/tests/unit/models/test_fused_losses.py
+++ b/tests/unit/models/test_fused_losses.py
@@ -13,8 +13,6 @@ BLOCK_SIZE cap (MAX_FUSED_SIZE_NPU = 4096), which forces the tighter
 multi-block streaming loop.
 """
 
-from types import SimpleNamespace
-
 import pytest
 import torch
 import triton
@@ -188,71 +186,54 @@ def test_eager_implementation_supports_differentiable_targets():
         assert targets.grad is not None, name
 
 
-def test_calculate_settings_respects_npu_cap():
-    """The NPU branch keeps its fixed Unified-Buffer cap at every vocab size.
+def test_tile_configs_stay_register_resident():
+    """Every autotune candidate sits in the measured non-spilling region.
 
-    Runs without NPU hardware -- the helper only reads ``device.type`` -- so
-    upstream CI still covers the branch.
+    This is the invariant that matters: the tile the autotuner ends up on is
+    machine-dependent and not worth asserting, but a candidate that spills to
+    local memory is never competitive on any device. The fixed
+    BLOCK_SIZE=131072 this module used to select was 512 elements/thread and
+    ran the forward kernel ~17x slower than a register-resident tile.
     """
     fused_losses = pytest.importorskip("speculators.losses.fused")
 
-    npu_cases = (
-        (512, 512),
-        (4096, 4096),
-        (8192, 4096),
-        (32768, 4096),
-        (131072, 4096),
-        (151936, 4096),
-    )
-    for vocab, expected in npu_cases:
-        block, _ = fused_losses._calculate_settings(vocab, SimpleNamespace(type="npu"))
-        assert block == expected, (
-            f"NPU cap: vocab={vocab} -> BLOCK_SIZE={block}, expected {expected}"
-        )
+    configs = fused_losses._tile_configs()
+    assert configs, "the autotuner needs at least one candidate"
+
+    warp_size = 64 if getattr(torch.version, "hip", None) is not None else 32
+    for config in configs:
+        block = config.kwargs["BLOCK_SIZE"]
+        threads = config.num_warps * warp_size
+        assert block == triton.next_power_of_2(block)
+        if fused_losses.is_npu_available():
+            assert block <= fused_losses.MAX_FUSED_SIZE_NPU
+            continue
+        elems_per_thread = block // threads
+        assert (
+            fused_losses._MIN_ELEMS_PER_THREAD
+            <= elems_per_thread
+            <= fused_losses._MAX_ELEMS_PER_THREAD
+        ), f"BLOCK_SIZE={block} at {threads} threads is {elems_per_thread} elems/thread"
 
 
-def test_calculate_settings_tile_stays_register_resident():
-    """CUDA tiles never exceed ELEMS_PER_THREAD elements per thread.
+def test_prune_oversized_tiles_never_empties_the_space():
+    """Pruning narrows the space for small vocabs but always leaves a candidate.
 
-    This is the invariant that matters. A wider tile spills to local memory:
-    the previous fixed BLOCK_SIZE=131072 spilled 234 bytes/thread and ran the
-    forward kernel ~17x slower at vocab sizes above 65536. The helper only
-    reads ``device.type``, so this runs without CUDA hardware.
+    A vocab narrower than every candidate tile (the 512-wide test shapes) must
+    still get a config -- an empty list would make the launch unschedulable --
+    and it should get only the narrowest, so tiny shapes do not pay to compile
+    the whole space.
     """
     fused_losses = pytest.importorskip("speculators.losses.fused")
-    device = SimpleNamespace(type="cuda")
 
-    for vocab in (512, 4096, 8192, 32000, 131072, 151936, 262144):
-        block, warps = fused_losses._calculate_settings(vocab, device)
-        threads = warps * 32
-        assert block <= triton.next_power_of_2(vocab)
-        assert block <= fused_losses.MAX_FUSED_SIZE
-        assert block <= threads * fused_losses.ELEMS_PER_THREAD, (
-            f"vocab={vocab}: BLOCK_SIZE={block} exceeds "
-            f"{fused_losses.ELEMS_PER_THREAD} elements/thread at {threads} threads"
-        )
-        assert threads >= fused_losses.MIN_THREADS_PER_PROGRAM
+    configs = fused_losses._tile_configs()
+    blocks = {config.kwargs["BLOCK_SIZE"] for config in configs}
 
-
-def test_calculate_settings_cuda_cases():
-    """The tile stops growing with the vocab once it hits MAX_FUSED_SIZE.
-
-    8192/8 warps is the configuration measured fastest on an A100 at the row
-    counts training uses, for both a 32k draft vocab and a full 152k vocab.
-    """
-    fused_losses = pytest.importorskip("speculators.losses.fused")
-    device = SimpleNamespace(type="cuda")
-
-    cuda_cases = (
-        (512, (512, 256 // 32)),
-        (4096, (4096, 256 // 32)),
-        (8192, (8192, 256 // 32)),
-        (32000, (8192, 256 // 32)),
-        (131072, (8192, 256 // 32)),
-        (151936, (8192, 256 // 32)),
-    )
-    for vocab, expected in cuda_cases:
-        assert fused_losses._calculate_settings(vocab, device) == expected, (
-            f"vocab={vocab} -> {fused_losses._calculate_settings(vocab, device)}, "
-            f"expected {expected}"
-        )
+    for vocab in (128, 512, 4096, 32000, 151936):
+        pruned = fused_losses._prune_oversized_tiles(configs, {"n_cols": vocab})
+        assert pruned, f"vocab={vocab} pruned every candidate"
+        cap = triton.next_power_of_2(vocab)
+        if any(block <= cap for block in blocks):
+            assert all(config.kwargs["BLOCK_SIZE"] <= cap for config in pruned)
+        else:
+            assert {config.kwargs["BLOCK_SIZE"] for config in pruned} == {min(blocks)}


### PR DESCRIPTION
## What's wrong

The fused losses pick their Triton tile size from a hand-written rule. For any vocabulary larger than 65536 that rule always returned the same thing: a `131072`-wide block with 32 warps.

That tile does not fit in registers. Each thread spills 234 bytes to local memory, and the forward kernel ends up running at **98 GB/s — 6% of A100 HBM peak**, about 17× slower than a tile that stays resident.

It hurts more than it looks like it should, because the forward pass streams every row *three* times (online-softmax stats over the logits, again over the targets, then the reduction) where the backward streams it once. So the forward pays the spill penalty three times over. The symptom in a profile is an eagle3 step that spends 73% of its time in forward with `bwd/fwd = 0.24`, when that ratio should be somewhere near 2.

**Who this hits:** anyone training against a verifier whose vocabulary is over 65536 *and* not passing `--draft-vocab-size`. That flag defaults to `None`, which means "use the full verifier vocab" — so this is the default path, not an exotic one. Qwen3 (151936), Qwen2.5 (152064), Llama-3.1/3.3 (128256), DeepSeek-R1 (129280), Mistral-Small-24B (131072), phi-4 (100352) and gpt-oss-120b (201088) are all over the line. The docs' `--draft-vocab-size 32000` examples are under it, and were never affected.

## The fix

Hand the tile choice to `triton.autotune`, keyed on `(vocab, OP)`, so every loss and every vocabulary gets an answer measured on whatever GPU is actually running — rather than swapping one machine-specific constant for another.

The search space is still bounded, because a spilling tile is never the right answer on any architecture. Registers grow at roughly two per element-per-thread, so the 255-register budget runs out near 128 elements/thread. Measured registers / spill-bytes per thread (forward kernel, V=151936, A100):

| BLOCK_SIZE | warps=4 | warps=8 | warps=16 | warps=32 |
|---|---|---|---|---|
| 4096 | 54/0 | 32/0 | 31/0 | 27/0 |
| 8192 | 96/6 | 48/0 | 32/0 | 31/0 |
| 16384 | 253/0 | 127/0 | 64/0 | 32/0 |
| 32768 | 255/126 | 254/0 | 97/0 | 53/0 |
| 65536 | 32/1222 | 255/152 | 128/38 | 64/38 |
| 131072 | 32/3748 | 32/1162 | 32/532 | **32/234** ← what we were using |

Candidates are restricted to that non-spilling region; the autotuner searches inside it. On an A100 it independently rediscovers `8192 / 8 warps` for a 151936 vocab, and finds something *better* than the hand-tuned answer at 32000 (`16384 / 16`, 14% faster on the KL kernel). Picks were identical across three fresh tuning runs.

## Results

The loss kernel's cost is `O(seq_len × vocab)` and never touches the hidden dimension, so **this removes a fixed amount of time per step no matter how big the target model is** — about 70 ms at `seq_len` 2048 and a 151936 vocab. What changes with model size is how much of the step that 70 ms was.

eagle3, `seq_len` 2048, 1× A100-SXM4-80GB, muon, bf16, synthetic data, 10 warmup + 50 measured steps. All four verifiers share the same 151936 vocab, so the only thing varying is hidden size:

| verifier | hidden | step ms (before → after) | fwd ms | tokens/s | speedup |
|---|---|---|---|---|---|
| Qwen3-0.6B | 1024 | 136.6 ± 0.6 → **62.6 ± 0.6** | 100.4 → 30.8 | 14 995 → **32 700** | **2.18×** |
| Qwen3-1.7B | 2048 | 181.8 ± 0.6 → **107.7 ± 0.7** | 114.8 → 44.8 | 11 266 → **19 010** | **1.69×** |
| Qwen3-8B | 4096 | 352.3 ± 1.2 → **280.0 ± 1.2** | 149.0 → 79.4 | 5 813 → **7 314** | **1.26×** |
| Qwen3-32B | 5120 | 672.8 ± 1.4 → **601.7 ± 1.3** | 179.3 → 110.4 | 3 044 → **3 404** | **1.12×** |

The forward saving is 69.7 / 70.0 / 69.6 / 68.9 ms — flat, as predicted. Every row is `p < 1e-140` on a Welch's t-test over the 50 measured steps. `bwd/fwd` on the 0.6B case goes from 0.24 to 0.65. Peak memory is identical in all four cases; the tile is a launch parameter, not an allocation.

The backward gets a smaller win (2–18%) because it also spilled, just once per row instead of three times.

<details>
<summary>Draft-vocab path (unaffected, for completeness)</summary>

With `--draft-vocab-size 32000` on Qwen3-0.6B the vocab never reached the spilling region, so there was nothing to fix. It still picks up ~1% from a better tile:

| | before | after |
|---|---|---|
| step_ms | 38.65 ± 0.71 | 38.19 ± 0.68 |
| tokens/s | 53 004 | 53 636 |

</details>

<details>
<summary>Side note: what the next bottleneck is</summary>

At 8B and 32B the step is now dominated by the **optimizer** — 116.8 ms and 350.3 ms, or 42% and 58% of the step. That is Muon's Newton–Schulz iteration on the `[151936, hidden]` lm_head, and it's unchanged by this PR. Worth a separate look.

</details>

## What this costs

- **Startup**: ~3.1 s once per process (~2.4 s per `(vocab, OP)` key). Irrelevant next to a real training run. Transient 256 MB for `do_bench`'s L2-clear buffer.
- **CI**: `tests/unit/models/test_fused_losses.py` goes from ~10 s to ~106 s on a cold Triton cache — each of the 21 candidates compiles separately at each test shape. This is the one thing I'd expect pushback on; happy to shrink the space if it's too steep.

## Correctness

- Loss values and gradients unchanged: max `|Δloss|` 3e-6, max `|Δgrad|` 1e-6 — both bf16 rounding.
- 18 tests pass, including `torch.compile(fullgraph=True)` on all 7 losses.
- The settings tests now assert the *invariant* that survives autotuning — every candidate sits in the measured non-spilling region, and pruning never empties the space — instead of a specific tile, which is machine-dependent by design.

Two things the autotuner forced, both worth knowing about if you touch this file:

- `_prune_oversized_tiles` gets **traced by Dynamo** when the launch is inside a compiled region, so it has to stay traceable. `min(configs, key=...)` over `Config` objects fails with `TypeError ... op min`; `min` over plain ints is fine.
- A vocabulary narrower than every candidate would prune the space to empty. Falling back to the narrowest tile keeps the launch schedulable and stops small shapes from compiling the entire space.

The NPU branch keeps its single fixed 4096 config — triton-ascend is Unified-Buffer bound rather than register bound, so there is nothing to search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
