### PR TITLE
fix: clean up stale docstrings, dead exports and script refs.

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -2,7 +2,8 @@
 
 This section contains the auto-generated Python API documentation for Speculators.
 
-Browse the [generated Python API reference](../reference/speculators/).
+Browse the [generated Python API reference](../reference/speculators/index.md).
 
 !!! warning
-    Using the Python API directly is **not officially supported** at this time and there are **no guarantees of backward compatibility** between releases. We recommend using the [CLI commands](../cli/index.md) as the primary entrypoints for interacting with Speculators.
+
+Using the Python API directly is **not officially supported** at this time and there are **no guarantees of backward compatibility** between releases. We recommend using the [CLI commands](../cli/index.md) as the primary entrypoints for interacting with Speculators.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -5,5 +5,4 @@ This section contains the auto-generated Python API documentation for Speculator
 Browse the [generated Python API reference](../reference/speculators/index.md).
 
 !!! warning
-
-Using the Python API directly is **not officially supported** at this time and there are **no guarantees of backward compatibility** between releases. We recommend using the [CLI commands](../cli/index.md) as the primary entrypoints for interacting with Speculators.
+    Using the Python API directly is **not officially supported** at this time and there are **no guarantees of backward compatibility** between releases. We recommend using the [CLI commands](../cli/index.md) as the primary entrypoints for interacting with Speculators.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -44,12 +44,12 @@ flowchart TD
     B --> C --> D -- "hs_i.safetensors files\ncontaining {hidden_states}" --> E
     F --> G --> H
 
-    click B "prepare_data/" _self
-    click F "prepare_data/" _self
-    click C "launch_vllm/" _self
-    click G "launch_vllm/" _self
-    click D "data_generation_offline/" _self
-    click E "train/" _self
-    click A "response_regeneration/" _self
-    click H "train/" _self
+    click B "prepare_data.md" _self
+    click F "prepare_data.md" _self
+    click C "launch_vllm.md" _self
+    click G "launch_vllm.md" _self
+    click D "data_generation_offline.md" _self
+    click E "train.md" _self
+    click A "response_regeneration.md" _self
+    click H "train.md" _self
 ```

--- a/docs/cli/prepare_data.md
+++ b/docs/cli/prepare_data.md
@@ -5,7 +5,7 @@ Converts on-policy target-model data into the format consumed by speculator trai
 1. Natural-language conversations whose assistant responses were produced by the target model.
 2. Speculator-format rows that already contain `input_ids` and `loss_mask`.
 
-For natural-language conversations, `prepare_data.py` asks the target model's vLLM `/render` endpoint to apply the serving chat template, tokenize each assistant turn, and derive its loss mask. Rendering only converts the data's representation: it does not generate responses or turn an arbitrary dataset into on-policy data.
+For natural-language conversations, `speculators prepare-data` asks the target model's vLLM `/render` endpoint to apply the serving chat template, tokenize each assistant turn, and derive its loss mask. Rendering only converts the data's representation: it does not generate responses or turn an arbitrary dataset into on-policy data.
 
 The output is ready for online training or offline hidden-state generation.
 
@@ -14,7 +14,12 @@ The output is ready for online training or offline hidden-state generation.
 Given a natural-language JSONL file such as:
 
 ```json
-{"conversations":[{"role":"user","content":"Hello"},{"role":"assistant","content":"Hello! How can I help?"}]}
+{
+    "conversations": [
+        { "role": "user", "content": "Hello" },
+        { "role": "assistant", "content": "Hello! How can I help?" }
+    ]
+}
 ```
 
 where the assistant response came from the target model:

--- a/docs/cli/prepare_data.md
+++ b/docs/cli/prepare_data.md
@@ -14,12 +14,7 @@ The output is ready for online training or offline hidden-state generation.
 Given a natural-language JSONL file such as:
 
 ```json
-{
-    "conversations": [
-        { "role": "user", "content": "Hello" },
-        { "role": "assistant", "content": "Hello! How can I help?" }
-    ]
-}
+{"conversations":[{"role":"user","content":"Hello"},{"role":"assistant","content":"Hello! How can I help?"}]}
 ```
 
 where the assistant response came from the target model:

--- a/src/speculators/models/dflash/config.py
+++ b/src/speculators/models/dflash/config.py
@@ -18,11 +18,12 @@ class DFlashSpeculatorConfig(SpeculatorModelConfig):
     """
     Configuration for DFlash speculator with vocabulary mapping.
 
-    DFlash features vocabulary mapping between draft (64K) and target (128K)
+    DFlash features vocabulary mapping between draft (32K) and target (128K)
     vocabularies, enabling cross-tokenizer speculation.
 
-    :param transformer_layer_config: Configuration for the transformer decoder layer
-    :param draft_vocab_size: Size of draft model vocabulary for speculation
+    Attributes:
+        transformer_layer_config: Configuration for the transformer decoder layer
+        draft_vocab_size: Size of draft model vocabulary for speculation
     """
 
     speculators_model_type: Literal["dflash"] = "dflash"

--- a/src/speculators/models/eagle3/config.py
+++ b/src/speculators/models/eagle3/config.py
@@ -19,9 +19,10 @@ class Eagle3SpeculatorConfig(SpeculatorModelConfig):
     EAGLE-3 features vocabulary mapping between draft (32K) and target (128K)
     vocabularies, enabling cross-tokenizer speculation.
 
-    :param transformer_layer_config: Configuration for the transformer decoder layer
-    :param draft_vocab_size: Size of draft model vocabulary for speculation
-    :param norm_before_residual: Apply hidden_norm before storing residual
+    Attributes:
+        transformer_layer_config: Configuration for the transformer decoder layer
+        draft_vocab_size: Size of draft model vocabulary for speculation
+        norm_before_residual: Apply hidden_norm before storing residual
     """
 
     speculators_model_type: Literal["eagle3"] = "eagle3"

--- a/src/speculators/models/mtp/config.py
+++ b/src/speculators/models/mtp/config.py
@@ -20,13 +20,14 @@ class MTPSpeculatorConfig(SpeculatorModelConfig):
     projection. ``embed_tokens`` and ``lm_head`` share the verifier's
     full vocabulary.
 
-    :param transformer_layer_config: Configuration for the underlying
-        transformer architecture (e.g., ``Qwen2Config``). All architecture
-        dimensions are derived from this config.
-    :param num_nextn_predict_layers: Number of MTP prediction heads in
-        the checkpoint. vLLM reads this field directly to instantiate the
-        correct number of MTP head instances. Currently only ``1`` is
-        supported.
+    Attributes:
+        transformer_layer_config: Configuration for the underlying
+            transformer architecture (e.g., ``Qwen2Config``). All architecture
+            dimensions are derived from this config.
+        num_nextn_predict_layers: Number of MTP prediction heads in
+            the checkpoint. vLLM reads this field directly to instantiate the
+            correct number of MTP head instances. Currently only ``1`` is
+            supported.
     """
 
     speculators_model_type: Literal["mtp"] = "mtp"

--- a/src/speculators/models/peagle/config.py
+++ b/src/speculators/models/peagle/config.py
@@ -18,7 +18,8 @@ class PEagleSpeculatorConfig(Eagle3SpeculatorConfig):
     P-EAGLE extends EAGLE-3 with parallel multi-token prediction using
     Conditional Drop Token (COD) sampling for memory-efficient training.
 
-    :param mask_token_id: Token ID used for masking
+    Attributes:
+        mask_token_id: Token ID used for masking
     """
 
     speculators_model_type: Literal["peagle"] = "peagle"  # type: ignore[assignment]

--- a/src/speculators/train/cli.py
+++ b/src/speculators/train/cli.py
@@ -1,4 +1,8 @@
-"""Training entrypoint — core logic moved from scripts/train.py."""
+"""Training entrypoint for ``speculators train`` / ``torchrun -m speculators.train``.
+
+``scripts/train.py`` is kept only as a deprecated backward-compatible shim
+around this module.
+"""
 
 import argparse
 import gc

--- a/src/speculators/train/config/artifacts.py
+++ b/src/speculators/train/config/artifacts.py
@@ -67,7 +67,7 @@ def dump_yaml(cfg: "TrainConfig") -> str:
 def save(cfg: "TrainConfig", save_dir: str) -> None:
     """Write ``run.yaml`` + ``train_command.txt`` next to the checkpoints.
 
-    Called at rank 0 by ``scripts/train.py`` so every checkpoint carries the
+    Called at rank 0 by ``speculators.train.cli`` so every checkpoint carries the
     config that produced it. ``run.yaml`` is the clean resolved config (re-run via
     ``--config run.yaml``); ``train_command.txt`` records the exact argv this
     config was resolved from plus the environment manifest.

--- a/src/speculators/train/config/schema.py
+++ b/src/speculators/train/config/schema.py
@@ -818,7 +818,7 @@ class TrainConfig(BaseSettings):
         """The impure CLI boundary: parse argv, layer, validate.
 
         Turns any configuration error into a clean ``SystemExit(2)``. This is what
-        ``scripts/train.py`` calls.
+        ``speculators.train.cli`` calls.
         """
         from speculators.train.config import resolution  # noqa: PLC0415
 

--- a/src/speculators/utils/__init__.py
+++ b/src/speculators/utils/__init__.py
@@ -2,7 +2,6 @@ from .pydantic_utils import PydanticClassRegistryMixin, ReloadableBaseModel
 from .registry import ClassRegistryMixin
 
 __all__ = [
-    "AutoImporterMixin",
     "ClassRegistryMixin",
     "PydanticClassRegistryMixin",
     "ReloadableBaseModel",

--- a/src/speculators/utils/registry.py
+++ b/src/speculators/utils/registry.py
@@ -12,8 +12,6 @@ dynamic discovery and instantiation based on configuration parameters.
 Classes:
     ClassRegistryMixin: Base mixin for creating class registries with decorators
         and optional auto-discovery capabilities through registry_auto_discovery flag.
-    AutoClassRegistryMixin: A backward-compatible version of ClassRegistryMixin with
-        auto-discovery enabled by default
 """
 
 from collections.abc import Callable
@@ -136,7 +134,7 @@ class ClassRegistryMixin:
         if not isinstance(clazz, type):
             raise TypeError(
                 "ClassRegistryMixin.register_decorator must be used as a class "
-                "decorator and without invocation."
+                "decorator and without invocation. "
                 f"Got improper clazz arg {clazz}."
             )
 
@@ -146,7 +144,7 @@ class ClassRegistryMixin:
             raise ValueError(
                 "ClassRegistryMixin.register_decorator must be used as a class "
                 "decorator and without invocation. "
-                f"Got imporoper name arg {name}."
+                f"Got improper name arg {name}."
             )
 
         # A subclass inherits its parent's registry attribute until it writes its
@@ -169,11 +167,6 @@ class ClassRegistryMixin:
     def registered_classes(cls) -> tuple[type[Any], ...]:
         """
         Returns a tuple of all classes that have been registered with this registry.
-
-        If registry_auto_discovery is True, this method will first call
-        auto_populate_registry to ensure that all available implementations from
-        the specified auto_package are discovered and registered before returning
-        the list.
 
         :return: A tuple containing all registered class implementations, including
             those discovered through auto-importing when registry_auto_discovery==True.

--- a/tests/unit/train/test_draft_config_init.py
+++ b/tests/unit/train/test_draft_config_init.py
@@ -1,4 +1,4 @@
-"""Tests for the draft-model initialization sources in ``scripts/train.py``.
+"""Tests for the draft-model initialization sources in ``speculators.train.cli``.
 
 Covers the three mutually exclusive init paths and their guard rails:
 - ``--draft-config``: decoder ``transformer_layer_config`` loaded from a file,

--- a/tests/unit/utils/test_registry.py
+++ b/tests/unit/utils/test_registry.py
@@ -4,6 +4,7 @@ Unit tests for the registry module in the Speculators library.
 
 import pytest
 
+import speculators.utils as utils_module
 from speculators.utils.registry import ClassRegistryMixin
 
 # ===== ClassRegistryMixin Tests =====
@@ -204,3 +205,18 @@ def test_auto_discovery_registry_initialization():
     assert TestAutoRegistry.registry_populated is False
     assert TestAutoRegistry.auto_package == "test_package.modules"
     assert TestAutoRegistry.registry_auto_discovery is True
+
+
+@pytest.mark.smoke
+def test_utils_wildcard_import_has_no_dead_names():
+    """Every name in speculators.utils.__all__ must actually exist on the module.
+
+    Regression test for a stale __all__ entry (e.g. a removed class) causing
+    `from speculators.utils import *` to raise AttributeError.
+    """
+
+    for name in utils_module.__all__:
+        assert hasattr(utils_module, name), (
+            f"'{name}' is listed in speculators.utils.__all__ but is not an "
+            "actual attribute of the module (stale export)."
+        )


### PR DESCRIPTION
<!-- markdownlint-disable -->

<!-- PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED. -->

## Purpose
Repository-wide audit of stale docstrings, dead exports, and deprecated script references.

- Removed the dead `AutoImporterMixin` export from `src/speculators/utils/__init__.py` (class no longer exists; broke `from speculators.utils import *`).
- Cleaned up stale references and typos in `src/speculators/utils/registry.py` (removed mentions of the deleted `AutoClassRegistryMixin` and the non-existent `auto_populate_registry`, fixed two typos in error messages).
- Converted Sphinx-style `:param:` docstrings to Google-style `Attributes:` blocks in `eagle3/config.py`, `dflash/config.py`, `mtp/config.py`, and `peagle/config.py` to eliminate Griffe parameter-mismatch warnings on `mkdocs build`; also fixed a stale `draft (64K)` → `draft (32K)` vocab-size note in `dflash/config.py`.
- Replaced stale `scripts/train.py` references (now a deprecated backward-compat shim) with the current entrypoints (`speculators train` / `speculators.train.cli`) in `train/config/__init__.py`, `train/config/artifacts.py`, `train/config/schema.py`, `train/cli.py`, `docs/cli/prepare_data.md`, and `tests/unit/train/test_draft_config_init.py`.
- Fixed directory-style mermaid `click` links in `docs/cli/index.md` to point at the actual `.md` pages.
- Fixed an ambiguous relative link in `docs/api/index.md` (`../reference/speculators/` → `../reference/speculators/index.md`) flagged by `mkdocs build`.

## Fixes #1091 

## Tests
Ran pre commit checks such as lints and ruff checks. 

### Notes for Reviewer
- In `src/speculators/models/peagle/config.py` I used `Attributes:` (plural) instead of `Attribute:` to match the convention used in `eagle3/dflash/mtp` config docstrings.
- I added one regression test to `tests/unit/utils/test_registry.py` covering the wildcard-import case (`hasattr check over speculators.utils.__all__`).
- I am still going through the codebase and if along the way i find any other subtle changes for the stale refs or documentation will update the same.

## Checklist

I have filled in:

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan/results, such as providing test command and pasting the results.
- [ ] (Optional) The necessary documentation update.
- [x] I (a human) have written or reviewed the code in this pr to the best of my ability.
